### PR TITLE
Can I build PEX with system wide site-packages?

### DIFF
--- a/tests/system_provided_packages/README.md
+++ b/tests/system_provided_packages/README.md
@@ -1,0 +1,1 @@
+Fire `vagrant up` to check if `pex` imports system wide site-packages.

--- a/tests/system_provided_packages/Vagrantfile
+++ b/tests/system_provided_packages/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$install_packages = <<SCRIPT
+which pex && exit 0
+sudo apt-get install -y python-pip python-gtk2
+sudo pip install pex wheel
+SCRIPT
+
+$import_gobject = <<SCRIPT
+echo "import gobject" > import_gobject.py
+export PEX_VERBOSE=1
+pex --inherit-path -- import_gobject.py
+SCRIPT
+
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provision "shell", inline: $install_packages
+
+  config.vm.provision "shell", inline: $import_gobject
+end

--- a/tests/system_provided_packages/Vagrantfile
+++ b/tests/system_provided_packages/Vagrantfile
@@ -2,13 +2,19 @@
 # vi: set ft=ruby :
 
 $install_packages = <<SCRIPT
-which pex && exit 0
+which pip && exit 0
 sudo apt-get install -y python-pip python-gtk2
-sudo pip install pex wheel
+sudo pip install wheel
 SCRIPT
 
 $import_gobject = <<SCRIPT
-echo "import gobject" > import_gobject.py
+cd /pex_src
+sudo python setup.py install
+cd
+cat > import_gobject.py << __EOF
+import gobject
+print gobject.__file__
+__EOF
 export PEX_VERBOSE=1
 pex --inherit-path -- import_gobject.py
 SCRIPT
@@ -16,6 +22,8 @@ SCRIPT
 Vagrant.configure(2) do |config|
 
   config.vm.box = "ubuntu/trusty64"
+
+  config.vm.synced_folder "../../", "/pex_src"
 
   config.vm.provision "shell", inline: $install_packages
 


### PR DESCRIPTION
I build an app for Linux that uses Python `gobject` bindings provided by my system (Debian in my case). It's in `/usr/lib/python2.7/dist-packages`.
When I start pex with `--inherit-path` it prints:

```
Scrubbing from site-packages: /usr/lib/python2.7/dist-packages
```

When I try to import `gobject` i get:

```
>>> import gobject
Traceback (most recent call last):
  File "<console>", line 1, in <module>
ImportError: No module named gobject
```

I want to distribute my app as a `deb` and resolve system wide dependencies when installing it by `dpkg`.
Is there any way I can use system provided lib in my PEX?
