### PR TITLE
Use uuid.UUID4.hex instead of .get_hex()

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -16,7 +16,11 @@ from uuid import uuid4
 
 def safe_copy(source, dest, overwrite=False):
   def do_copy():
-    temp_dest = dest + uuid4().get_hex()
+    uid = uuid4()
+    if hasattr(uid, 'hex'):
+      temp_dest = dest + uid.hex
+    else:
+      temp_dest = dest + uid.get_hex()
     shutil.copyfile(source, temp_dest)
     os.rename(temp_dest, dest)
 


### PR DESCRIPTION
On python3.4 the .get_hex() method was replaced by the .hex property. To
support both major versions of the interpreter let's try to use .hex if
it exists and fall back to get_hex() only when necessary.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>