### PR TITLE
Stabilize PythonInterpreter __eq__.

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -364,7 +364,6 @@ class PythonInterpreter(object):
                       of the extras associated with this interpreter.
     """
     self._binary = os.path.realpath(binary)
-    self._binary_stat = os.stat(self._binary)
     self._extras = extras or {}
     self._identity = identity
 
@@ -410,12 +409,12 @@ class PythonInterpreter(object):
         return location
 
   def __hash__(self):
-    return hash(self._binary_stat)
+    return hash((self._binary, self._identity))
 
   def __eq__(self, other):
     if not isinstance(other, PythonInterpreter):
       return False
-    return self._binary_stat == other._binary_stat
+    return (self._binary, self._identity) == (other._binary, other._identity)
 
   def __lt__(self, other):
     if not isinstance(other, PythonInterpreter):


### PR DESCRIPTION
The prior check used the binary's stat which was unstable across
variations of mounts atime setting on different machines. If the
partition the python binary lived on had atime enabled (default in
OSX so an important case), then equality checks would ~always fail
for even the same binary.

This change switches to using binary real path + its reporter
version  info which should be all we care about.  It's true that
the binary might be replaced by a new one of the same version at
the same path but compiled with different options though, so we
still could do more and instead use binary real path + a content
hash of the binary if needed.

https://rbcommons.com/s/twitter/r/1477/
