### PR TITLE
Support all potential abi tag permutations

### DIFF
--- a/pex/pep425.py
+++ b/pex/pep425.py
@@ -106,7 +106,7 @@ class PEP425(object):  # noqa
         'cp%smu' % version, 'cp%sm' % version,
         'cp%su' % version,
         'abi3'
-        ])
+      ])
 
     major_version = int(version[0])
     minor_versions = []

--- a/pex/pep425.py
+++ b/pex/pep425.py
@@ -100,7 +100,13 @@ class PEP425(object):  # noqa
     # Predict soabi for reasonable interpreters.  This is technically wrong but essentially right.
     abis = []
     if impl == 'cp' and version.startswith('3'):
-      abis.extend(['cp%sm' % version, 'abi3'])
+      abis.extend([
+        'cp%s' % version,
+        'cp%sdmu' % version, 'cp%sdm' % version, 'cp%sdu' % version, 'cp%sd' % version,
+        'cp%smu' % version, 'cp%sm' % version,
+        'cp%su' % version,
+        'abi3'
+        ])
 
     major_version = int(version[0])
     minor_versions = []


### PR DESCRIPTION
 * https://www.python.org/dev/peps/pep-0425/
 * https://www.python.org/dev/peps/pep-3149/

Basically the original code assumed the `--with-pymalloc` flag would always be set. This is not always the case, and the `d` and `u` flags are also not considered (details in PEP3149).

Have modified the code so that all permutations are considered.