### PR TITLE
Fix bug that caused pex not to cache the results of translation.

### DIFF
--- a/pex/translator.py
+++ b/pex/translator.py
@@ -41,7 +41,7 @@ class ChainedTranslator(TranslatorBase):
 
   def translate(self, package, into=None):
     for tx in self._translators:
-      dist = tx.translate(package, into=None)
+      dist = tx.translate(package, into=into)
       if dist:
         return dist
 

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,0 +1,34 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pex.translator import ChainedTranslator, TranslatorBase
+
+try:
+  import mock
+except ImportError:
+  from unittest import mock
+
+
+def test_info_is_passed_to_chained_translators():
+  translator = mock.MagicMock(spec=TranslatorBase)
+
+  t = ChainedTranslator(translator)
+  t.translate("fake_package", "fake_into")
+
+  translator.translate.assert_called_with("fake_package", into="fake_into")
+
+
+def test_chained_translator_short_circuit_translate():
+  initial_empty_translator = mock.MagicMock(spec=TranslatorBase)
+  initial_empty_translator.translate.return_value = None
+  translator_with_value = mock.MagicMock(spec=TranslatorBase)
+  translator_with_value.translate.return_value = "fake_success"
+  translator_after_value = mock.MagicMock(spec=TranslatorBase)
+
+  t = ChainedTranslator(initial_empty_translator, translator_with_value, translator_after_value)
+  result = t.translate("fake_package", "fake_into")
+
+  assert result == "fake_success"
+  assert initial_empty_translator.translate.called
+  assert translator_with_value.translate.called
+  assert not translator_after_value.translate.called


### PR DESCRIPTION

I'm under the impression that this is a simple "typo" error, and the intention was also to pass through the parameter to the chained translators.

Of course it's possible that this was intentional and I'm really missing the point :-)

See https://rbcommons.com/s/twitter/r/1666/