### PR TITLE
Speed up the best-case scenario of dependency resolution.

### DIFF
--- a/pex/crawler.py
+++ b/pex/crawler.py
@@ -101,7 +101,7 @@ class Crawler(object):
     def execute():
       while not converged.is_set():
         try:
-          link = queue.get(timeout=0.1)
+          link = queue.get(timeout=0.01)
         except Empty:
           continue
         if link not in seen:
@@ -134,7 +134,6 @@ class Crawler(object):
     queue.join()
     converged.set()
 
-    for worker in workers:
-      worker.join()
-
+    # We deliberately not join back the worker threads, since they are no longer of
+    # any use to us.
     return links

--- a/pex/link.py
+++ b/pex/link.py
@@ -6,6 +6,7 @@ from collections import Iterable
 
 from .compatibility import string as compatible_string
 from .compatibility import PY3
+from .util import Memoizer
 
 if PY3:
   import urllib.parse as urlparse
@@ -50,10 +51,17 @@ class Link(object):
   def _normalize(cls, filename):
     return 'file://' + os.path.realpath(os.path.expanduser(filename))
 
+  # A cache for the result of from_filename
+  _FROM_FILENAME_CACHE = Memoizer()
+
   @classmethod
   def from_filename(cls, filename):
     """Return a :class:`Link` wrapping the local filename."""
-    return cls(cls._normalize(filename))
+    result = cls._FROM_FILENAME_CACHE.get(filename)
+    if result is None:
+      result = cls(cls._normalize(filename))
+      cls._FROM_FILENAME_CACHE.store(filename, result)
+    return result
 
   def __init__(self, url):
     """Construct a :class:`Link` from a url.

--- a/pex/util.py
+++ b/pex/util.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import uuid
 from hashlib import sha1
+from threading import Lock
 
 from pkg_resources import find_distributions
 
@@ -145,3 +146,19 @@ class CacheHelper(object):
     dist = DistributionHelper.distribution_from_path(target_dir)
     assert dist is not None, 'Failed to cache distribution %s' % source
     return dist
+
+
+class Memoizer(object):
+  """A thread safe class for memoizing the results of a computation."""
+
+  def __init__(self):
+    self._data = {}
+    self._lock = Lock()
+
+  def get(self, key, default=None):
+    with self._lock:
+      return self._data.get(key, default)
+
+  def store(self, key, value):
+    with self._lock:
+      self._data[key] = value


### PR DESCRIPTION
A few small touchups that improve the speed of dependency resolution when
many packages are already in the local cache.

- when dispatching multiple crawling threads:
  - make each thread a bit more reactive by reducing the polling timeout from
    100ms to 10ms
  - do not wait for each of the workers threads to complet, just wait for them to complete their
    workload.
  Without this change, dependency resolution is guaranteed to take longer than 100ms per
  dependency, which is a large amount of time for just checking a local zipfile's content.

- cache the result of a couple calls that are repeated many times:
  - Link.from_filename
  - Package.from_href
  Each of this call is performed for each file in the cache, for each dependency that is resolved.
  While both these calls are not especially expensive, when we repeat them n^2 times in a largish
  local cache * set of dependencies they do add up.

Somewhat unscientific benchmarking on my system show that the average time for resolving a single
dependency (namely 'pytz==2013b') goes down from 150ms to 30ms.

Running the modified code on the urbancompass codebase produced similarly desireable timings.