### PR TITLE
Support Python 2.6

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -54,7 +54,7 @@ def configure_clp():
       '%prog builds a PEX (Python Executable) file based on the given specifications: '
       'sources, requirements, their dependencies and other options')
 
-  parser = OptionParser(usage=usage, version='%prog {}'.format(__version__))
+  parser = OptionParser(usage=usage, version='%prog {0}'.format(__version__))
 
   parser.add_option(
       '--pypi', '--no-pypi',


### PR DESCRIPTION
This string formatting nicety was introduced in Python 2.7 and breaks
Python 2.6 users like myself. This change is forwards and backwards
compatible between all Pythons.