### PR TITLE
Fix for decode() on Python 2.6

### DIFF
--- a/pex/http.py
+++ b/pex/http.py
@@ -119,7 +119,7 @@ class UrllibContext(Context):
 
     with contextlib.closing(self.open(link)) as fp:
       encoding = message_from_string(str(fp.headers)).get_content_charset(self.DEFAULT_ENCODING)
-      return fp.read().decode(encoding, errors='replace')
+      return fp.read().decode(encoding, 'replace')
 
 
 Context.register(UrllibContext)
@@ -222,7 +222,7 @@ class RequestsContext(Context):
       raise self.Error('Context.content only works with remote URLs.')
 
     with contextlib.closing(self.open(link)) as request:
-      return request.read().decode(request.encoding or self.DEFAULT_ENCODING, errors='replace')
+      return request.read().decode(request.encoding or self.DEFAULT_ENCODING, 'replace')
 
 
 if requests:


### PR DESCRIPTION
Addresses #44, but I don't know if it breaks compatibility with Python 3.