### PR TITLE
RFC: Add the ability to include extensions & shared libraries in pexs.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -330,6 +330,14 @@ def configure_clp():
            'times.')
 
   parser.add_option(
+      '--native-library',
+      dest='native_libraries',
+      metavar='FILE',
+      default=[],
+      action='append',
+      help='Native library to include in the archive & loader path.')
+
+  parser.add_option(
       '-v',
       dest='verbosity',
       default=0,
@@ -476,6 +484,9 @@ def build_pex(args, options, resolver_option_builder):
     log('  %s' % dist, v=options.verbosity)
     pex_builder.add_distribution(dist)
     pex_builder.add_requirement(dist.as_requirement())
+
+  for lib in options.native_libraries:
+    pex_builder.add_native_library(lib)
 
   if options.entry_point and options.script:
     die('Must specify at most one entry point or script.', INVALID_OPTIONS)

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -133,11 +133,13 @@ class PEXBuilder(object):
     """
     self._ensure_unfrozen('Adding source')
     self._chroot.link(filename, env_filename, "source")
-    if filename.endswith('.py'):
+    if env_filename.endswith('.py'):
       env_filename_pyc = os.path.splitext(env_filename)[0] + '.pyc'
       with open(filename) as fp:
         pyc_object = CodeMarshaller.from_py(fp.read(), env_filename)
       self._chroot.write(pyc_object.to_pyc(), env_filename_pyc, 'source')
+    elif any(env_filename.endswith(ext) for ext in ('.so', '.dll', '.pyd')):
+      self._pex_info.add_native_library(env_filename, CacheHelper.hash(filename))
 
   def add_resource(self, filename, env_filename):
     """Add a resource to the PEX environment.
@@ -300,6 +302,25 @@ class PEXBuilder(object):
     """Alias for add_dist_location."""
     self._ensure_unfrozen('Adding an egg')
     return self.add_dist_location(egg)
+
+  def add_native_library(self, location, name=None):
+    """Add a native library by its location on disk
+
+    :param location: The path to the native library (.so/.dylib/.dll)
+    :name: (optional) The name of the library when extracted (defaults to basename(location))
+
+    If any python extension library found in the package depends on a non-python native library,
+    this method can be used to include the native library in the pex. It will be extracted and
+    added to the proper loader path (LD_LIBRARY_PATH on most unixes).
+    """
+    self._ensure_unfrozen('Adding a native library')
+    if name is None:
+      name = os.path.basename(location)
+    target = os.path.join('native-libs', name)
+
+    self._chroot.link(location, target)
+    sha = CacheHelper.hash(location)
+    self._pex_info.add_native_library(target, sha)
 
   # TODO(wickman) Consider changing this behavior to put the onus on the consumer
   # of pex to write the pex sources correctly.

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -28,13 +28,15 @@ class PexInfo(object):
   distributions: {dist_name: str}   # map from distribution name (i.e. path in
                                     # the internal cache) to its cache key (sha1)
   requirements: list                # list of requirements for this environment
+  native_libraries: {path: str}     # list of native libraries (extensions & dependencies)
 
   # Environment options
   pex_root: ~/.pex                   # root of all pex-related files
   entry_point: string                # entry point into this pex
   script: string                     # script to execute in this pex environment
                                      # at most one of script/entry_point can be specified
-  zip_safe: True, default False      # is this pex zip safe?
+  zip_safe: True, default True       # is this pex zip safe? (forced to False in the
+                                     # presence of native_libraries)
   inherit_path: True, default False  # should this pex inherit site-packages + PYTHONPATH?
   ignore_errors: True, default False # should we ignore inability to resolve dependencies?
   always_write_cache: False          # should we always write the internal cache to disk first?
@@ -66,6 +68,7 @@ class PexInfo(object):
     pex_info = {
       'requirements': [],
       'distributions': {},
+      'native_libraries': {},
       'build_properties': cls.make_build_properties(),
     }
     return cls(info=pex_info)
@@ -120,6 +123,7 @@ class PexInfo(object):
                        '%s of type %s' % (info, type(info)))
     self._pex_info = info or {}
     self._distributions = self._pex_info.get('distributions', {})
+    self._native_libraries = self._pex_info.get('native_libraries', [])
     requirements = self._pex_info.get('requirements', [])
     if not isinstance(requirements, (list, tuple)):
       raise ValueError('Expected requirements to be a list, got %s' % type(requirements))
@@ -157,6 +161,9 @@ class PexInfo(object):
     By default zip_safe is True.  May be overridden at runtime by the $PEX_FORCE_LOCAL environment
     variable.
     """
+    if self._native_libraries:
+      return False
+
     return self._pex_info.get('zip_safe', True)
 
   @zip_safe.setter
@@ -226,6 +233,13 @@ class PexInfo(object):
     return self._distributions
 
   @property
+  def native_libraries(self):
+    return self._native_libraries
+
+  def add_native_library(self, path, sha):
+    self._native_libraries[path] = sha
+
+  @property
   def always_write_cache(self):
     return self._pex_info.get('always_write_cache', False)
 
@@ -259,6 +273,7 @@ class PexInfo(object):
     self._pex_info.update(other._pex_info)
     self._distributions.update(other.distributions)
     self._requirements.update(other.requirements)
+    self._native_libraries.update(other.native_libraries)
 
   def dump(self):
     pex_info_copy = self._pex_info.copy()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,9 +3,11 @@
 
 import os
 
-from twitter.common.contextutil import temporary_file
+from twitter.common.contextutil import temporary_dir, temporary_file
 
-from pex.testing import run_simple_pex_test
+from pex.compatibility import nested
+from pex.pex_builder import PEXBuilder
+from pex.testing import run_simple_pex, run_simple_pex_test, temporary_content
 
 
 def test_pex_execute():
@@ -30,3 +32,30 @@ def test_pex_interpreter():
     so, rc = run_simple_pex_test("", args=(fp.name,), coverage=True, env=env)
     assert so == b'Hello world\n'
     assert rc == 0
+
+
+def test_pex_library_path():
+  with nested(temporary_dir(),
+              temporary_content({'_ext.so': 125}),
+              temporary_dir()) as (pb_dir, lib, out_dir):
+    main_py = os.path.join(pb_dir, 'exe.py')
+    with open(main_py, 'w') as pyfile:
+      pyfile.write("""
+import os
+import os.path
+
+var_name = 'DYLD_LIBRARY_PATH' if os.uname()[0] == 'Darwin' else 'LD_LIBRARY_PATH'
+print(any(os.path.exists(os.path.join(p, '_ext.so'))
+          for p in os.environ[var_name].split(':')))
+""")
+
+    pb = PEXBuilder(path=pb_dir)
+    pb.add_native_library(os.path.join(lib, '_ext.so'))
+    pb.set_executable(main_py)
+    pb.freeze()
+    assert not pb.info.zip_safe
+    pex = os.path.join(out_dir, 'app.pex')
+    pb.build(pex)
+    out, rc = run_simple_pex(pex)
+    assert rc == 0
+    assert out == b'True\n'


### PR DESCRIPTION
Extensions already (sort-of) worked via add_source - this makes sure that when adding a .(so|dll|pyd), we force zip_safe to False.
In addition this adds the ability to include other shared libraries with the pex. This is intended to be used for dependencies of the python extensions (e.g. a cityhash extension will depend on a cityhash library).

The way this works is a bit hacky and only works well on unix-ish platforms. It works by changing LD_LIBRARY_PATH and re-execing the interpreter (so that the loader picks up the path change). If this should ever need to support windows, using something like AddDllDirectory will likely be cleaner.