### PR TITLE
Deprecate old-style requirement parsing

### DIFF
--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, print_function
 import json
 import os
 import sys
-import warnings
 from collections import namedtuple
 
 from .common import open_zip
@@ -85,13 +84,7 @@ class PexInfo(object):
 
   @classmethod
   def _parse_requirement_tuple(cls, requirement_tuple):
-    if isinstance(requirement_tuple, (tuple, list)):
-      if len(requirement_tuple) != 3:
-        raise ValueError('Malformed PEX requirement: %r' % (requirement_tuple,))
-      # pre 0.8.x requirement type:
-      warnings.warn('Attempting to use deprecated PEX feature.  Please upgrade past PEX 0.8.x.')
-      return requirement_tuple[0]
-    elif isinstance(requirement_tuple, compatibility_string):
+    if isinstance(requirement_tuple, compatibility_string):
       return requirement_tuple
     raise ValueError('Malformed PEX requirement: %r' % (requirement_tuple,))
 

--- a/tests/test_pex_info.py
+++ b/tests/test_pex_info.py
@@ -23,9 +23,8 @@ def test_backwards_incompatible_pex_info():
   with pytest.raises(ValueError):
     make_pex_info([('hello', False)])
 
-  # backwards compatibility
-  pi = make_pex_info([
-      ['hello==0.1', False, None],
-      ['world==0.2', False, None],
-  ])
-  assert pi.requirements == OrderedSet(['hello==0.1', 'world==0.2'])
+  with pytest.raises(ValueError):
+    make_pex_info([
+        ['hello==0.1', False, None],
+        ['world==0.2', False, None],
+    ])


### PR DESCRIPTION
Remove backwards-compatibility with pre-0.8.x pex.
