### PR TITLE
Consolidate PEX environment variable handling and add --help-variables option

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import sys
 from optparse import OptionGroup, OptionParser, OptionValueError
+from textwrap import TextWrapper
 
 from pex.archiver import Archiver
 from pex.base import maybe_requirement
@@ -32,6 +33,7 @@ from pex.resolvable import Resolvable
 from pex.resolver import CachingResolver, Resolver
 from pex.resolver_options import ResolverOptionsBuilder
 from pex.tracer import TRACER, TraceLogger
+from pex.variables import Variables
 from pex.version import SETUPTOOLS_REQUIREMENT, WHEEL_REQUIREMENT, __version__
 
 CANNOT_DISTILL = 101
@@ -102,6 +104,14 @@ def process_precedence(option, option_str, option_value, parser, builder):
     builder.no_use_wheel()
   else:
     raise OptionValueError
+
+
+def print_variable_help(option, option_str, option_value, parser):
+  for variable_name, variable_type, variable_help in Variables.iter_help():
+    print('\n%s: %s\n' % (variable_name, variable_type))
+    for line in TextWrapper(initial_indent=' ' * 4, subsequent_indent=' ' * 4).wrap(variable_help):
+      print(line)
+  sys.exit(0)
 
 
 def configure_clp_pex_resolution(parser, builder):
@@ -326,6 +336,13 @@ def configure_clp():
       action='callback',
       callback=increment_verbosity,
       help='Turn on logging verbosity, may be specified multiple times.')
+
+  parser.add_option(
+      '--help-variables',
+      action='callback',
+      callback=print_variable_help,
+      help='Print out help about the various environment variables used to change the behavior of '
+           'a running PEX file.')
 
   return parser, resolver_options_builder
 

--- a/pex/common.py
+++ b/pex/common.py
@@ -64,10 +64,7 @@ class MktempTeardownRegistry(object):
   def teardown(self):
     for td in self._registry.pop(self._getpid(), []):
       if self._exists(td):
-        if self._getenv('PEX_LEAVE_TEMPDIRS'):
-          print('Left temporary dir: %s' % td, file=sys.stderr)
-        else:
-          self._rmtree(td)
+        self._rmtree(td)
 
 
 _MKDTEMP_SINGLETON = MktempTeardownRegistry()

--- a/pex/http.py
+++ b/pex/http.py
@@ -12,6 +12,7 @@ from email import message_from_string
 from .common import safe_mkdtemp, safe_open
 from .compatibility import PY3, AbstractClass
 from .tracer import TRACER
+from .variables import ENV
 
 try:
   import requests
@@ -194,13 +195,13 @@ class RequestsContext(Context):
 
     return session
 
-  def __init__(self, session=None, verify=True, max_retries=5):
+  def __init__(self, session=None, verify=True, env=ENV):
     if requests is None:
       raise RuntimeError('requests is not available.  Cannot use a RequestsContext.')
 
     self._verify = verify
 
-    max_retries = int(os.environ.get('PEX_HTTP_RETRIES', max_retries))
+    max_retries = env.PEX_HTTP_RETRIES
 
     if max_retries < 0:
       raise ValueError('max_retries may not be negative.')

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -15,15 +15,12 @@ from pkg_resources import Distribution, Requirement, find_distributions
 
 from .base import maybe_requirement
 from .compatibility import string
-from .tracer import TraceLogger
+from .tracer import TRACER
 
 try:
   from numbers import Integral
 except ImportError:
   Integral = (int, long)
-
-
-TRACER = TraceLogger(predicate=TraceLogger.env_filter('PEX_VERBOSE'), prefix='pex.interpreter: ')
 
 
 # Determine in the most platform-compatible way possible the identity of the interpreter

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -20,9 +20,8 @@ from .finders import get_script_from_distributions
 from .interpreter import PythonInterpreter
 from .orderedset import OrderedSet
 from .pex_info import PexInfo
-from .tracer import TraceLogger
-
-TRACER = TraceLogger(predicate=TraceLogger.env_filter('PEX_VERBOSE'), prefix='pex: ')
+from .tracer import TRACER
+from .variables import ENV
 
 
 class DevNull(object):
@@ -58,7 +57,7 @@ class PEX(object):  # noqa: T000
       for key in filter(lambda key: key.startswith('PEX_'), os.environ):
         del os.environ[key]
 
-  def __init__(self, pex=sys.argv[0], interpreter=None):
+  def __init__(self, pex=sys.argv[0], interpreter=None, env=ENV):
     self._pex = pex
     self._interpreter = interpreter or PythonInterpreter.get()
     self._pex_info = PexInfo.from_pex(self._pex)
@@ -66,6 +65,7 @@ class PEX(object):  # noqa: T000
     env_pex_info = self._pex_info.copy()
     env_pex_info.update(self._pex_info_overrides)
     self._env = PEXEnvironment(self._pex, env_pex_info)
+    self._vars = env
 
   @classmethod
   def _extras_paths(cls):
@@ -243,7 +243,7 @@ class PEX(object):  # noqa: T000
     try:
       with self.patch_sys():
         working_set = self._env.activate()
-        if 'PEX_COVERAGE' in os.environ:
+        if self._vars.PEX_COVERAGE:
           self.start_coverage()
         TRACER.log('PYTHONPATH contains:')
         for element in sys.path:
@@ -260,13 +260,13 @@ class PEX(object):  # noqa: T000
       # squash all exceptions on interpreter teardown -- the primary type here are
       # atexit handlers failing to run because of things such as:
       #   http://stackoverflow.com/questions/2572172/referencing-other-modules-in-atexit
-      if 'PEX_TEARDOWN_VERBOSE' not in os.environ:
+      if not self._vars.PEX_TEARDOWN_VERBOSE:
         sys.stderr.flush()
         sys.stderr = DevNull()
         sys.excepthook = lambda *a, **kw: None
 
   def _execute(self):
-    if 'PEX_INTERPRETER' in os.environ:
+    if self._vars.PEX_INTERPRETER:
       return self.execute_interpreter()
 
     if self._pex_info_overrides.script and self._pex_info_overrides.entry_point:
@@ -286,11 +286,11 @@ class PEX(object):  # noqa: T000
     else:
       return self.execute_interpreter()
 
-  @classmethod
-  def execute_interpreter(cls):
-    force_interpreter = 'PEX_INTERPRETER' in os.environ
+  def execute_interpreter(self):
+    force_interpreter = self._vars.PEX_INTERPRETER
+    # TODO(wickman) Is this necessary?
     if force_interpreter:
-      del os.environ['PEX_INTERPRETER']
+      self._vars.delete('PEX_INTERPRETER')
     TRACER.log('%s, dropping into interpreter' % (
         'PEX_INTERPRETER specified' if force_interpreter else 'No entry point specified'))
     if sys.argv[1:]:
@@ -300,7 +300,7 @@ class PEX(object):  # noqa: T000
       except IOError as e:
         die("Could not open %s in the environment [%s]: %s" % (sys.argv[1], sys.argv[0], e))
       sys.argv = sys.argv[1:]
-      cls.execute_content(name, content)
+      self.execute_content(name, content)
     else:
       import code
       code.interact()
@@ -341,24 +341,21 @@ class PEX(object):  # noqa: T000
       sys.argv[0] = old_argv0
 
   # TODO(wickman) Find a way to make PEX_PROFILE work with all execute_*
-  @classmethod
-  def execute_entry(cls, entry_point):
-    runner = cls.execute_pkg_resources if ':' in entry_point else cls.execute_module
+  def execute_entry(self, entry_point):
+    runner = self.execute_pkg_resources if ':' in entry_point else self.execute_module
 
-    if 'PEX_PROFILE' not in os.environ:
+    if not self._vars.PEX_PROFILE:
       runner(entry_point)
     else:
       import pstats, cProfile
-      profile_output = os.environ['PEX_PROFILE']
-      safe_mkdir(os.path.dirname(profile_output))
-      cProfile.runctx('runner(entry_point)', globals=globals(), locals=locals(),
-                      filename=profile_output)
-      try:
-        entries = int(os.environ.get('PEX_PROFILE_ENTRIES', 1000))
-      except ValueError:
-        entries = 1000
-      pstats.Stats(profile_output).sort_stats(
-          os.environ.get('PEX_PROFILE_SORT', 'cumulative')).print_stats(entries)
+      safe_mkdir(os.path.dirname(self._vars.PEX_PROFILE))
+      cProfile.runctx('runner(entry_point)',
+          globals=globals(),
+          locals=locals(),
+          filename=self._vars.PEX_PROFILE)
+      (pstats.Stats(self._vars.PEX_PROFILE)
+             .sort_stats(self._vars.PEX_PROFILE_SORT)
+             .print_stats(self._vars.PEX_PROFILE_ENTRIES))
 
   @staticmethod
   def execute_module(module_name):

--- a/pex/tracer.py
+++ b/pex/tracer.py
@@ -7,6 +7,8 @@ import threading
 import time
 from contextlib import contextmanager
 
+from .variables import ENV
+
 __all__ = ('TraceLogger',)
 
 
@@ -132,4 +134,7 @@ class TraceLogger(object):
       self._local.parent = None
 
 
-TRACER = TraceLogger(predicate=TraceLogger.env_filter('PEX_VERBOSE'), prefix='pex: ')
+TRACER = TraceLogger(
+   predicate=lambda verbosity: verbosity <= ENV.PEX_VERBOSE,
+   prefix='pex: '
+)

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -1,0 +1,231 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# Due to the PEX_ properties, disable checkstyle.
+# checkstyle: noqa
+
+import os
+
+from .common import die
+
+__all__ = ('ENV', 'Variables')
+
+
+class Variables(object):
+  @classmethod
+  def process_pydoc(cls, pydoc):
+    if pydoc is None:
+      return 'Unknown', 'Unknown'
+    pydoc = pydoc.splitlines()
+    variable_type = pydoc[0]
+    variable_text = ' '.join(filter(None, (line.strip() for line in pydoc[2:])))
+    return variable_type, variable_text
+
+  @classmethod
+  def iter_help(cls):
+    for variable_name, value in sorted(cls.__dict__.items()):
+      if not variable_name.startswith('PEX_'):
+        continue
+      variable_type, variable_text = cls.process_pydoc(getattr(value, '__doc__'))
+      yield variable_name, variable_type, variable_text
+
+  def __init__(self, environ=os.environ):
+    self._environ = environ
+
+  def copy(self):
+    return self._environ.copy()
+
+  def delete(self, variable):
+    self._environ.pop(variable, None)
+
+  def set(self, variable, value):
+    self._environ[variable] = str(value)
+
+  def _get_bool(self, variable, default=False):
+    value = self._environ.get(variable)
+    if value is not None:
+      if value.lower() in ('0', 'false'):
+        return False
+      elif value.lower() in ('1', 'true'):
+        return True
+      else:
+        die('Invalid value for %s, must be 0/1/false/true, got %r' % (variable, value))
+    else:
+      return default
+
+  def _get_string(self, variable, default=None):
+    return self._environ.get(variable, default)
+
+  def _get_path(self, variable, default=None):
+    value = self._get_string(variable, default=default)
+    if value is not None:
+      return os.path.realpath(os.path.expanduser(value))
+
+  def _get_int(self, variable, default=None):
+    try:
+      return int(self._environ[variable])
+    except ValueError:
+      die('Invalid value for %s, must be an integer, got %r' % (variable, self._environ[variable]))
+    except KeyError:
+      return default
+
+  @property
+  def PEX_ALWAYS_CACHE(self):
+    """Boolean
+
+    Always write PEX dependencies to disk prior to invoking regardless whether or not the
+    dependencies are zip-safe.  For certain dependencies that are very large such as numpy, this
+    can reduce the RAM necessary to launch the PEX.  The data will be written into $PEX_ROOT,
+    which by default is $HOME/.pex.  Default: false.
+    """
+    return self._get_bool('PEX_ALWAYS_CACHE', default=False)
+
+  @property
+  def PEX_COVERAGE(self):
+    """Boolean
+
+    Enable coverage reporting for this PEX file.  This requires that the "coverage" module is
+    available in the PEX environment.  Default: false.
+    """
+    return self._get_bool('PEX_COVERAGE', default=False)
+
+  @property
+  def PEX_FORCE_LOCAL(self):
+    """Boolean
+
+    Force this PEX to be not-zip-safe. This forces all code and dependencies to be written into
+    $PEX_ROOT prior to invocation.  This is an option for applications with static assets that
+    refer to paths relative to __file__ instead of using pkgutil/pkg_resources.  Default: false.
+    """
+    return self._get_bool('PEX_FORCE_LOCAL', default=False)
+
+  @property
+  def PEX_IGNORE_ERRORS(self):
+    """Boolean
+
+    Ignore any errors resolving dependencies when invoking the PEX file. This can be useful if you
+    know that a particular failing dependency is not necessary to run the application.  Default:
+    false.
+    """
+    return self._get_bool('PEX_IGNORE_ERRORS', default=False)
+
+  @property
+  def PEX_INHERIT_PATH(self):
+    """Boolean
+
+    Allow inheriting packages from site-packages.  By default, PEX scrubs any packages and
+    namespace packages from sys.path prior to invoking the application.  This is generally not
+    advised, but can be used in situations when certain dependencies do not conform to standard
+    packaging practices and thus cannot be bundled into PEX files.  Default: false.
+    """
+    return self._get_bool('PEX_INHERIT_PATH', default=False)
+
+  @property
+  def PEX_INTERPRETER(self):
+    """Boolean
+
+    Drop into a REPL instead of invoking the predefined entry point of this PEX. This can be
+    useful for inspecting the PEX environment interactively.  It can also be used to treat the PEX
+    file as an interpreter in order to execute other scripts in the context of the PEX file, e.g.
+    "PEX_INTERPRETER=1 ./app.pex my_script.py".  Equivalent to setting PEX_MODULE to empty.
+    Default: false.
+    """
+    return self._get_bool('PEX_INTERPRETER', default=False)
+
+  @property
+  def PEX_MODULE(self):
+    """String
+
+    Override the entry point into the PEX file.  Can either be a module, e.g.  'SimpleHTTPServer',
+    or a specific entry point in module:symbol form, e.g.  "myapp.bin:main".
+    """
+    return self._get_string('PEX_MODULE', default=None)
+
+  @property
+  def PEX_PROFILE(self):
+    """Filename
+
+    Enable application profiling and dump a profile into the specified filename in the standard
+    "profile" module format.
+    """
+    return self._get_path('PEX_PROFILE', default=None)
+
+  @property
+  def PEX_PROFILE_ENTRIES(self):
+    """Integer
+
+    Toggle the number of profile entries printed out to stdout when profiling.  Default: 1000.
+    """
+    return self._get_int('PEX_PROFILE_ENTRIES', default=1000)
+
+  @property
+  def PEX_PROFILE_SORT(self):
+    """Integer
+
+    Toggle the profile sorting algorithm used to print out profile columns.  Default:
+    'cumulative'.
+    """
+    return self._get_string('PEX_PROFILE_SORT', default='cumulative')
+
+  @property
+  def PEX_PYTHON(self):
+    """String
+
+    Override the Python interpreter used to invoke this PEX.  Can be either an absolute path to an
+    interpreter or a base name e.g.  "python3.3".  If a base name is provided, the $PATH will be
+    searched for an appropriate match.
+    """
+    return self._get_string('PEX_PYTHON', default=None)
+
+  @property
+  def PEX_ROOT(self):
+    """Directory
+
+    The directory location for PEX to cache any dependencies and code.  PEX must write
+    not-zip-safe eggs and all wheels to disk in order to activate them.  Default: ~/.pex
+    """
+    return self._get_path('PEX_ROOT', default=None)
+
+  @property
+  def PEX_SCRIPT(self):
+    """String
+
+    The script name within the PEX environment to execute.  This must either be an entry point as
+    defined in a distribution's console_scripts, or a script as defined in a distribution's
+    scripts section.  While Python supports any script including shell scripts, PEX only supports
+    invocation of Python scripts in this fashion.
+    """
+    return self._get_string('PEX_SCRIPT', default=None)
+
+  @property
+  def PEX_TEARDOWN_VERBOSE(self):
+    """Boolean
+
+    Enable verbosity for when the interpreter shuts down.  This is mostly only useful for
+    debugging PEX itself.  Default: false.
+    """
+    return self._get_bool('PEX_TEARDOWN_VERBOSE', default=False)
+
+  @property
+  def PEX_VERBOSE(self):
+    """Integer
+
+    Set the verbosity level of PEX debug logging.  The higher the number, the more logging, with 0
+    being disabled.  This environment variable can be extremely useful in debugging PEX
+    environment issues.  Default: 0
+    """
+    return self._get_int('PEX_VERBOSE', default=0)
+
+  # TODO(wickman) Remove and push into --flags.
+  @property
+  def PEX_HTTP_RETRIES(self):
+    """Integer
+
+    The number of HTTP retries when performing dependency resolution when building a PEX file.
+    Default: 5.
+    """
+    return self._get_int('PEX_HTTP_RETRIES', default=5)
+
+
+# Global singleton environment
+ENV = Variables()

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -1,0 +1,74 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import pytest
+
+from pex.variables import Variables
+
+
+def test_process_pydoc():
+  def thing():
+    # no pydoc
+    pass
+  assert Variables.process_pydoc(thing.__doc__) == ('Unknown', 'Unknown')
+
+  def other_thing():
+    """Type
+
+    Properly
+         formatted
+      text.
+    """
+
+  assert Variables.process_pydoc(other_thing.__doc__) == (
+      'Type', 'Properly formatted text.')
+
+
+def test_iter_help():
+  for variable_name, variable_type, variable_text in Variables.iter_help():
+    assert variable_name.startswith('PEX_')
+    assert '\n' not in variable_type
+    assert '\n' not in variable_text
+
+
+def test_pex_bool_variables():
+  Variables(environ={})._get_bool('NOT_HERE', default=False) is False
+  Variables(environ={})._get_bool('NOT_HERE', default=True) is True
+
+  for value in ('0', 'faLsE', 'false'):
+    for default in (True, False):
+      Variables(environ={'HERE': value})._get_bool('HERE', default=default) is False
+  for value in ('1', 'TrUe', 'true'):
+    for default in (True, False):
+      Variables(environ={'HERE': value})._get_bool('HERE', default=default) is True
+  with pytest.raises(SystemExit):
+    Variables(environ={'HERE': 'garbage'})._get_bool('HERE')
+
+  # end to end
+  assert Variables().PEX_ALWAYS_CACHE is False
+  assert Variables({'PEX_ALWAYS_CACHE': '1'}).PEX_ALWAYS_CACHE is True
+
+
+def test_pex_string_variables():
+  Variables(environ={})._get_string('NOT_HERE') is None
+  Variables(environ={})._get_string('NOT_HERE', default='lolol') == 'lolol'
+  Variables(environ={'HERE': 'stuff'})._get_string('HERE') == 'stuff'
+  Variables(environ={'HERE': 'stuff'})._get_string('HERE', default='lolol') == 'stuff'
+
+
+def test_pex_get_int():
+  assert Variables()._get_int('HELLO') is None
+  assert Variables()._get_int('HELLO', default=42) == 42
+  assert Variables(environ={'HELLO': 23})._get_int('HELLO') == 23
+  assert Variables(environ={'HELLO': 23})._get_int('HELLO', default=42) == 23
+
+  with pytest.raises(SystemExit):
+    assert Variables(environ={'HELLO': 'welp'})._get_int('HELLO')
+
+
+def test_pex_vars_set():
+  v = Variables(environ={})
+  v.set('HELLO', '42')
+  assert v._get_int('HELLO') == 42
+  v.delete('HELLO')
+  assert v._get_int('HELLO') is None


### PR DESCRIPTION
Partially addresses #13.  To fully address, there should probably be a tutorial or at least an explicit link to the pex.variables api doc page.