### PR TITLE
Fix packager not including setup.py files in source distributions

### DIFF
--- a/pex/installer.py
+++ b/pex/installer.py
@@ -35,6 +35,7 @@ class InstallerBase(object):
   SETUP_BOOTSTRAP_MODULE = "sys.path.insert(0, %(path)r); import %(module)s"
   SETUP_BOOTSTRAP_FOOTER = """
 __file__ = 'setup.py'
+sys.argv[0] = 'setup.py'
 exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
 """
 

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -79,9 +79,6 @@ PROJECT_CONTENT = {
           package_data={'my_package': ['package_data/*.dat']},
       )
   '''),
-  'MANIFEST.in': dedent('''
-  include setup.py
-  '''),
   'scripts/hello_world': '#!/usr/bin/env python\nprint("hello world!")\n',
   'scripts/shell_script': '#!/usr/bin/env bash\necho hello world\n',
   'my_package/__init__.py': 0,


### PR DESCRIPTION
Removed setup.py from MANIFEST.in in pex/testing, which causes test_resolver to be an effective regression test.  Fixes #103.