### PR TITLE
Fix --inherit-path

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -295,7 +295,8 @@ class PEX(object):  # noqa: T000
     the interpreter.
     """
     try:
-      self.patch_sys()
+      if not self._pex_info.inherit_path:
+        self.patch_sys()
       working_set = self._activate()
       TRACER.log('PYTHONPATH contains:')
       for element in sys.path:


### PR DESCRIPTION
`--inherit-path` doesn't work with current master. Normally pex bootstrapper strips down `sys.path` to bare minimum, but I believe it should leave `sys.path` alone if `--inherit-path` was passed. I'm not sure about other stuff patched in `patch_sys` function (like `sys.modules`), but I think it's safer not to touch these either in this case.

I bumped on this bug trying to use `lxc` module. It's provided by `python-lxc` package on Ubuntu, but unfortunately it's not uploaded to pypi.
