### PR TITLE
sys.exit instead of returning pex exit code.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -523,7 +523,7 @@ def main():
 
     log('Running PEX file at %s with args %s' % (pex_builder.path(), cmdline), v=options.verbosity)
     pex = PEX(pex_builder.path(), interpreter=pex_builder.interpreter)
-    return pex.run(args=list(cmdline))
+    sys.exit(pex.run(args=list(cmdline)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix #115.