### PR TITLE
Tread carefully around DistributionNotFound.

### DIFF
--- a/pex/environment.py
+++ b/pex/environment.py
@@ -148,7 +148,10 @@ class PEXEnvironment(Environment):
         except DistributionNotFound as e:
           TRACER.log('Failed to resolve a requirement: %s' % e)
           unresolved_reqs.add(e.args[0].project_name)
-          if e.args[1]:
+          # Older versions of pkg_resources just call `DistributionNotFound(req)` instead of the
+          # modern `DistributionNotFound(req, requirers)` and so we may not have the 2nd requirers
+          # slot at all.
+          if len(e.args) >= 2 and e.args[1]:
             unresolved_reqs.update(e.args[1])
 
     unresolved_reqs = set([req.lower() for req in unresolved_reqs])


### PR DESCRIPTION
Old versions of pkg_resources do not populate the requirers argument so make sure its present - carefully - before using it.

https://rbcommons.com/s/twitter/r/2400/