### PR TITLE
Support PathResource that comes from egg

### DIFF
--- a/pex/finders.py
+++ b/pex/finders.py
@@ -268,7 +268,7 @@ def get_script_from_distribution(name, dist):
     return get_script_from_whl(name, dist)
   elif isinstance(dist._provider, (pkg_resources.PathMetadata)):
     script_path, script = get_script_from_egg(name, dist)
-    if script_path == None:
+    if script_path is None:
       script_path, script = get_script_from_whl(name, dist)
     return script_path, script
   return None, None

--- a/pex/finders.py
+++ b/pex/finders.py
@@ -238,7 +238,7 @@ def unregister_finders():
 
 def get_script_from_egg(name, dist):
   """Returns location, content of script in distribution or (None, None) if not there."""
-  if name in dist.metadata_listdir('scripts'):
+  if dist.resource_isdir('EGG-INFO/scripts') and name in dist.metadata_listdir('scripts'):
     return (
         os.path.join(dist.egg_info, 'scripts', name),
         dist.get_metadata('scripts/%s' % name).replace('\r\n', '\n').replace('\r', '\n'))
@@ -264,8 +264,13 @@ def get_script_from_whl(name, dist):
 def get_script_from_distribution(name, dist):
   if isinstance(dist._provider, FixedEggMetadata):
     return get_script_from_egg(name, dist)
-  elif isinstance(dist._provider, (WheelMetadata, pkg_resources.PathMetadata)):
+  elif isinstance(dist._provider, (WheelMetadata)):
     return get_script_from_whl(name, dist)
+  elif isinstance(dist._provider, (pkg_resources.PathMetadata)):
+    script_path, script = get_script_from_egg(name, dist)
+    if script_path == None:
+      script_path, script = get_script_from_whl(name, dist)
+    return script_path, script
   return None, None
 
 


### PR DESCRIPTION
I was seeing failures when creating an entry point to a script that was included in an egg. I'm not super familiar with the pex internals, but it seemed to only happen when the pex was actually executing (IE it found the script during the build process but not during execution).

My guess is that the eggs get converted to a PathResource at some point and since the PathResource is treated the same as a WheelResource it fails on paths that came from eggs because the scripts directory is in a different location.

My fix was to try both finding scripts from an egg location and from a wheel location when a PathResource is found. I'm happy to add/update tests if you can point me to the relevant ones.