### PR TITLE
Remove stderr print on SystemExit().code == None

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -321,7 +321,7 @@ class PEX(object):  # noqa: T000
     except SystemExit as se:
       # Print a SystemExit error message, avoiding a traceback in python3.
       # This must happen here, as sys.stderr is about to be torn down
-      if not isinstance(se.code, int):
+      if not isinstance(se.code, int) and se.code is not None:
         print(se.code, file=sys.stderr)
       raise
     finally:

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -60,6 +60,14 @@ def test_pex_sys_exit_prints_non_numeric_value_no_traceback():
   _test_sys_exit(sys_exit_arg, expected_output, 1)
 
 
+def test_pex_sys_exit_doesnt_print_none():
+  _test_sys_exit('', to_bytes(''), 0)
+
+
+def test_pex_sys_exit_prints_objects():
+  _test_sys_exit('Exception("derp")', to_bytes('derp\n'), 1)
+
+
 @pytest.mark.skipif('hasattr(sys, "pypy_version_info")')
 def test_pex_atexit_swallowing():
   body = textwrap.dedent("""


### PR DESCRIPTION
The existing SystemExit handler causes an extraneous 'None' to be printed at exit when pex is used with twitter.common.app (and presumably sys.exit() is called with no arguments, which leads to SystemExit().code == None). This adds a None check on se.code.
