### PR TITLE
crawler: Decode "&amp;" to "&" in urls

### DIFF
--- a/pex/crawler.py
+++ b/pex/crawler.py
@@ -33,7 +33,9 @@ class PageParser(object):
   def href_match_to_url(cls, match):
     def pick(group):
       return '' if group is None else group
-    return pick(match.group(1)) or pick(match.group(2)) or pick(match.group(3))
+    url = pick(match.group(1)) or pick(match.group(2)) or pick(match.group(3))
+    url = url.replace('&amp;', '&') # TODO Replace all html entities, in a way that's portable across python 2 and 3
+    return url
 
   @classmethod
   def rel_links(cls, page):

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -40,6 +40,10 @@ def test_page_parser_basic():
       assert lpp("<a href='stuff'> <a href=%s>" % target) == (['stuff', href], [])
 
 
+def test_page_parser_amps():
+  assert lpp('<a href="things?one=1&amp;two=2"') == (['things?one=1&two=2'], [])
+
+
 def test_page_parser_rels():
   VALID_RELS = tuple(PageParser.REL_TYPES)
   for rel in VALID_RELS + ('', ' ', 'blah'):


### PR DESCRIPTION
- Encountered when trying to fetch from a private pypicloud that redirects to s3 uris with query string params
- Added failing unit test that now passes
- Left a TODO for replacing all html entities, not just `&amp;`, since that requires some nontrivial python 2/3 compatibility work that wasn't obvious after a few googles
