### PR TITLE
Add the ability to include extensions & shared libraries in pexs.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -330,6 +330,14 @@ def configure_clp():
            'times.')
 
   parser.add_option(
+      '--native-library',
+      dest='native_libraries',
+      metavar='FILE',
+      default=[],
+      action='append',
+      help='Native library to include in the archive & loader path.')
+
+  parser.add_option(
       '-v',
       dest='verbosity',
       default=0,
@@ -476,6 +484,9 @@ def build_pex(args, options, resolver_option_builder):
     log('  %s' % dist, v=options.verbosity)
     pex_builder.add_distribution(dist)
     pex_builder.add_requirement(dist.as_requirement())
+
+  for lib in options.native_libraries:
+    pex_builder.add_native_library(lib)
 
   if options.entry_point and options.script:
     die('Must specify at most one entry point or script.', INVALID_OPTIONS)

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -58,10 +58,8 @@ class PEX(object):  # noqa: T000
     self._envs = []
     self._working_set = None
 
-  def _activate(self):
-    if not self._working_set:
-      working_set = WorkingSet([])
-
+  def _load_envs(self):
+    if not self._envs:
       # set up the local .pex environment
       pex_info = self._pex_info.copy()
       pex_info.update(self._pex_info_overrides)
@@ -73,8 +71,18 @@ class PEX(object):  # noqa: T000
         pex_info.update(self._pex_info_overrides)
         self._envs.append(PEXEnvironment(pex_path, pex_info))
 
-      # activate all of them
-      for env in self._envs:
+    return self._envs
+
+  def _maybe_reexec_for_library_path(self):
+    for env in self._load_envs():
+      env.maybe_reexec_for_library_path()
+
+  def _activate(self):
+    if not self._working_set:
+      working_set = WorkingSet([])
+
+      # activate all of the envs
+      for env in self._load_envs():
         for dist in env.activate():
           working_set.add(dist)
 
@@ -307,6 +315,9 @@ class PEX(object):  # noqa: T000
     """
     teardown_verbosity = self._vars.PEX_TEARDOWN_VERBOSE
     try:
+      # Do this upfront so we don't waste time patching.
+      self._maybe_reexec_for_library_path()
+
       with self.patch_sys():
         working_set = self._activate()
         TRACER.log('PYTHONPATH contains:')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,9 +3,11 @@
 
 import os
 
-from twitter.common.contextutil import temporary_file
+from twitter.common.contextutil import temporary_dir, temporary_file
 
-from pex.testing import run_simple_pex_test
+from pex.compatibility import nested
+from pex.pex_builder import PEXBuilder
+from pex.testing import run_simple_pex, run_simple_pex_test, temporary_content
 
 
 def test_pex_execute():
@@ -30,3 +32,30 @@ def test_pex_interpreter():
     so, rc = run_simple_pex_test("", args=(fp.name,), coverage=True, env=env)
     assert so == b'Hello world\n'
     assert rc == 0
+
+
+def test_pex_library_path():
+  with nested(temporary_dir(),
+              temporary_content({'_ext.so': 125}),
+              temporary_dir()) as (pb_dir, lib, out_dir):
+    main_py = os.path.join(pb_dir, 'exe.py')
+    with open(main_py, 'w') as pyfile:
+      pyfile.write("""
+import os
+import os.path
+
+var_name = 'DYLD_LIBRARY_PATH' if os.uname()[0] == 'Darwin' else 'LD_LIBRARY_PATH'
+print(any(os.path.exists(os.path.join(p, '_ext.so'))
+          for p in os.environ[var_name].split(':')))
+""")
+
+    pb = PEXBuilder(path=pb_dir)
+    pb.add_native_library(os.path.join(lib, '_ext.so'))
+    pb.set_executable(main_py)
+    pb.freeze()
+    assert not pb.info.zip_safe
+    pex = os.path.join(out_dir, 'app.pex')
+    pb.build(pex)
+    out, rc = run_simple_pex(pex)
+    assert rc == 0
+    assert out == b'True\n'


### PR DESCRIPTION
Extensions already (sort-of) worked via add_source - this makes sure that when adding a .(so|dll|pyd), we force zip_safe to False.

In addition this adds the ability to include other shared libraries with the pex. This is intended to be used for dependencies of the python extensions (e.g. a cityhash extension will depend on a cityhash library).

This is an updated version of #61.
