### PR TITLE
Make it possible to use an alternate CA chain for pex

### DIFF
--- a/pex/iterator.py
+++ b/pex/iterator.py
@@ -22,8 +22,8 @@ class IteratorInterface(AbstractClass):
 class Iterator(IteratorInterface):
   """A requirement iterator, the glue between fetchers, crawlers and requirements."""
 
-  def __init__(self, fetchers=None, crawler=None, follow_links=False):
-    self._crawler = crawler or Crawler()
+  def __init__(self, crawler, fetchers=None, follow_links=False):
+    self._crawler = crawler
     self._fetchers = fetchers if fetchers is not None else [PyPIFetcher()]
     self.__follow_links = follow_links
 

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -230,7 +230,7 @@ class CachingResolver(Resolver):
 
   # Short-circuiting package iterator.
   def package_iterator(self, resolvable, existing=None):
-    iterator = Iterator(fetchers=[Fetcher([self.__cache])])
+    iterator = Iterator(resolvable.options.get_crawler(), fetchers=[Fetcher([self.__cache])])
     packages = self.filter_packages_by_interpreter(
         resolvable.compatible(iterator), self._interpreter, self._platform)
 

--- a/pex/resolver_options.py
+++ b/pex/resolver_options.py
@@ -114,6 +114,9 @@ class ResolverOptionsBuilder(object):
         [precedent for precedent in self._precedence if precedent is not SourcePackage])
     return self
 
+  def ssl_options(self, client_cert=None, ca_bundle=None):
+    self._context.set_ssl(client_cert=client_cert, ca_bundle=ca_bundle)
+
   def build(self, key):
     return ResolverOptions(
         fetchers=self._fetchers,

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -17,7 +17,7 @@ except ImportError:
 def test_empty_iteration():
   crawler_mock = mock.create_autospec(Crawler, spec_set=True)
   crawler_mock.crawl.return_value = []
-  iterator = Iterator(crawler=crawler_mock)
+  iterator = Iterator(crawler_mock)
 
   assert list(iterator.iter(Requirement.parse('foo'))) == []
   assert len(crawler_mock.crawl.mock_calls) == 1
@@ -30,7 +30,7 @@ def test_iteration_with_return():
   pex_url = 'https://pypi.python.org/packages/source/p/pex/pex-0.8.6.tar.gz'
   crawler_mock = mock.create_autospec(Crawler, spec_set=True)
   crawler_mock.crawl.return_value = [pex_url]
-  iterator = Iterator(crawler=crawler_mock, follow_links=True)
+  iterator = Iterator(crawler_mock, follow_links=True)
 
   assert list(iterator.iter(Requirement.parse('pex'))) == [SourcePackage(pex_url)]
   assert len(crawler_mock.crawl.mock_calls) == 1


### PR DESCRIPTION
Pex is amazing in that it actually allows the end user to validate the
SSL when items are being obtained from an additional pypi repository.

Unfortunately, this validation will only occur for the authorities that
are specified in certifi. This limits two important use cases for
internal and none standard pypi servers:

* There is no method to use an alternate certificate authority chain,
  such as, for instance, is presented from a custom CA root
* There is no method to use client certificates, which can be an
  alternative to username and password.

This commit seeks to redress this, by allowing both of these options to
be specified, with configuration that mirrors that of pip.