### PR TITLE
Improve error messaging for platform constrained Untranslateable errors.

### DIFF
--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -167,7 +167,8 @@ class Resolver(object):
     if dist is None:
       raise Untranslateable('Package %s is not translateable by %s' % (package, translator))
     if not distribution_compatible(dist, self._interpreter, self._platform):
-      raise Untranslateable('Could not get distribution for %s on appropriate platform.' % package)
+      raise Untranslateable(
+        'Could not get distribution for %s on platform %s.' % (package, self._platform))
     return dist
 
   def resolve(self, resolvables, resolvable_set=None):


### PR DESCRIPTION
### before

```
[illuminati pex (master)]$ pex --no-pypi --find-links=http://science-binaries.local.twitter.com/home/third_party/python/ thrift==0.9.3 --platform=linux-x86_64
Traceback (most recent call last):
  File "/Users/kwilson/Python/CPython-2.7.10/bin/pex", line 9, in <module>
    load_entry_point('pex==1.1.0', 'console_scripts', 'pex')()
  File "build/bdist.macosx-10.4-x86_64/egg/pex/bin/pex.py", line 509, in main
  File "build/bdist.macosx-10.4-x86_64/egg/pex/bin/pex.py", line 471, in build_pex
  File "build/bdist.macosx-10.4-x86_64/egg/pex/resolver.py", line 199, in resolve
  File "build/bdist.macosx-10.4-x86_64/egg/pex/resolver.py", line 256, in build
  File "build/bdist.macosx-10.4-x86_64/egg/pex/resolver.py", line 170, in build
pex.resolver.Untranslateable: Could not get distribution for SourcePackage('file:///Users/kwilson/.pex/build/thrift-0.9.3.tar.gz') on appropriate platform.
```

### after

```
[illuminati pex (kwlzn/platform_clarity)]$ pex --no-pypi --find-links=http://science-binaries.local.twitter.com/home/third_party/python/ thrift==0.9.3 --platform=linux-x86_64
Traceback (most recent call last):
  File "/Users/kwilson/Python/CPython-2.7.10/bin/pex", line 9, in <module>
    load_entry_point('pex==1.1.0', 'console_scripts', 'pex')()
  File "build/bdist.macosx-10.4-x86_64/egg/pex/bin/pex.py", line 509, in main
  File "build/bdist.macosx-10.4-x86_64/egg/pex/bin/pex.py", line 471, in build_pex
  File "build/bdist.macosx-10.4-x86_64/egg/pex/resolver.py", line 200, in resolve
  File "build/bdist.macosx-10.4-x86_64/egg/pex/resolver.py", line 257, in build
  File "build/bdist.macosx-10.4-x86_64/egg/pex/resolver.py", line 171, in build
pex.resolver.Untranslateable: Could not get distribution for SourcePackage('file:///Users/kwilson/.pex/build/thrift-0.9.3.tar.gz') on platform linux-x86_64.
```
