### PR TITLE
PEX files may depend on Homebrew's python's site-packages

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -103,10 +103,8 @@ class PEX(object):  # noqa: T000
     except ImportError:
       site_libs = set()
     homebrew_prefix = '/usr/local'
-    homebrew_path = '%s/lib/python%d.%d/site-packages' % \
-                    (homebrew_prefix, sys.version_info[0], sys.version_info[1])
-    if os.path.realpath(sys.executable).startswith('%s/Cellar/python' % homebrew_prefix) \
-        and homebrew_path in sys.path:
+    homebrew_path = homebrew_prefix + '/lib/python%d.%d/site-packages' % sys.version_info[:2]
+    if os.path.realpath(sys.executable).startswith(homebrew_prefix + '/Cellar/python'):
       site_libs.update([homebrew_path])
     site_libs.update([sysconfig.get_python_lib(plat_specific=False),
                       sysconfig.get_python_lib(plat_specific=True)])

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -102,6 +102,12 @@ class PEX(object):  # noqa: T000
       site_libs = set(getsitepackages())
     except ImportError:
       site_libs = set()
+    homebrew_prefix = '/usr/local'
+    homebrew_path = '%s/lib/python%d.%d/site-packages' % \
+                    (homebrew_prefix, sys.version_info[0], sys.version_info[1])
+    if os.path.realpath(sys.executable).startswith('%s/Cellar/python' % homebrew_prefix) \
+        and homebrew_path in sys.path:
+      site_libs.update([homebrew_path])
     site_libs.update([sysconfig.get_python_lib(plat_specific=False),
                       sysconfig.get_python_lib(plat_specific=True)])
     real_site_libs = set(os.path.realpath(path) for path in site_libs)


### PR DESCRIPTION
Hello! This one is a decidedly narrow case, but given the popularity of both Homebrew and OS X as a development platform I hope it is worth your time.

Homebrew, the OS X package manger, interposes an additional site-packages[0] directory via sitecustomize.py[1], so it is relatively unknown to pex. As a consequence, I've found cases where a pex file missing certain dependencies would run correctly on a machine using Homebrew'd python that happened to have those dependencies installed.

This patch is intended as a starting point for a conversation about how best to teach pex about Homebrew's site-packages directory. Locally it appears to work, but has a few flaws. Most notably, users may have installed to a non-default Homebrew prefix, which is tricky for us to look up as Homebrew does not write down its own prefix and instead looks up its location from $0[3].

Other alternatives considered include:
- Changing Homebrew to use one of the default site-package directories – this is likely to be a non-starter due to their "strict policy never to write stuff outside of [/usr/local]". 
- Attempting to inspect sitecustomize.py from _site_libs and removing additional paths it adds
  - This seems to be a more general solution in that it might address similar situations outside of Homebrew, but
  - Unwinding changes made to sys.path by an arbitrary system-dependent python file is, as you likely guessed, not easy
  - I am happy to continue investigating how possible this would be if it would be a preferred solution
- Rather than unwinding changes made by site.py, running a `python -S -c 'import sys; print sys.path'` or similar to use as a baseline – this approach has the downside of only working with python interpreters that support -S as a flag, as well as likely others of which I'm not aware (the comment on `minimum_sys` mentions this flag, so I assume this option was already considered and discarded).

Hopefully there's a good idea that I've missed and we can find a good way to throw the ImportError I so crave when running certain pex files on my machine. Thank you for reading!

[0] https://github.com/Homebrew/homebrew/blob/8c6777b2b8e847d5f2b447eae532fa8ecffa6467/share/doc/homebrew/Homebrew-and-Python.md#site-packages-and-the-pythonpath
[1] https://github.com/Homebrew/homebrew/blob/8c6777b2b8e847d5f2b447eae532fa8ecffa6467/Library/Formula/python.rb#L266-L314
[3] https://github.com/Homebrew/homebrew/blob/8c6777b2b8e847d5f2b447eae532fa8ecffa6467/bin/brew#L7-L8
