### PR TITLE
fix infinite recursion when PEX_PYTHON points at a symlink

### DIFF
--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -82,8 +82,7 @@ def maybe_reexec_pex():
   target = find_in_path(target_python)
   if not target:
     die('Failed to find interpreter specified by PEX_PYTHON: %s' % target)
-  current = os.path.realpath(sys.executable)
-  if os.path.exists(target) and target != current:
+  if os.path.exists(target) and os.path.realpath(target) != os.path.realpath(sys.executable):
     TRACER.log('Detected PEX_PYTHON, re-exec to %s' % target)
     ENV.delete('PEX_PYTHON')
     os.execve(target, [target_python] + sys.argv, ENV.copy())

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,8 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+import sys
 
-from twitter.common.contextutil import temporary_file
+from twitter.common.contextutil import environment_as, temporary_dir, temporary_file
 
 from pex.testing import run_simple_pex_test
 
@@ -30,3 +31,17 @@ def test_pex_interpreter():
     so, rc = run_simple_pex_test("", args=(fp.name,), coverage=True, env=env)
     assert so == b'Hello world\n'
     assert rc == 0
+
+
+def test_pex_python_symlink():
+  with temporary_dir() as td:
+    with environment_as(HOME=td):
+      symlink_path = os.path.join(td, 'python-symlink')
+      os.symlink(sys.executable, symlink_path)
+      pexrc_path = os.path.join(td, '.pexrc')
+      with open(pexrc_path, 'w') as pexrc:
+        pexrc.write("PEX_PYTHON=%s" % symlink_path)
+
+      body = "print('Hello')"
+      _, rc = run_simple_pex_test(body, coverage=True)
+      assert rc == 0


### PR DESCRIPTION
When PEX_PYTHON is in ~/.pexrc and set to a symlink, pex_bootstrapper repeatedly compares the symlink to the real path, determines they're not the same, and continues recursing.  This goes on for hundreds of iterations until (it seems) something gets shoved out of the max env var length and the whole thing blows up because it can't find "locale".