### PR TITLE
support /etc/pexrc

### DIFF
--- a/pex/variables.py
+++ b/pex/variables.py
@@ -52,7 +52,7 @@ class Variables(object):
 
   def _from_rc(self, rc):
     ret_vars = {}
-    for filename in [rc, os.path.join(os.path.dirname(sys.argv[0]), '.pexrc')]:
+    for filename in ['/etc/pexrc', rc, os.path.join(os.path.dirname(sys.argv[0]), '.pexrc')]:
       try:
         with open(os.path.expanduser(filename)) as fh:
           rc_items = map(self._get_kv, fh)


### PR DESCRIPTION
This will allow system administrators to make it more likely that pexes are executed using a "clean" python instead of whatever users have installed on their path.  /etc/pexrc is the first rc read so that it has the lowest precedence and determined users can still override whatever they like.