### PR TITLE
[pex] Memoize calls to Crawler.crawl() for performance win in find-links based resolution.

### DIFF
--- a/pex/crawler.py
+++ b/pex/crawler.py
@@ -12,6 +12,7 @@ from .compatibility import PY3
 from .http import Context
 from .link import Link
 from .tracer import TRACER
+from .util import Memoizer
 
 if PY3:
   from queue import Empty, Queue
@@ -64,6 +65,14 @@ def partition(L, pred):
 class Crawler(object):
   """A multi-threaded crawler that supports local (disk) and remote (web) crawling."""
 
+  # Memoizer for calls to Crawler.crawl().
+  _CRAWL_CACHE = Memoizer()
+
+  @classmethod
+  def reset_cache(cls):
+    """Reset the internal crawl cache. This is intended primarily for tests."""
+    cls._CRAWL_CACHE = Memoizer()
+
   @classmethod
   def crawl_local(cls, link):
     try:
@@ -99,7 +108,22 @@ class Crawler(object):
     self._threads = threads
     self.context = context or Context.get()
 
+  def _make_cache_key(self, links, follow_links):
+    return (follow_links,) + tuple(links)
+
   def crawl(self, link_or_links, follow_links=False):
+    links = list(Link.wrap_iterable(link_or_links))
+    cache_key = self._make_cache_key(links, follow_links)
+
+    # Memoize crawling to a global Memoizer (Crawler._CRAWL_CACHE).
+    result = self._CRAWL_CACHE.get(cache_key)
+    if result is None:
+      result = self._crawl(links, follow_links)
+      self._CRAWL_CACHE.store(cache_key, result)
+
+    return result
+
+  def _crawl(self, link_or_links, follow_links):
     links, seen = set(), set()
     queue = Queue()
     converged = threading.Event()
@@ -127,7 +151,8 @@ class Crawler(object):
                 queue.put(rel)
         queue.task_done()
 
-    for link in Link.wrap_iterable(link_or_links):
+    for i, link in enumerate(link_or_links):
+      TRACER.log('crawling link i=%s link=%s follow_links=%s' % (i, link, follow_links), V=3)
       queue.put(link)
 
     workers = []
@@ -140,6 +165,5 @@ class Crawler(object):
     queue.join()
     converged.set()
 
-    # We deliberately not join back the worker threads, since they are no longer of
-    # any use to us.
+    # We deliberately do not join the worker threads, since they are no longer of any use to us.
     return links


### PR DESCRIPTION
While investigating a user-reported performance issue in the creation of pex files (via pants), profiling revealed around ~60% of the total time being spent in pex's Crawler.crawl() function with over 47 calls. Note that calls to Crawler.crawl() involve use of the `re` module to match html tags from a given index page (in our case, with roughly ~5000+ files) - with excessive application of the `re` module being a known culprit for slowness.

I was able to approximately repro the same scenario directly with pex:

```
pex --disable-cache --no-pypi -f http://$URL -f http://$URL/dist \
    pex psutil requests ansible jsonschema -o /tmp/throwaway
```

..and further inspection here revealed upwards of 24 non-cached Crawler.crawl() calls just for these 5 dependencies.

This PR memoizes calls to Crawler.crawl() to save overhead on subsequent calls for a ~2x/200% speedup in the above test case:

before
--------

```
real    0m19.943s
user    0m5.437s
sys     0m2.427s
```

after
-----

```
real    0m8.288s
user    0m3.420s
sys     0m1.986s
```