### PR TITLE
Unescapes html in PageParser.href_match_to_url

### DIFF
--- a/pex/crawler.py
+++ b/pex/crawler.py
@@ -7,6 +7,7 @@ import os
 import re
 import threading
 import traceback
+import xml.sax.saxutils
 
 from .compatibility import PY3
 from .http import Context
@@ -34,7 +35,8 @@ class PageParser(object):
   def href_match_to_url(cls, match):
     def pick(group):
       return '' if group is None else group
-    return pick(match.group(1)) or pick(match.group(2)) or pick(match.group(3))
+    return xml.sax.saxutils.unescape(
+      pick(match.group(1)) or pick(match.group(2)) or pick(match.group(3)))
 
   @classmethod
   def rel_links(cls, page):

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -95,7 +95,7 @@ class PythonIdentity(object):
   @classmethod
   def from_path(cls, dirname):
     interp, version = dirname.split('-')
-    major, minor, patch = version.split('.')
+    major, minor, patch = version.split('.')[:3]
     return cls(str(interp), int(major), int(minor), int(patch))
 
   def __init__(self, interpreter, major, minor, patch):


### PR DESCRIPTION
PageParser breaks if the links contain any escaped characters. This fixes that
bug.