### PR TITLE
Updates interpreter path parsing to handle Jenkins

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -95,7 +95,7 @@ class PythonIdentity(object):
   @classmethod
   def from_path(cls, dirname):
     interp, version = dirname.split('-')
-    major, minor, patch = version.split('.')
+    major, minor, patch = version.split('.')[:3]
     return cls(str(interp), int(major), int(minor), int(patch))
 
   def __init__(self, interpreter, major, minor, patch):


### PR DESCRIPTION
When building a pex on Jenkins inside an auto-generated virtualenv, I keep ending up with interpreter names like `CPython-2.7.3.tmp.ba3a2c39daab46ef978ba07fe335079d`. If we simply split on dots to get version number, we'll end up with an invalid version number. To avoid this, we now just take the first 3 items when splitting on a dot. This allows pex building for me on Jenkins.