### PR TITLE
Fixes to get pex to work on windows.

### DIFF
--- a/pex/compiler.py
+++ b/pex/compiler.py
@@ -4,9 +4,9 @@
 from __future__ import absolute_import
 
 import subprocess
-import tempfile
 
 from .compatibility import to_bytes
+from .util import named_temporary_file
 
 
 _COMPILER_MAIN = """
@@ -78,7 +78,7 @@ class Compiler(object):
     :returns: A list of relative paths of the compiled bytecode files.
     :raises: A :class:`Compiler.Error` if there was a problem bytecode compiling any of the files.
     """
-    with tempfile.NamedTemporaryFile() as fp:
+    with named_temporary_file() as fp:
       fp.write(to_bytes(_COMPILER_MAIN % {'root': root, 'relpaths': relpaths}, encoding='utf-8'))
       fp.flush()
       process = subprocess.Popen([self._interpreter.binary, fp.name],

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -104,6 +104,9 @@ class PEX(object):  # noqa: T000
       site_libs = set()
     site_libs.update([sysconfig.get_python_lib(plat_specific=False),
                       sysconfig.get_python_lib(plat_specific=True)])
+    # On windows getsitepackages() returns the python stdlib too.
+    if sys.prefix in site_libs:
+      site_libs.remove(sys.prefix)
     real_site_libs = set(os.path.realpath(path) for path in site_libs)
     return site_libs | real_site_libs
 

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -96,12 +96,16 @@ class PEX(object):  # noqa: T000
       yield os.path.join(standard_lib, path)
 
   @classmethod
-  def _site_libs(cls):
+  def _get_site_packages(cls):
     try:
       from site import getsitepackages
-      site_libs = set(getsitepackages())
+      return set(getsitepackages())
     except ImportError:
-      site_libs = set()
+      return set()
+
+  @classmethod
+  def site_libs(cls):
+    site_libs = cls._get_site_packages()
     site_libs.update([sysconfig.get_python_lib(plat_specific=False),
                       sysconfig.get_python_lib(plat_specific=True)])
     # On windows getsitepackages() returns the python stdlib too.
@@ -193,7 +197,7 @@ class PEX(object):  # noqa: T000
     :returns: (sys.path, sys.path_importer_cache, sys.modules) tuple of a
       bare python installation.
     """
-    site_libs = set(cls._site_libs())
+    site_libs = set(cls.site_libs())
     for site_lib in site_libs:
       TRACER.log('Found site-library: %s' % site_lib)
     for extras_path in cls._extras_paths():

--- a/pex/util.py
+++ b/pex/util.py
@@ -7,6 +7,7 @@ import contextlib
 import errno
 import os
 import shutil
+import tempfile
 import uuid
 from hashlib import sha1
 from threading import Lock
@@ -200,3 +201,19 @@ class Memoizer(object):
   def store(self, key, value):
     with self._lock:
       self._data[key] = value
+
+
+@contextlib.contextmanager
+def named_temporary_file(*args, **kwargs):
+  """
+  Due to a bug in python (https://bugs.python.org/issue14243), we need
+  this to be able to use the temporary file without deleting it.
+  """
+  assert 'delete' not in kwargs
+  kwargs['delete'] = False
+  fp = tempfile.NamedTemporaryFile(*args, **kwargs)
+  try:
+    with fp:
+      yield fp
+  finally:
+    os.remove(fp.name)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -16,7 +16,7 @@ from pex.compatibility import nested
 from pex.installer import EggInstaller, WheelInstaller
 from pex.pex_builder import PEXBuilder
 from pex.testing import make_bdist, temporary_content, write_zipfile
-from pex.util import CacheHelper, DistributionHelper
+from pex.util import CacheHelper, DistributionHelper, named_temporary_file
 
 try:
   from unittest import mock
@@ -159,3 +159,16 @@ def test_access_zipped_assets_integration():
       pass
     assert output == 'accessed\n'
     assert po.returncode == 0
+
+
+def test_named_temporary_file():
+  name = ''
+  with named_temporary_file() as fp:
+    name = fp.name
+    fp.write(b'hi')
+    fp.flush()
+    assert os.path.exists(name)
+    with open(name) as new_fp:
+      assert new_fp.read() == 'hi'
+
+  assert not os.path.exists(name)


### PR DESCRIPTION
The fixes are:
 - os.link doesn't exist on windows. Always copy instead.
 - NamedTemporaryFile doesn't work correctly on windows (see https://bugs.python.org/issue14243)
 - sys.prefix is part of site.getsitepackages() on windows. Don't remove it.