### PR TITLE
Don't normalize version numbers as names.

### DIFF
--- a/pex/package.py
+++ b/pex/package.py
@@ -133,7 +133,7 @@ class SourcePackage(Package):
 
   @property
   def raw_version(self):
-    return safe_name(self._raw_version)
+    return self._raw_version
 
   # SourcePackages are always compatible as they can be translated to a distribution.
   def compatible(self, identity, platform=Platform.current()):
@@ -167,7 +167,7 @@ class EggPackage(Package):
 
   @property
   def raw_version(self):
-    return safe_name(self._raw_version)
+    return self._raw_version
 
   @property
   def py_version(self):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -24,6 +24,15 @@ def test_source_packages():
   assert sl.raw_version == '1.5'
 
 
+def test_local_specifier():
+  for ext in ('.tar.gz', '.tar', '.tgz', '.zip', '.tar.bz2'):
+    sl = SourcePackage('a_p_r-3.1.3+pexed.1' + ext)
+    assert sl.name == 'a-p-r'
+    assert sl.raw_version == '3.1.3+pexed.1'
+    assert sl.version == parse_version(sl.raw_version)
+    assert sl.satisfies('a_p_r==3.1.3+pexed.1')
+
+
 def test_egg_packages():
   el = EggPackage('psutil-0.4.1-py2.6-macosx-10.7-intel.egg')
   assert el.name == 'psutil'


### PR DESCRIPTION
Version numbers can have + in them as a local version - `0.1-pex.1` & `0.1+pex.1` take completely different paths in pkg_resources.