### PR TITLE
Specify alter_sys=True when invoking runpy.run_module

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -427,7 +427,7 @@ class PEX(object):  # noqa: T000
   @staticmethod
   def execute_module(module_name):
     import runpy
-    runpy.run_module(module_name, run_name='__main__')
+    runpy.run_module(module_name, run_name='__main__', alter_sys=True)
 
   @staticmethod
   def execute_pkg_resources(spec):


### PR DESCRIPTION
Specify `alter_sys=True` when invoking `runpy.run_module` so that `__main__` points to the entry point module.

Fixes #210 