### PR TITLE
Add python 2.x abi tag support

### DIFF
--- a/pex/pep425.py
+++ b/pex/pep425.py
@@ -99,14 +99,18 @@ class PEP425(object):  # noqa
     """
     # Predict soabi for reasonable interpreters.  This is technically wrong but essentially right.
     abis = []
-    if impl == 'cp' and version.startswith('3'):
+    if impl == 'cp' and (version.startswith('2') or version.startswith('3')):
       abis.extend([
         'cp%s' % version,
         'cp%sdmu' % version, 'cp%sdm' % version, 'cp%sdu' % version, 'cp%sd' % version,
         'cp%smu' % version, 'cp%sm' % version,
-        'cp%su' % version,
-        'abi3'
+        'cp%su' % version
       ])
+
+      if version.startswith('3'):
+        abis.extend([
+          'abi3'
+        ])
 
     major_version = int(version[0])
     minor_versions = []

--- a/tests/test_pep425.py
+++ b/tests/test_pep425.py
@@ -46,6 +46,18 @@ def test_iter_supported_tags():
     for interp in ('cp', 'py'):
       for interp_suffix in ('2', '20', '21', '22', '23', '24', '25', '26'):
         for platform in ('linux_x86_64', 'any'):
-          yield (interp + interp_suffix, 'none', platform)
+          abis = ['none']
+
+          if interp == 'cp' and interp_suffix == '26' and platform == 'linux_x86_64':
+            abis.extend([
+              'cp%s' % interp_suffix,
+              'cp%sdmu' % interp_suffix, 'cp%sdm' % interp_suffix,
+              'cp%sdu' % interp_suffix, 'cp%sd' % interp_suffix,
+              'cp%smu' % interp_suffix, 'cp%sm' % interp_suffix,
+              'cp%su' % interp_suffix
+            ])
+
+          for abi in abis:
+            yield (interp + interp_suffix, abi, platform)
 
   assert set(PEP425.iter_supported_tags(identity, platform)) == set(iter_solutions())


### PR DESCRIPTION
Not quite sure how to test this short of running it across a whole bunch of libraries. I updated the test case accordingly.

Left the existing code pertaining to the cp3 abi tags as is in case we need to change the supported tags for cp2 and cp3 independently.

But it has been tested with the cryptography==1.2.3 issue mentioned in #213.

