### PR TITLE
Add a test which enables PEX_VERBOSE and checks whether enabling inhe…

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -171,7 +171,6 @@ class PEX(object):  # noqa: T000
 
     user_site_distributions.update(all_distribution_paths(USER_SITE))
 
-
     for path in user_site_distributions:
       TRACER.log('Scrubbing from user site: %s' % path)
 
@@ -318,7 +317,8 @@ class PEX(object):  # noqa: T000
     """
     teardown_verbosity = self._vars.PEX_TEARDOWN_VERBOSE
     try:
-      pex_inherit_path = True if self._vars.PEX_INHERIT_PATH or self._pex_info.inherit_path else False
+      pex_inherit_path = True if (
+        self._vars.PEX_INHERIT_PATH or self._pex_info.inherit_path) else False
       with self.patch_sys(pex_inherit_path):
         working_set = self._activate()
         TRACER.log('PYTHONPATH contains:')

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -317,8 +317,7 @@ class PEX(object):  # noqa: T000
     """
     teardown_verbosity = self._vars.PEX_TEARDOWN_VERBOSE
     try:
-      pex_inherit_path = True if (
-        self._vars.PEX_INHERIT_PATH or self._pex_info.inherit_path) else False
+      pex_inherit_path = self._vars.PEX_INHERIT_PATH or self._pex_info.inherit_path
       with self.patch_sys(pex_inherit_path):
         working_set = self._activate()
         TRACER.log('PYTHONPATH contains:')

--- a/tests/test_inherits_path_option.py
+++ b/tests/test_inherits_path_option.py
@@ -1,0 +1,47 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+
+from twitter.common.contextutil import temporary_dir
+
+from pex.pex_builder import PEXBuilder
+from pex.testing import run_simple_pex, write_simple_pex
+
+
+def write_inheriting_pex(td, exe_contents, dists=None, coverage=False):
+  """Write a pex file that contains an executable entry point
+
+  :param td: temporary directory path
+  :param exe_contents: entry point python file
+  :type exe_contents: string
+  :param dists: distributions to include, typically sdists or bdists
+  :param coverage: include coverage header
+  """
+  dists = dists or []
+
+  with open(os.path.join(td, 'exe.py'), 'w') as fp:
+    fp.write(exe_contents)
+
+  pb = PEXBuilder(path=td, preamble=COVERAGE_PREAMBLE if coverage else None)
+  pb.info.inherit_path = True
+
+  for dist in dists:
+    pb.add_egg(dist.location)
+
+  pb.set_executable(os.path.join(td, 'exe.py'))
+  pb.freeze()
+
+  return pb
+
+def test_inherits_path_option():
+  with temporary_dir() as td:
+    pb = write_inheriting_pex(td, 'import sys\nimport os\nprint(os.environ)\nprint(sys.path)')
+    pex_path = os.path.join(td, 'show_path.pex')
+    pb.build(pex_path)
+
+    env = os.environ.copy()
+    env['PEX_VERBOSE'] = '1'
+
+    so, rc = run_simple_pex(pex_path, env=env)
+    assert 'Scrubbing from site-packages' not in so, 'Site packages should not be scrubbed:\n%s' % so

--- a/tests/test_inherits_path_option.py
+++ b/tests/test_inherits_path_option.py
@@ -3,49 +3,40 @@
 
 import os
 
+from contextlib import contextmanager
+
 from twitter.common.contextutil import environment_as, temporary_dir
 
 from pex.pex_builder import PEXBuilder
-from pex.testing import run_simple_pex, write_simple_pex
+from pex.testing import run_simple_pex
 
 
-def write_inheriting_pex(td, exe_contents):
+@contextmanager
+def write_and_run_simple_pex(inheriting=False):
   """Write a pex file that contains an executable entry point
 
-  :param td: temporary directory path
-  :param exe_contents: entry point python file
-  :type exe_contents: string
-  :param dists: distributions to include, typically sdists or bdists
-  :param coverage: include coverage header
+  :param inheriting: whether this pex should inherit site-packages paths
+  :type inheriting: bool
   """
-  with open(os.path.join(td, 'exe.py'), 'w') as fp:
-    fp.write(exe_contents)
+  with temporary_dir() as td:
+    pex_path = os.path.join(td, 'show_path.pex')
+    with open(os.path.join(td, 'exe.py'), 'w') as fp:
+      fp.write('')  # No contents, we just want the startup messages
 
-  pb = PEXBuilder(path=td, preamble=None)
-  pb.info.inherit_path = True
-  pb.set_executable(os.path.join(td, 'exe.py'))
-  pb.freeze()
-
-  return pb
+    pb = PEXBuilder(path=td, preamble=None)
+    pb.info.inherit_path = inheriting
+    pb.set_executable(os.path.join(td, 'exe.py'))
+    pb.freeze()
+    pb.build(pex_path)
+    with environment_as(PEX_VERBOSE='1'):
+      yield run_simple_pex(pex_path)[0]
 
 
 def test_inherits_path_option():
-  with temporary_dir() as td:
-    pb = write_inheriting_pex(td, 'import sys\nimport os\nprint(os.environ)\nprint(sys.path)')
-    pex_path = os.path.join(td, 'show_path.pex')
-    pb.build(pex_path)
-
-    with environment_as(PEX_VERBOSE='1'):
-      so, rc = run_simple_pex(pex_path)
-      assert 'Scrubbing from site-packages' not in str(so), 'Site packages should not be scrubbed.'
+  with write_and_run_simple_pex(inheriting=True) as so:
+    assert 'Scrubbing from site-packages' not in str(so), 'Site packages should not be scrubbed.'
 
 
 def test_does_not_inherit_path_option():
-  with temporary_dir() as td:
-    pb = write_simple_pex(td, 'import sys\nimport os\nprint(os.environ)\nprint(sys.path)')
-    pex_path = os.path.join(td, 'show_path.pex')
-    pb.build(pex_path)
-
-    with environment_as(PEX_VERBOSE='1'):
-      so, rc = run_simple_pex(pex_path)
-      assert 'Scrubbing from site-packages' in str(so), 'Site packages should be scrubbed.'
+  with write_and_run_simple_pex(inheriting=False) as so:
+    assert 'Scrubbing from site-packages' in str(so), 'Site packages should be scrubbed.'

--- a/tests/test_inherits_path_option.py
+++ b/tests/test_inherits_path_option.py
@@ -3,8 +3,7 @@
 
 import os
 
-from twitter.common.contextutil import environment_as
-from twitter.common.contextutil import temporary_dir
+from twitter.common.contextutil import environment_as, temporary_dir
 
 from pex.pex_builder import PEXBuilder
 from pex.testing import run_simple_pex, write_simple_pex


### PR DESCRIPTION
Grapeshot uses Pants to build PEX objects. We install MySQL interface code in site-packages and hence would like PEXes to collect this path on start-up. We have discovered the PANTS option to do this doesn't work. Fault traced to the environment scrubbing not honouring the setting or the equiv env variable.

PR adds a test which build such a PEX, enables PEX_VERBOSE, launches PEX and checks whether the enabling of inherit_path results in site-packages being not scrubbed. Since this fails, add processing of inherit_path to the pex environment booting. Test now passes.
