### PR TITLE
Fix old pkg_resources egg version normalization.

### DIFF
--- a/pex/package.py
+++ b/pex/package.py
@@ -3,7 +3,7 @@
 
 import os
 
-from pkg_resources import EGG_NAME, parse_version, safe_name
+from pkg_resources import EGG_NAME, parse_version, safe_name, safe_version
 
 from .archiver import Archiver
 from .base import maybe_requirement
@@ -133,7 +133,7 @@ class SourcePackage(Package):
 
   @property
   def raw_version(self):
-    return self._raw_version
+    return safe_version(self._raw_version)
 
   # SourcePackages are always compatible as they can be translated to a distribution.
   def compatible(self, identity, platform=Platform.current()):
@@ -167,7 +167,7 @@ class EggPackage(Package):
 
   @property
   def raw_version(self):
-    return self._raw_version
+    return safe_version(self._raw_version)
 
   @property
   def py_version(self):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -44,9 +44,18 @@ def test_egg_packages():
   for req in ('foo', 'bar==0.4.1'):
     assert not el.satisfies(req)
 
+  # Legacy pkg_resources normalized version numbers.
+  el = EggPackage('pyfoo-1.0.0_bar-py2.7-linux-x86_64.egg')
+  assert el.name == 'pyfoo'
+  assert el.raw_version == '1.0.0-bar'
+  assert el.py_version == '2.7'
+  assert el.platform == 'linux-x86_64'
+  for req in ('pyfoo', 'pyfoo==1.0.0-bar'):
+    assert el.satisfies(req)
+
   el = EggPackage('pytz-2012b-py2.6.egg')
   assert el.name == 'pytz'
-  assert el.raw_version == '2012b'
+  assert el.raw_version == '2012b0'
   assert el.py_version == '2.6'
   assert el.platform is None
 


### PR DESCRIPTION
Before recent releases of `setuptools`, version numbers in egg filenames were mangled. `safe_version` handles this correctly in modern `setuptools` and should work on older setuptools as well.

Closes #226.