### PR TITLE
open with utf-8 support

### DIFF
--- a/pex/installer.py
+++ b/pex/installer.py
@@ -32,12 +32,12 @@ def after_installation(function):
 
 
 class InstallerBase(object):
-  SETUP_BOOTSTRAP_HEADER = "import sys"
+  SETUP_BOOTSTRAP_HEADER = "import io, sys"
   SETUP_BOOTSTRAP_MODULE = "sys.path.insert(0, %(path)r); import %(module)s"
   SETUP_BOOTSTRAP_FOOTER = """
 __file__ = 'setup.py'
 sys.argv[0] = 'setup.py'
-exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
+exec(compile(io.open(__file__, encoding='utf-8').read().replace('\\r\\n', '\\n'), __file__, 'exec'))
 """
 
   class Error(Exception): pass


### PR DESCRIPTION
Without this fix, pex will raise pex.resolver.Untranslateable due to
non utf-8 characters in setup.py or \__init\__.py:

$ pex -r requirements.txt -c foobar -o foobar.pex
**** Failed to install pygments-markdown-lexer-0.1.0.dev39. stdout:

**** Failed to install pygments-markdown-lexer-0.1.0.dev39. stderr:
Traceback (most recent call last):
  File "<stdin>", line 7, in <module>
  File "/tmp/virtualenv/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 158: ordinal not in range(128)

Traceback (most recent call last):
  File "/tmp/virtualenv/bin/pex", line 11, in <module>
    sys.exit(main())
  File "/tmp/virtualenv/lib/python3.4/site-packages/pex/bin/pex.py", line 509, in main
    pex_builder = build_pex(reqs, options, resolver_options_builder)
  File "/tmp/virtualenv/lib/python3.4/site-packages/pex/bin/pex.py", line 471, in build_pex
    resolveds = resolver.resolve(resolvables)
  File "/tmp/virtualenv/lib/python3.4/site-packages/pex/resolver.py", line 200, in resolve
    dist = self.build(package, resolvable.options)
  File "/tmp/virtualenv/lib/python3.4/site-packages/pex/resolver.py", line 257, in build
    dist = super(CachingResolver, self).build(package, options)
  File "/tmp/virtualenv/lib/python3.4/site-packages/pex/resolver.py", line 168, in build
    raise Untranslateable('Package %s is not translateable by %s' % (package, translator))
pex.resolver.Untranslateable: Package SourcePackage('file:///root/.pex/build/pygments-markdown-lexer-0.1.0.dev39.zip') is not translateable by ChainedTranslator(WheelTranslator, EggTranslator, SourceTranslator)