### PR TITLE
Upgrade deps and cover CPython 3.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ env:
   - TOXENV=py27-requests-cachecontrol
   - TOXENV=py33
   - TOXENV=py34
-  - TOXENV=py34-requests
-  - TOXENV=py34-requests-cachecontrol
+  - TOXENV=py35
+  - TOXENV=py35-requests
+  - TOXENV=py35-requests-cachecontrol
   - TOXENV=pypy
   - TOXENV=style
   - TOXENV=isort-check

--- a/pex/version.py
+++ b/pex/version.py
@@ -3,5 +3,5 @@
 
 __version__ = '1.1.5'
 
-SETUPTOOLS_REQUIREMENT = 'setuptools>=2.2,<20'
-WHEEL_REQUIREMENT = 'wheel>=0.24.0,<0.27.0'
+SETUPTOOLS_REQUIREMENT = 'setuptools>=2.2,<20.11'
+WHEEL_REQUIREMENT = 'wheel>=0.24.0,<0.30.0'

--- a/tox.ini
+++ b/tox.ini
@@ -2,18 +2,18 @@
 skip_missing_interpreters = True
 minversion = 1.8
 envlist =
-	py{py,27,34}-requests,style,isort-check
+	py{py,27,35}-requests,style,isort-check
 
 [testenv]
 commands =
     py.test {posargs:}
 deps =
-    pytest==2.5.2
+    pytest==2.9.1
     twitter.common.contextutil>=0.3.1,<0.4.0
     twitter.common.dirutil>=0.3.1,<0.4.0
     twitter.common.lang>=0.3.1,<0.4.0
     twitter.common.testing>=0.3.1,<0.4.0
-    wheel==0.24.0
+    wheel==0.29.0
     py26: mock
     py27: mock
     pypy: mock
@@ -22,7 +22,7 @@ deps =
     requests: responses
     cachecontrol: CacheControl
     cachecontrol: lockfile
-    coverage: coverage==3.7.1
+    coverage: coverage==4.0.3
 
 [integration]
 commands =
@@ -35,10 +35,16 @@ commands = {[integration]commands}
 [testenv:py27-requests-cachecontrol-coverage]
 commands = {[integration]commands}
 
+[testenv:py34-coverage]
+commands = {[integration]commands}
+
 [testenv:py34-requests-cachecontrol-coverage]
 commands = {[integration]commands}
 
-[testenv:py34-coverage]
+[testenv:py35-coverage]
+commands = {[integration]commands}
+
+[testenv:py35-requests-cachecontrol-coverage]
 commands = {[integration]commands}
 
 [testenv:pypy-requests-cachecontrol-coverage]
@@ -55,7 +61,7 @@ commands =
 [testenv:coverage]
 basepython = python2.7
 deps =
-    coverage==3.7.1
+    coverage==4.0.3
     tox
 commands =
     # meta
@@ -111,10 +117,13 @@ commands = pex {posargs:}
 commands = pex {posargs:}
 
 [testenv:py27-package]
-commands = pex --cache-dir {envtmpdir}/buildcache wheel requests . -o dist/pex -e pex.bin.pex:main -v
+commands = pex --cache-dir {envtmpdir}/buildcache wheel requests . -o dist/pex27 -e pex.bin.pex:main -v
 
 [testenv:py34-package]
-commands = pex --cache-dir {envtmpdir}/buildcache wheel requests . -o dist/pex -e pex.bin.pex:main -v
+commands = pex --cache-dir {envtmpdir}/buildcache wheel requests . -o dist/pex34 -e pex.bin.pex:main -v
+
+[testenv:py35-package]
+commands = pex --cache-dir {envtmpdir}/buildcache wheel requests . -o dist/pex35 -e pex.bin.pex:main -v
 
 # Would love if you didn't have to enumerate environments here :-\
 [testenv:py26]
@@ -129,6 +138,9 @@ commands = pex --cache-dir {envtmpdir}/buildcache wheel requests . -o dist/pex -
 [testenv:py34]
 [testenv:py34-requests]
 [testenv:py34-requests-cachecontrol]
+[testenv:py35]
+[testenv:py35-requests]
+[testenv:py35-requests-cachecontrol]
 [testenv:pypy]
 [testenv:pypy-requests]
 [testenv:pypy-requests-cachecontrol]


### PR DESCRIPTION
This modernizes pex deps both as a tool and for development (coverage
and testing). The travis build is updated to include 3.5 and the tox
tooling for building release pexes is expanded to cover 3.5.

This addresses #238

https://rbcommons.com/s/twitter/r/3763/