### PR TITLE
Fix bdist_pex to work with python2.

### DIFF
--- a/pex/commands/bdist_pex.py
+++ b/pex/commands/bdist_pex.py
@@ -1,12 +1,11 @@
 import os
 from distutils import log
 
-from configparser import ConfigParser
 from setuptools import Command
 
 from pex.bin.pex import build_pex, configure_clp
 from pex.common import die
-from pex.compatibility import string
+from pex.compatibility import ConfigParser, StringIO, string
 from pex.variables import ENV
 
 
@@ -49,9 +48,9 @@ class bdist_pex(Command):  # noqa
 
     if isinstance(raw_entry_points, string):
       parser = ConfigParser()
-      parser.read_string(raw_entry_points)
+      parser.readfp(StringIO(raw_entry_points))
       if parser.has_section('console_scripts'):
-        return parser['console_scripts']
+        return dict(parser.items('console_scripts'))
     elif isinstance(raw_entry_points, dict):
       try:
         return dict(split_and_strip(script)

--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -23,6 +23,13 @@ except ImportError:
     from io import StringIO
     from io import BytesIO
 
+try:
+  # Python 2.x
+  from ConfigParser import ConfigParser
+except ImportError:
+  # Python 3.x
+  from configparser import ConfigParser
+
 AbstractClass = ABCMeta('AbstractClass', (object,), {})
 PY2 = sys_version_info[0] == 2
 PY3 = sys_version_info[0] == 3
@@ -94,6 +101,7 @@ WINDOWS = os.name == 'nt'
 __all__ = (
   'AbstractClass',
   'BytesIO',
+  'ConfigParser',
   'PY2',
   'PY3',
   'StringIO',

--- a/tests/test_bdist_pex.py
+++ b/tests/test_bdist_pex.py
@@ -1,0 +1,50 @@
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import subprocess
+import sys
+from textwrap import dedent
+
+from twitter.common.contextutil import pushd
+
+from pex.testing import temporary_content
+
+
+def assert_entry_points(entry_points):
+  setup_py = dedent("""
+      from setuptools import setup
+
+      setup(
+        name='my_app',
+        version='0.0.0',
+        zip_safe=True,
+        packages=[''],
+        entry_points=%(entry_points)r,
+      )
+    """ % dict(entry_points=entry_points))
+
+  my_app = dedent("""
+      def do_something():
+        print("hello world!")
+    """)
+
+  with temporary_content({'setup.py': setup_py, 'my_app.py': my_app}) as project_dir:
+    with pushd(project_dir):
+      subprocess.check_call([sys.executable, 'setup.py', 'bdist_pex'])
+      process = subprocess.Popen([os.path.join(project_dir, 'dist', 'my_app-0.0.0.pex')],
+                                 stdout=subprocess.PIPE)
+      stdout, _ = process.communicate()
+      assert 0 == process.returncode
+      assert stdout == b'hello world!\n'
+
+
+def test_entry_points_dict():
+  assert_entry_points({'console_scripts': ['my_app = my_app:do_something']})
+
+
+def test_entry_points_ini_string():
+  assert_entry_points(dedent("""
+      [console_scripts]
+      my_app=my_app:do_something
+    """))


### PR DESCRIPTION
Previously `entry_points` handling for ini-file style only worked under
python3.  This adds tests for this narrow use case, more are needed for
other existing functionality.

This addresses #243.

https://rbcommons.com/s/twitter/r/3765/