### PR TITLE
Repair the `py27-coverage-simple` tox env.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
     cachecontrol: CacheControl
     cachecontrol: lockfile
     coverage: coverage==4.0.3
+whitelist_externals = open
 
 [integration]
 commands =
@@ -55,10 +56,12 @@ commands = {[integration]commands}
 [testenv:py27-coverage-simple]
 basepython = python2.7
 commands =
+    coverage erase
     coverage run -p -m py.test {posargs:}
-    python scripts/combine_coverage.py
+    coverage combine
     coverage report
     coverage html
+    open htmlcov/index.html
 
 [testenv:coverage]
 basepython = python2.7


### PR DESCRIPTION
Enables the use of `tox -e py27-coverage-simple` for rapid iteration.