### PR TITLE
Allow passing an interpreter to pex.build_pex

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -457,9 +457,10 @@ def interpreter_from_options(options):
     return interpreter
 
 
-def build_pex(args, options, resolver_option_builder):
-  with TRACER.timed('Resolving interpreter', V=2):
-    interpreter = interpreter_from_options(options)
+def build_pex(args, options, resolver_option_builder, interpreter=None):
+  if interpreter is None:
+    with TRACER.timed('Resolving interpreter', V=2):
+      interpreter = interpreter_from_options(options)
 
   if interpreter is None:
     die('Could not find compatible interpreter', CANNOT_SETUP_INTERPRETER)


### PR DESCRIPTION
In the Heron project we initialize pex directly in code and need like to resolve our interpreter externally (see https://github.com/twitter/heron/blob/master/3rdparty/pex/_pex.py#L158-L159). This patch allows us to do that.