### PR TITLE
Don't ignore exit codes when using setuptools entry points

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -391,7 +391,7 @@ class PEX(object):  # noqa: T000
 
     entry_point = get_entry_point_from_console_script(script_name, dists)
     if entry_point:
-      return self.execute_entry(entry_point)
+      sys.exit(self.execute_entry(entry_point))
 
     dist, script_path, script_content = get_script_from_distributions(script_name, dists)
     if not dist:
@@ -426,7 +426,7 @@ class PEX(object):  # noqa: T000
   @classmethod
   def execute_entry(cls, entry_point):
     runner = cls.execute_pkg_resources if ':' in entry_point else cls.execute_module
-    runner(entry_point)
+    return runner(entry_point)
 
   @staticmethod
   def execute_module(module_name):
@@ -444,7 +444,7 @@ class PEX(object):  # noqa: T000
     else:
       # setuptools < 11.3
       runner = entry.load(require=False)
-    sys.exit(runner())
+    return runner()
 
   def cmdline(self, args=()):
     """The commandline to run this environment.

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -444,7 +444,7 @@ class PEX(object):  # noqa: T000
     else:
       # setuptools < 11.3
       runner = entry.load(require=False)
-    runner()
+    sys.exit(runner())
 
   def cmdline(self, args=()):
     """The commandline to run this environment.


### PR DESCRIPTION
Setuptools does not require `console_scripts` entry points to call `sys.exit()` (or similar) to exit non-zero:

> The functions you specify are called with no arguments, and their return value is passed to `sys.exit()`, so you can return an errorlevel or message to print to stderr

This patch updates pex to follow the same behavior.

Fixes #137.