### PR TITLE
Fix bdist_pex --pex-args

### DIFF
--- a/pex/commands/bdist_pex.py
+++ b/pex/commands/bdist_pex.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 from distutils import log
 
 from setuptools import Command
@@ -29,7 +30,7 @@ class bdist_pex(Command):  # noqa
     self.pex_args = ''
 
   def finalize_options(self):
-    self.pex_args = self.pex_args.split()
+    self.pex_args = shlex.split(self.pex_args)
 
   def _write(self, pex_builder, target, script=None):
     builder = pex_builder.clone()

--- a/tests/test_bdist_pex.py
+++ b/tests/test_bdist_pex.py
@@ -40,6 +40,30 @@ def assert_entry_points(entry_points):
       assert stdout == b'hello world!\n'
 
 
+def assert_pex_args_shebang(shebang):
+  setup_py = dedent("""
+      from setuptools import setup
+
+      setup(
+        name='my_app',
+        version='0.0.0',
+        zip_safe=True,
+        packages=[''],
+      )
+    """)
+
+  with temporary_content({'setup.py': setup_py}) as project_dir:
+    with pushd(project_dir):
+      assert subprocess.check_call(
+        [sys.executable, 'setup.py', 'bdist_pex',
+         '--pex-args=--python-shebang="%(shebang)s"' %
+         dict(shebang=shebang)]) == 0
+
+      with open(os.path.join(project_dir, 'dist',
+                             'my_app-0.0.0.pex'), 'rb') as fp:
+        assert fp.readline().decode().rstrip() == shebang
+
+
 def test_entry_points_dict():
   assert_entry_points({'console_scripts': ['my_app = my_app:do_something']})
 
@@ -49,3 +73,11 @@ def test_entry_points_ini_string():
       [console_scripts]
       my_app=my_app:do_something
     """))
+
+
+def test_pex_args_shebang_with_spaces():
+  assert_pex_args_shebang('#!/usr/bin/env python')
+
+
+def test_pex_args_shebang_without_spaces():
+  assert_pex_args_shebang('#!/usr/bin/python')


### PR DESCRIPTION
Splitting on spaces will break on commands like:

    python setup.py bdist_pex \
        --pex-args="--python-shebang='#!/usr/bin/env python'"

This uses `shlex.split()` to do it safely.