### PR TITLE
Fix bdist_pex interpreter cache directory

### DIFF
--- a/pex/commands/bdist_pex.py
+++ b/pex/commands/bdist_pex.py
@@ -77,6 +77,7 @@ class bdist_pex(Command):  # noqa
     # Update cache_dir with pex_root in case this is being called directly.
     if options.cache_dir:
       options.cache_dir = make_relative_to_root(options.cache_dir)
+    options.interpreter_cache_dir = make_relative_to_root(options.interpreter_cache_dir)
 
     if options.entry_point or options.script:
       die('Must not specify entry_point or script to --pex-args')


### PR DESCRIPTION
Running bdist_pex results in the creation of a directory literally
named *{pex_root}*. Within it is a subdirectory named *interpreter*.

This fixes it by following behavior similar to that found at https://github.com/pantsbuild/pex/blob/master/pex/bin/pex.py#L536.