### PR TITLE
Repair Executor error handling for other classes of IOError/OSError.

### DIFF
--- a/pex/executor.py
+++ b/pex/executor.py
@@ -13,10 +13,13 @@ class Executor(object):
   class ExecutionError(Exception):
     """Indicates failure to execute."""
 
-    def __init__(self, msg, cmd):
-      super(Executor.ExecutionError, self).__init__(msg)  # noqa
+    def __init__(self, msg, cmd, exc=None):
+      super(Executor.ExecutionError, self).__init__(  # noqa
+        '%s while trying to execute `%s`' % (msg, cmd)
+      )
       self.executable = cmd.split()[0] if isinstance(cmd, string) else cmd[0]
       self.cmd = cmd
+      self.exc = exc
 
   class NonZeroExit(ExecutionError):
     """Indicates a non-zero exit code."""
@@ -66,6 +69,8 @@ class Executor(object):
     except (IOError, OSError) as e:
       if e.errno == errno.ENOENT:
         raise cls.ExecutableNotFound(cmd, e)
+      else:
+        raise cls.ExecutionError(repr(e), cmd, e)
 
   @classmethod
   def execute(cls, cmd, env=None, cwd=None, stdin_payload=None, **kwargs):

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -6,6 +6,7 @@ import os
 import pytest
 from twitter.common.contextutil import temporary_dir
 
+from pex.common import safe_mkdir
 from pex.executor import Executor
 
 TEST_EXECUTABLE = '/a/nonexistent/path/to/nowhere'
@@ -90,3 +91,12 @@ def test_executor_exceptions_nonzeroexit(cmd):
   assert exc.exit_code == TEST_CODE
   assert exc.stdout == TEST_STDOUT
   assert exc.stderr == TEST_STDERR
+
+
+def test_executor_execute_dir():
+  with temporary_dir() as temp_dir:
+    test_dir = os.path.realpath(os.path.join(temp_dir, 'tmp'))
+    safe_mkdir(test_dir)
+    assert os.path.isdir(test_dir)
+    with pytest.raises(Executor.ExecutionError):
+      Executor.execute(test_dir)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -98,5 +98,6 @@ def test_executor_execute_dir():
     test_dir = os.path.realpath(os.path.join(temp_dir, 'tmp'))
     safe_mkdir(test_dir)
     assert os.path.isdir(test_dir)
-    with pytest.raises(Executor.ExecutionError):
+    with pytest.raises(Executor.ExecutionError) as e:
       Executor.execute(test_dir)
+    assert test_dir in str(e)


### PR DESCRIPTION
Addresses handling of @benley's case of attempted execution of a dir, which produced the following unhandled `AttributeError`:

```
Traceback (most recent call last):
  File ".bootstrap/_pex/pex.py", line 328, in execute
  File ".bootstrap/_pex/pex.py", line 260, in _wrap_coverage
  File ".bootstrap/_pex/pex.py", line 292, in _wrap_profiling
  File ".bootstrap/_pex/pex.py", line 371, in _execute
  File ".bootstrap/_pex/pex.py", line 429, in execute_entry
  File ".bootstrap/_pex/pex.py", line 434, in execute_module
  File "/usr/lib/python2.7/runpy.py", line 180, in run_module
    fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/nonexistent/.pex/install/pex_wrapper-0.0.0-py2.7.egg.355ab1e4a2649222db04cd7b5a7f2a400079ce2a/pex_wrapper-0.0.0-py2.7.egg/pex_wrapper.py", line 256, in <module>
    sys.exit(main())
  File "/nonexistent/.pex/install/pex_wrapper-0.0.0-py2.7.egg.355ab1e4a2649222db04cd7b5a7f2a400079ce2a/pex_wrapper-0.0.0-py2.7.egg/pex_wrapper.py", line 253, in main
    pex_builder.build(output)
  File "/nonexistent/.pex/install/pex-1.1.13-py2.py3-none-any.whl.54e2486bd5c6fda99021a6500098c4976315d6fc/pex-1.1.13-py2.py3-none-any.whl/pex/pex_builder.py", line 424, in build
    self.freeze(bytecode_compile=bytecode_compile)
  File "/nonexistent/.pex/install/pex-1.1.13-py2.py3-none-any.whl.54e2486bd5c6fda99021a6500098c4976315d6fc/pex-1.1.13-py2.py3-none-any.whl/pex/pex_builder.py", line 411, in freeze
    self._precompile_source()
  File "/nonexistent/.pex/install/pex-1.1.13-py2.py3-none-any.whl.54e2486bd5c6fda99021a6500098c4976315d6fc/pex-1.1.13-py2.py3-none-any.whl/pex/pex_builder.py", line 335, in _precompile_source
    compiled_relpaths = compiler.compile(self._chroot.path(), source_relpaths)
  File "/nonexistent/.pex/install/pex-1.1.13-py2.py3-none-any.whl.54e2486bd5c6fda99021a6500098c4976315d6fc/pex-1.1.13-py2.py3-none-any.whl/pex/compiler.py", line 86, in compile
    out, _ = Executor.execute([self._interpreter.binary, fp.name])
  File "/nonexistent/.pex/install/pex-1.1.13-py2.py3-none-any.whl.54e2486bd5c6fda99021a6500098c4976315d6fc/pex-1.1.13-py2.py3-none-any.whl/pex/executor.py", line 83, in execute
    stdout_raw, stderr_raw = process.communicate(input=stdin_payload)
AttributeError: 'NoneType' object has no attribute 'communicate'
```