### PR TITLE
Update wheel dependency to >0.26.0

### DIFF
--- a/pex/version.py
+++ b/pex/version.py
@@ -4,4 +4,4 @@
 __version__ = '1.1.14'
 
 SETUPTOOLS_REQUIREMENT = 'setuptools>=2.2,<20.11'
-WHEEL_REQUIREMENT = 'wheel>=0.24.0,<0.30.0'
+WHEEL_REQUIREMENT = 'wheel>=0.26.0,<0.30.0'


### PR DESCRIPTION
Howdy friends,

Recently got bit by this bug when attempting to build a python3 ptpython pex.

Repro steps:

```
osx ~ ❯❯❯ pex pex -c pex -o ~/bin/pex  # clean pex build
osx ~ ❯❯❯ pex ptpython --python python3 -c ptpython -o ~/bin/ptpython
**** Failed to install ptpython-0.35 (caused by: NonZeroExit("received exit code 1 during execution of `['/export/apps/python/3.5.1/bin/python3.5', '-', 'bdist_wheel', '--dist-dir=/var/folders/4y/x7m68gms1cjcc8tpjlxcwz5h0005tq/T/tmpcoBD5s']` while trying to execute `['/export/apps/python/3.5.1/bin/python3.5', '-', 'bdist_wheel', '--dist-dir=/var/folders/4y/x7m68gms1cjcc8tpjlxcwz5h0005tq/T/tmpcoBD5s']`",)
):
stdout:
running bdist_wheel
running build
running build_py
creating build
creating build/lib
creating build/lib/ptpython
copying ptpython/__init__.py -> build/lib/ptpython
copying ptpython/__main__.py -> build/lib/ptpython
copying ptpython/completer.py -> build/lib/ptpython
copying ptpython/eventloop.py -> build/lib/ptpython
copying ptpython/filters.py -> build/lib/ptpython
copying ptpython/history_browser.py -> build/lib/ptpython
copying ptpython/ipython.py -> build/lib/ptpython
copying ptpython/key_bindings.py -> build/lib/ptpython
copying ptpython/layout.py -> build/lib/ptpython
copying ptpython/prompt_style.py -> build/lib/ptpython
copying ptpython/python_input.py -> build/lib/ptpython
copying ptpython/repl.py -> build/lib/ptpython
copying ptpython/style.py -> build/lib/ptpython
copying ptpython/utils.py -> build/lib/ptpython
copying ptpython/validator.py -> build/lib/ptpython
creating build/lib/ptpython/contrib
copying ptpython/contrib/__init__.py -> build/lib/ptpython/contrib
copying ptpython/contrib/asyncssh_repl.py -> build/lib/ptpython/contrib
creating build/lib/ptpython/entry_points
copying ptpython/entry_points/__init__.py -> build/lib/ptpython/entry_points
copying ptpython/entry_points/run_ptipython.py -> build/lib/ptpython/entry_points
copying ptpython/entry_points/run_ptpython.py -> build/lib/ptpython/entry_points
installing to build/bdist.macosx-10.9-x86_64/wheel
running install
running install_lib
creating build/bdist.macosx-10.9-x86_64
creating build/bdist.macosx-10.9-x86_64/wheel
creating build/bdist.macosx-10.9-x86_64/wheel/ptpython
copying build/lib/ptpython/__init__.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython
copying build/lib/ptpython/__main__.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython
copying build/lib/ptpython/completer.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython
creating build/bdist.macosx-10.9-x86_64/wheel/ptpython/contrib
copying build/lib/ptpython/contrib/__init__.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython/contrib
copying build/lib/ptpython/contrib/asyncssh_repl.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython/contrib
creating build/bdist.macosx-10.9-x86_64/wheel/ptpython/entry_points
copying build/lib/ptpython/entry_points/__init__.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython/entry_points
copying build/lib/ptpython/entry_points/run_ptipython.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython/entry_points
copying build/lib/ptpython/entry_points/run_ptpython.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython/entry_points
copying build/lib/ptpython/eventloop.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython
copying build/lib/ptpython/filters.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython
copying build/lib/ptpython/history_browser.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython
copying build/lib/ptpython/ipython.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython
copying build/lib/ptpython/key_bindings.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython
copying build/lib/ptpython/layout.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython
copying build/lib/ptpython/prompt_style.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython
copying build/lib/ptpython/python_input.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython
copying build/lib/ptpython/repl.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython
copying build/lib/ptpython/style.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython
copying build/lib/ptpython/utils.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython
copying build/lib/ptpython/validator.py -> build/bdist.macosx-10.9-x86_64/wheel/ptpython
running install_egg_info
running egg_info
writing requirements to ptpython.egg-info/requires.txt
writing entry points to ptpython.egg-info/entry_points.txt
writing dependency_links to ptpython.egg-info/dependency_links.txt
writing ptpython.egg-info/PKG-INFO
writing top-level names to ptpython.egg-info/top_level.txt
reading manifest file 'ptpython.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'ptpython.egg-info/SOURCES.txt'
Copying ptpython.egg-info to build/bdist.macosx-10.9-x86_64/wheel/ptpython-0.35-py3.5.egg-info
running install_scripts

stderr:
no previously-included directories found matching 'examples/sample?/build'
Traceback (most recent call last):
  File "<stdin>", line 7, in <module>
  File "setup.py", line 40, in <module>
    'ptipython':  ['ipython'] # For ptipython, we need to have IPython
  File "/export/apps/python/3.5.1/lib/python3.5/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/export/apps/python/3.5.1/lib/python3.5/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/export/apps/python/3.5.1/lib/python3.5/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/Users/lcarvalh/.pex/interpreters/CPython-3.5.1/wheel-0.25.0-py3.5.egg/wheel/bdist_wheel.py", line 229, in run
  File "/Users/lcarvalh/.pex/interpreters/CPython-3.5.1/wheel-0.25.0-py3.5.egg/wheel/bdist_wheel.py", line 394, in egg2dist
  File "/Users/lcarvalh/.pex/interpreters/CPython-3.5.1/wheel-0.25.0-py3.5.egg/wheel/metadata.py", line 194, in pkginfo_to_dict
TypeError: unorderable types: EntryPoint() < EntryPoint()


Traceback (most recent call last):
  File ".bootstrap/_pex/pex.py", line 326, in execute
  File ".bootstrap/_pex/pex.py", line 258, in _wrap_coverage
  File ".bootstrap/_pex/pex.py", line 290, in _wrap_profiling
  File ".bootstrap/_pex/pex.py", line 369, in _execute
  File ".bootstrap/_pex/pex.py", line 427, in execute_entry
  File ".bootstrap/_pex/pex.py", line 445, in execute_pkg_resources
  File "/Users/lcarvalh/.pex/install/pex-1.1.14-py2.py3-none-any.whl.8350b5e3ea62522c62fc3adc036502afbb66b0d3/pex-1.1.14-py2.py3-none-any.whl/pex/bin/pex.py", line 540, in main
    pex_builder = build_pex(reqs, options, resolver_options_builder)
  File "/Users/lcarvalh/.pex/install/pex-1.1.14-py2.py3-none-any.whl.8350b5e3ea62522c62fc3adc036502afbb66b0d3/pex-1.1.14-py2.py3-none-any.whl/pex/bin/pex.py", line 489, in build_pex
    resolveds = resolver.resolve(resolvables)
  File "/Users/lcarvalh/.pex/install/pex-1.1.14-py2.py3-none-any.whl.8350b5e3ea62522c62fc3adc036502afbb66b0d3/pex-1.1.14-py2.py3-none-any.whl/pex/resolver.py", line 200, in resolve
    dist = self.build(package, resolvable.options)
  File "/Users/lcarvalh/.pex/install/pex-1.1.14-py2.py3-none-any.whl.8350b5e3ea62522c62fc3adc036502afbb66b0d3/pex-1.1.14-py2.py3-none-any.whl/pex/resolver.py", line 257, in build
    dist = super(CachingResolver, self).build(package, options)
  File "/Users/lcarvalh/.pex/install/pex-1.1.14-py2.py3-none-any.whl.8350b5e3ea62522c62fc3adc036502afbb66b0d3/pex-1.1.14-py2.py3-none-any.whl/pex/resolver.py", line 168, in build
    raise Untranslateable('Package %s is not translateable by %s' % (package, translator))
pex.resolver.Untranslateable: Package SourcePackage('file:///private/var/folders/4y/x7m68gms1cjcc8tpjlxcwz5h0005tq/T/tmpQ3FfxQ/ptpython-0.35.tar.gz') is not translateable by ChainedTranslator(WheelTranslator, EggTranslator, SourceTranslator)
```

Tracker of bug https://bitbucket.org/pypa/wheel/issues/148/unorderable-types-error-for-python-3