### PR TITLE
URL fix to Tox Documentation in README, setuptools requirements update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ is available at https://pex.readthedocs.io.
 Development
 ===========
 
-pex uses `tox <https://testrun.org/tox/latest/>`_ for test and development automation.  To run
+pex uses `tox <https://tox.readthedocs.io/en/latest/>`_ for test and development automation.  To run
 the test suite, just invoke tox:
 
 .. code-block:: bash

--- a/pex/version.py
+++ b/pex/version.py
@@ -3,5 +3,5 @@
 
 __version__ = '1.1.14'
 
-SETUPTOOLS_REQUIREMENT = 'setuptools>=2.2,<20.11'
+SETUPTOOLS_REQUIREMENT = 'setuptools>=20.2,<28.7.1'
 WHEEL_REQUIREMENT = 'wheel>=0.26.0,<0.30.0'

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -4,4 +4,4 @@ coverage run -p -m py.test tests
 coverage run -p -m pex.bin.pex -v --help >&/dev/null
 coverage run -p -m pex.bin.pex -v -- scripts/do_nothing.py
 coverage run -p -m pex.bin.pex -v requests -- scripts/do_nothing.py
-coverage run -p -m pex.bin.pex -v . 'setuptools>=2.2,<20' -- scripts/do_nothing.py
+coverage run -p -m pex.bin.pex -v . 'setuptools>=20.2,<28.7.1' -- scripts/do_nothing.py


### PR DESCRIPTION
Link is currently broken in documentation. 

Also updating Setuptools requirements as per [Issue #306](https://github.com/pantsbuild/pex/issues/306)

According to the Setuptools changelog, [Version 20.2](https://setuptools.readthedocs.io/en/latest/history.html#id138) is when local version segments were added (PEP-440) 
