### PR TITLE
--constraints in pex

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -341,6 +341,16 @@ def configure_clp():
            'times.')
 
   parser.add_option(
+      '--constraints',
+      dest='constraint_files',
+      metavar='FILE',
+      default=[],
+      type=str,
+      action='append',
+      help='Add requirements from the given requirements file.  This option can be used multiple '
+           'times.')
+
+  parser.add_option(
       '-v',
       dest='verbosity',
       default=0,
@@ -476,6 +486,13 @@ def build_pex(args, options, resolver_option_builder):
 
   for requirements_txt in options.requirement_files:
     resolvables.extend(requirements_from_file(requirements_txt, resolver_option_builder))
+
+  for constraints_txt in options.constraint_files:
+    constraints = []
+    for r in requirements_from_file(constraints_txt, resolver_option_builder):
+      r.is_constraint = True
+      constraints.append(r)
+    resolvables.extend(constraints)
 
   resolver_kwargs = dict(interpreter=interpreter, platform=options.platform)
 

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -347,7 +347,7 @@ def configure_clp():
       default=[],
       type=str,
       action='append',
-      help='Add requirements from the given requirements file.  This option can be used multiple '
+      help='Add constraints from the given constraints file.  This option can be used multiple '
            'times.')
 
   parser.add_option(
@@ -487,6 +487,8 @@ def build_pex(args, options, resolver_option_builder):
   for requirements_txt in options.requirement_files:
     resolvables.extend(requirements_from_file(requirements_txt, resolver_option_builder))
 
+  # pip states the constraints format is identical tor requirements
+  # https://pip.pypa.io/en/stable/user_guide/#constraints-files
   for constraints_txt in options.constraint_files:
     constraints = []
     for r in requirements_from_file(constraints_txt, resolver_option_builder):

--- a/pex/package.py
+++ b/pex/package.py
@@ -224,6 +224,16 @@ class WheelPackage(Package):
         return True
     return False
 
+  def __eq__(self, other):
+    return (self._name == other._name and
+            self._raw_version == other._raw_version and
+            self._py_tag == other._py_tag and
+            self._abi_tag == other._abi_tag and
+            self._arch_tag == other._arch_tag)
+
+  def __hash__(self):
+    return hash((self._name, self._raw_version, self._py_tag, self._abi_tag, self._arch_tag))
+
 
 Package.register(SourcePackage)
 Package.register(EggPackage)

--- a/pex/resolvable.py
+++ b/pex/resolvable.py
@@ -37,6 +37,8 @@ class Resolvable(AbstractClass):
 
   _REGISTRY = []
 
+  is_constraint = False
+
   @classmethod
   def register(cls, implementation):
     """Register an implementation of a Resolvable.

--- a/pex/resolvable.py
+++ b/pex/resolvable.py
@@ -37,7 +37,15 @@ class Resolvable(AbstractClass):
 
   _REGISTRY = []
 
-  is_constraint = False
+  @property
+  def is_constraint(self):
+    if hasattr(self, "_is_constraint"):
+      return self._is_constraint
+    return False
+
+  @is_constraint.setter
+  def set_is_constraint(self, value):
+    self._is_constraint = value
 
   @classmethod
   def register(cls, implementation):

--- a/pex/resolvable.py
+++ b/pex/resolvable.py
@@ -44,7 +44,7 @@ class Resolvable(AbstractClass):
     return False
 
   @is_constraint.setter
-  def set_is_constraint(self, value):
+  def is_constraint(self, value):
     self._is_constraint = value
 
   @classmethod

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -43,18 +43,19 @@ class StaticIterator(IteratorInterface):
         yield package
 
 
-class _ResolvedPackages(namedtuple('_ResolvedPackages', 'resolvable packages parent')):
+class _ResolvedPackages(namedtuple('_ResolvedPackages', 'resolvable packages parent constraint_only')):
   @classmethod
   def empty(cls):
-    return cls(None, OrderedSet(), None)
+    return cls(None, OrderedSet(), None, False)
 
   def merge(self, other):
     if other.resolvable is None:
-      return _ResolvedPackages(self.resolvable, self.packages, self.parent)
+      return _ResolvedPackages(self.resolvable, self.packages, self.parent, self.constraint_only)
     return _ResolvedPackages(
         self.resolvable,
         self.packages & other.packages,
-        self.parent)
+        self.parent,
+        self.constraint_only and other.constraint_only)
 
 
 class _ResolvableSet(object):
@@ -103,12 +104,12 @@ class _ResolvableSet(object):
 
   def merge(self, resolvable, packages, parent=None):
     """Add a resolvable and its resolved packages."""
-    self.__tuples.append(_ResolvedPackages(resolvable, OrderedSet(packages), parent))
+    self.__tuples.append(_ResolvedPackages(resolvable, OrderedSet(packages), parent, resolvable.is_constraint))
     self._check()
 
   def get(self, name):
     """Get the set of compatible packages given a resolvable name."""
-    resolvable, packages, parent = self._collapse().get(
+    resolvable, packages, parent, constraint_only = self._collapse().get(
         self.normalize(name), _ResolvedPackages.empty())
     return packages
 
@@ -129,7 +130,7 @@ class _ResolvableSet(object):
     """
     def map_packages(resolved_packages):
       packages = OrderedSet(built_packages.get(p, p) for p in resolved_packages.packages)
-      return _ResolvedPackages(resolved_packages.resolvable, packages, resolved_packages.parent)
+      return _ResolvedPackages(resolved_packages.resolvable, packages, resolved_packages.parent, resolved_packages.constraint_only)
 
     return _ResolvableSet([map_packages(rp) for rp in self.__tuples])
 
@@ -138,6 +139,8 @@ class Resolver(object):
   """Interface for resolving resolvable entities into python packages."""
 
   class Error(Exception): pass
+
+  is_constraint = False
 
   @classmethod
   def filter_packages_by_interpreter(cls, packages, interpreter, platform):
@@ -188,7 +191,9 @@ class Resolver(object):
         processed_resolvables.add(resolvable)
 
       built_packages = {}
-      for resolvable, packages, parent in resolvable_set.packages():
+      for resolvable, packages, parent, constraint_only in resolvable_set.packages():
+        if constraint_only:
+            continue
         assert len(packages) > 0, 'ResolvableSet.packages(%s) should not be empty' % resolvable
         package = next(iter(packages))
         if resolvable.name in processed_packages:

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -43,7 +43,9 @@ class StaticIterator(IteratorInterface):
         yield package
 
 
-class _ResolvedPackages(namedtuple('_ResolvedPackages', 'resolvable packages parent constraint_only')):
+class _ResolvedPackages(namedtuple('_ResolvedPackages',
+                                   'resolvable packages parent constraint_only')):
+
   @classmethod
   def empty(cls):
     return cls(None, OrderedSet(), None, False)
@@ -104,7 +106,8 @@ class _ResolvableSet(object):
 
   def merge(self, resolvable, packages, parent=None):
     """Add a resolvable and its resolved packages."""
-    self.__tuples.append(_ResolvedPackages(resolvable, OrderedSet(packages), parent, resolvable.is_constraint))
+    self.__tuples.append(_ResolvedPackages(resolvable, OrderedSet(packages),
+                                           parent, resolvable.is_constraint))
     self._check()
 
   def get(self, name):
@@ -130,7 +133,8 @@ class _ResolvableSet(object):
     """
     def map_packages(resolved_packages):
       packages = OrderedSet(built_packages.get(p, p) for p in resolved_packages.packages)
-      return _ResolvedPackages(resolved_packages.resolvable, packages, resolved_packages.parent, resolved_packages.constraint_only)
+      return _ResolvedPackages(resolved_packages.resolvable, packages,
+                               resolved_packages.parent, resolved_packages.constraint_only)
 
     return _ResolvableSet([map_packages(rp) for rp in self.__tuples])
 
@@ -191,7 +195,7 @@ class Resolver(object):
       built_packages = {}
       for resolvable, packages, parent, constraint_only in resolvable_set.packages():
         if constraint_only:
-            continue
+          continue
         assert len(packages) > 0, 'ResolvableSet.packages(%s) should not be empty' % resolvable
         package = next(iter(packages))
         if resolvable.name in processed_packages:

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -140,8 +140,6 @@ class Resolver(object):
 
   class Error(Exception): pass
 
-  is_constraint = False
-
   @classmethod
   def filter_packages_by_interpreter(cls, packages, interpreter, platform):
     return [package for package in packages

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -4,7 +4,7 @@
 import pytest
 from pkg_resources import Requirement, parse_version
 
-from pex.package import EggPackage, SourcePackage
+from pex.package import EggPackage, SourcePackage, WheelPackage
 
 
 def test_source_packages():
@@ -68,3 +68,36 @@ def test_egg_packages():
 
   with pytest.raises(EggPackage.InvalidPackage):
     EggPackage('bar-py2.6.egg')
+
+
+def test_wheel_package():
+  wp = WheelPackage(
+      'file:///home/user/.pex/build/requests-2.12.1-py2.py3-none-any.whl'
+  )
+  assert wp.name == "requests"
+  assert wp.raw_version == "2.12.1"
+  assert wp._py_tag == "py2.py3"
+  assert wp._abi_tag == "none"
+  assert wp._arch_tag == "any"
+
+
+@pytest.mark.parametrize("package_name", [
+  "transmute_core-0.4.5-py2.py3-none-any-gobbledy.whl"
+])
+def test_invalid_wheel_package_name(package_name):
+  with pytest.raises(WheelPackage.InvalidPackage):
+    WheelPackage(package_name)
+
+
+def test_different_wheel_packages_should_be_equal():
+  pypi_package = WheelPackage(
+    'https://pypi.python.org/packages/9b/31/'
+    'e9925a2b9a06f97c3450bac6107928d3533bfe64ca5615442504104321e8/'
+    'requests-2.12.1-py2.py3-none-any.whl'
+  )
+  local_package = WheelPackage(
+    'https://internalpypi.mycompany.org/packages/9b/31/'
+    'e9925a2b9a06f97c3450bac6107928d3533bfe64ca5615442504104321e8/'
+    'requests-2.12.1-py2.py3-none-any.whl'
+  )
+  assert pypi_package == local_package

--- a/tests/test_pex_binary.py
+++ b/tests/test_pex_binary.py
@@ -80,3 +80,9 @@ def test_clp_requirements_txt():
   parser, builder = configure_clp()
   options, _ = parser.parse_args(args='-r requirements1.txt -r requirements2.txt'.split())
   assert options.requirement_files == ['requirements1.txt', 'requirements2.txt']
+
+
+def test_clp_constraints_txt():
+  parser, builder = configure_clp()
+  options, _ = parser.parse_args(args='--constraint requirements1.txt'.split())
+  assert options.constraint_files == ['requirements1.txt']

--- a/tests/test_resolvable.py
+++ b/tests/test_resolvable.py
@@ -111,3 +111,11 @@ def test_resolvables_from_iterable():
       ResolvablePackage.from_string('foo-2.3.4.tar.gz', builder),
       ResolvableRequirement.from_string('foo==2.3.4', builder),
   ]
+
+
+def test_resolvable_is_constraint_getter_setter():
+  builder = ResolverOptionsBuilder()
+  req = ResolvableRequirement.from_string('foo', builder)
+  assert req.is_constraint is False
+  req.is_constraint = True
+  assert req.is_constraint is True

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -10,7 +10,7 @@ from pex.common import safe_copy
 from pex.fetcher import Fetcher
 from pex.package import EggPackage, SourcePackage
 from pex.resolvable import ResolvableRequirement
-from pex.resolver import Unsatisfiable, _ResolvableSet, Resolver, resolve
+from pex.resolver import Resolver, Unsatisfiable, _ResolvableSet, resolve
 from pex.resolver_options import ResolverOptionsBuilder
 from pex.testing import make_sdist
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -58,7 +58,7 @@ def test_resolvable_set():
   rs.merge(rq, [source_pkg, binary_pkg])
   assert rs.get(source_pkg.name) == set([source_pkg, binary_pkg])
   assert rs.get(binary_pkg.name) == set([source_pkg, binary_pkg])
-  assert rs.packages() == [(rq, set([source_pkg, binary_pkg]), None)]
+  assert rs.packages() == [(rq, set([source_pkg, binary_pkg]), None, False)]
 
   # test methods
   assert rs.extras('foo') == set(['ext'])
@@ -82,7 +82,7 @@ def test_resolvable_set_built():
 
   rs.merge(rq, [source_pkg])
   assert rs.get('foo') == set([source_pkg])
-  assert rs.packages() == [(rq, set([source_pkg]), None)]
+  assert rs.packages() == [(rq, set([source_pkg]), None, False)]
 
   with pytest.raises(Unsatisfiable):
     rs.merge(rq, [binary_pkg])
@@ -90,4 +90,4 @@ def test_resolvable_set_built():
   updated_rs = rs.replace_built({source_pkg: binary_pkg})
   updated_rs.merge(rq, [binary_pkg])
   assert updated_rs.get('foo') == set([binary_pkg])
-  assert updated_rs.packages() == [(rq, set([binary_pkg]), None)]
+  assert updated_rs.packages() == [(rq, set([binary_pkg]), None, False)]

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -100,6 +100,40 @@ def test_resolvable_set_constraint_and_non_constraint():
   assert rs.packages() == [(rq, set([package]), None, False)]
 
 
+def test_constraints_limits_versions_usable():
+  builder = ResolverOptionsBuilder()
+  rs = _ResolvableSet()
+  req = ResolvableRequirement.from_string("foo>0.5", builder)
+  constraint = ResolvableRequirement.from_string("foo==0.7", builder)
+  constraint.is_constraint = True
+
+  version_packages = []
+  for version in range(6, 10):
+    version_string = "foo-0.{0}.tar.gz".format(version)
+    package = SourcePackage.from_href(version_string)
+    version_packages.append(package)
+  rs.merge(req, version_packages)
+  rs.merge(constraint, [version_packages[1]])
+  assert rs.packages() == [(req, set([version_packages[1]]), None, False)]
+
+
+def test_constraints_range():
+  builder = ResolverOptionsBuilder()
+  rs = _ResolvableSet()
+  req = ResolvableRequirement.from_string("foo>0.5", builder)
+  constraint = ResolvableRequirement.from_string("foo<0.9", builder)
+  constraint.is_constraint = True
+
+  version_packages = []
+  for version in range(1, 10):
+    version_string = "foo-0.{0}.tar.gz".format(version)
+    package = SourcePackage.from_href(version_string)
+    version_packages.append(package)
+  rs.merge(req, version_packages[4:])
+  rs.merge(constraint, version_packages[:8])
+  assert rs.packages() == [(req, set(version_packages[4:8]), None, False)]
+
+
 def test_resolver_with_constraint():
   builder = ResolverOptionsBuilder()
   r = Resolver()


### PR DESCRIPTION
this is an implementation of adding constraint support to pex:

https://pip.pypa.io/en/stable/user_guide/#constraints-files

As the "-c" keyword is already used, this implementation opts for "--constraint" by itself.

It works pretty well:

```
pex requests --constraints constraints.txt -o /tmp/requests.pex
```

with the constraints file
```
requests==2.12.1
aiohttp==1.2.0
```

resulted in a pex that had requests versioned 2.12.1, but not aiohttp.

I really wanted to start the conversation with this PR: I'm new to the Pex code and didn't know the best place to implement this, so I wanted to get feedback on an approach before doing a bunch of work to add tests.

One issue along the way: conflicts arose when attempting to reference the same package twice:

```
pex requests requests==2.12.1 -o /tmp/requests.pex
```
This was caused by a lack of semantic equality in the WheelPackage, so I added that too. Happy to pick that up in another PR/Issue if that's more appropriate.