### PR TITLE
Add support for controlling prerelease resolution.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,14 @@ matrix:
       env: TOXENV=pypy
 
 install:
-  - pip install tox
+  # NB: We only directly need tox, but in some of the python environments we run in (2.6, 2.7, 3.3,
+  # 3.4) we get an old version of setuptools (12.0.5) that leads to a failure of tox to execute
+  # pex's own setup.py file:
+  #
+  #   error in pex setup command: 'install_requires' must be a string or list of strings containing
+  #   valid project/version requirement specifiers
+  #
+  - pip install -U setuptools tox
 
 script:
   - tox -v

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -102,6 +102,15 @@ def process_index_url(option, option_str, option_value, parser, builder):
   builder.add_index(option_value)
 
 
+def process_prereleases(option, option_str, option_value, parser, builder):
+  if option_str == '--pre':
+    builder.allow_prereleases(True)
+  elif option_str == '--no-pre':
+    builder.allow_prereleases(False)
+  else:
+    raise OptionValueError
+
+
 def process_precedence(option, option_str, option_value, parser, builder):
   if option_str == '--build':
     builder.allow_builds()
@@ -159,6 +168,16 @@ def configure_clp_pex_resolution(parser, builder):
       callback_args=(builder,),
       type=str,
       help='Additional cheeseshop indices to use to satisfy requirements.')
+
+  group.add_option(
+    '--pre', '--no-pre',
+    dest='allow_prereleases',
+    default=False,
+    action='callback',
+    callback=process_prereleases,
+    callback_args=(builder,),
+    help='Whether to include pre-release and development versions of requirements; '
+         'Default: only stable versions are used')
 
   group.add_option(
       '--disable-cache',

--- a/pex/iterator.py
+++ b/pex/iterator.py
@@ -22,10 +22,11 @@ class IteratorInterface(AbstractClass):
 class Iterator(IteratorInterface):
   """A requirement iterator, the glue between fetchers, crawlers and requirements."""
 
-  def __init__(self, fetchers=None, crawler=None, follow_links=False):
+  def __init__(self, fetchers=None, crawler=None, follow_links=False, allow_prereleases=False):
     self._crawler = crawler or Crawler()
     self._fetchers = fetchers if fetchers is not None else [PyPIFetcher()]
     self.__follow_links = follow_links
+    self.__allow_prereleases = allow_prereleases
 
   def _iter_requirement_urls(self, req):
     return itertools.chain.from_iterable(fetcher.urls(req) for fetcher in self._fetchers)
@@ -34,5 +35,5 @@ class Iterator(IteratorInterface):
     url_iterator = self._iter_requirement_urls(req)
     crawled_url_iterator = self._crawler.crawl(url_iterator, follow_links=self.__follow_links)
     for package in filter(None, map(Package.from_href, crawled_url_iterator)):
-      if package.satisfies(req):
+      if package.satisfies(req, allow_prereleases=self.__allow_prereleases):
         yield package

--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -54,6 +54,8 @@ def requirements_from_lines(lines, builder=None, relpath=None):
       builder.allow_all_external()
     elif line.startswith('--allow-unverified'):
       builder.allow_unverified(_get_parameter(line))
+    elif line.startswith('--pre'):
+      builder.allow_prereleases(True)
     elif line.startswith('--no-index'):
       builder.clear_indices()
     elif line.startswith('--no-use-wheel'):

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -281,7 +281,8 @@ def resolve(
     context=None,
     precedence=None,
     cache=None,
-    cache_ttl=None):
+    cache_ttl=None,
+    allow_prereleases=False):
 
   """Produce all distributions needed to (recursively) meet `requirements`
 
@@ -296,7 +297,6 @@ def resolve(
     `Platform.current()`.
   :keyword context: (optional) A :class:`Context` object to use for network access.  If
     unspecified, the resolver will attempt to use the best available network context.
-  :type threads: int
   :keyword precedence: (optional) An ordered list of allowable :class:`Package` classes
     to be used for producing distributions.  For example, if precedence is supplied as
     ``(WheelPackage, SourcePackage)``, wheels will be preferred over building from source, and
@@ -311,6 +311,8 @@ def resolve(
     is older than cache_ttl seconds, it will be ignored.  If ``cache_ttl`` is not specified,
     resolving inexact requirements will always result in making network calls through the
     ``context``.
+  :keyword allow_prereleases: (optional) Include pre-release and development versions.  If
+    unspecified only stable versions will be resolved.
   :returns: List of :class:`pkg_resources.Distribution` instances meeting ``requirements``.
   :raises Unsatisfiable: If ``requirements`` is not transitively satisfiable.
   :raises Untranslateable: If no compatible distributions could be acquired for
@@ -341,6 +343,7 @@ def resolve(
 
   builder = ResolverOptionsBuilder(
       fetchers=fetchers,
+      allow_prereleases=allow_prereleases,
       precedence=precedence,
       context=context,
   )

--- a/pex/resolver_options.py
+++ b/pex/resolver_options.py
@@ -43,12 +43,14 @@ class ResolverOptionsBuilder(object):
                allow_all_external=False,
                allow_external=None,
                allow_unverified=None,
+               allow_prereleases=False,
                precedence=None,
                context=None):
     self._fetchers = fetchers if fetchers is not None else [PyPIFetcher()]
     self._allow_all_external = allow_all_external
     self._allow_external = allow_external if allow_external is not None else set()
     self._allow_unverified = allow_unverified if allow_unverified is not None else set()
+    self._allow_prereleases = allow_prereleases
     self._precedence = precedence if precedence is not None else Sorter.DEFAULT_PACKAGE_PRECEDENCE
     self._context = context or Context.get()
 
@@ -58,6 +60,7 @@ class ResolverOptionsBuilder(object):
         allow_all_external=self._allow_all_external,
         allow_external=self._allow_external.copy(),
         allow_unverified=self._allow_unverified.copy(),
+        allow_prereleases=self._allow_prereleases,
         precedence=self._precedence[:],
         context=self._context,
     )
@@ -114,11 +117,16 @@ class ResolverOptionsBuilder(object):
         [precedent for precedent in self._precedence if precedent is not SourcePackage])
     return self
 
+  def allow_prereleases(self, allowed):
+    self._allow_prereleases = allowed
+    return self
+
   def build(self, key):
     return ResolverOptions(
         fetchers=self._fetchers,
         allow_external=self._allow_all_external or key in self._allow_external,
         allow_unverified=key in self._allow_unverified,
+        allow_prereleases=self._allow_prereleases,
         precedence=self._precedence,
         context=self._context,
     )
@@ -129,11 +137,13 @@ class ResolverOptions(ResolverOptionsInterface):
                fetchers=None,
                allow_external=False,
                allow_unverified=False,
+               allow_prereleases=False,
                precedence=None,
                context=None):
     self._fetchers = fetchers if fetchers is not None else [PyPIFetcher()]
     self._allow_external = allow_external
     self._allow_unverified = allow_unverified
+    self._allow_prereleases = allow_prereleases
     self._precedence = precedence if precedence is not None else Sorter.DEFAULT_PACKAGE_PRECEDENCE
     self._context = context or Context.get()
 
@@ -171,4 +181,5 @@ class ResolverOptions(ResolverOptionsInterface):
         fetchers=self._fetchers,
         crawler=self.get_crawler(),
         follow_links=self._allow_external,
+        allow_prereleases=self._allow_prereleases
     )

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -85,7 +85,7 @@ PROJECT_CONTENT = {
 
       setup(
           name=%(project_name)r,
-          version='0.0.0',
+          version=%(version)r,
           zip_safe=%(zip_safe)r,
           packages=['my_package'],
           scripts=[
@@ -106,29 +106,39 @@ PROJECT_CONTENT = {
 
 
 @contextlib.contextmanager
-def make_installer(name='my_project', installer_impl=EggInstaller, zip_safe=True,
+def make_installer(name='my_project', version='0.0.0', installer_impl=EggInstaller, zip_safe=True,
                    install_reqs=None):
-  interp = {'project_name': name, 'zip_safe': zip_safe, 'install_requires': install_reqs or []}
+  interp = {'project_name': name,
+            'version': version,
+            'zip_safe': zip_safe,
+            'install_requires': install_reqs or []}
   with temporary_content(PROJECT_CONTENT, interp=interp) as td:
     yield installer_impl(td)
 
 
 @contextlib.contextmanager
-def make_source_dir(name='my_project', install_reqs=None):
-  interp = {'project_name': name, 'zip_safe': True, 'install_requires': install_reqs or []}
+def make_source_dir(name='my_project', version='0.0.0', install_reqs=None):
+  interp = {'project_name': name,
+            'version': version,
+            'zip_safe': True,
+            'install_requires': install_reqs or []}
   with temporary_content(PROJECT_CONTENT, interp=interp) as td:
     yield td
 
 
-def make_sdist(name='my_project', zip_safe=True, install_reqs=None):
-  with make_installer(name=name, installer_impl=Packager, zip_safe=zip_safe,
+def make_sdist(name='my_project', version='0.0.0', zip_safe=True, install_reqs=None):
+  with make_installer(name=name, version=version, installer_impl=Packager, zip_safe=zip_safe,
                       install_reqs=install_reqs) as packager:
     return packager.sdist()
 
 
 @contextlib.contextmanager
-def make_bdist(name='my_project', installer_impl=EggInstaller, zipped=False, zip_safe=True):
-  with make_installer(name=name, installer_impl=installer_impl, zip_safe=zip_safe) as installer:
+def make_bdist(name='my_project', version='0.0.0', installer_impl=EggInstaller, zipped=False,
+               zip_safe=True):
+  with make_installer(name=name,
+                      version=version,
+                      installer_impl=installer_impl,
+                      zip_safe=zip_safe) as installer:
     dist_location = installer.bdist()
     if zipped:
       yield DistributionHelper.distribution_from_path(dist_location)

--- a/pex/version.py
+++ b/pex/version.py
@@ -3,5 +3,11 @@
 
 __version__ = '1.1.20'
 
-SETUPTOOLS_REQUIREMENT = 'setuptools>=5.7,<31.0'
+PACKAGING_REQUIREMENT = 'packaging>=16.8'
+
+# NB: We exlude 7.0b1 since it will use `packaging` if present and we install a modern version of
+# packaging that may not be compatible. Versions before 7.0b1 don't use `packaging` and versions
+# after use a vendored `packaging`.
+SETUPTOOLS_REQUIREMENT = 'setuptools>=5.7,!=7.0b1<31.0'
+
 WHEEL_REQUIREMENT = 'wheel>=0.26.0,<0.30.0'

--- a/pex/version.py
+++ b/pex/version.py
@@ -5,7 +5,7 @@ __version__ = '1.1.20'
 
 PACKAGING_REQUIREMENT = 'packaging>=16.8'
 
-# NB: We exlude 7.0b1 since it will use `packaging` if present and we install a modern version of
+# NB: We exclude 7.0b1 since it will use `packaging` if present and we install a modern version of
 # packaging that may not be compatible. Versions before 7.0b1 don't use `packaging` and versions
 # after use a vendored `packaging`.
 SETUPTOOLS_REQUIREMENT = 'setuptools>=5.7,!=7.0b1<31.0'

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
     'pex.commands',
   ],
   install_requires = [
+    PACKAGING_REQUIREMENT,
     SETUPTOOLS_REQUIREMENT,
   ],
   tests_require = [

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -26,13 +26,23 @@ def test_empty_iteration():
   assert kwargs == {'follow_links': False}
 
 
-def test_iteration_with_return():
-  pex_url = 'https://pypi.python.org/packages/source/p/pex/pex-0.8.6.tar.gz'
-  crawler_mock = mock.create_autospec(Crawler, spec_set=True)
-  crawler_mock.crawl.return_value = [pex_url]
-  iterator = Iterator(crawler=crawler_mock, follow_links=True)
+def assert_iteration(all_versions, *expected_versions, **iterator_kwargs):
+  def package_url(version):
+    return 'https://pypi.python.org/packages/source/p/pex/pex-%s.tar.gz' % version
 
-  assert list(iterator.iter(Requirement.parse('pex'))) == [SourcePackage(pex_url)]
+  urls = [package_url(v) for v in all_versions]
+  crawler_mock = mock.create_autospec(Crawler, spec_set=True)
+  crawler_mock.crawl.return_value = urls
+  iterator = Iterator(crawler=crawler_mock, follow_links=True, **iterator_kwargs)
+
+  assert list(iterator.iter(Requirement.parse('pex'))) == [SourcePackage(package_url(v))
+                                                           for v in expected_versions]
   assert len(crawler_mock.crawl.mock_calls) == 1
   _, _, kwargs = crawler_mock.crawl.mock_calls[0]
   assert kwargs == {'follow_links': True}
+
+
+def test_iteration_with_return():
+  assert_iteration(['0.8.6', '0.8.6b1'], '0.8.6')  # Iterator should exclude prereleases by default.
+  assert_iteration(['0.8.6', '0.8.6b1'], '0.8.6', allow_prereleases=False)
+  assert_iteration(['0.8.6', '0.8.6b1'], '0.8.6', '0.8.6b1', allow_prereleases=True)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -101,3 +101,30 @@ def test_different_wheel_packages_should_be_equal():
     'requests-2.12.1-py2.py3-none-any.whl'
   )
   assert pypi_package == local_package
+
+
+def test_prereleases():
+  def source_package(version):
+    return SourcePackage('setuptools-%s.tar.gz' % version)
+
+  def egg_package(version):
+    return EggPackage('setuptools-%s-py2.7.egg' % version)
+
+  def wheel_package(version):
+    return WheelPackage('file:///tmp/setuptools-%s-py2.py3-none-any.whl' % version)
+
+  requirement = 'setuptools>=6,<8'
+
+  for package in (egg_package, source_package, egg_package, wheel_package):
+    stable_package = package('7.0')
+    assert stable_package.satisfies(requirement)
+    assert stable_package.satisfies(requirement, allow_prereleases=False)
+    assert stable_package.satisfies(requirement, allow_prereleases=True)
+
+    prerelease_package = package('7.0b1')
+
+    # satisfies should exclude prereleases by default.
+    assert not prerelease_package.satisfies(requirement)
+
+    assert not prerelease_package.satisfies(requirement, allow_prereleases=False)
+    assert prerelease_package.satisfies(requirement, allow_prereleases=True)

--- a/tests/test_pex_binary.py
+++ b/tests/test_pex_binary.py
@@ -86,3 +86,17 @@ def test_clp_constraints_txt():
   parser, builder = configure_clp()
   options, _ = parser.parse_args(args='--constraint requirements1.txt'.split())
   assert options.constraint_files == ['requirements1.txt']
+
+
+def test_clp_prereleases():
+  with parser_pair() as (builder, parser):
+    configure_clp_pex_resolution(parser, builder)
+
+    options, _ = parser.parse_args(args=[])
+    assert not builder._allow_prereleases
+
+    options, _ = parser.parse_args(args=['--no-pre'])
+    assert not builder._allow_prereleases
+
+    options, _ = parser.parse_args(args=['--pre'])
+    assert builder._allow_prereleases

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -53,6 +53,24 @@ def test_all_external():
   assert reqs[1].options._allow_external
 
 
+def test_allow_prereleases():
+  # Prereleases should be disallowed by default.
+  reqs = requirements_from_lines(dedent("""
+  simple_requirement
+  specific_requirement==2
+  """).splitlines())
+  assert not reqs[0].options._allow_prereleases
+  assert not reqs[1].options._allow_prereleases
+
+  reqs = requirements_from_lines(dedent("""
+  --pre
+  simple_requirement
+  specific_requirement==2
+  """).splitlines())
+  assert reqs[0].options._allow_prereleases
+  assert reqs[1].options._allow_prereleases
+
+
 def test_index_types():
   reqs = requirements_from_lines(dedent("""
   simple_requirement

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -48,6 +48,26 @@ def test_diamond_local_resolve_cached():
       assert len(dists) == 2
 
 
+def test_resolve_prereleases():
+  stable_dep = make_sdist(name='dep', version='2.0.0')
+  prerelease_dep = make_sdist(name='dep', version='3.0.0rc3')
+
+  with temporary_dir() as td:
+    for sdist in (stable_dep, prerelease_dep):
+      safe_copy(sdist, os.path.join(td, os.path.basename(sdist)))
+    fetchers = [Fetcher([td])]
+
+    def assert_resolve(expected_version, **resolve_kwargs):
+      dists = resolve(['dep>=1,<4'], fetchers=fetchers, **resolve_kwargs)
+      assert 1 == len(dists)
+      dist = dists[0]
+      assert expected_version == dist.version
+
+    assert_resolve('2.0.0')
+    assert_resolve('2.0.0', allow_prereleases=False)
+    assert_resolve('3.0.0rc3', allow_prereleases=True)
+
+
 def test_resolvable_set():
   builder = ResolverOptionsBuilder()
   rs = _ResolvableSet()

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     twitter.common.lang>=0.3.1,<0.4.0
     twitter.common.testing>=0.3.1,<0.4.0
     wheel==0.29.0
+    packaging==16.8
     py26: mock
     py27: mock
     pypy: mock


### PR DESCRIPTION
This change both allows control over whether prereleases are allowed
when resolving requirements and changes the default from allowing
prereleases to disallowing them - in line with pip behavior.

Support includes a pip-alike `--pre` cli option, support for `--pre` in
requirements.txt files, and API support for consumers of the pex
library, notably pants.

This closes #28.