### PR TITLE
Ensure `packaging` dependency is self-contained.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+1.2.1
+-----
+
+This release is a quick fix for a bootstrapping bug that inadvertently went out in 1.2.0 (Issue
+#354).
+
+* Ensure `packaging` dependency is self-contained. (#355)
+  `#355 <https://github.com/pantsbuild/pex/pull/355>`_
+  `Fixes #354 <https://github.com/pantsbuild/pex/issues/354>`_
+
 1.2.0
 -----
 

--- a/pex/package.py
+++ b/pex/package.py
@@ -3,7 +3,6 @@
 
 import os
 
-from packaging.specifiers import SpecifierSet
 from pkg_resources import EGG_NAME, parse_version, safe_name, safe_version
 
 from .archiver import Archiver
@@ -80,15 +79,10 @@ class Package(Link):
     link_name = safe_name(self.name).lower()
     if link_name != requirement.key:
       return False
-
-    # TODO(John Sirois): This is a bit roundabout. Modern setuptools `Requirement` objects expose a
-    # `specifiers` field which is a `SpecifierSet`, but we can't be sure we have that. We can be
-    # sure though we have the `Requirement.specs` list of `(op, version)` tuples in all versions of
-    # setuptools we depend upon (we use `Requirement.specs` elsewhere in the codebase as well).
-    # Kill this re-parsing once our lower-bound setuptools dependency give access to
-    # `Requirement.specifiers`.
-    specifiers = ','.join(op + version for op, version in requirement.specs)
-    return self.raw_version in SpecifierSet(specifiers, prereleases=allow_prereleases)
+    # NB: If we upgrade to setuptools>=34 the SpecifierSet used here (requirement.specifier) will
+    # come from a non-vendored `packaging` package and pex's bootstrap code in `PEXBuilder` will
+    # need an update.
+    return requirement.specifier.contains(self.raw_version, prereleases=allow_prereleases)
 
   def compatible(self, identity, platform=Platform.current()):
     """Is this link compatible with the given :class:`PythonIdentity` identity and platform?

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,8 +1,11 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 
-PACKAGING_REQUIREMENT = 'packaging>=16.8,<17.0'
+# NB: If we upgrade to setuptools>=34 pex's bootstrap code in `PEXBuilder` will need an update to
+# include the `packaging` package in the `.bootstrap/` code since we use
+# `packaging.specifiers.SpecifierSet` - indirectly - through `pkg_resources.Requirement.specifier`.
 SETUPTOOLS_REQUIREMENT = 'setuptools>=20.0,<34.0'
+
 WHEEL_REQUIREMENT = 'wheel>=0.26.0,<0.30.0'

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
     'pex.commands',
   ],
   install_requires = [
-    PACKAGING_REQUIREMENT,
     SETUPTOOLS_REQUIREMENT,
   ],
   tests_require = [


### PR DESCRIPTION
This dependency was not included in the pex `.bootstrap/` previously
leading to issues with use of pex as a library. We use the vendored
version from setuptools for now - which it leaks through its API. Notes
are added in the right spots to deal with setuptools de-vendoring of
`packaging` in its newest releases when we upgrade setuptools next.

Closes #354