### PR TITLE
Follow redirects on HTTP requests

### DIFF
--- a/pex/crawler.py
+++ b/pex/crawler.py
@@ -95,6 +95,7 @@ class Crawler(object):
   @classmethod
   def crawl_remote(cls, context, link):
     try:
+      link = context.resolve(link)
       content = context.content(link)
     except context.Error as e:
       TRACER.log('Failed to read %s: %s' % (link.url, e), V=1)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -152,6 +152,7 @@ def test_crawler_remote():
   Crawler.reset_cache()
 
   mock_context = mock.create_autospec(Context, spec_set=True)
+  mock_context.resolve = lambda link: link
   mock_context.content.side_effect = [MOCK_INDEX_A, MOCK_INDEX_B, Exception('shouldnt get here')]
   expected_output = set([Link('http://url1.test.com/3to2-1.0.tar.gz'),
                          Link('http://url2.test.com/APScheduler-2.1.0.tar.gz')])
@@ -161,6 +162,19 @@ def test_crawler_remote():
   assert c.crawl(test_links) == expected_output
 
   # Test memoization of Crawler.crawl().
+  assert c.crawl(test_links) == expected_output
+
+
+def test_crawler_remote_redirect():
+  Crawler.reset_cache()
+
+  mock_context = mock.create_autospec(Context, spec_set=True)
+  mock_context.resolve = lambda link: Link('http://url2.test.com')
+  mock_context.content.side_effect = [MOCK_INDEX_A]
+  expected_output = set([Link('http://url2.test.com/3to2-1.0.tar.gz')])
+
+  c = Crawler(mock_context)
+  test_links = [Link('http://url1.test.com')]
   assert c.crawl(test_links) == expected_output
 
 


### PR DESCRIPTION
Lack of redirects support is notable when local PyPI server is used
with fallback to official one. For example, that's how pypiserver
implementation works.

On the PyPI pages all the package links are relative, not absolute.
What means that we cannot use original request url to construct full
package url to fetch it, we should respect the url to where we were
redirected.

Without redirects resolution we end with the urls which our pypiserver
cannot process and the HTTP 404 response obliviously will never match
the md5 package digest, so we'll fail on verification stage in anyway.

This fixes #200 #270