### PR TITLE
Fix bug in cached dependency resolution with exact resolvable

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -197,7 +197,7 @@ def configure_clp_pex_resolution(parser, builder):
       '--cache-ttl',
       dest='cache_ttl',
       type=int,
-      default=None,
+      default=3600,
       help='The cache TTL to use for inexact requirement specifications.')
 
   group.add_option(

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -239,7 +239,6 @@ class CachingResolver(Resolver):
 
   # Short-circuiting package iterator.
   def package_iterator(self, resolvable, existing=None):
-    packages = []
     iterator = Iterator(fetchers=[Fetcher([self.__cache])])
     packages = self.filter_packages_by_interpreter(
       resolvable.compatible(iterator),

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -240,20 +240,15 @@ class CachingResolver(Resolver):
   # Short-circuiting package iterator.
   def package_iterator(self, resolvable, existing=None):
     packages = []
-    if self.__cache_ttl or resolvable.exact:
-      iterator = Iterator(fetchers=[Fetcher([self.__cache])])
-      packages = self.filter_packages_by_interpreter(
-        resolvable.compatible(iterator),
-        self._interpreter,
-        self._platform
-      )
+    iterator = Iterator(fetchers=[Fetcher([self.__cache])])
+    packages = self.filter_packages_by_interpreter(
+      resolvable.compatible(iterator),
+      self._interpreter,
+      self._platform
+    )
 
-      if packages:
-        if resolvable.exact:
-          return packages
-
-        if self.__cache_ttl:
-          packages = self.filter_packages_by_ttl(packages, self.__cache_ttl)
+    if packages and self.__cache_ttl:
+      packages = self.filter_packages_by_ttl(packages, self.__cache_ttl)
 
     return itertools.chain(
       packages,

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -4,6 +4,7 @@
 import os
 
 import pytest
+import time
 from twitter.common.contextutil import temporary_dir
 
 from pex.common import safe_copy
@@ -68,6 +69,15 @@ def test_cached_dependency_pinned_unpinned_resolution_multi_run():
       # Second, run, the unbounded 'project' req will find the 1.0.0 in the cache. But should also
       # return SourcePackages found in td
       dists = resolve(['project', 'project==1.1.0'], fetchers=fetchers, cache=cd, cache_ttl=1000)
+      assert len(dists) == 1
+      assert dists[0].version == '1.1.0'
+      # Third run, if exact resolvable and inexact resolvable, and cache_ttl is expired, exact
+      # resolvable should pull from pypi as well since inexact will and the resulting
+      # resolvable_set.merge() would fail.
+      Crawler.reset_cache()
+      time.sleep(1)
+      dists = resolve(['project', 'project==1.1.0'], fetchers=fetchers, cache=cd,
+                      cache_ttl=1)
       assert len(dists) == 1
       assert dists[0].version == '1.1.0'
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+import time
 
 import pytest
-import time
 from twitter.common.contextutil import temporary_dir
 
 from pex.common import safe_copy


### PR DESCRIPTION
  * Add unit test and patch code to pass unit test

  Bug description:
  1. Exact resolvable and inexact resolvable
  2. First run completes, pushes exact resolvable into cache
  3. Second run fails with Unsatisfiable

  Reproduce:
  $ pex psutil psutil==3.2.1 -o test.pex
  $ pex psutil psutil==3.2.1 -o test.pex
  Could not satisfy all requirements for psutil:
      psutil, psutil==3.2.1

  The bug manifest itself in #178 because by default --cache-ttl is
  set to None. This doesn't change those semantics. The default is still
  None, so we simply don't return an exact resolvable found in cache
  if the --cache-ttl isn't set. Doing so also fixes another bug where
  --cache-ttl is set, there is an exact resolvable found in cache, but
  it is expired.

  It should be noted that this patch could affect the performance of
  default pex runs which specify an exact resolvable but don't set
  --cache-ttl.

@kwlzn this should fix #178 now, however, it changes the previous behavior by not returning an exact resolvable found in cache which might affect default performance. I was a little hesitant to set a default for --cache-ttl. Let me know if you think I should do that.