### PR TITLE
Pass platform for SourceTranslator

### DIFF
--- a/pex/resolver_options.py
+++ b/pex/resolver_options.py
@@ -172,7 +172,10 @@ class ResolverOptions(ResolverOptionsInterface):
         translators.append(EggTranslator(interpreter=interpreter, platform=platform))
       elif package is SourcePackage:
         installer_impl = WheelInstaller if WheelPackage in self._precedence else EggInstaller
-        translators.append(SourceTranslator(installer_impl=installer_impl, interpreter=interpreter))
+        translators.append(SourceTranslator(
+            installer_impl=installer_impl,
+            interpreter=interpreter,
+            platform=platform))
 
     return ChainedTranslator(*translators)
 


### PR DESCRIPTION
Similarly to WheelTranslator and EggTranslator, pass the platform to SourceTranslator. Without it, SourceTranslator takes the current platform.