### PR TITLE
Minimum setuptools version should be 20.3

### DIFF
--- a/pex/version.py
+++ b/pex/version.py
@@ -6,6 +6,6 @@ __version__ = '1.2.7'
 # NB: If we upgrade to setuptools>=34 pex's bootstrap code in `PEXBuilder` will need an update to
 # include the `packaging` package in the `.bootstrap/` code since we use
 # `packaging.specifiers.SpecifierSet` - indirectly - through `pkg_resources.Requirement.specifier`.
-SETUPTOOLS_REQUIREMENT = 'setuptools>=20.0,<34.0'
+SETUPTOOLS_REQUIREMENT = 'setuptools>=20.3,<34.0'
 
 WHEEL_REQUIREMENT = 'wheel>=0.26.0,<0.30.0'


### PR DESCRIPTION
In https://github.com/pantsbuild/pex/pull/355 package.py was updated to assume that the Requirement class has the specifier attribute.

The specifier attribute wasn't added to the Requirement class until setuptools 20.3 https://github.com/pypa/setuptools/commit/de4bdcffb9f11769465ba3b6bb67cfb8a5b196e2

The error when there is an older setuptools is
```
Exception message: Requirement instance has no attribute 'specifier'
```