### PR TITLE
Allow passing a preamble file to the CLI

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -356,6 +356,14 @@ def configure_clp():
            'immediately and not save it to a file.')
 
   parser.add_option(
+      '-p', '--preamble-file',
+      dest='preamble_file',
+      metavar='FILE',
+      default=None,
+      type=str,
+      help='The name of a file to be included as the preamble for the generated .pex file')
+
+  parser.add_option(
       '-r', '--requirement',
       dest='requirement_files',
       metavar='FILE',
@@ -513,8 +521,15 @@ def build_pex(args, options, resolver_option_builder):
   if not interpreters:
     die('Could not find compatible interpreter', CANNOT_SETUP_INTERPRETER)
 
+  try:
+    with open(options.preamble_file) as preamble_fd:
+      preamble = preamble_fd.read()
+  except TypeError:
+    # options.preamble_file is None
+    preamble = None
+
   interpreter = _lowest_version_interpreter(interpreters)
-  pex_builder = PEXBuilder(path=safe_mkdtemp(), interpreter=interpreter)
+  pex_builder = PEXBuilder(path=safe_mkdtemp(), interpreter=interpreter, preamble=preamble)
 
   pex_info = pex_builder.info
   pex_info.zip_safe = options.zip_safe

--- a/tests/test_pex_binary.py
+++ b/tests/test_pex_binary.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from optparse import OptionParser
 from tempfile import NamedTemporaryFile
 
-from pex.bin.pex import configure_clp, configure_clp_pex_resolution
+from pex.bin.pex import configure_clp, configure_clp_pex_resolution, build_pex
 from pex.compatibility import to_bytes
 from pex.fetcher import PyPIFetcher
 from pex.package import SourcePackage, WheelPackage
@@ -95,10 +95,12 @@ def test_clp_preamble_file():
     tmpfile.write(to_bytes('print "foo!"'))
     tmpfile.flush()
 
-    # XXX ? can we assert that the PEXBuilder actually gets the contents of the preamble file?
-    parser, builder = configure_clp()
-    options, _ = parser.parse_args(args=['--preamble-file', tmpfile.name])
+    parser, resolver_options_builder = configure_clp()
+    options, reqs = parser.parse_args(args=['--preamble-file', tmpfile.name])
     assert options.preamble_file == tmpfile.name
+
+    pex_builder = build_pex(reqs, options, resolver_options_builder)
+    assert pex_builder._preamble == to_bytes('print "foo!"')
 
 
 def test_clp_prereleases():

--- a/tests/test_pex_binary.py
+++ b/tests/test_pex_binary.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from optparse import OptionParser
 from tempfile import NamedTemporaryFile
 
-from pex.bin.pex import configure_clp, configure_clp_pex_resolution, build_pex
+from pex.bin.pex import build_pex, configure_clp, configure_clp_pex_resolution
 from pex.compatibility import to_bytes
 from pex.fetcher import PyPIFetcher
 from pex.package import SourcePackage, WheelPackage

--- a/tests/test_pex_binary.py
+++ b/tests/test_pex_binary.py
@@ -1,6 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from tempfile import NamedTemporaryFile
+
 from contextlib import contextmanager
 from optparse import OptionParser
 
@@ -86,6 +88,18 @@ def test_clp_constraints_txt():
   parser, builder = configure_clp()
   options, _ = parser.parse_args(args='--constraint requirements1.txt'.split())
   assert options.constraint_files == ['requirements1.txt']
+
+
+def test_clp_preamble_file():
+  with NamedTemporaryFile() as tmpfile:
+    tmpfile.write('print "foo!"')
+    tmpfile.flush()
+
+    parser, builder = configure_clp()
+    options, _ = parser.parse_args(args=['--preamble-file', tmpfile.name])
+    assert options.preamble_file == tmpfile.name
+
+    # XXX ? can we assert that the PEXBuilder actually gets the contents of the preamble file?
 
 
 def test_clp_prereleases():

--- a/tests/test_pex_binary.py
+++ b/tests/test_pex_binary.py
@@ -1,12 +1,12 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from tempfile import NamedTemporaryFile
-
 from contextlib import contextmanager
 from optparse import OptionParser
+from tempfile import NamedTemporaryFile
 
 from pex.bin.pex import configure_clp, configure_clp_pex_resolution
+from pex.compatibility import to_bytes
 from pex.fetcher import PyPIFetcher
 from pex.package import SourcePackage, WheelPackage
 from pex.resolver_options import ResolverOptionsBuilder
@@ -92,14 +92,13 @@ def test_clp_constraints_txt():
 
 def test_clp_preamble_file():
   with NamedTemporaryFile() as tmpfile:
-    tmpfile.write('print "foo!"')
+    tmpfile.write(to_bytes('print "foo!"'))
     tmpfile.flush()
 
+    # XXX ? can we assert that the PEXBuilder actually gets the contents of the preamble file?
     parser, builder = configure_clp()
     options, _ = parser.parse_args(args=['--preamble-file', tmpfile.name])
     assert options.preamble_file == tmpfile.name
-
-    # XXX ? can we assert that the PEXBuilder actually gets the contents of the preamble file?
 
 
 def test_clp_prereleases():

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -101,6 +101,30 @@ def test_pex_builder_shebang():
           assert fp.read(len(expected_preamble)) == expected_preamble
 
 
+def test_pex_builder_preamble():
+  with temporary_dir() as td:
+    target = os.path.join(td, 'foo.pex')
+    should_create = os.path.join(td, 'foo.1')
+
+    tempfile_preamble = "\n".join([
+      "import sys",
+      "open('{0}', 'w').close()".format(should_create),
+      "sys.exit(3)"
+    ])
+
+    pex_builder = PEXBuilder(preamble=tempfile_preamble)
+    pex_builder.build(target)
+
+    assert not os.path.exists(should_create)
+
+    pex = PEX(target)
+    process = pex.run(blocking=False)
+    process.wait()
+
+    assert process.returncode == 3
+    assert os.path.exists(should_create)
+
+
 def test_pex_builder_compilation():
   with nested(temporary_dir(), temporary_dir(), temporary_dir()) as (td1, td2, td3):
     src = os.path.join(td1, 'src.py')


### PR DESCRIPTION
This PR adds a new CLI option, `-p` or `--preamble-file`, that is used to provide a preamble to the pex builder object.

We use pex via its API in the internal build tooling at NerdWallet (👋, we're neighbors!).  We've been leveraging it for multi-platform support, but now that #394 / 1.2.9 has landed the only thing missing from the CLI that we leverage is the preamble in the builder, which was pretty easy to hook up.  Once this PR has landed we can remove all of the API integration and just rely on the `pex` CLI!

The CLI option and the PEXBuilder preamble functionality are covered by tests.

Local functional testing:

```
(pex-foo) 
evanborgstrom@evanborgstrom /tmp/preamble — u:34 j:1 (21:49:54 08.16)
#536 ❯❯❯ echo 'print "foo!"' > preamble
(pex-foo) 
evanborgstrom@evanborgstrom /tmp/preamble — u:34 j:1 (21:50:11 08.16)
#537 ❯❯❯ pex -p preamble 
foo!
Python 2.7.13 (default, Jun  7 2017, 11:02:53) 
[GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> 
(pex-foo) 
evanborgstrom@evanborgstrom /tmp/preamble — u:34 j:1 (21:50:18 08.16)
#538 ❯❯❯ pex 
Python 2.7.13 (default, Jun  7 2017, 11:02:53) 
[GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> 
```