### PR TITLE
Leverage `subprocess32` when available.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ matrix:
 
     - language: python
       python: "2.7"
+      env: TOXENV=py27-subprocess
+
+    - language: python
+      python: "2.7"
       env: TOXENV=py27-requests
 
     - language: python

--- a/pex/executor.py
+++ b/pex/executor.py
@@ -2,9 +2,21 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import errno
-import subprocess
+import os
 
-from .compatibility import string
+from .compatibility import PY2, string
+from .tracer import TRACER
+
+if os.name == 'posix' and PY2:
+  try:
+    # Use the subprocess backports if they're available for improved robustness.
+    import subprocess32 as subprocess
+  except ImportError:
+    TRACER.log('Please build pex with the subprocess32 module for more reliable requirement '
+               'installation and interpreter execution.')
+    import subprocess
+else:
+  import subprocess
 
 
 class Executor(object):

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,14 @@ setup(
     SETUPTOOLS_REQUIREMENT,
     WHEEL_REQUIREMENT,
   ],
+  extras_require={
+    # For improved subprocess robustness under python2.7.
+    'subprocess': ['subprocess32>=3.2.7'],
+    # For improved requirement resolution and fetching robustness.
+    'requests': ['requests>=2.8.14'],
+    # For improved requirement resolution and fetching performance.
+    'cachecontrol': ['CacheControl>=0.12.3'],
+  },
   tests_require = [
     'mock',
     'twitter.common.contextutil>=0.3.1,<0.4.0',

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
     cachecontrol: CacheControl
     cachecontrol: lockfile
     coverage: coverage==4.0.3
+    subprocess: subprocess32
 whitelist_externals = open
 
 [integration]
@@ -77,10 +78,10 @@ deps =
 commands =
     # meta
     tox -e py27-coverage
-    tox -e py27-requests-cachecontrol-coverage
-    tox -e py34-requests-cachecontrol-coverage
-    tox -e py34-coverage
-    tox -e pypy-requests-cachecontrol-coverage
+    tox -e py27-subprocess-requests-cachecontrol-coverage
+    tox -e py36-requests-cachecontrol-coverage
+    tox -e py36-coverage
+    tox -e pypy-subprocess-requests-cachecontrol-coverage
     python scripts/combine_coverage.py
     coverage report
     coverage html
@@ -137,6 +138,7 @@ commands = pex --cache-dir {envtmpdir}/buildcache wheel requests . -o dist/pex36
 [testenv:py27]
 [testenv:py27-requests]
 [testenv:py27-requests-cachecontrol]
+[testenv:py27-subprocess]
 [testenv:py33]
 [testenv:py33-requests]
 [testenv:py33-requests-cachecontrol]
@@ -152,3 +154,4 @@ commands = pex --cache-dir {envtmpdir}/buildcache wheel requests . -o dist/pex36
 [testenv:pypy]
 [testenv:pypy-requests]
 [testenv:pypy-requests-cachecontrol]
+[testenv:pypy-subprocess]


### PR DESCRIPTION
This allows for an upgrade in subprocess robustness when available that
Pants will leverage for one. Also formalize the pex optional
dependencies with `extras_require`, mainly for documentation purposes.