### PR TITLE
Create --pex-path argument for pex cli and load pex path into pex-info metadata 

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -609,7 +609,6 @@ def main(args=None):
   else:
     options.pex_root = ENV.PEX_ROOT  # If option not specified fallback to env variable.
 
-
   # Don't alter cache if it is disabled.
   if options.cache_dir:
     options.cache_dir = make_relative_to_root(options.cache_dir)

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -154,7 +154,7 @@ def configure_clp_pex_resolution(parser, builder):
     dest='pex_path',
     type=str,
     default=None,
-    help='Pex path for resolving pexes that should be composed into the output pex environment.')
+    help='A colon separated list of other pex files to merge into the runtime environment.')
 
   group.add_option(
       '-f', '--find-links', '--repo',

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -150,6 +150,13 @@ def configure_clp_pex_resolution(parser, builder):
       help='Whether to use pypi to resolve dependencies; Default: use pypi')
 
   group.add_option(
+    '--pex-path',
+    dest='pex_path',
+    type=str,
+    default=None,
+    help='Pex path for resolving pexes that should be composed into the output pex environment.')
+
+  group.add_option(
       '-f', '--find-links', '--repo',
       metavar='PATH/URL',
       action='callback',
@@ -533,6 +540,7 @@ def build_pex(args, options, resolver_option_builder):
 
   pex_info = pex_builder.info
   pex_info.zip_safe = options.zip_safe
+  pex_info.pex_path = options.pex_path
   pex_info.always_write_cache = options.always_write_cache
   pex_info.ignore_errors = options.ignore_errors
   pex_info.inherit_path = options.inherit_path
@@ -600,6 +608,7 @@ def main(args=None):
     ENV.set('PEX_ROOT', options.pex_root)
   else:
     options.pex_root = ENV.PEX_ROOT  # If option not specified fallback to env variable.
+
 
   # Don't alter cache if it is disabled.
   if options.cache_dir:

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -71,8 +71,13 @@ class PEX(object):  # noqa: T000
       pex_info.update(self._pex_info_overrides)
       self._envs.append(PEXEnvironment(self._pex, pex_info))
 
+      # set default value to empty string if pex path is not specified
+      #  in either the environment or with the --pex-path arg to pex cli
+      if pex_info.pex_path is None:
+        pex_info.pex_path = ''
+
       # set up other environments as specified in PEX_PATH
-      for pex_path in filter(None, self._vars.PEX_PATH.split(os.pathsep)):
+      for pex_path in filter(None, pex_info.pex_path.split(os.pathsep)):
         pex_info = PexInfo.from_pex(pex_path)
         pex_info.update(self._pex_info_overrides)
         self._envs.append(PEXEnvironment(pex_path, pex_info))

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -71,16 +71,12 @@ class PEX(object):  # noqa: T000
       pex_info.update(self._pex_info_overrides)
       self._envs.append(PEXEnvironment(self._pex, pex_info))
 
-      # set default value to empty string if pex path is not specified
-      #  in either the environment or with the --pex-path arg to pex cli
-      if pex_info.pex_path is None:
-        pex_info.pex_path = ''
-
-      # set up other environments as specified in PEX_PATH
-      for pex_path in filter(None, pex_info.pex_path.split(os.pathsep)):
-        pex_info = PexInfo.from_pex(pex_path)
-        pex_info.update(self._pex_info_overrides)
-        self._envs.append(PEXEnvironment(pex_path, pex_info))
+      if pex_info.pex_path:
+        # set up other environments as specified in PEX_PATH
+        for pex_path in filter(None, pex_info.pex_path.split(os.pathsep)):
+          pex_info = PexInfo.from_pex(pex_path)
+          pex_info.update(self._pex_info_overrides)
+          self._envs.append(PEXEnvironment(pex_path, pex_info))
 
       # activate all of them
       for env in self._envs:

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -166,6 +166,19 @@ class PexInfo(object):
     self._pex_info['zip_safe'] = bool(value)
 
   @property
+  def pex_path(self):
+    """The PEX_PATH to search in to resolve dependencies.
+
+    This is meant to replace PEX_PATH environment variable which gets scrubbed on a python
+    module re-exec and loses context for the executing environment.
+    """
+    return self._pex_info.get('pex_path')
+
+  @pex_path.setter
+  def pex_path(self, value):
+    self._pex_info['pex_path'] = value
+
+  @property
   def inherit_path(self):
     """Whether or not this PEX should be allowed to inherit system dependencies.
 

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -98,6 +98,7 @@ class PexInfo(object):
       'inherit_path': supplied_env.PEX_INHERIT_PATH,
       'ignore_errors': supplied_env.PEX_IGNORE_ERRORS,
       'always_write_cache': supplied_env.PEX_ALWAYS_CACHE,
+      'pex_path': supplied_env.PEX_PATH,
     }
     # Filter out empty entries not explicitly set in the environment.
     return cls(info=dict((k, v) for (k, v) in pex_info.items() if v is not None))

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -168,10 +168,10 @@ class PexInfo(object):
 
   @property
   def pex_path(self):
-    """The PEX_PATH to search in to resolve dependencies.
+    """A colon separated list of other pex files to merge into the runtime environment.
 
-    This is meant to replace PEX_PATH environment variable which gets scrubbed on a python
-    module re-exec and loses context for the executing environment.
+    This pex info property is used to persist the PEX_PATH environment variable into the pex info
+    metadata for reuse within a built pex.
     """
     return self._pex_info.get('pex_path')
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -194,7 +194,7 @@ def test_pex_re_exec_failure():
 
     # create 2 pex files for PEX_PATH
     pex1_path = os.path.join(output_dir, 'pex1.pex')
-    res1 = run_pex_command(['--disable-cache', 'scapy', '-o', pex1_path])
+    res1 = run_pex_command(['--disable-cache', 'requests', '-o', pex1_path])
     res1.assert_success()
     pex2_path = os.path.join(output_dir, 'pex2.pex')
     res2 = run_pex_command(['--disable-cache', 'flask', '-o', pex2_path])
@@ -205,7 +205,7 @@ def test_pex_re_exec_failure():
     test_file_path = os.path.join(output_dir, 'test.py')
     with open(test_file_path, 'w') as fh:
       fh.write(dedent('''
-        import scapy
+        import requests
         import flask
         import sys
         import os
@@ -241,7 +241,7 @@ def test_pex_path_arg():
 
     # create 2 pex files for PEX_PATH
     pex1_path = os.path.join(output_dir, 'pex1.pex')
-    res1 = run_pex_command(['--disable-cache', 'scapy', '-o', pex1_path])
+    res1 = run_pex_command(['--disable-cache', 'requests', '-o', pex1_path])
     res1.assert_success()
     pex2_path = os.path.join(output_dir, 'pex2.pex')
     res2 = run_pex_command(['--disable-cache', 'flask', '-o', pex2_path])
@@ -254,7 +254,7 @@ def test_pex_path_arg():
     test_file_path = os.path.join(output_dir, 'test.py')
     with open(test_file_path, 'w') as fh:
       fh.write(dedent('''
-        import scapy
+        import requests
         import flask
         import sys
         import os

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -233,7 +233,7 @@ def test_pex_re_exec_failure():
     stdout, rc = run_simple_pex(pex_out_path, [test_file_path], env=env)
 
     assert rc == 0
-    assert stdout == 'Hello world\n'
+    assert stdout == b'Hello world\n'
 
 
 def test_pex_path_arg():
@@ -277,4 +277,4 @@ def test_pex_path_arg():
     # run test.py with composite env
     stdout, rc = run_simple_pex(pex_out_path, [test_file_path])
     assert rc == 0
-    assert stdout == 'Success!\n'
+    assert stdout == b'Success!\n'


### PR DESCRIPTION
Problem:
Pex environments rely on the PEX_PATH environment variable to resolve modules from other pexes when composing them into a single pex. Python scripts that re-execute (like a server listening for fs changes, a Jupyter notebook)  throw an ImportError upon re-exec due to environment scrubbing that removes this PEX_PATH information. 

Solution:
Add a --pex-path argument to the pex client and plumb the data through to the pex-info metadata. Resolve pexes to compose into the current pex being built by reading from the new pex_path property of the pex-info metadata. This will ensure a self-contained environment that does not lose context on a python script re-exec. 

Relates to: https://github.com/pantsbuild/pants/issues/4682