### PR TITLE
Adds `-m` option to saved .pex file interpreter emulation

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -407,7 +407,14 @@ class PEX(object):  # noqa: T000
       return self.execute_interpreter()
 
   def execute_interpreter(self):
-    if sys.argv[1:]:
+    if len(sys.argv) < 2:
+      import code
+      code.interact()
+    elif len(sys.argv) > 2 and sys.argv[1] == '-m':
+      mod = sys.argv[2]
+      sys.argv = sys.argv[2:]
+      self.execute_module(mod)
+    else:
       try:
         with open(sys.argv[1]) as fp:
           name, content = sys.argv[1], fp.read()
@@ -415,9 +422,6 @@ class PEX(object):  # noqa: T000
         die("Could not open %s in the environment [%s]: %s" % (sys.argv[1], sys.argv[0], e))
       sys.argv = sys.argv[1:]
       self.execute_content(name, content)
-    else:
-      import code
-      code.interact()
 
   def execute_script(self, script_name):
     dists = list(self._activate())

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -125,6 +125,35 @@ def test_pex_repl_built():
     assert b'>>>' in stdout
 
 
+def test_pex_module_cli():
+  """Tests running a module in the context of the pex cli itself."""
+  with temporary_dir() as output_dir:
+    # Create a temporary pex containing just `requests` with no entrypoint.
+    pex_path = os.path.join(output_dir, 'requests.pex')
+    results = run_pex_command(['--disable-cache',
+                               'requests',
+                               '-m', 'pydoc',
+                               '-o', pex_path])
+    results.assert_success()
+
+    stdout, rc = run_simple_pex(pex_path)
+    assert rc == 0
+    assert b'pydoc - the Python documentation tool' in stdout
+
+
+def test_pex_module_built():
+  """Tests running a module in the context of a built pex."""
+  with temporary_dir() as output_dir:
+    # Create a temporary pex containing just `requests` with no entrypoint.
+    pex_path = os.path.join(output_dir, 'requests.pex')
+    results = run_pex_command(['--disable-cache', 'requests', '-o', pex_path])
+    results.assert_success()
+
+    stdout, rc = run_simple_pex(pex_path, args=['-m', 'pydoc'])
+    assert rc == 0
+    assert b'pydoc - the Python documentation tool' in stdout
+
+
 @pytest.mark.skipif(WINDOWS, reason='No symlinks on windows')
 def test_pex_python_symlink():
   with temporary_dir() as td:


### PR DESCRIPTION
This allows you to invoke a module from a saved PEX file with `app.pex -m <module>`, in addition to invoking a script with `app.pex <file>` and a REPL with `app.pex`, as could already be done previously.

This makes a saved PEX file more suitable as a basic replacement for the `python` binary on platforms that allow you to do that but that don't have good support for Python dependency management themselves, such as PySpark.