### PR TITLE
Change PEX re-exec variable from ENV to os.environ

### DIFF
--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -133,9 +133,8 @@ def maybe_reexec_pex(compatibility_constraints):
   Python interpreter to re-exec this pex with.
 
   """
-  if os.environ.get('SHOULD_EXIT_BOOTSTRAP_REEXEC'):
+  if os.environ.pop('SHOULD_EXIT_BOOTSTRAP_REEXEC', None):
     # We've already been here and selected an interpreter. Continue to execution.
-    os.environ.pop('SHOULD_EXIT_BOOTSTRAP_REEXEC', None)
     return
 
   target = None
@@ -145,7 +144,7 @@ def maybe_reexec_pex(compatibility_constraints):
       # TODO: Kill this off completely in favor of PEX_PYTHON_PATH
       # https://github.com/pantsbuild/pex/issues/431
       target = _select_pex_python_interpreter(ENV.PEX_PYTHON,
-                                                            compatibility_constraints)
+                                              compatibility_constraints)
     elif ENV.PEX_PYTHON_PATH:
       target = _select_interpreter(ENV.PEX_PYTHON_PATH, compatibility_constraints)
 

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -325,26 +325,6 @@ class Variables(object):
     """
     return self._get_bool('PEX_IGNORE_RCFILES', default=False)
 
-  @property
-  def SHOULD_EXIT_BOOTSTRAP_REEXEC(self):
-    """Boolean
-
-    Whether to re-exec in maybe_reexec_pex function of pex_bootstrapper.py. Default: false.
-    This is necessary because that function relies on checking against variables present in the
-    ENV to determine whether to re-exec or return to current execution. When we introduced
-    interpreter constraints to a pex, these constraints can influence interpreter selection without
-    the need for a PEX_PYTHON or PEX_PYTHON_PATH ENV variable set. Since re-exec previously checked
-    for PEX_PYTHON or PEX_PYTHON_PATH but not constraints, this would result in a loop with no
-    stopping criteria. Setting SHOULD_EXIT_BOOTSTRAP_REEXEC will let the runtime know to break out
-    of a second execution of maybe_reexec_pex if neither PEX_PYTHON or PEX_PYTHON_PATH are set but
-    interpreter constraints are specified.
-    """
-    return bool(self._environ.get('SHOULD_EXIT_BOOTSTRAP_REEXEC', ''))
-
-  @SHOULD_EXIT_BOOTSTRAP_REEXEC.setter
-  def SHOULD_EXIT_BOOTSTRAP_REEXEC(self, value):
-    self._environ['SHOULD_EXIT_BOOTSTRAP_REEXEC'] = str(value)
-
 
 # Global singleton environment
 ENV = Variables()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -571,8 +571,8 @@ def test_entry_point_targeting():
 
 def test_interpreter_selection_using_os_environ_for_bootstrap_reexec():
   """
-  This test is a special test meant to verify proper function of the
-  pex bootstrapper's interpreter selection logic and validate the corresponding
+  This is a test for verifying the proper function of the
+  pex bootstrapper's interpreter selection logic and validate a corresponding
   bugfix. More details on the nature of the bug can be found at:
   https://github.com/pantsbuild/pex/pull/441
   """
@@ -584,17 +584,13 @@ def test_interpreter_selection_using_os_environ_for_bootstrap_reexec():
     # execute with. The child interpreter is the interpreter we expect the 
     # child pex to execute with. 
     if (sys.version_info[0], sys.version_info[1]) == (3, 6):
-      parent_interpreter_version = '3.6.2'
+      child_pex_interpreter_version = '3.6.3'
     else:
-      parent_interpreter_version = '2.7.10'
-    if (sys.version_info[0], sys.version_info[1]) == (3, 6):
-      child_interpreter_version = '3.6.3'
-    else:
-      child_interpreter_version = '2.7.11'
+      child_pex_interpreter_version = '2.7.10'
 
     # Write parent pex's pexrc.
     with open(pexrc_path, 'w') as pexrc:
-      pexrc.write("PEX_PYTHON=%s" % ensure_python_interpreter(parent_interpreter_version))
+      pexrc.write("PEX_PYTHON=%s" % sys.executable)
 
     test_setup_path = os.path.join(td, 'setup.py')
     with open(test_setup_path, 'w') as fh:
@@ -643,7 +639,7 @@ def test_interpreter_selection_using_os_environ_for_bootstrap_reexec():
             print(stdout)
           finally:
             shutil.rmtree(td)
-        '''.format(ensure_python_interpreter(child_interpreter_version))))
+        '''.format(ensure_python_interpreter(child_pex_interpreter_version))))
 
     pex_out_path = os.path.join(td, 'parent.pex')
     res = run_pex_command(['--disable-cache',
@@ -656,6 +652,6 @@ def test_interpreter_selection_using_os_environ_for_bootstrap_reexec():
     stdout, rc = run_simple_pex(pex_out_path)
     assert rc == 0
     # Ensure that child pex used the proper interpreter as specified by its pexrc.
-    correct_interpreter_path = ensure_python_interpreter(child_interpreter_version)
+    correct_interpreter_path = ensure_python_interpreter(child_pex_interpreter_version)
     correct_interpreter_path = correct_interpreter_path.encode()  # Py 2/3 compatibility 
     assert correct_interpreter_path in stdout


### PR DESCRIPTION
Currently, if an application packaged as a pex builds and runs a product pex as part of its functionality (i.e. a Pants pex that builds and runs pexes), the interpreter selection logic in a product pex will short-circuit because the flag telling it to do so has already been set in the initial bootstrapping logic of the main app's pex. Consequently, when the main app runs a product pex as part of its functionality, the interpreter selection in accordance with a pexrc for the product pex is skipped because the environment (`os.environ`) now contains the `SHOULD_EXIT_BOOTSTRAP_REEXEC` flag set to `"True"` from the bootstrap phase of the main app's pex. 

This is because `SHOULD_EXIT_BOOTSTRAP_REEXEC` (the flag governing whether or not to re-exec) was being set in an ENV object variable, which is composed into the environment of the re-execution call `os.execve` via the `env` parameter.

The global instance of ENV is unique to each isolated Pex environment, but for this use case we need environment data that can be shared across Pex environments. This changes in this PR switch the implementation of `SHOULD_EXIT_BOOTSTRAP_REEXEC` from ENV to os.environ, where changes to this variable will be visible across different pex environments running from the same Python process.