### PR TITLE
RFC: Prepend, not append, bundled dists to sys.path

### DIFF
--- a/pex/environment.py
+++ b/pex/environment.py
@@ -132,7 +132,9 @@ class PEXEnvironment(Environment):
   def activate(self):
     if not self._activated:
       with TRACER.timed('Activating PEX virtual environment from %s' % self._pex):
+        before = sys.path[:]
         self._working_set = self._activate()
+        sys.path = sys.path[len(before):] + before
       self._activated = True
 
     return self._working_set


### PR DESCRIPTION
If you build with `--inherit-path`, right now the dependencies
explicitly bundled in the pex are put on sys.path *after* the existing
$PYTHONPATH.

This is bad, because it can lead to things you expect to be pinned (or
transitive dependencies which you expect to be pinned) to leak in from
the system with incorrect versions.

Instead, put things we explicitly bundle at fixed versions _early_ on
the $PYTHONPATH, so that the system entries are just fallbacks, rather
than overrides.

If this looks reasonable in concept, I'll clean it up a little and add an integration test.
I could also put this behind a flag if that would be preferred.