### PR TITLE
scrub path when not inheriting

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -206,7 +206,7 @@ class PEX(object):  # noqa: T000
 
     user_site_distributions.update(all_distribution_paths(USER_SITE))
 
-    if not inherit_path:
+    if inherit_path == 'false':
       scrub_paths = site_distributions | user_site_distributions
       for path in user_site_distributions:
         TRACER.log('Scrubbing from user site: %s' % path)


### PR DESCRIPTION
Since the last release `inherit_path` is a (non-empty) string and the path is therefore no longer scrubbed.

FYI, I realize it would be preferable to have a regression test for this and to run the tests prior to opening a PR, however I'm having hard time getting the tests to run behind the Chinese firewall.