### PR TITLE
Add blacklist handling for skipping requirements in pex resolver

### DIFF
--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -181,7 +181,7 @@ class Resolver(object):
         'Could not get distribution for %s on platform %s.' % (package, self._platform))
     return dist
 
-  def resolvable_is_blacklisted(self, resolvable_name):
+  def _resolvable_is_blacklisted(self, resolvable_name):
     return (
       resolvable_name in self._blacklist and
       self._interpreter.identity.matches(self._blacklist[resolvable_name])
@@ -203,7 +203,7 @@ class Resolver(object):
 
         # TODO: Remove blacklist strategy in favor of smart requirement handling
         # https://github.com/pantsbuild/pex/issues/456
-        if not self.resolvable_is_blacklisted(resolvable.name):
+        if not self._resolvable_is_blacklisted(resolvable.name):
           resolvable_set.merge(resolvable, packages, parent)
         processed_resolvables.add(resolvable)
 
@@ -347,6 +347,8 @@ def resolve(requirements,
     that universal requirement resolves for a target interpreter version do not error out on
     interpreter specific requirements such as backport libs like `functools32`.
     For example, a valid blacklist is {'functools32': 'CPython>3'}.
+    NOTE: this keyword is a temporary fix and will be reverted in favor of a long term solution
+    tracked by: https://github.com/pantsbuild/pex/issues/456
   :returns: List of :class:`pkg_resources.Distribution` instances meeting ``requirements``.
   :raises Unsatisfiable: If ``requirements`` is not transitively satisfiable.
   :raises Untranslateable: If no compatible distributions could be acquired for
@@ -442,6 +444,8 @@ def resolve_multi(requirements,
     that universal requirement resolves for a target interpreter version do not error out on
     interpreter specific requirements such as backport libs like `functools32`.
     For example, a valid blacklist is {'functools32': 'CPython>3'}.
+    NOTE: this keyword is a temporary fix and will be reverted in favor of a long term solution
+    tracked by: https://github.com/pantsbuild/pex/issues/456
   :yields: All :class:`pkg_resources.Distribution` instances meeting ``requirements``.
   :raises Unsatisfiable: If ``requirements`` is not transitively satisfiable.
   :raises Untranslateable: If no compatible distributions could be acquired for

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -362,7 +362,7 @@ def test_resolver_blacklist():
     blacklist = {'project2': '>3'}
     required_project = "project2;python_version<'3'"
 
-  project1 = make_sdist(name='project1', version='1.0.0', install_reqs=["project2;python_version<'3'"])
+  project1 = make_sdist(name='project1', version='1.0.0', install_reqs=[required_project])
   project2 = make_sdist(name='project2', version='1.1.0')
 
   with temporary_dir() as td:


### PR DESCRIPTION
## Problem
When resolving for a specific interpreter version, the pex resolver fails to resolve universal requirements that transitively require libraries with interpreter constraints that conflict with the target interpreter version (see: https://github.com/Julian/jsonschema/blob/master/setup.py#L43 ).

## Solution
The short term solution is to allow the caller of pex.resolver#resolve to supply a blacklist dict that maps package name -> interpreter constraint, enabling the resolver to skip blacklisted requirement names at resolve time if the target interpreter conforms with the interpreter constraint. The long-term solution is to be addressed by https://github.com/pantsbuild/pex/issues/456. 

## Result
It is now possible for systems that build pex files (Pants) via the pex api to blacklist certain requirements that are redundant (backports) or otherwise should not be included in the output pex.