### PR TITLE
Repair style issues in master.

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -656,14 +656,18 @@ def test_interpreter_selection_using_os_environ_for_bootstrap_reexec():
     correct_interpreter_path = correct_interpreter_path.encode()  # Py 2/3 compatibility 
     assert correct_interpreter_path in stdout
 
+
 def test_inherit_path_fallback():
   inherit_path("=fallback")
+
 
 def test_inherit_path_backwards_compatibility():
   inherit_path("")
 
+
 def test_inherit_path_prefer():
   inherit_path("=prefer")
+
 
 def inherit_path(inherit_path):
   with temporary_dir() as output_dir:

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import sys
 import time
 
 import pytest
@@ -12,7 +11,6 @@ from pex.common import safe_copy
 from pex.compatibility import PY2
 from pex.crawler import Crawler
 from pex.fetcher import Fetcher
-from pex.interpreter import PythonInterpreter
 from pex.package import EggPackage, SourcePackage
 from pex.resolvable import ResolvableRequirement
 from pex.resolver import Resolver, Unsatisfiable, _ResolvableSet, resolve, resolve_multi


### PR DESCRIPTION
before:

```
[omerta pex2 (master)]$ tox -e style
GLOB sdist-make: /Users/kwilson/dev/pex2/setup.py
style create: /Users/kwilson/dev/pex2/.tox/style
style installdeps: twitter.checkstyle
style inst: /Users/kwilson/dev/pex2/.tox/dist/pex-1.3.2.zip
style installed: gitdb==0.6.4,GitPython==0.3.2rc1,pep8==1.4.5,pex==1.3.2,pyflakes==0.7.2,smmap==0.9.0,twitter.checkstyle==0.1.0,twitter.common.app==0.3.0,twitter.common.collections==0.3.0,twitter.common.contextutil==0.3.0,twitter.common.dirutil==0.3.0,twitter.common.lang==0.3.0,twitter.common.log==0.3.0,twitter.common.options==0.3.0,twitter.common.process==0.3.0,twitter.common.string==0.3.0,twitter.common.util==0.3.0
style runtests: PYTHONHASHSEED='3976592587'
style runtests: commands[0] | twitterstyle -n ImportOrder /Users/kwilson/dev/pex2/pex /Users/kwilson/dev/pex2/tests
T302:ERROR   /Users/kwilson/dev/pex2/tests/test_integration.py:659 Expected 2 blank lines, found 1
     |def test_inherit_path_fallback():

T302:ERROR   /Users/kwilson/dev/pex2/tests/test_integration.py:662 Expected 2 blank lines, found 1
     |def test_inherit_path_backwards_compatibility():

T302:ERROR   /Users/kwilson/dev/pex2/tests/test_integration.py:665 Expected 2 blank lines, found 1
     |def test_inherit_path_prefer():

T302:ERROR   /Users/kwilson/dev/pex2/tests/test_integration.py:668 Expected 2 blank lines, found 1
     |def inherit_path(inherit_path):

F401:ERROR   /Users/kwilson/dev/pex2/tests/test_resolver.py:005 'sys' imported but unused
     |import sys

F401:ERROR   /Users/kwilson/dev/pex2/tests/test_resolver.py:015 'PythonInterpreter' imported but unused
     |from pex.interpreter import PythonInterpreter

ERROR: InvocationError: '/Users/kwilson/dev/pex2/.tox/style/bin/twitterstyle -n ImportOrder /Users/kwilson/dev/pex2/pex /Users/kwilson/dev/pex2/tests'
_______________________________________________________ summary ________________________________________________________
ERROR:   style: commands failed
```

after:

```
[omerta pex2 (kwlzn/style_fixes)]$ tox -e style
GLOB sdist-make: /Users/kwilson/dev/pex2/setup.py
style inst-nodeps: /Users/kwilson/dev/pex2/.tox/dist/pex-1.3.2.zip
style installed: gitdb==0.6.4,GitPython==0.3.2rc1,pep8==1.4.5,pex==1.3.2,pyflakes==0.7.2,smmap==0.9.0,twitter.checkstyle==0.1.0,twitter.common.app==0.3.0,twitter.common.collections==0.3.0,twitter.common.contextutil==0.3.0,twitter.common.dirutil==0.3.0,twitter.common.lang==0.3.0,twitter.common.log==0.3.0,twitter.common.options==0.3.0,twitter.common.process==0.3.0,twitter.common.string==0.3.0,twitter.common.util==0.3.0
style runtests: PYTHONHASHSEED='3671025614'
style runtests: commands[0] | twitterstyle -n ImportOrder /Users/kwilson/dev/pex2/pex /Users/kwilson/dev/pex2/tests
_______________________________________________________ summary ________________________________________________________
  style: commands succeeded
  congratulations :)
```
