### PR TITLE
Repair isort-check failure in master.

### DIFF
--- a/pex/compiler.py
+++ b/pex/compiler.py
@@ -7,7 +7,6 @@ from .compatibility import to_bytes
 from .executor import Executor
 from .util import named_temporary_file
 
-
 _COMPILER_MAIN = """
 from __future__ import print_function
 

--- a/pex/link.py
+++ b/pex/link.py
@@ -7,8 +7,9 @@ import os
 import posixpath
 from collections import Iterable
 
+from .compatibility import PY3, WINDOWS, pathname2url
 from .compatibility import string as compatible_string
-from .compatibility import PY3, WINDOWS, pathname2url, url2pathname
+from .compatibility import url2pathname
 from .util import Memoizer
 
 if PY3:

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -16,7 +16,6 @@ from .interpreter import PythonInterpreter
 from .pex_info import PexInfo
 from .util import CacheHelper, DistributionHelper
 
-
 BOOTSTRAP_ENVIRONMENT = b"""
 import os
 import sys

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -9,8 +9,8 @@ import warnings
 from collections import namedtuple
 
 from .common import open_zip
-from .compatibility import string as compatibility_string
 from .compatibility import PY2
+from .compatibility import string as compatibility_string
 from .orderedset import OrderedSet
 from .util import merge_split
 from .variables import ENV

--- a/pex/resolvable.py
+++ b/pex/resolvable.py
@@ -8,8 +8,8 @@ from abc import abstractmethod, abstractproperty
 from pkg_resources import Requirement, safe_extra
 
 from .base import maybe_requirement, requirement_is_exact
-from .compatibility import string as compatibility_string
 from .compatibility import AbstractClass
+from .compatibility import string as compatibility_string
 from .installer import InstallerBase, Packager
 from .package import Package
 from .resolver_options import ResolverOptionsBuilder, ResolverOptionsInterface

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -5,9 +5,10 @@ import zipimport
 
 import pkg_resources
 
+from pex.finders import ChainedFinder
 from pex.finders import _add_finder as add_finder
 from pex.finders import _remove_finder as remove_finder
-from pex.finders import ChainedFinder, find_eggs_in_zip, get_script_from_egg
+from pex.finders import find_eggs_in_zip, get_script_from_egg
 
 try:
   import mock

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -12,10 +12,9 @@ from pex.common import open_zip
 from pex.compatibility import WINDOWS, nested
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
-from pex.testing import write_simple_pex as write_pex
 from pex.testing import make_bdist
+from pex.testing import write_simple_pex as write_pex
 from pex.util import DistributionHelper
-
 
 exe_main = """
 import sys


### PR DESCRIPTION
```
[omerta pex2 (master)]$ tox -e isort-check
GLOB sdist-make: /Users/kwilson/dev/pex2/setup.py
isort-check create: /Users/kwilson/dev/pex2/.tox/isort-check
isort-check installdeps: isort
isort-check inst: /Users/kwilson/dev/pex2/.tox/dist/pex-1.3.2.zip
isort-check installed: futures==3.2.0,isort==4.3.4,pex==1.3.2
isort-check runtests: PYTHONHASHSEED='1082216549'
isort-check runtests: commands[0] | isort -ns __init__.py -rc -c /Users/kwilson/dev/pex2/pex /Users/kwilson/dev/pex2/tests
ERROR: /Users/kwilson/dev/pex2/pex/link.py Imports are incorrectly sorted.
ERROR: /Users/kwilson/dev/pex2/pex/pex_builder.py Imports are incorrectly sorted.
ERROR: /Users/kwilson/dev/pex2/pex/compiler.py Imports are incorrectly sorted.
ERROR: /Users/kwilson/dev/pex2/pex/pex_info.py Imports are incorrectly sorted.
ERROR: /Users/kwilson/dev/pex2/pex/resolvable.py Imports are incorrectly sorted.
ERROR: /Users/kwilson/dev/pex2/tests/test_pex_builder.py Imports are incorrectly sorted.
ERROR: /Users/kwilson/dev/pex2/tests/test_finders.py Imports are incorrectly sorted.
ERROR: InvocationError: '/Users/kwilson/dev/pex2/.tox/isort-check/bin/isort -ns __init__.py -rc -c /Users/kwilson/dev/pex2/pex /Users/kwilson/dev/pex2/tests'
_______________________________________________________________ summary ________________________________________________________________
ERROR:   isort-check: commands failed
```

```
[omerta pex2 (kwlzn/isort_repair)]$ tox -e isort-run
GLOB sdist-make: /Users/kwilson/dev/pex2/setup.py
isort-run create: /Users/kwilson/dev/pex2/.tox/isort-run
isort-run installdeps: isort
isort-run inst: /Users/kwilson/dev/pex2/.tox/dist/pex-1.3.2.zip
isort-run installed: futures==3.2.0,isort==4.3.4,pex==1.3.2
isort-run runtests: PYTHONHASHSEED='3102512657'
isort-run runtests: commands[0] | isort -ns __init__.py -rc /Users/kwilson/dev/pex2/pex /Users/kwilson/dev/pex2/tests
Fixing /Users/kwilson/dev/pex2/pex/link.py
Fixing /Users/kwilson/dev/pex2/pex/pex_builder.py
Fixing /Users/kwilson/dev/pex2/pex/compiler.py
Fixing /Users/kwilson/dev/pex2/pex/pex_info.py
Fixing /Users/kwilson/dev/pex2/pex/resolvable.py
Fixing /Users/kwilson/dev/pex2/tests/test_pex_builder.py
Fixing /Users/kwilson/dev/pex2/tests/test_finders.py
Skipped 3 files
_______________________________________________________________ summary ________________________________________________________________
  isort-run: commands succeeded
  congratulations :)
```