### PR TITLE
Use pytest instead of py.test per upstream recommendation, #dropthedot

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-coverage run -p -m py.test tests
+coverage run -p -m pytest tests
 coverage run -p -m pex.bin.pex -v --help >&/dev/null
 coverage run -p -m pex.bin.pex -v -- scripts/do_nothing.py
 coverage run -p -m pex.bin.pex -v requests -- scripts/do_nothing.py

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
 
 [testenv]
 commands =
-    py.test {posargs:-vvsx}
+    pytest {posargs:-vvsx}
     # Ensure pex's main entrypoint can be run externally.
     pex --cache-dir {envtmpdir}/buildcache wheel requests . -e pex.bin.pex:main --version
 deps =
@@ -65,7 +65,7 @@ commands = {[integration]commands}
 basepython = python2.7
 commands =
     coverage erase
-    coverage run -p -m py.test {posargs:}
+    coverage run -p -m pytest {posargs:}
     coverage combine
     coverage report
     coverage html


### PR DESCRIPTION
http://blog.pytest.org/2016/whats-new-in-pytest-30/
https://twitter.com/hashtag/dropthedot