### PR TITLE
Complete manylinux support in pex.

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -36,6 +36,13 @@ pex.finders module
     :members:
     :show-inheritance:
 
+pex.glibc module
+----------------
+
+.. automodule:: pex.glibc
+    :members:
+    :show-inheritance:
+
 pex.http module
 --------------------
 
@@ -103,6 +110,13 @@ pex.pex_info module
 -------------------
 
 .. automodule:: pex.pex_info
+    :members:
+    :show-inheritance:
+
+pex.platforms module
+--------------------
+
+.. automodule:: pex.platforms
     :members:
     :show-inheritance:
 

--- a/docs/buildingpex.rst
+++ b/docs/buildingpex.rst
@@ -376,11 +376,11 @@ in certain situations when particular extensions may not be necessary to run a p
 The platform to build the pex for. Right now it defaults to the current system, but you can specify
 something like ``linux-x86_64`` or ``macosx-10.6-x86_64``. This will look for bdists for the particular platform.
 
-To build manylinux wheels for specific tags, you can add them to the platform with hyphens like
-``PLATFORM-PYVER-IMPL-ABI``, where ``PLATFORM`` is either ``manylinux1-x86_64`` or ``manylinux1-i686``, ``PYVER``
-is a two-digit string representing the python version (e.g., ``36``), ``IMPL`` is the python implementation
-abbreviation (e.g., ``cp``, ``pp``, ``jp``), and ``ABI`` is the ABI tag (e.g., ``cp36m``, ``cp27mu``, ``abi3``,
-``none``). A complete example: ``manylinux1_x86_64-36-cp-cp36m``.
+To resolve wheels for specific interpreter/platform tags, you can append them to the platform name with hyphens
+like ``PLATFORM-IMPL-PYVER-ABI``, where ``PLATFORM`` is the platform (e.g. ``linux-x86_64``,
+``macosx-10.4-x86_64``), ``IMPL`` is the python implementation abbreviation (e.g. ``cp``, ``pp``, ``jp``), ``PYVER``
+is a two-digit string representing the python version (e.g., ``36``) and ``ABI`` is the ABI tag (e.g., ``cp36m``,
+``cp27mu``, ``abi3``, ``none``). A complete example: ``linux_x86_64-cp-36-cp36m``.
 
 Tailoring PEX execution at runtime
 ----------------------------------

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -346,12 +346,12 @@ def configure_clp_pex_environment(parser):
       action='append',
       help='The platform for which to build the PEX. This option can be passed multiple times '
            'to create a multi-platform pex. To use wheels for specific interpreter/platform tags'
-           'platform tags, you can append them to the platform with hyphens like: '
-           'PLATFORM-IMPL-PYVER-ABI (e.g. "linux_x86_64-cp-27-cp27mu", "macosx_10.12_x86_64-cp-36'
-           '-cp36m") PLATFORM is the host platform e.g. "linux-x86_64", "macosx-10.12-x86_64", etc'
-           '". IMPL is the python implementation abbreviation (e.g. "cp", "pp", "jp"). PYVER is '
-           'a two-digit string representing the python version (e.g. "27", "36"). ABI is the ABI '
-           'tag (e.g. "cp36m", "cp27mu", "abi3", "none"). Default: current platform.')
+           ', you can append them to the platform with hyphens like: PLATFORM-IMPL-PYVER-ABI '
+           '(e.g. "linux_x86_64-cp-27-cp27mu", "macosx_10.12_x86_64-cp-36-cp36m") PLATFORM is '
+           'the host platform e.g. "linux-x86_64", "macosx-10.12-x86_64", etc". IMPL is the '
+           'python implementation abbreviation (e.g. "cp", "pp", "jp"). PYVER is a two-digit '
+           'string representing the python version (e.g. "27", "36"). ABI is the ABI tag '
+           '(e.g. "cp36m", "cp27mu", "abi3", "none"). Default: current platform.')
 
   group.add_option(
       '--interpreter-cache-dir',
@@ -702,7 +702,7 @@ def main(args=None):
       return 0
 
     if not _compatible_with_current_platform(options.platforms):
-      log('WARNING: attempting to run PEX with incompatible platforms!', v=1)
+      log('WARNING: attempting to run PEX with incompatible platforms!')
 
     pex_builder.freeze()
 

--- a/pex/finders.py
+++ b/pex/finders.py
@@ -102,6 +102,7 @@ class WheelMetadata(pkg_resources.EggMetadata):
   @classmethod
   def _split_wheelname(cls, wheelname):
     split_wheelname = wheelname.rsplit('-', 4)
+    assert len(split_wheelname) == 5, 'invalid wheel name: %s' % (wheelname)
     split_wheelname[0] = split_wheelname[0].replace('-', '_')
     return '-'.join(split_wheelname[:-3])
 

--- a/pex/package.py
+++ b/pex/package.py
@@ -170,6 +170,8 @@ class EggPackage(Package):
     elif self.py_version == '3.2':
       self._supported_tags.add(('pp321', abi_tag, tag_platform))
     elif self.py_version == '3.3':
+      # N.B. PyPy 3.3 maps to `pp352` because of PyPy versioning.
+      # see e.g. http://doc.pypy.org/en/latest/release-pypy3.3-v5.2-alpha1.html
       self._supported_tags.add(('pp352', abi_tag, tag_platform))
     elif self.py_version == '3.5':
       self._supported_tags.add(('pp357', abi_tag, tag_platform))

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -1,0 +1,80 @@
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from collections import namedtuple
+
+from .pep425tags import get_abbr_impl, get_abi_tag, get_impl_ver, get_platform, get_supported
+
+
+class Platform(namedtuple('Platform', ['platform', 'impl', 'version', 'abi'])):
+  """Represents a target platform and it's extended interpreter compatibility
+  tags (e.g. implementation, version and ABI)."""
+
+  SEP = '-'
+
+  def __new__(cls, platform, impl=None, version=None, abi=None):
+    platform = platform.replace('-', '_').replace('.', '_')
+    if all((impl, version, abi)):
+      abi = cls._maybe_prefix_abi(impl, version, abi)
+    return super(cls, Platform).__new__(cls, platform, impl, version, abi)
+
+  def __str__(self):
+    return self.SEP.join(self) if all(self) else self.platform
+
+  @classmethod
+  def current(cls):
+    platform = get_platform()
+    impl = get_abbr_impl()
+    version = get_impl_ver()
+    abi = get_abi_tag()
+    return cls(platform, impl, version, abi)
+
+  @classmethod
+  def create(cls, platform):
+    if isinstance(platform, Platform):
+      return platform
+
+    platform = platform.lower()
+    if platform == 'current':
+      return cls.current()
+
+    try:
+      platform, impl, version, abi = platform.rsplit(cls.SEP, 3)
+    except ValueError:
+      return cls(platform)
+    else:
+      return cls(platform, impl, version, abi)
+
+  @staticmethod
+  def _maybe_prefix_abi(impl, version, abi):
+    # N.B. This permits users to pass in simpler extended platform strings like
+    # `linux-x86_64-cp-27-mu` vs e.g. `linux-x86_64-cp-27-cp27mu`.
+    impl_ver = ''.join((impl, version))
+    return abi if abi.startswith(impl_ver) else ''.join((impl_ver, abi))
+
+  @property
+  def is_extended(self):
+    return all(attr is not None for attr in (self.impl, self.version, self.abi))
+
+  def supported_tags(self, interpreter=None, force_manylinux=True):
+    """Returns a list of supported PEP425 tags for the current platform."""
+    if interpreter and not self.is_extended:
+      tags = get_supported(
+        platform=self.platform,
+        impl=interpreter.identity.abbr_impl,
+        version=interpreter.identity.impl_ver,
+        abi=interpreter.identity.abi_tag,
+        force_manylinux=force_manylinux
+      )
+    else:
+      tags = get_supported(
+        platform=self.platform,
+        impl=self.impl,
+        version=self.version,
+        abi=self.abi,
+        force_manylinux=force_manylinux
+      )
+
+    return tags

--- a/pex/resolver_options.py
+++ b/pex/resolver_options.py
@@ -17,19 +17,19 @@ from .translator import ChainedTranslator, EggTranslator, SourceTranslator, Whee
 
 class ResolverOptionsInterface(object):
   def get_context(self):
-    raise NotImplemented
+    raise NotImplementedError
 
   def get_crawler(self):
-    raise NotImplemented
+    raise NotImplementedError
 
   def get_sorter(self):
-    raise NotImplemented
+    raise NotImplementedError
 
   def get_translator(self, interpreter, supported_tags):
-    raise NotImplemented
+    raise NotImplementedError
 
   def get_iterator(self):
-    raise NotImplemented
+    raise NotImplementedError
 
 
 class ResolverOptionsBuilder(object):
@@ -44,6 +44,7 @@ class ResolverOptionsBuilder(object):
                allow_external=None,
                allow_unverified=None,
                allow_prereleases=None,
+               use_manylinux=None,
                precedence=None,
                context=None):
     self._fetchers = fetchers if fetchers is not None else [PyPIFetcher()]
@@ -53,6 +54,7 @@ class ResolverOptionsBuilder(object):
     self._allow_prereleases = allow_prereleases
     self._precedence = precedence if precedence is not None else Sorter.DEFAULT_PACKAGE_PRECEDENCE
     self._context = context or Context.get()
+    self._use_manylinux = use_manylinux
 
   def clone(self):
     return ResolverOptionsBuilder(
@@ -61,6 +63,7 @@ class ResolverOptionsBuilder(object):
         allow_external=self._allow_external.copy(),
         allow_unverified=self._allow_unverified.copy(),
         allow_prereleases=self._allow_prereleases,
+        use_manylinux=self._use_manylinux,
         precedence=self._precedence[:],
         context=self._context,
     )
@@ -105,6 +108,14 @@ class ResolverOptionsBuilder(object):
   def no_use_wheel(self):
     self._precedence = tuple(
         [precedent for precedent in self._precedence if precedent is not WheelPackage])
+    return self
+
+  def use_manylinux(self):
+    self._use_manylinux = True
+    return self
+
+  def no_use_manylinux(self):
+    self._use_manylinux = False
     return self
 
   def allow_builds(self):
@@ -152,6 +163,7 @@ class ResolverOptionsBuilder(object):
         allow_external=self._allow_all_external or key in self._allow_external,
         allow_unverified=key in self._allow_unverified,
         allow_prereleases=self._allow_prereleases,
+        use_manylinux=self._use_manylinux,
         precedence=self._precedence,
         context=self._context,
     )
@@ -163,12 +175,14 @@ class ResolverOptions(ResolverOptionsInterface):
                allow_external=False,
                allow_unverified=False,
                allow_prereleases=None,
+               use_manylinux=None,
                precedence=None,
                context=None):
     self._fetchers = fetchers if fetchers is not None else [PyPIFetcher()]
     self._allow_external = allow_external
     self._allow_unverified = allow_unverified
     self._allow_prereleases = allow_prereleases
+    self._use_manylinux = use_manylinux
     self._precedence = precedence if precedence is not None else Sorter.DEFAULT_PACKAGE_PRECEDENCE
     self._context = context or Context.get()
 

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 from pex import interpreter
+from pex.testing import IS_PYPY, ensure_python_interpreter
 
 try:
   from mock import patch
@@ -21,3 +22,11 @@ class TestPythonInterpreter(object):
     with patch.dict(os.environ, clear=True):
       reload(interpreter)
       interpreter.PythonInterpreter.all()
+
+  @pytest.mark.skipif(IS_PYPY)
+  def test_interpreter_versioning(self):
+    test_version_tuple = (2, 7, 10)
+    test_version = '.'.join(str(x) for x in test_version_tuple)
+    test_interpreter = ensure_python_interpreter(test_version)
+    py_interpreter = interpreter.PythonInterpreter.from_binary(test_interpreter)
+    assert py_interpreter.identity.version == test_version_tuple

--- a/tests/test_pep425tags.py
+++ b/tests/test_pep425tags.py
@@ -1,0 +1,168 @@
+# This file was forked from the pip project master branch on 2016/12/05
+
+import sys
+
+from pex import pep425tags
+
+try:
+  from mock import patch
+except ImportError:
+  from unittest.mock import patch
+
+
+class TestPEP425Tags(object):
+
+  def mock_get_config_var(self, **kwd):
+    """
+    Patch sysconfig.get_config_var for arbitrary keys.
+    """
+    import pex.pep425tags
+
+    get_config_var = pex.pep425tags.sysconfig.get_config_var
+
+    def _mock_get_config_var(var):
+      if var in kwd:
+        return kwd[var]
+      return get_config_var(var)
+    return _mock_get_config_var
+
+  def abi_tag_unicode(self, flags, config_vars):
+    """
+    Used to test ABI tags, verify correct use of the `u` flag
+    """
+    import pex.pep425tags
+
+    config_vars.update({'SOABI': None})
+    base = pex.pep425tags.get_abbr_impl() + pex.pep425tags.get_impl_ver()
+
+    if sys.version_info < (3, 3):
+      config_vars.update({'Py_UNICODE_SIZE': 2})
+      mock_gcf = self.mock_get_config_var(**config_vars)
+      with patch('pex.pep425tags.sysconfig.get_config_var', mock_gcf):
+        abi_tag = pex.pep425tags.get_abi_tag()
+        assert abi_tag == base + flags
+
+      config_vars.update({'Py_UNICODE_SIZE': 4})
+      mock_gcf = self.mock_get_config_var(**config_vars)
+      with patch('pex.pep425tags.sysconfig.get_config_var', mock_gcf):
+        abi_tag = pex.pep425tags.get_abi_tag()
+        assert abi_tag == base + flags + 'u'
+
+    else:
+      # On Python >= 3.3, UCS-4 is essentially permanently enabled, and
+      # Py_UNICODE_SIZE is None. SOABI on these builds does not include
+      # the 'u' so manual SOABI detection should not do so either.
+      config_vars.update({'Py_UNICODE_SIZE': None})
+      mock_gcf = self.mock_get_config_var(**config_vars)
+      with patch('pex.pep425tags.sysconfig.get_config_var', mock_gcf):
+        abi_tag = pex.pep425tags.get_abi_tag()
+        assert abi_tag == base + flags
+
+  def test_broken_sysconfig(self):
+    """
+    Test that pep425tags still works when sysconfig is broken.
+    Can be a problem on Python 2.7
+    Issue #1074.
+    """
+    import pex.pep425tags
+
+    def raises_ioerror(var):
+      raise IOError("I have the wrong path!")
+
+    with patch('pex.pep425tags.sysconfig.get_config_var', raises_ioerror):
+      assert len(pex.pep425tags.get_supported())
+
+  def test_no_hyphen_tag(self):
+    """
+    Test that no tag contains a hyphen.
+    """
+    import pex.pep425tags
+
+    mock_gcf = self.mock_get_config_var(SOABI='cpython-35m-darwin')
+
+    with patch('pex.pep425tags.sysconfig.get_config_var', mock_gcf):
+      supported = pex.pep425tags.get_supported()
+
+    for (py, abi, plat) in supported:
+      assert '-' not in py
+      assert '-' not in abi
+      assert '-' not in plat
+
+  def test_manual_abi_noflags(self):
+    """
+    Test that no flags are set on a non-PyDebug, non-Pymalloc ABI tag.
+    """
+    self.abi_tag_unicode('', {'Py_DEBUG': False, 'WITH_PYMALLOC': False})
+
+  def test_manual_abi_d_flag(self):
+    """
+    Test that the `d` flag is set on a PyDebug, non-Pymalloc ABI tag.
+    """
+    self.abi_tag_unicode('d', {'Py_DEBUG': True, 'WITH_PYMALLOC': False})
+
+  def test_manual_abi_m_flag(self):
+    """
+    Test that the `m` flag is set on a non-PyDebug, Pymalloc ABI tag.
+    """
+    self.abi_tag_unicode('m', {'Py_DEBUG': False, 'WITH_PYMALLOC': True})
+
+  def test_manual_abi_dm_flags(self):
+    """
+    Test that the `dm` flags are set on a PyDebug, Pymalloc ABI tag.
+    """
+    self.abi_tag_unicode('dm', {'Py_DEBUG': True, 'WITH_PYMALLOC': True})
+
+
+class TestManylinux1Tags(object):
+
+  @patch('pex.pep425tags.get_platform', lambda: 'linux_x86_64')
+  @patch('pex.pep425tags.have_compatible_glibc', lambda major, minor: True)
+  def test_manylinux1_compatible_on_linux_x86_64(self):
+    """
+    Test that manylinux1 is enabled on linux_x86_64
+    """
+    assert pep425tags.is_manylinux1_compatible()
+
+  @patch('pex.pep425tags.get_platform', lambda: 'linux_i686')
+  @patch('pex.pep425tags.have_compatible_glibc', lambda major, minor: True)
+  def test_manylinux1_compatible_on_linux_i686(self):
+    """
+    Test that manylinux1 is enabled on linux_i686
+    """
+    assert pep425tags.is_manylinux1_compatible()
+
+  @patch('pex.pep425tags.get_platform', lambda: 'linux_x86_64')
+  @patch('pex.pep425tags.have_compatible_glibc', lambda major, minor: False)
+  def test_manylinux1_2(self):
+    """
+    Test that manylinux1 is disabled with incompatible glibc
+    """
+    assert not pep425tags.is_manylinux1_compatible()
+
+  @patch('pex.pep425tags.get_platform', lambda: 'arm6vl')
+  @patch('pex.pep425tags.have_compatible_glibc', lambda major, minor: True)
+  def test_manylinux1_3(self):
+    """
+    Test that manylinux1 is disabled on arm6vl
+    """
+    assert not pep425tags.is_manylinux1_compatible()
+
+  @patch('pex.pep425tags.get_platform', lambda: 'linux_x86_64')
+  @patch('pex.pep425tags.have_compatible_glibc', lambda major, minor: True)
+  @patch('sys.platform', 'linux2')
+  def test_manylinux1_tag_is_first(self):
+    """
+    Test that the more specific tag manylinux1 comes first.
+    """
+    groups = {}
+    for pyimpl, abi, arch in pep425tags.get_supported():
+      groups.setdefault((pyimpl, abi), []).append(arch)
+
+    for arches in groups.values():
+      if arches == ['any']:
+        continue
+      # Expect the most specific arch first:
+      if len(arches) == 3:
+        assert arches == ['manylinux1_x86_64', 'linux_x86_64', 'any']
+      else:
+        assert arches == ['manylinux1_x86_64', 'linux_x86_64']

--- a/tests/test_pex_binary.py
+++ b/tests/test_pex_binary.py
@@ -160,6 +160,7 @@ def test_clp_prereleases_resolver():
                    allow_external=None,
                    allow_unverified=None,
                    allow_prereleases=None,
+                   use_manylinux=None,
                    precedence=None,
                    context=None
                    ):
@@ -168,6 +169,7 @@ def test_clp_prereleases_resolver():
                                                  allow_external=allow_external,
                                                  allow_unverified=allow_unverified,
                                                  allow_prereleases=allow_prereleases,
+                                                 use_manylinux=None,
                                                  precedence=precedence,
                                                  context=context)
         self._fetchers.insert(0, fetcher)

--- a/tests/test_pex_bootstrapper.py
+++ b/tests/test_pex_bootstrapper.py
@@ -9,7 +9,7 @@ from twitter.common.contextutil import temporary_dir
 from pex.common import open_zip
 from pex.interpreter import PythonInterpreter
 from pex.pex_bootstrapper import find_compatible_interpreters, get_pex_info
-from pex.testing import PYPY, ensure_python_interpreter, write_simple_pex
+from pex.testing import IS_PYPY, ensure_python_interpreter, write_simple_pex
 
 
 def test_get_pex_info():
@@ -32,7 +32,7 @@ def test_get_pex_info():
       assert pex_info.dump() == pex_info_2.dump()
 
 
-@pytest.mark.skipif(PYPY)
+@pytest.mark.skipif(IS_PYPY)
 def test_find_compatible_interpreters():
   pex_python_path = ':'.join([
     ensure_python_interpreter('2.7.9'),

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1,0 +1,86 @@
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import sys
+
+import pytest
+
+from pex.pep425tags import get_abi_tag, get_impl_tag
+from pex.platforms import Platform
+
+EXPECTED_BASE = [('py27', 'none', 'any'), ('py2', 'none', 'any')]
+
+
+def test_platform():
+  assert Platform('linux-x86_64', 'cp', '27', 'mu') == ('linux_x86_64', 'cp', '27', 'cp27mu')
+  assert str(
+    Platform('linux-x86_64', 'cp', '27', 'm')
+  ) == 'linux_x86_64-cp-27-cp27m'
+  assert str(Platform('linux-x86_64')) == 'linux_x86_64'
+
+
+def test_platform_create():
+  assert Platform.create('linux-x86_64') == ('linux_x86_64', None, None, None)
+  assert Platform.create('linux-x86_64-cp-27-cp27mu') == ('linux_x86_64', 'cp', '27', 'cp27mu')
+  assert Platform.create('linux-x86_64-cp-27-mu') == ('linux_x86_64', 'cp', '27', 'cp27mu')
+  assert Platform.create(
+    'macosx-10.4-x86_64-cp-27-m') == ('macosx_10_4_x86_64', 'cp', '27', 'cp27m')
+
+
+def test_platform_create_noop():
+  existing = Platform.create('linux-x86_64')
+  assert Platform.create(existing) == existing
+
+
+def test_platform_current():
+  assert Platform.create('current') == Platform.current()
+
+
+def assert_tags(platform, expected_tags, manylinux=None):
+  tags = Platform.create(platform).supported_tags(force_manylinux=manylinux)
+  for expected_tag in expected_tags:
+    assert expected_tag in tags
+
+
+def test_platform_supported_tags_linux():
+  assert_tags(
+    'linux-x86_64-cp-27-mu',
+    EXPECTED_BASE + [('cp27', 'cp27mu', 'linux_x86_64')]
+  )
+
+
+def test_platform_supported_tags_manylinux():
+  assert_tags(
+    'linux-x86_64-cp-27-mu',
+    EXPECTED_BASE + [('cp27', 'cp27mu', 'manylinux1_x86_64')],
+    True
+  )
+
+
+@pytest.mark.skipif("(sys.version_info[0], sys.version_info[1]) == (2, 6)")
+def test_platform_supported_tags_osx_minimal():
+  assert_tags(
+    'macosx-10.4-x86_64',
+    [
+      (get_impl_tag(), 'none', 'any'),
+      ('py%s' % sys.version_info[0], 'none', 'any'),
+      (get_impl_tag(), get_abi_tag(), 'macosx_10_4_x86_64')
+    ]
+  )
+
+
+def test_platform_supported_tags_osx_full():
+  assert_tags(
+    'macosx-10.12-x86_64-cp-27-m',
+    EXPECTED_BASE + [
+      ('cp27', 'cp27m', 'macosx_10_4_x86_64'),
+      ('cp27', 'cp27m', 'macosx_10_5_x86_64'),
+      ('cp27', 'cp27m', 'macosx_10_6_x86_64'),
+      ('cp27', 'cp27m', 'macosx_10_7_x86_64'),
+      ('cp27', 'cp27m', 'macosx_10_8_x86_64'),
+      ('cp27', 'cp27m', 'macosx_10_9_x86_64'),
+      ('cp27', 'cp27m', 'macosx_10_10_x86_64'),
+      ('cp27', 'cp27m', 'macosx_10_11_x86_64'),
+      ('cp27', 'cp27m', 'macosx_10_12_x86_64'),
+    ]
+  )

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
 
 [testenv]
 commands =
-    py.test {posargs:-vvsx}
+    py.test {posargs:-vvs}
     # Ensure pex's main entrypoint can be run externally.
     pex --cache-dir {envtmpdir}/buildcache wheel requests . -e pex.bin.pex:main --version
 deps =


### PR DESCRIPTION
This PR includes two parts:

  1) a squash merge of #316 that implements partial manylinux support and ABI targeting.
  2) a squash merge of a fast-follow retrofit of #399 that completes manylinux support and ABI targeting, fixes all broken tests, adds tests and corrects a few breaking issues.

_N.B. #316 has already been reviewed, so feel free to review only the second commit in the "Commits" view._

The second part of this change provides the following:

  - Puts manylinux support behind a feature flag for operational purposes (with implicit support for manylinux in any linux platform targeting).
  - Carries forward the `Platform` abstraction w/ the notion of the new extended form and adds test coverage.
  - Removes manual `Resolver._identity` construction in favor of `PythonInterpreter.identity` usage.
  - Realigns the extended Platform form to (platform, impl, version, abi) and updates docs.
  - Fixes breakage of `--platform` + `--interpreter` CLI modes and adds test coverage.
  - Fixes breakage of platform incompatibility warnings and adds test coverage.
  - Fixes interpreter version identification breakage in `PlatformIdentity` and adds test coverage.
  - Fixes breakage of runtime resolution for mixed linux + manylinux inner dists and adds test coverage.
  - Pushes `getsource()` calls into a function call.
  - Adds (forked from upstream) test coverage for the fork of `pep425tags.py`.
  - Adds integration test coverage for ABI targeting and other cases.
  - Adds better debug logging for diagnosing resolve failures.
  - Cleans up some terminology and misc style.

Once this change is approved, the plan is to:

  1) land #316 independently.
  2) rebase this PR to only include the second squash merged commit and land that immediately after.
  3) cut pex 1.4.0
