### PR TITLE
Eliminate the python3.3 shard.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,6 @@ matrix:
       env: TOXENV=py27-requests-cachecontrol
 
     - language: python
-      python: "3.3"
-      env: TOXENV=py33
-
-    - language: python
       python: "3.4"
       env: TOXENV=py34
 


### PR DESCRIPTION
This eliminates testing for python3.3, based on these deprecation warnings and issues seen in https://travis-ci.org/pantsbuild/pex/jobs/380524527#L504 :

```
Installing setuptools, pip, wheel...
  Complete output from command /home/travis/build/p....tox/py33/bin/python - setuptools pip wheel:
  DEPRECATION: Python 3.3 supported has been deprecated and support for it will be dropped in the future. Please upgrade your Python.
...
Collecting wheel
wheel requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*' but the running Python is 3.3.6
```