### PR TITLE
Update RELEASE.rst pip usage for cache avoidance

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -51,7 +51,7 @@ Dogfood
 
 ::
 
-    $ pip install --upgrade pex
+    $ pip install --no-cache-dir --upgrade pex
     ...
     $ pex --version
     pex 1.1.1


### PR DESCRIPTION
This is more aggressively cached by pip as of the new warehouse backend for PyPI.