### PR TITLE
Isolate integration tests onto their own shard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,10 +62,7 @@ matrix:
       env: TOXENV=pypy
 
     - language: python
-      python:
-        - "pypy"
-        - "2.7"
-        - "3.6"
+      python: "pypy"
       env: TOXENV=integration-tests
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,9 @@ matrix:
 
     - language: python
       python:
+        - "pypy"
         - "2.7"
         - "3.6"
-        - "pypy"
       env: TOXENV=integration-tests
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,11 +62,16 @@ matrix:
       env: TOXENV=pypy
 
     - language: python
-      python:
-        - "pypy"
-        - 2.7
-        - 3.6
-      env: TOXENV=integration-tests
+      python: "pypy"
+      env: TOXENV=pypy-integration
+
+    - language: python
+      python: "2.7"
+      env: TOXENV=py27-integration
+
+    - language: python
+      python: "3.6"
+      env: TOXENV=py36-integration
 
 install:
   - pip install -U tox "setuptools<34"

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,16 +62,16 @@ matrix:
       env: TOXENV=pypy
 
     - language: python
-      python: "pypy"
-      env: TOXENV=pypy-integration
-
-    - language: python
       python: "2.7"
       env: TOXENV=py27-integration
 
     - language: python
       python: "3.6"
       env: TOXENV=py36-integration
+
+    - language: python
+      python: "pypy"
+      env: TOXENV=pypy-integration
 
 install:
   - pip install -U tox "setuptools<34"

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,9 @@ matrix:
 
     - language: python
       python:
-        - "pypy"
         - "2.7"
         - "3.6"
+        - "pypy"
       env: TOXENV=integration-tests
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,13 @@ matrix:
       python: "pypy"
       env: TOXENV=pypy
 
+    - language: python
+      python:
+        - "pypy"
+        - "2.7"
+        - "3.6"
+      env: TOXENV=integration-tests
+
 install:
   - pip install -U tox "setuptools<34"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,9 @@ matrix:
 
     - language: python
       python:
-        - "pypy2.7"
-        - "2.7"
-        - "3.6"
+        - "pypy"
+        - 2.7
+        - 3.6
       env: TOXENV=integration-tests
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,10 @@ matrix:
       env: TOXENV=pypy
 
     - language: python
-      python: "pypy"
+      python:
+        - "pypy2.7"
+        - "2.7"
+        - "3.6"
       env: TOXENV=integration-tests
 
 install:

--- a/tests/test_bdist_pex.py
+++ b/tests/test_bdist_pex.py
@@ -19,7 +19,7 @@ def assert_entry_points(entry_points):
         name='my_app',
         version='0.0.0',
         zip_safe=True,
-        packages=[],
+        packages=[''],
         entry_points=%(entry_points)r,
       )
     """ % dict(entry_points=entry_points))
@@ -48,7 +48,7 @@ def assert_pex_args_shebang(shebang):
         name='my_app',
         version='0.0.0',
         zip_safe=True,
-        packages=[],
+        packages=[''],
       )
     """)
 

--- a/tests/test_bdist_pex.py
+++ b/tests/test_bdist_pex.py
@@ -19,7 +19,7 @@ def assert_entry_points(entry_points):
         name='my_app',
         version='0.0.0',
         zip_safe=True,
-        packages=[''],
+        packages=[],
         entry_points=%(entry_points)r,
       )
     """ % dict(entry_points=entry_points))
@@ -48,7 +48,7 @@ def assert_pex_args_shebang(shebang):
         name='my_app',
         version='0.0.0',
         zip_safe=True,
-        packages=[''],
+        packages=[],
       )
     """)
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ whitelist_externals = open
 deps =
     tox
 commands =
-    #tox -e pypy-requests -- -k "tests/test_integration.py" {posargs:-vvs}
+    tox -e pypy-requests -- -k "tests/test_integration.py" {posargs:-vvs}
     tox -e py27-requests -- -k "tests/test_integration.py" {posargs:-vvs}
     tox -e py36-requests -- -k "tests/test_integration.py" {posargs:-vvs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,9 +34,9 @@ whitelist_externals = open
 deps =
     tox
 commands =
-    tox -e pypy-integration
     tox -e py27-integration
     tox -e py36-integration
+    tox -e pypy-integration
 
 [testenv:pypy-integration]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -34,9 +34,9 @@ whitelist_externals = open
 deps =
     tox
 commands =
-    tox -e pypy-requests -- -k "tests/test_integration.py" {posargs:-vvs}
-    tox -e py27-requests -- -k "tests/test_integration.py" {posargs:-vvs}
-    tox -e py36-requests -- -k "tests/test_integration.py" {posargs:-vvs}
+    tox -e pypy-integration
+    tox -e py27-integration
+    tox -e py36-integration
 
 [testenv:pypy-integration]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
 
 [testenv]
 commands =
-    py.test {posargs:-vvs -k "not test_integration"}
+    py.test -k "not tests/test_integration.py" {posargs:-vvs}
 
     # Ensure pex's main entrypoint can be run externally.
     pex --cache-dir {envtmpdir}/buildcache wheel requests . -e pex.bin.pex:main --version
@@ -34,10 +34,9 @@ whitelist_externals = open
 deps =
     tox
 commands =
-    # meta
-    tox "-k test_integration -vvsx" -e pypy-requests
-    tox "-k test_integration -vvsx" -e py27-requests
-    tox "-k test_integration -vvsx" -e py36-requests
+    #tox -e pypy-requests -- -k "tests/test_integration.py" {posargs:-vvs}
+    tox -e py27-requests -- -k "tests/test_integration.py" {posargs:-vvs}
+    tox -e py36-requests -- -k "tests/test_integration.py" {posargs:-vvs}
 
 [integration]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,12 @@
 skip_missing_interpreters = True
 minversion = 1.8
 envlist =
-	py{py,27,36}-requests,style,isort-check
+	py{py,27,36}-requests,style,isort-check,integration-tests
 
 [testenv]
 commands =
-    py.test {posargs:-vvs}
+    py.test {posargs:-vvs -k "not test_integration"}
+
     # Ensure pex's main entrypoint can be run externally.
     pex --cache-dir {envtmpdir}/buildcache wheel requests . -e pex.bin.pex:main --version
 deps =
@@ -28,6 +29,15 @@ deps =
     coverage: coverage==4.0.3
     subprocess: subprocess32
 whitelist_externals = open
+
+[testenv:integration-tests]
+deps =
+    tox
+commands =
+    # meta
+    tox "-k test_integration -vvsx" -e pypy-requests
+    tox "-k test_integration -vvsx" -e py27-requests
+    tox "-k test_integration -vvsx" -e py36-requests
 
 [integration]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,24 @@ commands =
     tox -e py27-requests -- -k "tests/test_integration.py" {posargs:-vvs}
     tox -e py36-requests -- -k "tests/test_integration.py" {posargs:-vvs}
 
+[testenv:pypy-integration]
+deps =
+    tox
+commands =
+    tox -e pypy-requests -- -k "tests/test_integration.py" {posargs:-vvs}
+
+[testenv:py27-integration]
+deps =
+    tox
+commands =
+    tox -e py27-requests -- -k "tests/test_integration.py" {posargs:-vvs}
+
+[testenv:py36-integration]
+deps =
+    tox
+commands =
+    tox -e py36-requests -- -k "tests/test_integration.py" {posargs:-vvs}
+
 [integration]
 commands =
     # This is necessary due to https://bitbucket.org/hpk42/tox/issue/175/cant-do-substitution-base-commands


### PR DESCRIPTION
Use pytest keyword collection to omit integration tests by default. Use a new tox env to pass a positional arg that overrides the default POSARGS for py.test in tox.ini. 

I only did {py27, py26, pypy}-requests because that is what runs when you run a local `tox` command, but I am happy to add more.