### PR TITLE
Fix #499

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,15 +63,15 @@ matrix:
 
     - language: python
       python: "2.7"
-      env: TOXENV=py27-integration
+      env: TOXENV=py27-requests-integration
 
     - language: python
       python: "3.6"
-      env: TOXENV=py36-integration
+      env: TOXENV=py36-requests-integration
 
     - language: python
       python: "pypy"
-      env: TOXENV=pypy-integration
+      env: TOXENV=pypy-requests-integration
 
 install:
   - pip install -U tox "setuptools<34"

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
 
 [testenv]
 commands =
-    py.test -k "not tests/test_integration.py" {posargs:-vvs}
+    py.test --ignore="tests/test_integration.py" {posargs:-vvs}
 
     # Ensure pex's main entrypoint can be run externally.
     pex --cache-dir {envtmpdir}/buildcache wheel requests . -e pex.bin.pex:main --version
@@ -34,27 +34,21 @@ whitelist_externals = open
 deps =
     tox
 commands =
-    tox -e py27-integration
-    tox -e py36-integration
-    tox -e pypy-integration
+    tox -e py27-requests-integration -- {posargs:-vvs}
+    tox -e py36-requests-integration -- {posargs:-vvs}
+    tox -e pypy-requests-integration -- {posargs:-vvs}
 
-[testenv:pypy-integration]
-deps =
-    tox
+[testenv:py27-requests-integration]
 commands =
-    tox -e pypy-requests -- -k "tests/test_integration.py" {posargs:-vvs}
+    py.test tests/test_integration.py {posargs:-vvs}
 
-[testenv:py27-integration]
-deps =
-    tox
+[testenv:py36-requests-integration]
 commands =
-    tox -e py27-requests -- -k "tests/test_integration.py" {posargs:-vvs}
+    py.test tests/test_integration.py {posargs:-vvs}
 
-[testenv:py36-integration]
-deps =
-    tox
+[testenv:pypy-requests-integration]
 commands =
-    tox -e py36-requests -- -k "tests/test_integration.py" {posargs:-vvs}
+    py.test tests/test_integration.py {posargs:-vvs}
 
 [integration]
 commands =


### PR DESCRIPTION
Refactor tox.ini to support pytest keyword options in the integration test environments.

Test with:
`tox -e py27-requests-integration -- -k jupyter`
`tox -e integration-tests -- -k jupyter`
