### PR TITLE
Add resource / source bundling to pex cli

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -914,52 +914,49 @@ def test_cross_platform_abi_targeting_behavior_exact():
 def test_pex_source_bundling():
   with temporary_dir() as output_dir:
     with temporary_dir() as input_dir:
-      test_file_path = os.path.join(input_dir, 'exe.py')
-      with open(test_file_path, 'w') as fh:
+      with open(os.path.join(input_dir, 'exe.py'), 'w') as fh:
         fh.write(dedent('''
           print('hello')
           '''
           ))
 
-      pex1_path = os.path.join(output_dir, 'pex1.pex')
-      res1 = run_pex_command([
-        '-o', pex1_path,
+      pex_path = os.path.join(output_dir, 'pex1.pex')
+      res = run_pex_command([
+        '-o', pex_path,
         '-D', input_dir,
-        '-e', 'exe',])
-      res1.assert_success()
+        '-e', 'exe',
+      ])
+      res.assert_success()
 
-      stdout, rc = run_simple_pex(pex1_path)
+      stdout, rc = run_simple_pex(pex_path)
 
       assert rc == 0
       assert stdout == b'hello\n'
 
+
 def test_pex_resource_bundling():
   with temporary_dir() as output_dir:
     with temporary_dir() as input_dir, temporary_dir() as resources_input_dir:
-      resource_file_path = os.path.join(resources_input_dir, 'greetings', 'greeting')
-
       with open(os.path.join(resources_input_dir, 'greeting'), 'w') as fh:
         fh.write('hello')
-      pex1_path = os.path.join(output_dir, 'pex1.pex')
+      pex_path = os.path.join(output_dir, 'pex1.pex')
 
-      test_file_path = os.path.join(input_dir, 'exe.py')
-      with open(test_file_path, 'w') as fh:
+      with open(os.path.join(input_dir, 'exe.py'), 'w') as fh:
         fh.write(dedent('''
           import pkg_resources
           with pkg_resources.resource_stream('__main__', 'greeting') as f:
             print(f.read())
-          '''
-          .format(pex_location=pex1_path)
-          ))
+          '''))
 
-      res1 = run_pex_command([
-        '-o', pex1_path,
+      res = run_pex_command([
+        '-o', pex_path,
         '-D', input_dir,
         '-R', resources_input_dir,
-        '-e', 'exe',])
-      res1.assert_success()
+        '-e', 'exe',
+      ])
+      res.assert_success()
 
-      stdout, rc = run_simple_pex(pex1_path)
+      stdout, rc = run_simple_pex(pex_path)
 
       assert rc == 0
       assert stdout == b'hello\n'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -944,8 +944,7 @@ def test_pex_resource_bundling():
       with open(os.path.join(input_dir, 'exe.py'), 'w') as fh:
         fh.write(dedent('''
           import pkg_resources
-          with pkg_resources.resource_stream('__main__', 'greeting') as f:
-            print(f.read())
+          print(pkg_resources.resource_string('__main__', 'greeting'))
           '''))
 
       res = run_pex_command([

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -944,7 +944,7 @@ def test_pex_resource_bundling():
       with open(os.path.join(input_dir, 'exe.py'), 'w') as fh:
         fh.write(dedent('''
           import pkg_resources
-          print(pkg_resources.resource_string('__main__', 'greeting'))
+          print(pkg_resources.resource_string('__main__', 'greeting').decode('utf-8'))
           '''))
 
       res = run_pex_command([


### PR DESCRIPTION
Pex supports adding sources and resources directly via the PEXBuilder API, but not the CLI. This adds flags to allow adding sources and resources via directories.

Fixes #490
Fixes #491 

I paired on this with @dotordogh! 

Two questions came up while working on this

- what should happen if the output location is inside the input path?
- it looks like if the entry point doesn't exist, pex won't complain. Maybe it should?
