### PR TITLE
Bump wheel version to latest.

### DIFF
--- a/pex/version.py
+++ b/pex/version.py
@@ -8,4 +8,4 @@ __version__ = '1.4.4'
 # `packaging.specifiers.SpecifierSet` - indirectly - through `pkg_resources.Requirement.specifier`.
 SETUPTOOLS_REQUIREMENT = 'setuptools>=20.3,<34.0'
 
-WHEEL_REQUIREMENT = 'wheel>=0.26.0,<0.30.0'
+WHEEL_REQUIREMENT = 'wheel>=0.26.0,<0.32.0'

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     twitter.common.dirutil>=0.3.1,<0.4.0
     twitter.common.lang>=0.3.1,<0.4.0
     twitter.common.testing>=0.3.1,<0.4.0
-    wheel==0.29.0
+    wheel==0.31.1
     packaging==16.8
     setuptools<34.0
     list-tests: mock==2.0.0


### PR DESCRIPTION
After a long release hiatus, `wheel` has cut more releases beyond our currently pinned version that should be innocuous to consume: https://github.com/pypa/wheel/blob/master/CHANGES.txt