### PR TITLE
Introduce a controlled env for pex testing.

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,0 +1,17 @@
+# An image with the necessary binaries and libraries to develop pex.
+FROM ubuntu:18.04
+
+# Base dependencies for pex development.
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  # Make sure we can build platform-specific packages as needed (subprocess32 for example).
+  build-essential \
+  # We run tests against CPython 2.7, CPython 3 and pypy.
+  python2.7-dev \
+  python-dev \
+  pypy-dev \
+  # We use tox to run tests and more.
+  tox \
+  # We use pyenv to bootstrap interpreters in tests and pyenv needs these.
+  curl \
+  zlib1g-dev \
+  libssl1.0-dev

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,7 +1,6 @@
 # An image with the necessary binaries and libraries to develop pex.
 FROM ubuntu:18.04
 
-# Base dependencies for pex development.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   # Make sure we can build platform-specific packages as needed (subprocess32 for example).
   build-essential \

--- a/docker/user/Dockerfile
+++ b/docker/user/Dockerfile
@@ -1,0 +1,20 @@
+# TODO(John Sirois): Use a fixed image once base is published to Docker Hub; ie: pantsbuild/pex:base
+ARG BASE_ID
+FROM ${BASE_ID}
+
+# Prepare developer shim that can operate on local files and not mess up perms in the process.
+ARG USER
+ARG UID
+ARG GROUP
+ARG GID
+
+COPY create_docker_image_user.sh /root/
+RUN /root/create_docker_image_user.sh ${USER} ${UID} ${GROUP} ${GID}
+
+VOLUME /dev/pex
+WORKDIR /dev/pex
+RUN chown -R ${UID}:${GID} /dev/pex
+
+USER ${USER}:${GROUP}
+
+ENTRYPOINT ["tox"]

--- a/docker/user/create_docker_image_user.sh
+++ b/docker/user/create_docker_image_user.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 if (( $# != 4 )); then
-  echo >2 "Usage $0 <user> <uid> <group> <gid> [PATH...]"
+  echo >2 "Usage $0 <user> <uid> <group> <gid>"
   exit 1
 fi
 

--- a/docker/user/create_docker_image_user.sh
+++ b/docker/user/create_docker_image_user.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if (( $# != 4 )); then
+  echo >2 "Usage $0 <user> <uid> <group> <gid> [PATH...]"
+  exit 1
+fi
+
+uid=$2
+gid=$4
+
+if ! id -g ${gid} >/dev/null; then
+  group=$3
+  addgroup --gid=${gid} ${group} >&2
+fi
+
+if ! id -u ${uid} >/dev/null; then
+  user=$1
+  adduser --disabled-login --gecos "" --uid=${uid} --gid=${gid} --home=/home/${user} ${user} >&2
+fi

--- a/dtox.sh
+++ b/dtox.sh
@@ -10,13 +10,13 @@ BASE_INPUT=(
 base_hash=$(cat ${BASE_INPUT[@]} | git hash-object -t blob --stdin)
 
 function base_id() {
-  docker images -q -f label=${base_hash} pantsbuild/pex
+  docker images -q -f label=base_hash=${base_hash} pantsbuild/pex:base
 }
 
 if [[ -z "$(base_id)" ]]; then
   docker build \
     --tag pantsbuild/pex:base \
-    --label ${base_hash} \
+    --label base_hash=${base_hash} \
     "${ROOT}/docker/base"
 fi
 
@@ -25,7 +25,7 @@ USER_INPUT=(
   "${ROOT}/docker/user/create_docker_image_user.sh"
 )
 user_hash=$(cat ${USER_INPUT[@]} | git hash-object -t blob --stdin)
-if [[ -z "$(docker images -q -f label=${user_hash} pantsbuild/pex)" ]]; then
+if [[ -z "$(docker images -q -f label=user_hash=${user_hash} pantsbuild/pex:user)" ]]; then
   docker build \
     --build-arg BASE_ID=$(base_id) \
     --build-arg USER=$(id -un) \
@@ -33,7 +33,7 @@ if [[ -z "$(docker images -q -f label=${user_hash} pantsbuild/pex)" ]]; then
     --build-arg GROUP=$(id -gn) \
     --build-arg GID=$(id -g) \
     --tag pantsbuild/pex:user \
-    --label ${user_hash} \
+    --label user_hash=${user_hash} \
     "${ROOT}/docker/user"
 fi
 

--- a/dtox.sh
+++ b/dtox.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+BASE_INPUT=(
+  "${ROOT}/docker/base/Dockerfile"
+)
+base_hash=$(cat ${BASE_INPUT[@]} | git hash-object -t blob --stdin)
+
+function base_id() {
+  docker images -q -f label=${base_hash} pantsbuild/pex
+}
+
+if [[ -z "$(base_id)" ]]; then
+  docker build \
+    --tag pantsbuild/pex:base \
+    --label ${base_hash} \
+    "${ROOT}/docker/base"
+fi
+
+USER_INPUT=(
+  "${ROOT}/docker/user/Dockerfile"
+  "${ROOT}/docker/user/create_docker_image_user.sh"
+)
+user_hash=$(cat ${USER_INPUT[@]} | git hash-object -t blob --stdin)
+if [[ -z "$(docker images -q -f label=${user_hash} pantsbuild/pex)" ]]; then
+  docker build \
+    --build-arg BASE_ID=$(base_id) \
+    --build-arg USER=$(id -un) \
+    --build-arg UID=$(id -u) \
+    --build-arg GROUP=$(id -gn) \
+    --build-arg GID=$(id -g) \
+    --tag pantsbuild/pex:user \
+    --label ${user_hash} \
+    "${ROOT}/docker/user"
+fi
+
+exec docker run \
+  --tty \
+  --rm \
+  --volume $(pwd):/dev/pex \
+  pantsbuild/pex:user \
+  "$@"

--- a/dtox.sh
+++ b/dtox.sh
@@ -38,6 +38,7 @@ if [[ -z "$(docker images -q -f label=user_hash=${user_hash} pantsbuild/pex:user
 fi
 
 exec docker run \
+  --interactive \
   --tty \
   --rm \
   --volume $(pwd):/dev/pex \


### PR DESCRIPTION
Although this could be used as a stepping stone to containerized
Travis CI, in the short term it helps me have a working test
environment. The `pex.testing.ensure_python_interpreter` fails to
install CPython 2.7.9, 2.7.10, etc. on Arch Linux atm.