### PR TITLE
Simplify `.travis.yml`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,66 +11,53 @@ cache:
   directories:
     - .pyenv_test
 
+language: python
+
 matrix:
   include:
-    - language: python
-      python: "2.7"
+    - python: "2.7"
       env: TOXENV=style
 
-    - language: python
-      python: "2.7"
+    - python: "2.7"
       env: TOXENV=isort-check
 
-    - language: python
-      python: "2.7"
+    - python: "2.7"
       env: TOXENV=py27
 
-    - language: python
-      python: "2.7"
+    - python: "2.7"
       env: TOXENV=py27-subprocess
 
-    - language: python
-      python: "2.7"
+    - python: "2.7"
       env: TOXENV=py27-requests
 
-    - language: python
-      python: "2.7"
+    - python: "2.7"
       env: TOXENV=py27-requests-cachecontrol
 
-    - language: python
-      python: "3.4"
+    - python: "3.4"
       env: TOXENV=py34
 
-    - language: python
-      python: "3.5"
+    - python: "3.5"
       env: TOXENV=py35
 
-    - language: python
-      python: "3.6"
+    - python: "3.6"
       env: TOXENV=py36
 
-    - language: python
-      python: "3.6"
+    - python: "3.6"
       env: TOXENV=py36-requests
 
-    - language: python
-      python: "3.6"
+    - python: "3.6"
       env: TOXENV=py36-requests-cachecontrol
 
-    - language: python
-      python: "pypy"
+    - python: "pypy"
       env: TOXENV=pypy
 
-    - language: python
-      python: "2.7"
+    - python: "2.7"
       env: TOXENV=py27-integration
 
-    - language: python
-      python: "3.6"
+    - python: "3.6"
       env: TOXENV=py36-integration
 
-    - language: python
-      python: "pypy"
+    - python: "pypy"
       env: TOXENV=pypy-integration
 
 install:


### PR DESCRIPTION
All of our shards are now and foreseeably `language: python`.