### PR TITLE
Expand the range of supported setuptools.

### DIFF
--- a/pex/testing.py
+++ b/pex/testing.py
@@ -332,6 +332,7 @@ def ensure_python_distribution(version):
   if not os.path.exists(interpreter_location):
     os.environ['PYENV_ROOT'] = pyenv_root
     subprocess.check_call([pyenv, 'install', '--keep', version])
+    subprocess.check_call([pip, 'install', '-U', 'pip'])
     subprocess.check_call([pip, 'install', SETUPTOOLS_REQUIREMENT])
 
   python = os.path.join(interpreter_location, 'bin', 'python' + version[0:3])

--- a/pex/version.py
+++ b/pex/version.py
@@ -5,8 +5,6 @@ __version__ = '1.4.5'
 
 # Versions 34.0.0 through 35.0.2 (last pre-36.0.0) de-vendored dependencies which causes problems
 # for pex code so we exclude that range.
-__exclusions = '!=34.*,!=35.*'
-SETUPTOOLS_REQUIREMENT = 'setuptools>=20.3,<41,{exclusions}'.format(exclusions=__exclusions)
-del __exclusions
+SETUPTOOLS_REQUIREMENT = 'setuptools>=20.3,<41,!=34.*,!=35.*'
 
 WHEEL_REQUIREMENT = 'wheel>=0.26.0,<0.32'

--- a/pex/version.py
+++ b/pex/version.py
@@ -3,9 +3,10 @@
 
 __version__ = '1.4.5'
 
-# NB: If we upgrade to setuptools>=34 pex's bootstrap code in `PEXBuilder` will need an update to
-# include the `packaging` package in the `.bootstrap/` code since we use
-# `packaging.specifiers.SpecifierSet` - indirectly - through `pkg_resources.Requirement.specifier`.
-SETUPTOOLS_REQUIREMENT = 'setuptools>=20.3,<34.0'
+# Versions 34.0.0 through 35.0.2 (last pre-36.0.0) de-vendored dependencies which causes problems
+# for pex code so we exclude that range.
+__exclusions = '!=34.*,!=35.*'
+SETUPTOOLS_REQUIREMENT = 'setuptools>=20.3,<41,{exclusions}'.format(exclusions=__exclusions)
+del __exclusions
 
-WHEEL_REQUIREMENT = 'wheel>=0.26.0,<0.32.0'
+WHEEL_REQUIREMENT = 'wheel>=0.26.0,<0.32'


### PR DESCRIPTION
We now just exclude the island where setuptools ran a disruptive
de-vendoring experiment.