### PR TITLE
Cleanup bootstrap dependencies before handoff.

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -458,8 +458,8 @@ class PEX(object):  # noqa: T000
       sys.argv = sys.argv[1:]
       self.execute_content(program, content)
     else:
-      import code
       with self.demoted_bootstrap():
+        import code
         code.interact()
 
   def execute_script(self, script_name):
@@ -507,22 +507,22 @@ class PEX(object):  # noqa: T000
 
   @classmethod
   def execute_module(cls, module_name):
-    import runpy
     with cls.demoted_bootstrap():
+      import runpy
       runpy.run_module(module_name, run_name='__main__')
 
   @classmethod
   def execute_pkg_resources(cls, spec):
-    entry = EntryPoint.parse("run = {0}".format(spec))
-
-    # See https://pythonhosted.org/setuptools/history.html#id25 for rationale here.
-    if hasattr(entry, 'resolve'):
-      # setuptools >= 11.3
-      runner = entry.resolve()
-    else:
-      # setuptools < 11.3
-      runner = entry.load(require=False)
     with cls.demoted_bootstrap():
+      entry = EntryPoint.parse("run = {0}".format(spec))
+
+      # See https://pythonhosted.org/setuptools/history.html#id25 for rationale here.
+      if hasattr(entry, 'resolve'):
+        # setuptools >= 11.3
+        runner = entry.resolve()
+      else:
+        # setuptools < 11.3
+        runner = entry.load(require=False)
       return runner()
 
   def cmdline(self, args=()):

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -201,7 +201,7 @@ def write_simple_pex(td, exe_contents, dists=None, sources=None, coverage=False)
   pb = PEXBuilder(path=td, preamble=COVERAGE_PREAMBLE if coverage else None)
 
   for dist in dists:
-    pb.add_egg(dist.location)
+    pb.add_dist_location(dist.location)
 
   for env_filename, contents in sources:
     src_path = os.path.join(td, env_filename)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1074,4 +1074,3 @@ def test_pex_interpreter_interact_custom_setuptools_useable():
                                 env={'PEX_VERBOSE': '1'},
                                 stdin=test_script)
     assert rc == 0, stdout
-

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1001,3 +1001,77 @@ def test_multiplatform_entrypoint():
 
     greeting = subprocess.check_output([pex_out_path])
     assert b'Hello World!' == greeting.strip()
+
+
+@contextmanager
+def pex_with_entrypoints(entry_point):
+  setup_py = dedent("""
+    from setuptools import setup
+
+    setup(
+      name='my_app',
+      version='0.0.0',
+      zip_safe=True,
+      packages=[''],
+      install_requires=['setuptools==36.2.7'],
+      entry_points={'console_scripts': ['my_app_function = my_app:do_something',
+                                        'my_app_module = my_app']},
+    )
+  """)
+
+  my_app = dedent("""
+    from setuptools.sandbox import run_setup
+
+    def do_something():
+      return run_setup
+
+    if __name__ == '__main__':
+      do_something()
+  """)
+
+  with temporary_content({'setup.py': setup_py, 'my_app.py': my_app}) as project_dir:
+    with temporary_dir() as out:
+      pex = os.path.join(out, 'pex.pex')
+      pex_command = ['--validate-entry-point', '-c', entry_point, project_dir, '-o', pex]
+      results = run_pex_command(pex_command)
+      results.assert_success()
+      yield pex
+
+
+def test_pex_script_module_custom_setuptools_useable():
+  with pex_with_entrypoints('my_app_module') as pex:
+    stdout, rc = run_simple_pex(pex, env={'PEX_VERBOSE': '1'})
+    assert rc == 0, stdout
+
+
+def test_pex_script_function_custom_setuptools_useable():
+  with pex_with_entrypoints('my_app_function') as pex:
+    stdout, rc = run_simple_pex(pex, env={'PEX_VERBOSE': '1'})
+    assert rc == 0, stdout
+
+
+@contextmanager
+def pex_with_no_entrypoints():
+  with temporary_dir() as out:
+    pex = os.path.join(out, 'pex.pex')
+    run_pex_command(['setuptools==36.2.7', '-o', pex])
+    test_script = b'from setuptools.sandbox import run_setup; print(str(run_setup))'
+    yield pex, test_script, out
+
+
+def test_pex_interpreter_execute_custom_setuptools_useable():
+  with pex_with_no_entrypoints() as (pex, test_script, out):
+    script = os.path.join(out, 'script.py')
+    with open(script, 'wb') as fp:
+      fp.write(test_script)
+    stdout, rc = run_simple_pex(pex, args=(script,), env={'PEX_VERBOSE': '1'})
+    assert rc == 0, stdout
+
+
+def test_pex_interpreter_interact_custom_setuptools_useable():
+  with pex_with_no_entrypoints() as (pex, test_script, _):
+    stdout, rc = run_simple_pex(pex,
+                                env={'PEX_VERBOSE': '1'},
+                                stdin=test_script)
+    assert rc == 0, stdout
+

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -17,6 +17,7 @@ from pex.installer import EggInstaller, WheelInstaller
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
+from pex.resolver import resolve
 from pex.testing import (
     IS_PYPY,
     ensure_python_interpreter,
@@ -359,3 +360,16 @@ def test_execute_interpreter_stdin_program():
     assert 0 == process.returncode
     assert b'one two\n' == stdout
     assert b'' == stderr
+
+
+def test_pex_run_custom_setuptools_useable():
+  with temporary_dir() as resolve_cache:
+    dists = resolve(['setuptools==36.2.7'], cache=resolve_cache)
+    with temporary_dir() as temp_dir:
+      pex = write_simple_pex(
+        temp_dir,
+        'from setuptools.sandbox import run_setup',
+        dists=dists,
+      )
+      rc = PEX(pex.path()).run()
+      assert rc == 0


### PR DESCRIPTION
Previously we polluted the third party import space with any third
party dependencies of the pex bootstrap code (currently a subset of
setuptools). We now unimport all third_party code in bootstrap and
place bootstrap at the end of `sys.path` before handing off to user
code to allow their custom versions of overlapping third party code
to be imported.

Added a failing test that the demoted_bootstrap code now fixes.

Fixes #437.