### PR TITLE
Fix for super() usage on "old style class" ZipFile

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -78,7 +78,7 @@ class MktempTeardownRegistry(object):
 _MKDTEMP_SINGLETON = MktempTeardownRegistry()
 
 
-class PermPreservingZipFile(zipfile.ZipFile):
+class PermPreservingZipFile(zipfile.ZipFile, object):
   """A ZipFile that works around https://bugs.python.org/issue15795"""
 
   def _extract_member(self, member, targetpath, pwd):


### PR DESCRIPTION
I was experiencing an error of "TypeError: must be type, not classobj"
on the line using `super()._extract_member()` below.
This error appears to be due to the `zipfile.ZipFile` class never inheriting from
`object` which is a requirement since py2.2 (2001).

Since the use of `super()` in `PermPreservingZipFile()` depends on
`object` being somewhere in the inheritance tree, I am including it in
the class definition of `PermPreservingZipFile()`. My testing of this patch
locally has proven to solve the "TypeError" I was seeing.