### PR TITLE
Fixup `PEX.demote_bootstrap`: fully unimport.

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -419,6 +419,9 @@ class PEX(object):  # noqa: T000
         TRACER.log('Un-importing third party bootstrap dependency %s from %s'
                    % (mod, bootstrap_path))
         sys.modules.pop(mod)
+        submod_prefix = mod + '.'
+        for submod in [m for m in sys.modules.keys() if m.startswith(submod_prefix)]:
+          sys.modules.pop(submod)
     sys.path.pop(bootstrap_path_index)
     sys.path.append(bootstrap_path)
 

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -180,7 +180,7 @@ except ImportError:
 """
 
 
-def write_simple_pex(td, exe_contents, dists=None, sources=None, coverage=False):
+def write_simple_pex(td, exe_contents, dists=None, sources=None, coverage=False, interpreter=None):
   """Write a pex file that contains an executable entry point
 
   :param td: temporary directory path
@@ -189,6 +189,7 @@ def write_simple_pex(td, exe_contents, dists=None, sources=None, coverage=False)
   :param dists: distributions to include, typically sdists or bdists
   :param sources: sources to include, as a list of pairs (env_filename, contents)
   :param coverage: include coverage header
+  :param interpreter: a custom interpreter to use to build the pex
   """
   dists = dists or []
   sources = sources or []
@@ -198,7 +199,9 @@ def write_simple_pex(td, exe_contents, dists=None, sources=None, coverage=False)
   with open(os.path.join(td, 'exe.py'), 'w') as fp:
     fp.write(exe_contents)
 
-  pb = PEXBuilder(path=td, preamble=COVERAGE_PREAMBLE if coverage else None)
+  pb = PEXBuilder(path=td,
+                  preamble=COVERAGE_PREAMBLE if coverage else None,
+                  interpreter=interpreter)
 
   for dist in dists:
     pb.add_dist_location(dist.location)

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 import textwrap
 from contextlib import contextmanager
-from pex.interpreter import PythonInterpreter
 from types import ModuleType
 
 import pytest
@@ -15,6 +14,7 @@ from twitter.common.contextutil import temporary_file
 from pex.bin.pex import get_interpreter
 from pex.compatibility import PY2, WINDOWS, nested, to_bytes
 from pex.installer import EggInstaller, WheelInstaller
+from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import textwrap
 from contextlib import contextmanager
+from pex.interpreter import PythonInterpreter
 from types import ModuleType
 
 import pytest
@@ -370,6 +371,32 @@ def test_pex_run_custom_setuptools_useable():
         temp_dir,
         'from setuptools.sandbox import run_setup',
         dists=dists,
+      )
+      rc = PEX(pex.path()).run()
+      assert rc == 0
+
+
+def test_pex_run_conflicting_custom_setuptools_useable():
+  # Here we use an older setuptools to build the pex which has a newer setuptools requirement.
+  # These setuptools dists have different pkg_resources APIs:
+  # $ diff \
+  #   <(zipinfo -1 setuptools-20.3.1-py2.py3-none-any.whl | grep pkg_resources/ | sort) \
+  #   <(zipinfo -1 setuptools-40.4.3-py2.py3-none-any.whl | grep pkg_resources/ | sort)
+  # 2a3,4
+  # > pkg_resources/py31compat.py
+  # > pkg_resources/_vendor/appdirs.py
+  with temporary_dir() as resolve_cache:
+    dists = resolve(['setuptools==20.3.1'], cache=resolve_cache)
+    interpreter = PythonInterpreter.from_binary(sys.executable,
+                                                path_extras=[dist.location for dist in dists],
+                                                include_site_extras=False)
+    dists = resolve(['setuptools==40.4.3'], cache=resolve_cache)
+    with temporary_dir() as temp_dir:
+      pex = write_simple_pex(
+        temp_dir,
+        'from pkg_resources import appdirs, py31compat',
+        dists=dists,
+        interpreter=interpreter
       )
       rc = PEX(pex.path()).run()
       assert rc == 0


### PR DESCRIPTION
Previously only root 3rdparty packages copied into the bootstrap were
unimported leaving subpackages in-place. This could lead to a mismatch
in 3rdparty package API expectations when a re-imported 3rdparty root
package from the user PEX sys.path was from a different version of the
3rdparty package.

Fixes #550