### PR TITLE
Sort requirements before dumping to PEX-INFO

### DIFF
--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -301,7 +301,7 @@ class PexInfo(object):
 
   def dump(self, **kwargs):
     pex_info_copy = self._pex_info.copy()
-    pex_info_copy['requirements'] = list(self._requirements)
+    pex_info_copy['requirements'] = list(sorted(self._requirements))
     pex_info_copy['interpreter_constraints'] = list(self._interpreter_constraints)
     pex_info_copy['distributions'] = self._distributions.copy()
     return json.dumps(pex_info_copy, **kwargs)


### PR DESCRIPTION
I have a goal of making pex builds reproducible given the right conditions, and this is one easy first step. Because at various points during requirement resolution the dependencies are put into sets and dicts, the order is unreliable and changes from build to build.