### PR TITLE
Apply more pinning to jupyter in IT.

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -879,9 +879,11 @@ def test_platform_specific_egg_resolution_matching():
 def test_jupyter_appnope_env_markers():
   # NB: jupyter 1.0.0 does not properly pin its dep graph and both ipykernel and ipython support
   # python 3 only post 5 and 6 respectively; so we add those deps explictly only to constrain them
-  # low such that they support python 2.7 for this test.
+  # low such that they support python 2.7 for this test. We also pin jupyter's unconstrained dep on
+  # jupyter_console low to avoid a conflict with ipython on prompt-toolkit.
   res = run_pex_command(['--disable-cache',
                          'jupyter==1.0.0',
+                         'jupyter_console<5.4',
                          'ipykernel<5',
                          'ipython<6',
                          '-c', 'jupyter',


### PR DESCRIPTION
I ran into the following in `test_jupyter_appnope_env_markers` this am`:
```
Could not satisfy all requirements for prompt-toolkit<2.0.0,>=1.0.4:
    prompt-toolkit<2.0.0,>=1.0.4(from: ipython<6), prompt-toolkit<2.1.0,>=2.0.0(from: jupyter==1.0.0->jupyter-console)
```