### PR TITLE
Bump our wheel ceiling from 0.32 to 0.33.

### DIFF
--- a/pex/version.py
+++ b/pex/version.py
@@ -7,4 +7,4 @@ __version__ = '1.4.7'
 # for pex code so we exclude that range.
 SETUPTOOLS_REQUIREMENT = 'setuptools>=20.3,<41,!=34.*,!=35.*'
 
-WHEEL_REQUIREMENT = 'wheel>=0.26.0,<0.32'
+WHEEL_REQUIREMENT = 'wheel>=0.26.0,<0.33'


### PR DESCRIPTION
Wheel has released 0.32.0 and 0.32.1 with no breaking changes for pex
purposes but some bug fixes our users may want.