### PR TITLE
Narrow the env marker test.

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -876,21 +876,13 @@ def test_platform_specific_egg_resolution_matching():
 
 
 @pytest.mark.skipif(NOT_CPYTHON27)
-def test_jupyter_appnope_env_markers():
-  # NB: jupyter 1.0.0 does not properly pin its dep graph and both ipykernel and ipython support
-  # python 3 only post 5 and 6 respectively; so we add those deps explictly only to constrain them
-  # low such that they support python 2.7 for this test. We also pin jupyter's unconstrained dep on
-  # jupyter_console low to avoid a conflict with ipython on prompt-toolkit.
+def test_ipython_appnope_env_markers():
   res = run_pex_command(['--disable-cache',
-                         'jupyter==1.0.0',
-                         'jupyter_console<5.4',
-                         'ipykernel<5',
-                         'ipython<6',
-                         '-c', 'jupyter',
+                         'ipython==5.8.0',
+                         '-c', 'ipython',
                          '--',
                          '--version'])
   res.assert_success()
-  assert len(res.output) > 4
 
 
 # TODO: https://github.com/pantsbuild/pex/issues/479


### PR DESCRIPTION
The jupyter dist is just a meta-dist with fully unconstrained deps on ~6
other dists. This test was added to test environment marker support in
pex, which ipython - not jupyter - leverages heavily.