### PR TITLE
Fix resolve regressions introduced by the 1.4.8.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -654,7 +654,7 @@ def build_pex(args, options, resolver_option_builder):
   with TRACER.timed('Resolving distributions'):
     try:
       resolveds = resolve_multi(resolvables,
-                                interpreters=interpreters,
+                                interpreters=setup_interpreters,
                                 platforms=options.platforms,
                                 cache=options.cache_dir,
                                 cache_ttl=options.cache_ttl,

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -557,7 +557,7 @@ def resolve_multi(requirements,
   """
 
   interpreters = interpreters or [PythonInterpreter.get()]
-  platforms = platforms or [Platform.current()]
+  platforms = platforms or ['current']
 
   seen = set()
   for interpreter in interpreters:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1078,6 +1078,9 @@ def test_pex_interpreter_interact_custom_setuptools_useable():
     assert rc == 0, stdout
 
 
+@pytest.mark.skipif(IS_PYPY,
+                    reason='Our pyenv interpreter setup fails under pypy: '
+                           'https://github.com/pantsbuild/pex/issues/477')
 def test_setup_python():
   interpreter = ensure_python_interpreter(PY27)
   with temporary_dir() as out:
@@ -1090,6 +1093,9 @@ def test_setup_python():
     subprocess.check_call([pex, '-c', 'import jsonschema'])
 
 
+@pytest.mark.skipif(IS_PYPY,
+                    reason='Our pyenv interpreter setup fails under pypy: '
+                           'https://github.com/pantsbuild/pex/issues/477')
 def test_setup_interpreter_constraint():
   interpreter = ensure_python_interpreter(PY27)
   with temporary_dir() as out:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1076,3 +1076,28 @@ def test_pex_interpreter_interact_custom_setuptools_useable():
                                 env=make_env(PEX_VERBOSE=1),
                                 stdin=test_script)
     assert rc == 0, stdout
+
+
+def test_setup_python():
+  interpreter = ensure_python_interpreter(PY27)
+  with temporary_dir() as out:
+    pex = os.path.join(out, 'pex.pex')
+    results = run_pex_command(['jsonschema==2.6.0',
+                               '--disable-cache',
+                               '--python={}'.format(interpreter),
+                               '-o', pex])
+    results.assert_success()
+    subprocess.check_call([pex, '-c', 'import jsonschema'])
+
+
+def test_setup_interpreter_constraint():
+  interpreter = ensure_python_interpreter(PY27)
+  with temporary_dir() as out:
+    pex = os.path.join(out, 'pex.pex')
+    with environment_as(PATH=os.path.dirname(interpreter)):
+      results = run_pex_command(['jsonschema==2.6.0',
+                                 '--disable-cache',
+                                 '--interpreter-constraint=CPython=={}'.format(PY27),
+                                 '-o', pex])
+      results.assert_success()
+      subprocess.check_call([pex, '-c', 'import jsonschema'])


### PR DESCRIPTION
PR #571 regressed the half-broken state of having
`--interpreter_constraint` selected interpreters not setup to also
having `--python` selected interpreters also not setup. In addition,
PR #568 incorrectly classified the current Platform passed by
`resolve_multi` as a user-specified extended platform specification
breaking custom interpreter resolution. Fix both and add tests that
failed prior to this combination of fixes.

A more comprehensive fix is tracked in part by #579.