### PR TITLE
Cleanup `PexInfo` and `PythonInterpreter`.

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -293,14 +293,6 @@ class PythonInterpreter(object):
 
   CACHE = {}  # memoize executable => PythonInterpreter
 
-  try:
-    # Versions of distribute prior to the setuptools merge would automatically replace
-    # 'setuptools' requirements with 'distribute'.  It provided the 'replacement' kwarg
-    # to toggle this, but it was removed post-merge.
-    COMPATIBLE_SETUPTOOLS = Requirement.parse('setuptools>=1.0', replacement=False)
-  except TypeError:
-    COMPATIBLE_SETUPTOOLS = Requirement.parse('setuptools>=1.0')
-
   class Error(Exception): pass
   class IdentificationError(Error): pass
   class InterpreterNotFound(Error): pass

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, print_function
 import json
 import os
 import warnings
-from collections import namedtuple
 
 from .common import open_zip
 from .compatibility import PY2
@@ -14,8 +13,6 @@ from .compatibility import string as compatibility_string
 from .orderedset import OrderedSet
 from .util import merge_split
 from .variables import ENV
-
-PexPlatform = namedtuple('PexPlatform', 'interpreter version strict')
 
 
 # TODO(wickman) Split this into a PexInfoBuilder/PexInfo to ensure immutability.
@@ -53,13 +50,15 @@ class PexInfo(object):
   @classmethod
   def make_build_properties(cls, interpreter=None):
     from .interpreter import PythonInterpreter
-    from pkg_resources import get_platform
+    from .platforms import Platform
 
     pi = interpreter or PythonInterpreter.get()
+    plat = Platform.current()
+    platform_name = plat.platform
     return {
       'class': pi.identity.interpreter,
       'version': pi.identity.version,
-      'platform': get_platform(),
+      'platform': platform_name,
     }
 
   @classmethod


### PR DESCRIPTION
Kill an unused type in `PexInfo` as well as our last remaining use of
`pkg_resources.get_platform`. Also kill unused `COMPATIBLE_SETUPTOOLS`
constants in `PythonInterpreter`.