### PR TITLE
Filter top-level requirements against env markers.

### DIFF
--- a/pex/environment.py
+++ b/pex/environment.py
@@ -130,6 +130,7 @@ class PEXEnvironment(Environment):
       platform=platform_name,
       **kw
     )
+    self._target_interpreter_env = self._interpreter.identity.pkg_resources_env(platform_name)
     self._supported_tags.extend(platform.supported_tags(self._interpreter))
     TRACER.log(
       'E: tags for %r x %r -> %s' % (self.platform, self._interpreter, self._supported_tags),
@@ -161,7 +162,7 @@ class PEXEnvironment(Environment):
     # Resolve them one at a time so that we can figure out which ones we need to elide should
     # there be an interpreter incompatibility.
     for req in reqs:
-      if req.marker and not req.marker.evaluate():
+      if req.marker and not req.marker.evaluate(environment=self._target_interpreter_env):
         TRACER.log('Skipping activation of `%s` due to environment marker de-selection' % req)
         continue
       with TRACER.timed('Resolving %s' % req, V=2):

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -261,7 +261,7 @@ Calculated platform: {calculated_platform!r}""".format(
         'Could not get distribution for %s on platform %s.' % (package, self._platform))
     return dist
 
-  def resolvable_in_target_interpreter_env(self, resolvable):
+  def is_resolvable_in_target_interpreter_env(self, resolvable):
     if not isinstance(resolvable, ResolvableRequirement):
       return True
     elif resolvable.requirement.marker is None:
@@ -271,7 +271,7 @@ Calculated platform: {calculated_platform!r}""".format(
 
   def resolve(self, resolvables, resolvable_set=None):
     resolvables = [(resolvable, None) for resolvable in resolvables
-                   if self.resolvable_in_target_interpreter_env(resolvable)]
+                   if self.is_resolvable_in_target_interpreter_env(resolvable)]
     resolvable_set = resolvable_set or _ResolvableSet()
     processed_resolvables = set()
     processed_packages = {}

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -220,6 +220,8 @@ Calculated platform: {calculated_platform!r}""".format(
     self._interpreter = interpreter or PythonInterpreter.get()
     self._platform = self._maybe_expand_platform(self._interpreter, platform)
     self._allow_prereleases = allow_prereleases
+    platform_name = self._platform.platform
+    self._target_interpreter_env = self._interpreter.identity.pkg_resources_env(platform_name)
     self._supported_tags = self._platform.supported_tags(
       self._interpreter,
       use_manylinux
@@ -259,8 +261,17 @@ Calculated platform: {calculated_platform!r}""".format(
         'Could not get distribution for %s on platform %s.' % (package, self._platform))
     return dist
 
+  def resolvable_in_target_interpreter_env(self, resolvable):
+    if not isinstance(resolvable, ResolvableRequirement):
+      return True
+    elif resolvable.requirement.marker is None:
+      return True
+    else:
+      return resolvable.requirement.marker.evaluate(environment=self._target_interpreter_env)
+
   def resolve(self, resolvables, resolvable_set=None):
-    resolvables = [(resolvable, None) for resolvable in resolvables]
+    resolvables = [(resolvable, None) for resolvable in resolvables
+                   if self.resolvable_in_target_interpreter_env(resolvable)]
     resolvable_set = resolvable_set or _ResolvableSet()
     processed_resolvables = set()
     processed_packages = {}
@@ -297,9 +308,7 @@ Calculated platform: {calculated_platform!r}""".format(
         new_parent = '%s->%s' % (parent, resolvable) if parent else str(resolvable)
         # We patch packaging.markers.default_environment here so we find optional reqs for the
         # platform we're building the PEX for, rather than the one we're on.
-        with patched_packing_env(
-          self._interpreter.identity.pkg_resources_env(self._platform.platform)
-        ):
+        with patched_packing_env(self._target_interpreter_env):
           resolvables.extend(
             (ResolvableRequirement(req, resolvable.options), new_parent) for req in
             distribution.requires(extras=resolvable_set.extras(resolvable.name))


### PR DESCRIPTION
Previously, only transitive requirements were filtered.

Fixes #456 
Fixes #122