### PR TITLE
Proposal: Add extended path prefix for Windows filepath

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -171,7 +171,7 @@ def safe_path(path):
   if os.name == "nt":
     extended_path_prefix = u"\\\\?\\"
     if not path.startswith(extended_path_prefix):
-      return extended_path_prefix + path
+      return os.path.abspath(extended_path_prefix + path)
   return path
 
 


### PR DESCRIPTION
I recently ran across an issue similar to #319, where I received a `FileNotFoundError` while trying to run my pex file that I had created. As can be seen in the traceback in that issue, the error occurred [here](https://github.com/pantsbuild/pex/blob/39bcfaaa1e64c7edd57c8514c8086e624dbd1c56/pex/util.py#L178), during the `safe_open` command. 

After a little research, I found that the issue most likely stems from the [maximum path length limitations in Windows](https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file#maximum-path-length-limitation), where paths cannot be 260 characters or above. In the example given in the issue, the path is 261 characters long. This is shown in the example below, where I am able to open a filepath that is 259 characters long, but not 260:

<details>
<summary>Maximum path length test</summary>

```python
In [1]: len(os.path.abspath(os.path.curdir + 'a'*227))
Out[1]: 260

In [2]: len(os.path.abspath(os.path.curdir + 'a'*226))
Out[2]: 259

In [3]: with open(os.path.abspath(os.path.curdir + 'a'*227),'wb') as f:
    ...:     pass
    ...:
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-42-dda94ce7e14c> in <module>()
----> 1 with open(os.path.abspath(os.path.curdir + 'a'*227),'wb') as f:
      2     pass

FileNotFoundError: [Errno 2] No such file or directory: 'C:\\filepath_maximum_le
ngth_example\\.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
aa'

In [4]: with open(os.path.abspath(os.path.curdir + 'a'*226),'wb') as f:
    ...:     pass
    ...:

```
</details>

This limitation can be mitigated by prefixing the filepath with `\\?\`, which allows files paths up to 32767 characters long. This is illustrated by the example below:

<details>
<summary>Maximum path length test with "\\?\" prefix</summary>

```python
In [1]: with open(os.path.abspath(os.path.curdir + 'a'*227),'wb') as f:
    ...:     pass
    ...:
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-42-dda94ce7e14c> in <module>()
----> 1 with open(os.path.abspath(os.path.curdir + 'a'*227),'wb') as f:
      2     pass

FileNotFoundError: [Errno 2] No such file or directory: 'C:\\filepath_maximum_le
ngth_example\\.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
aa'

In [2]: with open(u'\\\\?\\' + os.path.abspath(os.path.curdir + 'a'*227),'wb')
    ...:  as f:
    ...:     pass
```
</details>

There was discussion about accounting for this within cpython [here](https://bugs.python.org/issue18199), but it was decided that it wouldn't be added since Windows 10 Anniversary would allow long file paths. Unfortunately, this behavior seems to be opt-in in Windows 10, by [modifying a group policy](https://stackoverflow.com/a/27694470/7810672). In addition, those who still use Windows 7 don't have this option either.

In this PR, I took a shot at modifying `safe_open` to include the `\\?\` prefix to account for longer filepaths. I then tested this by trying to run the pex that had previously failed, which I was now able to do after the change was made. I also confirmed that I was able to properly build pex files (which I could do prior to making this change).

Ideally, this behavior would be incorporated as part of cpython, but failing that, it'd be nice if every path that is used within `pex` would have this `\\?\` prefix appended to it, but I realize that it would be cumbersome to implement everywhere. Therefore, I propose that the change is implemented in `safe_open` so that users can at least run a pex file on Windows, even if some of the other peripherals/cleanup may not work as intended.