### PR TITLE
Pex exits with correct code when using entrypoint

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -278,8 +278,7 @@ class PEX(object):  # noqa: T000
 
   def _wrap_coverage(self, runner, *args):
     if not self._vars.PEX_COVERAGE and self._vars.PEX_COVERAGE_FILENAME is None:
-      runner(*args)
-      return
+      return runner(*args)
 
     try:
       import coverage
@@ -296,7 +295,7 @@ class PEX(object):  # noqa: T000
     cov.start()
 
     try:
-      runner(*args)
+      return runner(*args)
     finally:
       TRACER.log('Stopping coverage')
       cov.stop()
@@ -310,8 +309,7 @@ class PEX(object):  # noqa: T000
 
   def _wrap_profiling(self, runner, *args):
     if not self._vars.PEX_PROFILE and self._vars.PEX_PROFILE_FILENAME is None:
-      runner(*args)
-      return
+      return runner(*args)
 
     pex_profile_filename = self._vars.PEX_PROFILE_FILENAME
     pex_profile_sort = self._vars.PEX_PROFILE_SORT
@@ -348,7 +346,9 @@ class PEX(object):  # noqa: T000
       self.patch_sys(pex_inherit_path)
       working_set = self._activate()
       self.patch_pkg_resources(working_set)
-      self._wrap_coverage(self._wrap_profiling, self._execute)
+      exit_code = self._wrap_coverage(self._wrap_profiling, self._execute)
+      if exit_code:
+        sys.exit(exit_code)
     except Exception:
       # Allow the current sys.excepthook to handle this app exception before we tear things down in
       # finally, then reraise so that the exit status is reflected correctly.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -854,7 +854,7 @@ def test_pex_exit_code_propagation():
                                '-o', pex_path])
     results.assert_success()
 
-    assert subprocess.call([pex_path, tester_path]) == 1
+    assert subprocess.call([pex_path, os.path.realpath(tester_path)]) == 1
 
 
 @pytest.mark.skipif(NOT_CPYTHON27)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -837,6 +837,27 @@ def test_pex_manylinux_runtime():
     assert out.strip() == '[1, 2, 3]'
 
 
+def test_pex_exit_code_propagation():
+  """Tests exit code propagation."""
+  test_stub = dedent(
+    """
+    def test_fail():
+      assert False
+    """
+  )
+
+  with temporary_content({'tester.py': test_stub}) as output_dir:
+    pex_path = os.path.join(output_dir, 'test.pex')
+    tester_path = os.path.join(output_dir, 'tester.py')
+    results = run_pex_command(['pytest==3.9.1',
+                               '-e', 'pytest:main',
+                               '-D', output_dir,
+                               '-o', pex_path])
+    results.assert_success()
+
+    assert subprocess.call([pex_path]) == 1
+
+
 @pytest.mark.skipif(NOT_CPYTHON27)
 def test_platform_specific_inline_egg_resolution():
   with temporary_dir() as td:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -851,11 +851,10 @@ def test_pex_exit_code_propagation():
     tester_path = os.path.join(output_dir, 'tester.py')
     results = run_pex_command(['pytest==3.9.1',
                                '-e', 'pytest:main',
-                               '-D', output_dir,
                                '-o', pex_path])
     results.assert_success()
 
-    assert subprocess.call([pex_path]) == 1
+    assert subprocess.call([pex_path, tester_path]) == 1
 
 
 @pytest.mark.skipif(NOT_CPYTHON27)


### PR DESCRIPTION
Currently the exit code from an entrypoint is swallowed, so running pex
always exits 0.

Tested with:
```
tox -e py27-package
dist/pex27 -e pytest:main pytest -D /path/to/failing/test/dir
```

before this PR, this exits 0, after it exits 1.

I'm not sure how to properly integration test this, as it is in the
outer-most wrapper layer of the pex binary, so looks like it's bypassed
by the way we tend to test things?