### PR TITLE
Fix *_custom_setuptools_useable ITs.

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1022,13 +1022,17 @@ def pex_with_entrypoints(entry_point):
   """)
 
   my_app = dedent("""
-    from setuptools.sandbox import run_setup
+    import sys
 
     def do_something():
-      return run_setup
+      try:
+        from setuptools.sandbox import run_setup
+        return 0
+      except:
+        return 1
 
     if __name__ == '__main__':
-      do_something()
+      sys.exit(do_something())
   """)
 
   with temporary_content({'setup.py': setup_py, 'my_app.py': my_app}) as project_dir:


### PR DESCRIPTION
Ensure the entrypoint function used to test both entrypoints and modules
explicitly tests that it's the import that works and then chains the
appropriate return / `__main__` behavior to express the result of the
test.