### PR TITLE
Update PyPI default URL to pypi.org

### DIFF
--- a/pex/fetcher.py
+++ b/pex/fetcher.py
@@ -47,7 +47,7 @@ class Fetcher(FetcherBase):
 
 
 class PyPIFetcher(FetcherBase):
-  PYPI_BASE = 'https://pypi.python.org/simple/'
+  PYPI_BASE = 'https://pypi.org/simple/'
 
   def __init__(self, pypi_base=PYPI_BASE, use_mirrors=False):
     if use_mirrors:

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -5,13 +5,13 @@ from pex.fetcher import PyPIFetcher
 
 
 def test_pypifetcher():
-  fetcher = PyPIFetcher('https://pypi.python.org/simple')
-  assert fetcher._pypi_base == 'https://pypi.python.org/simple/'
-  assert fetcher.urls('setuptools') == ['https://pypi.python.org/simple/setuptools/']
+  fetcher = PyPIFetcher('https://pypi.org/simple')
+  assert fetcher._pypi_base == 'https://pypi.org/simple/'
+  assert fetcher.urls('setuptools') == ['https://pypi.org/simple/setuptools/']
 
   fetcher = PyPIFetcher()
-  assert fetcher._pypi_base == 'https://pypi.python.org/simple/'
-  assert fetcher.urls('setuptools') == ['https://pypi.python.org/simple/setuptools/']
+  assert fetcher._pypi_base == 'https://pypi.org/simple/'
+  assert fetcher.urls('setuptools') == ['https://pypi.org/simple/setuptools/']
 
   fetcher = PyPIFetcher('file:///srv/simple')
   assert fetcher._pypi_base == 'file:///srv/simple/'

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -54,7 +54,7 @@ def patch_requests():
 
 @contextmanager
 def make_url(blob, md5_fragment=None):
-  url = 'http://pypi.python.org/foo.tar.gz'
+  url = 'http://pypi.org/foo.tar.gz'
   if md5_fragment:
     url += '#md5=%s' % md5_fragment
 
@@ -148,7 +148,7 @@ def test_requests_context_retries_from_environment():
 
 def timeout_side_effect(timeout_error=None, num_timeouts=1):
   timeout_error = timeout_error or requests.packages.urllib3.exceptions.ConnectTimeoutError
-  url = 'http://pypi.python.org/foo.tar.gz'
+  url = 'http://pypi.org/foo.tar.gz'
 
   num_requests = [0]  # hack, because python closures?
   def timeout(*args, **kwargs):

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -28,7 +28,7 @@ def test_empty_iteration():
 
 def assert_iteration(all_versions, *expected_versions, **iterator_kwargs):
   def package_url(version):
-    return 'https://pypi.python.org/packages/source/p/pex/pex-%s.tar.gz' % version
+    return 'https://pypi.org/packages/source/p/pex/pex-%s.tar.gz' % version
 
   urls = [package_url(v) for v in all_versions]
   crawler_mock = mock.create_autospec(Crawler, spec_set=True)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -91,7 +91,7 @@ def test_invalid_wheel_package_name(package_name):
 
 def test_different_wheel_packages_should_be_equal():
   pypi_package = WheelPackage(
-    'https://pypi.python.org/packages/9b/31/'
+    'https://pypi.org/packages/9b/31/'
     'e9925a2b9a06f97c3450bac6107928d3533bfe64ca5615442504104321e8/'
     'requests-2.12.1-py2.py3-none-any.whl'
   )


### PR DESCRIPTION
As of April 13th, 2018, pypi.org is the cannonical URL for PyPI.
The domain pypi.python.org still exists and redirects to pypi.org,
but might be disabled in the future.

https://packaging.python.org/guides/migrating-to-pypi-org/