### PR TITLE
Fixup PEXEnvironment extras resolution.

### DIFF
--- a/pex/environment.py
+++ b/pex/environment.py
@@ -159,10 +159,13 @@ class PEXEnvironment(Environment):
     unresolved_reqs = set()
     resolveds = set()
 
+    environment = self._target_interpreter_env.copy()
+    environment['extra'] = list(set(itertools.chain(*(req.extras for req in reqs))))
+
     # Resolve them one at a time so that we can figure out which ones we need to elide should
     # there be an interpreter incompatibility.
     for req in reqs:
-      if req.marker and not req.marker.evaluate(environment=self._target_interpreter_env):
+      if req.marker and not req.marker.evaluate(environment=environment):
         TRACER.log('Skipping activation of `%s` due to environment marker de-selection' % req)
         continue
       with TRACER.timed('Resolving %s' % req, V=2):


### PR DESCRIPTION
In #582 and #592 support for environment markers was added to the pex
runtime. In so doing, the resolver was fixed to record full requirement
strings into PEX-INFO. Since part of those full requirement strings
could now include environment markers that selected for active extras,
a bug was introduced since we did not also add the active extras to the
environment marker evaluation environment.

This change adds a failing test that is fixed by properly setting up the
environment marker environment to include active extras.

Fixes #615.