### PR TITLE
Allow pex to be invoked using runpy (python -m pex).

### DIFF
--- a/pex/__main__.py
+++ b/pex/__main__.py
@@ -1,0 +1,4 @@
+from pex.bin import pex
+
+
+__name__ == '__main__' and pex.main()

--- a/pex/__main__.py
+++ b/pex/__main__.py
@@ -1,4 +1,8 @@
-from pex.bin import pex
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import absolute_import
+
+from pex.bin import pex
 
 __name__ == '__main__' and pex.main()


### PR DESCRIPTION
Today I went to run pex using [pip-run](https://pypi.org/project/pip-run), but found that running `python -m pex` results in the usual error:

```
python3: No module named pex.__main__; 'pex' is a package and cannot be directly executed
```

Of course, one can use `python -m pex.bin.pex` but that's unintuitive. How about let the pex package also supply the pex command?