### PR TITLE
When iterating over Zipfiles, always use the Unix file separator to fix a Windows issue

### DIFF
--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -117,12 +117,9 @@ class _ZipIterator(namedtuple('_ZipIterator', ['zipfile_path', 'prefix'])):
 
   def _filter_names(self, relpath, pattern, group):
     # We use '/' here instead of os.sep because the zip file format spec specifies that paths must use forward slashes.
-    # See section 4.4.17 of https://support.pkware.com/display/PKZIP/APPNOTE
-    prefix = self.prefix + ((relpath + '/') if relpath else '')
-    pat = re.compile(r'^{prefix}{pattern}$'
-                     .format(prefix=prefix,
-                             pattern=pattern))
-
+    # See section 4.4.17 of https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
+    relpath_pat = '{}/'.format(relpath) if relpath else ''
+    pat = re.compile(r'^{}{}{}$'.format(self.prefix, relpath_pat, pattern))
     with contextlib.closing(zipfile.ZipFile(self.zipfile_path)) as zf:
       for name in zf.namelist():
         match = pat.match(name)

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -118,7 +118,7 @@ class _ZipIterator(namedtuple('_ZipIterator', ['zipfile_path', 'prefix'])):
   def _filter_names(self, relpath, pattern, group):
     prefix = self.prefix + ((relpath + os.sep) if relpath else '')
     if os.sep == '\\':
-        prefix = prefix.replace('\\', '/')
+      prefix = prefix.replace('\\', '/')
     pat = re.compile(r'^{prefix}{pattern}$'
                      .format(prefix=prefix,
                              pattern=pattern))

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -123,7 +123,7 @@ class _ZipIterator(namedtuple('_ZipIterator', ['zipfile_path', 'prefix'])):
     # We use '/' here instead of os.sep because the zip file format spec specifies that paths must
     # use forward slashes. See section 4.4.17 of
     # https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
-    relpath_pat = '{}/'.format(relpath) if relpath else ''
+    relpath_pat = '{}/'.format(relpath.replace(os.sep, '/')) if relpath else ''
     pat = re.compile(r'^{}{}{}$'.format(self.prefix, relpath_pat, pattern))
     with contextlib.closing(zipfile.ZipFile(self.zipfile_path)) as zf:
       for name in zf.namelist():

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -116,8 +116,11 @@ class _ZipIterator(namedtuple('_ZipIterator', ['zipfile_path', 'prefix'])):
       yield package
 
   def _filter_names(self, relpath, pattern, group):
+    prefix = self.prefix + ((relpath + os.sep) if relpath else '')
+    if os.sep == '\\':
+        prefix = prefix.replace('\\', '/')
     pat = re.compile(r'^{prefix}{pattern}$'
-                     .format(prefix=self.prefix + ((relpath + os.sep) if relpath else ''),
+                     .format(prefix=prefix,
                              pattern=pattern))
 
     with contextlib.closing(zipfile.ZipFile(self.zipfile_path)) as zf:

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -116,7 +116,8 @@ class _ZipIterator(namedtuple('_ZipIterator', ['zipfile_path', 'prefix'])):
       yield package
 
   def _filter_names(self, relpath, pattern, group):
-    # We use '/' here instead of os.sep because the zip file format spec specifies that paths must use forward slashes.
+    # We use '/' here instead of os.sep because the zip file format spec specifies that paths must
+    # use forward slashes.
     # See section 4.4.17 of https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
     relpath_pat = '{}/'.format(relpath) if relpath else ''
     pat = re.compile(r'^{}{}{}$'.format(self.prefix, relpath_pat, pattern))

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -100,12 +100,13 @@ class _ZipIterator(namedtuple('_ZipIterator', ['zipfile_path', 'prefix'])):
     prefix = ''
     path = root
     while path:
-      # We replace os.sep with '/' here because the zip file format spec specifies that paths must
-      # use forward slashes. See section 4.4.17 of
+      # We use '/' here because the zip file format spec specifies that paths must use
+      # forward slashes. See section 4.4.17 of
       # https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT.
       if zipfile.is_zipfile(path):
-        return cls(zipfile_path=path, prefix='{}{}'.format(prefix, os.sep).replace(os.sep, '/'))
-      prefix = os.path.join(prefix, os.path.basename(path)).replace(os.sep, '/')
+        return cls(zipfile_path=path, prefix='{}/'.format(prefix) if prefix else '')
+      path_base = os.path.basename(path)
+      prefix = '{}/{}'.format(path_base, prefix) if prefix else path_base
       path = os.path.dirname(path)
     raise ValueError('Could not find the zip file housing {}'.format(root))
 
@@ -119,10 +120,10 @@ class _ZipIterator(namedtuple('_ZipIterator', ['zipfile_path', 'prefix'])):
       yield package
 
   def _filter_names(self, relpath, pattern, group):
-    # We replace os.sep with '/' here because the zip file format spec specifies that paths must
-    # use forward slashes. See section 4.4.17 of
+    # We use '/' here because the zip file format spec specifies that paths must use
+    # forward slashes. See section 4.4.17 of
     # https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT.
-    relpath_pat = '' if not relpath else '{}{}'.format(relpath, os.sep).replace(os.sep, '/')
+    relpath_pat = '' if not relpath else '{}/'.format(relpath.replace(os.sep, '/'))
     pat = re.compile(r'^{}{}{}$'.format(self.prefix, relpath_pat, pattern))
     with contextlib.closing(zipfile.ZipFile(self.zipfile_path)) as zf:
       for name in zf.namelist():

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -116,9 +116,9 @@ class _ZipIterator(namedtuple('_ZipIterator', ['zipfile_path', 'prefix'])):
       yield package
 
   def _filter_names(self, relpath, pattern, group):
-    prefix = self.prefix + ((relpath + os.sep) if relpath else '')
-    if os.sep == '\\':
-      prefix = prefix.replace('\\', '/')
+    # We use '/' here instead of os.sep because the zip file format spec specifies that paths must use forward slashes.
+    # See section 4.4.17 of https://support.pkware.com/display/PKZIP/APPNOTE
+    prefix = self.prefix + ((relpath + '/') if relpath else '')
     pat = re.compile(r'^{prefix}{pattern}$'
                      .format(prefix=prefix,
                              pattern=pattern))

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -100,8 +100,8 @@ class _ZipIterator(namedtuple('_ZipIterator', ['zipfile_path', 'prefix'])):
     prefix = ''
     path = root
     while path:
-      # We use '/' here instead of os.sep because the zip file format spec specifies that paths
-      # must use forward slashes. See section 4.4.17 of
+      # We replace os.sep with '/' here because the zip file format spec specifies that paths must
+      # use forward slashes. See section 4.4.17 of
       # https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT.
       if zipfile.is_zipfile(path):
         return cls(zipfile_path=path, prefix='{}{}'.format(prefix, os.sep).replace(os.sep, '/'))
@@ -119,10 +119,9 @@ class _ZipIterator(namedtuple('_ZipIterator', ['zipfile_path', 'prefix'])):
       yield package
 
   def _filter_names(self, relpath, pattern, group):
-    # We use '/' here instead of os.sep because the zip file format spec specifies that paths must
+    # We replace os.sep with '/' here because the zip file format spec specifies that paths must
     # use forward slashes. See section 4.4.17 of
-    # https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT. Note that relpath is constructed
-    # using os.sep by the time it is passed in here, so we need to replace it with '/'.
+    # https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT.
     relpath_pat = '' if not relpath else '{}{}'.format(relpath, os.sep).replace(os.sep, '/')
     pat = re.compile(r'^{}{}{}$'.format(self.prefix, relpath_pat, pattern))
     with contextlib.closing(zipfile.ZipFile(self.zipfile_path)) as zf:


### PR DESCRIPTION
Hello!

I know pex doesn't officially support windows, but there seems to be a regression in pex 1.6.0 with windows with respect to the way the vendoring works. Specifically, the regex for iterating the zip path in the vendoring uses the os separator, which has two problems on windows (where the separator is `\`):

1. `\` is an escape sequence, so unless the separator is added twice in the string, it uses it to escape the character immediately after the separator, causing the regex compilation to fail.
1. The path in the zip file uses unix separators (`/`), so using the os separator is actually wrong.

This PR addresses this by updating the regex to replace windows separators (`\`) in the prefix var with the unix separator.