### PR TITLE
Fix invalid regex and escape sequences causing DeprecationWarning

### DIFF
--- a/pex/finders.py
+++ b/pex/finders.py
@@ -103,7 +103,7 @@ class WheelMetadata(pkg_resources.EggMetadata):
   @classmethod
   def _escape(cls, filename_component):
     # See: https://www.python.org/dev/peps/pep-0427/#escaping-and-unicode
-    return re.sub("[^\w\d.]+", "_", filename_component, re.UNICODE)
+    return re.sub(r"[^\w\d.]+", "_", filename_component, re.UNICODE)
 
   @classmethod
   def _split_wheelname(cls, wheelname):

--- a/pex/vendor/_vendored/wheel/wheel/metadata.py
+++ b/pex/vendor/_vendored/wheel/wheel/metadata.py
@@ -13,7 +13,7 @@ from .pkginfo import read_pkg_info
 
 # Wheel itself is probably the only program that uses non-extras markers
 # in METADATA/PKG-INFO. Support its syntax with the extra at the end only.
-EXTRA_RE = re.compile("""^(?P<package>.*?)(;\s*(?P<condition>.*?)(extra == '(?P<extra>.*?)')?)$""")
+EXTRA_RE = re.compile(r"^(?P<package>.*?)(;\s*(?P<condition>.*?)(extra == '(?P<extra>.*?)')?)$")
 
 MayRequiresKey = namedtuple('MayRequiresKey', ('condition', 'extra'))
 


### PR DESCRIPTION
These bad escape sequences were causing `DeprecationWarning`s when running Pants with Python 3.

Invalid entries found through the regex `'re\..*\\'`, and equality to original string tested by comparing the two in a REPL.