### PR TITLE
Fix interpreter finding

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -343,7 +343,7 @@ class PythonInterpreter(object):
     return cls.CACHE[binary]
 
   @classmethod
-  def _matches_binary_name(basefile):
+  def _matches_binary_name(cls, basefile):
     return any(matcher.match(basefile) is not None for matcher in cls.REGEXEN)
 
   @classmethod

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -266,6 +266,7 @@ class PythonInterpreter(object):
     re.compile(r'[Pp]ython$'),
 
     re.compile(r'python[23].[0-9]$'),
+    re.compile(r'python[23]$'),
     re.compile(r'pypy$'),
     re.compile(r'pypy-1.[0-9]$'),
   )

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -265,8 +265,8 @@ class PythonInterpreter(object):
     # NB: OSX ships python binaries named Python so we allow for capital-P.
     re.compile(r'[Pp]ython$'),
 
-    re.compile(r'python[23].[0-9]$'),
     re.compile(r'python[23]$'),
+    re.compile(r'python[23].[0-9]$'),
     re.compile(r'pypy$'),
     re.compile(r'pypy-1.[0-9]$'),
   )
@@ -356,7 +356,7 @@ class PythonInterpreter(object):
     for path in paths:
       for fn in cls.expand_path(path):
         basefile = os.path.basename(fn)
-        if self._matches_binary_name(basefile):
+        if cls._matches_binary_name(basefile):
           try:
             pythons.append(cls.from_binary(fn))
           except Exception as e:

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -343,6 +343,10 @@ class PythonInterpreter(object):
     return cls.CACHE[binary]
 
   @classmethod
+  def _matches_binary_name(basefile):
+    return any(matcher.match(basefile) is not None for matcher in cls.REGEXEN)
+
+  @classmethod
   def find(cls, paths):
     """
       Given a list of files or directories, try to detect python interpreters amongst them.
@@ -352,7 +356,7 @@ class PythonInterpreter(object):
     for path in paths:
       for fn in cls.expand_path(path):
         basefile = os.path.basename(fn)
-        if any(matcher.match(basefile) is not None for matcher in cls.REGEXEN):
+        if self._matches_binary_name(basefile):
           try:
             pythons.append(cls.from_binary(fn))
           except Exception as e:

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -73,4 +73,4 @@ class TestPythonInterpreter(object):
     )
 
     for name in valid_binary_names:
-      assert interpreter.PythonIdentity._matches_binary_name(name), 'Expected {} to be valid'.format(name)
+      assert interpreter.PythonInterpreter._matches_binary_name(name), 'Expected {} to be valid'.format(name)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -58,3 +58,19 @@ class TestPythonInterpreter(object):
 
     py_interpreter3 = interpreter.PythonInterpreter.from_binary(test_interpreter1)
     assert py_interpreter1 is py_interpreter3
+
+  def test_binary_name_matching(self):
+    valid_binary_names = (
+      'jython',
+      'pypy',
+      'pypy-1.1',
+      'python',
+      'Python',
+      'python2',
+      'python2.7',
+      'python3',
+      'python3.6'
+    )
+
+    for name in valid_binary_names:
+      assert interpreter.PythonIdentity._matches_binary_name(name), 'Expected {} to be valid'.format(name)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -72,6 +72,6 @@ class TestPythonInterpreter(object):
       'python3.6'
     )
 
+    matches = interpreter.PythonInterpreter._matches_binary_name
     for name in valid_binary_names:
-      assert interpreter.PythonInterpreter._matches_binary_name(name), \
-        'Expected {} to be valid binary name'.format(name)
+      assert matches(name), 'Expected {} to be valid binary name'.format(name)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -73,4 +73,5 @@ class TestPythonInterpreter(object):
     )
 
     for name in valid_binary_names:
-      assert interpreter.PythonInterpreter._matches_binary_name(name), 'Expected {} to be valid'.format(name)
+      assert interpreter.PythonInterpreter._matches_binary_name(name), \
+        'Expected {} to be valid binary name'.format(name)


### PR DESCRIPTION
## Problem:
We currently don't expect interpreter binaries to have a name such as `python3` or `python2`. However those are valid names for interpreters.

Ex:
```
$ python3 -c 'import sys; print(sys.executable)'
/Library/Frameworks/Python.framework/Versions/3.6/bin/python3
```

## Solution:
Add entry to support those filenames.