### PR TITLE
Add User-Agent header when resolving via urllib

### DIFF
--- a/pex/http.py
+++ b/pex/http.py
@@ -134,6 +134,8 @@ class Context(AbstractClass):
 class UrllibContext(Context):
   """Default Python standard library Context."""
 
+  USER_AGENT = 'pex/%s' % PEX_VERSION
+
   def open(self, link):
     return urllib_request.urlopen(link.url)
 
@@ -146,7 +148,7 @@ class UrllibContext(Context):
       return fp.read().decode(encoding, 'replace')
 
   def resolve(self, link):
-    request = urllib_request.Request(link.url)
+    request = urllib_request.Request(link.url, headers={'User-Agent': self.USER_AGENT})
     request.get_method = lambda: 'HEAD'
     with contextlib.closing(urllib_request.urlopen(request)) as response:
       return link.wrap(response.url)

--- a/pex/http.py
+++ b/pex/http.py
@@ -57,6 +57,7 @@ class Context(AbstractClass):
   """
 
   DEFAULT_ENCODING = 'iso-8859-1'
+  USER_AGENT = 'pex/%s' % PEX_VERSION
 
   class Error(Exception):
     """Error base class for Contexts to wrap application-specific exceptions."""
@@ -134,10 +135,9 @@ class Context(AbstractClass):
 class UrllibContext(Context):
   """Default Python standard library Context."""
 
-  USER_AGENT = 'pex/%s' % PEX_VERSION
-
   def open(self, link):
-    return urllib_request.urlopen(link.url)
+    request = urllib_request.Request(link.url, headers={'User-Agent': self.USER_AGENT})
+    return urllib_request.urlopen(request)
 
   def content(self, link):
     if link.local:
@@ -211,7 +211,6 @@ class StreamFilelike(object):
 
 class RequestsContext(Context):
   """A requests-based Context."""
-  USER_AGENT = 'pex/%s' % PEX_VERSION
 
   @staticmethod
   def _create_session(max_retries):


### PR DESCRIPTION
At least some Python Index servers return a simple format of packages page, redirecting to <path>/<package> to <path>/+simple/<package>.

So there is a different result between `pex` run using `urllib` and using `requests` - in one case it errors.