### PR TITLE
Honor interpreter constraints even when PEX_PYTHON and PEX_PYTHON_PATH not set

### DIFF
--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -116,6 +116,10 @@ def maybe_reexec_pex(compatibility_constraints):
     elif ENV.PEX_PYTHON_PATH:
       target = _select_interpreter(ENV.PEX_PYTHON_PATH, compatibility_constraints)
 
+    else:
+      # Apply constraints to target using regular PATH
+      target = _select_interpreter(pex_python_path=None, compatibility_constraints=compatibility_constraints)
+
   if target and os.path.realpath(target) != os.path.realpath(sys.executable):
     cmdline = [target] + sys.argv
     TRACER.log('Re-executing: cmdline="%s", sys.executable="%s", PEX_PYTHON="%s", '

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -94,12 +94,14 @@ def maybe_reexec_pex(compatibility_constraints):
   interpreter specified by PEX_PYTHON. If PEX_PYTHON_PATH is set, it attempts to search the path for
   a matching interpreter in accordance with the interpreter constraints. If both variables are
   present in a pexrc, this function gives precedence to PEX_PYTHON_PATH and errors out if no
-  compatible interpreters can be found on said path. If neither variable is set, fall through to
-  plain pex execution using PATH searching or the currently executing interpreter.
+  compatible interpreters can be found on said path.
+
+  If neither variable is set, we fall back to plain PEX execution using PATH searching or the
+  currently executing interpreter. If compatibility constraints are used, we match those constraints
+  against these interpreters.
 
   :param compatibility_constraints: list of requirements-style strings that constrain the
   Python interpreter to re-exec this pex with.
-
   """
   if os.environ.pop('SHOULD_EXIT_BOOTSTRAP_REEXEC', None):
     # We've already been here and selected an interpreter. Continue to execution.

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -116,7 +116,7 @@ def maybe_reexec_pex(compatibility_constraints):
     elif ENV.PEX_PYTHON_PATH:
       target = _select_interpreter(ENV.PEX_PYTHON_PATH, compatibility_constraints)
 
-    else:
+    elif compatibility_constraints:
       # Apply constraints to target using regular PATH
       target = _select_interpreter(
         pex_python_path=None,

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -118,7 +118,10 @@ def maybe_reexec_pex(compatibility_constraints):
 
     else:
       # Apply constraints to target using regular PATH
-      target = _select_interpreter(pex_python_path=None, compatibility_constraints=compatibility_constraints)
+      target = _select_interpreter(
+        pex_python_path=None,
+        compatibility_constraints=compatibility_constraints
+      )
 
   if target and os.path.realpath(target) != os.path.realpath(sys.executable):
     cmdline = [target] + sys.argv

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -430,8 +430,7 @@ def test_interpreter_constraints_honored_without_ppp_or_pp():
       PATH=":".join([
         os.path.dirname(py36_path),
         os.path.dirname(py35_path)
-      ]),
-      PEX_VERBOSE="1"
+      ])
     )
     res = run_pex_command(['--disable-cache',
       '--interpreter-constraint===%s' % PY35,
@@ -483,12 +482,19 @@ def test_interpreter_resolution_pex_python_path_precedence_over_pex_python():
 def test_plain_pex_exec_no_ppp_no_pp_no_constraints():
   with temporary_dir() as td:
     pex_out_path = os.path.join(td, 'pex.pex')
-    res = run_pex_command(['--disable-cache',
-      '-o', pex_out_path])
+    env = make_env(
+      PEX_IGNORE_RCFILES="1",
+      PATH=os.path.dirname(os.path.realpath(sys.executable))
+    )
+    res = run_pex_command([
+      '--disable-cache',
+      '-o', pex_out_path],
+      env=env
+    )
     res.assert_success()
 
     stdin_payload = b'import os, sys; print(os.path.realpath(sys.executable)); sys.exit(0)'
-    stdout, rc = run_simple_pex(pex_out_path, stdin=stdin_payload)
+    stdout, rc = run_simple_pex(pex_out_path, stdin=stdin_payload, env=env)
     assert rc == 0
     assert os.path.realpath(sys.executable).encode() in stdout
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1160,13 +1160,19 @@ def test_setup_interpreter_constraint():
   interpreter = ensure_python_interpreter(PY27)
   with temporary_dir() as out:
     pex = os.path.join(out, 'pex.pex')
+    env = make_env(
+      PEX_IGNORE_RCFILES='1',
+      PATH=os.path.dirname(interpreter),
+    )
     results = run_pex_command(['jsonschema==2.6.0',
                                '--disable-cache',
                                '--interpreter-constraint=CPython=={}'.format(PY27),
                                '-o', pex],
-                              env=make_env(PATH=os.path.dirname(interpreter)))
+                              env=env)
     results.assert_success()
-    subprocess.check_call([pex, '-c', 'import jsonschema'])
+
+    stdout, rc = run_simple_pex(pex, env=env, stdin='import jsonschema')
+    assert rc == 0
 
 
 @pytest.mark.skipif(IS_PYPY,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1171,7 +1171,7 @@ def test_setup_interpreter_constraint():
                               env=env)
     results.assert_success()
 
-    stdout, rc = run_simple_pex(pex, env=env, stdin='import jsonschema')
+    stdout, rc = run_simple_pex(pex, env=env, stdin=b'import jsonschema')
     assert rc == 0
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -423,14 +423,19 @@ def test_interpreter_constraints_honored_without_ppp_or_pp():
   with temporary_dir() as td:
 
     py36_path = ensure_python_interpreter(PY36)
+    py35_path = ensure_python_interpreter(PY35)
 
     pex_out_path = os.path.join(td, 'pex.pex')
     env = make_env(
       PEX_IGNORE_RCFILES="1",
-      PATH=os.path.dirname(py36_path)
+      PATH=":".join([
+        os.path.dirname(py36_path),
+        os.path.dirname(py35_path)
+      ]),
+      PEX_VERBOSE="1"
     )
     res = run_pex_command(['--disable-cache',
-      '--interpreter-constraint===%s' % PY36,
+      '--interpreter-constraint===%s' % PY35,
       '-o', pex_out_path],
       env=env
     )
@@ -443,9 +448,9 @@ def test_interpreter_constraints_honored_without_ppp_or_pp():
     print("BL: stdout = {}".format(stdout))
     assert rc == 0
 
-    # If the constraints are honored, it will have run python3.6 and not python3.5
+    # If the constraints are honored, it will have run python3.5 and not python3.6
     if sys.version_info[0] == 3:
-      assert ("Python %s" % PY36) in str(stdout).split("\n")[0]
+      assert ("Python %s" % PY35) in str(stdout).split("\n")[0]
 
 
 @pytest.mark.skipif(NOT_CPYTHON36)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -427,9 +427,9 @@ def test_interpreter_constraints_honored_without_ppp_or_pp():
     pex_out_path = os.path.join(td, 'pex.pex')
     env = make_env(
       PEX_IGNORE_RCFILES="1",
-      PATH=":".join([
+      PATH=os.pathsep.join([
+        os.path.dirname(py35_path),
         os.path.dirname(py36_path),
-        os.path.dirname(py35_path)
       ])
     )
     res = run_pex_command(['--disable-cache',
@@ -443,12 +443,12 @@ def test_interpreter_constraints_honored_without_ppp_or_pp():
     stdin_payload = b'import sys; print(sys.executable); sys.exit(0)'
 
     stdout, rc = run_simple_pex(pex_out_path, stdin=stdin_payload, env=env)
-    print("BL: stdout = {}".format(stdout))
     assert rc == 0
 
-    # If the constraints are honored, it will have run python3.5 and not python3.6
-    if sys.version_info[0] == 3:
-      assert ("Python %s" % PY36) in str(stdout).split("\n")[0]
+    # If the constraints are honored, it will have run python3.6 and not python3.5
+    # Without constraints, we would expect it to use python3.5 as it is the minimum interpreter
+    # in the PATH.
+    assert str(py36_path).encode() in stdout
 
 
 @pytest.mark.skipif(NOT_CPYTHON36)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -415,6 +415,7 @@ def test_interpreter_resolution_with_pex_python_path():
     else:
       assert str(pex_python_path.split(':')[0]).encode() in stdout
 
+
 @pytest.mark.skipif(IS_PYPY)
 def test_interpreter_constraints_honored_without_ppp_or_pp():
 
@@ -445,6 +446,7 @@ def test_interpreter_constraints_honored_without_ppp_or_pp():
     # If the constraints are honored, it will have run python3.6 and not python3.5
     if sys.version_info[0] == 3:
       assert ("Python %s" % PY36) in str(stdout).split("\n")[0]
+
 
 @pytest.mark.skipif(NOT_CPYTHON36)
 def test_interpreter_resolution_pex_python_path_precedence_over_pex_python():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,6 +22,7 @@ from pex.testing import (
     NOT_CPYTHON36,
     NOT_CPYTHON36_OR_LINUX,
     PY27,
+    PY35,
     PY36,
     ensure_python_interpreter,
     get_dep_dist_names_from_pex,
@@ -418,10 +419,8 @@ def test_interpreter_resolution_with_pex_python_path():
 
 @pytest.mark.skipif(IS_PYPY)
 def test_interpreter_constraints_honored_without_ppp_or_pp():
-
   # Create a pex with interpreter constraints, but for not the default interpreter in the path.
   with temporary_dir() as td:
-
     py36_path = ensure_python_interpreter(PY36)
     py35_path = ensure_python_interpreter(PY35)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -433,7 +433,7 @@ def test_interpreter_constraints_honored_without_ppp_or_pp():
       ])
     )
     res = run_pex_command(['--disable-cache',
-      '--interpreter-constraint===%s' % PY35,
+      '--interpreter-constraint===%s' % PY36,
       '-o', pex_out_path],
       env=env
     )
@@ -448,7 +448,7 @@ def test_interpreter_constraints_honored_without_ppp_or_pp():
 
     # If the constraints are honored, it will have run python3.5 and not python3.6
     if sys.version_info[0] == 3:
-      assert ("Python %s" % PY35) in str(stdout).split("\n")[0]
+      assert ("Python %s" % PY36) in str(stdout).split("\n")[0]
 
 
 @pytest.mark.skipif(NOT_CPYTHON36)


### PR DESCRIPTION
Solves issue #656, where if no `PEX_PYTHON_PATH` and no `PEX_PYHON` are configured, we still honour `--interpreter-constraint` flag when bootstrapping a PEX.

There is an integration test that worked only when applied the last commit, but there is a lot of nuance to running it that I'd like a hand with. In particular, I'd like to know if there's a way of:
- Specifying "please ignore system-wide settings for PEX_PYTHON_PATH" in a test **or** Specifying 
"please override PEX_PYTHON_PATH with `None`". I think the first one should be easy to implement with a command-line flag defined in the same place as `--rcfile`.
- Specifying "This test only runs on Python3.5", because I need two different interpreters to play with (one for the environment that the pex runs in, another one to pass to `--interpreter-constraint`).