### PR TITLE
OR interpreter constraints when multiple given

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -317,10 +317,10 @@ def configure_clp_pex_environment(parser):
     default=[],
     type='str',
     action='append',
-    help='A constraint that determines the interpreter compatibility for '
-         'this pex, using the Requirement-style format, e.g. "CPython>=3", or ">=2.7" '
-         'for requirements agnostic to interpreter class. This option can be passed multiple '
-         'times.')
+    help='Constrain the selected Python interpreter. Specify with Requirement-style syntax, '
+         'e.g. "CPython>=2.7,<3" (A CPython interpreter with version >=2.7 AND version <3) '
+         'or "PyPy" (A pypy interpreter of any version). This argument may be repeated multiple '
+         'times to OR the constraints.')
 
   group.add_option(
     '--rcfile',

--- a/pex/interpreter_constraints.py
+++ b/pex/interpreter_constraints.py
@@ -21,21 +21,18 @@ def validate_constraints(constraints):
       die("Compatibility requirements are not formatted properly: %s" % str(e))
 
 
-def matched_interpreters(interpreters, constraints, meet_all_constraints=False):
-  """Given some filters, yield any interpreter that matches at least one of them, or all of them
-     if meet_all_constraints is set to True.
+def matched_interpreters(interpreters, constraints):
+  """Given some filters, yield any interpreter that matches at least one of them.
 
   :param interpreters: a list of PythonInterpreter objects for filtering
   :param constraints: A sequence of strings that constrain the interpreter compatibility for this
-    pex, using the Requirement-style format, e.g. ``'CPython>=3', or just ['>=2.7','<3']``
-    for requirements agnostic to interpreter class.
-  :param meet_all_constraints: whether to match against all filters.
-    Defaults to matching interpreters that match at least one filter.
+    pex. Each string uses the Requirement-style format, e.g. 'CPython>=3' or '>=2.7,<3' for requirements
+    agnostic to interpreter class. Multiple requirement strings may be combined into a list to OR the constraints,
+    such as ['CPython>=2.7,<3', 'CPython>=3.4'].
   :return interpreter: returns a generator that yields compatible interpreters
   """
-  check = all if meet_all_constraints else any
   for interpreter in interpreters:
-    if check(interpreter.identity.matches(filt) for filt in constraints):
+    if any(interpreter.identity.matches(filt) for filt in constraints):
       TRACER.log("Constraints on interpreters: %s, Matching Interpreter: %s"
                  % (constraints, interpreter.binary), V=3)
       yield interpreter

--- a/pex/interpreter_constraints.py
+++ b/pex/interpreter_constraints.py
@@ -27,10 +27,11 @@ def matched_interpreters(interpreters, constraints, meet_all_constraints=False):
 
   :param interpreters: a list of PythonInterpreter objects for filtering
   :param constraints: A sequence of strings that constrain the interpreter compatibility for this
-    pex, using the Requirement-style format, e.g. ``'CPython>=3', or just ['>=2.7','<3']``
-    for requirements agnostic to interpreter class.
-  :param meet_all_constraints: whether to match against all filters.
-    Defaults to matching interpreters that match at least one filter.
+    pex. Each string uses the Requirement-style format, e.g. 'CPython>=3' or '>=2.7,<3' for requirements
+    agnostic to interpreter class. Multiple requirement strings may be combined into a list, such as
+    ['CPython>=2.7,<3', 'CPython>=3.4'], to either OR or AND the requirements depending on `meet_all_constraints`.
+  :param meet_all_constraints: whether to match against all filters (AND).
+    Defaults to matching interpreters that match at least one filter (OR).
   :return interpreter: returns a generator that yields compatible interpreters
   """
   check = all if meet_all_constraints else any

--- a/pex/interpreter_constraints.py
+++ b/pex/interpreter_constraints.py
@@ -21,18 +21,21 @@ def validate_constraints(constraints):
       die("Compatibility requirements are not formatted properly: %s" % str(e))
 
 
-def matched_interpreters(interpreters, constraints):
-  """Given some filters, yield any interpreter that matches at least one of them.
+def matched_interpreters(interpreters, constraints, meet_all_constraints=False):
+  """Given some filters, yield any interpreter that matches at least one of them, or all of them
+     if meet_all_constraints is set to True.
 
   :param interpreters: a list of PythonInterpreter objects for filtering
   :param constraints: A sequence of strings that constrain the interpreter compatibility for this
-    pex. Each string uses the Requirement-style format, e.g. 'CPython>=3' or '>=2.7,<3' for requirements
-    agnostic to interpreter class. Multiple requirement strings may be combined into a list to OR the constraints,
-    such as ['CPython>=2.7,<3', 'CPython>=3.4'].
+    pex, using the Requirement-style format, e.g. ``'CPython>=3', or just ['>=2.7','<3']``
+    for requirements agnostic to interpreter class.
+  :param meet_all_constraints: whether to match against all filters.
+    Defaults to matching interpreters that match at least one filter.
   :return interpreter: returns a generator that yields compatible interpreters
   """
+  check = all if meet_all_constraints else any
   for interpreter in interpreters:
-    if any(interpreter.identity.matches(filt) for filt in constraints):
+    if check(interpreter.identity.matches(filt) for filt in constraints):
       TRACER.log("Constraints on interpreters: %s, Matching Interpreter: %s"
                  % (constraints, interpreter.binary), V=3)
       yield interpreter

--- a/pex/interpreter_constraints.py
+++ b/pex/interpreter_constraints.py
@@ -21,22 +21,18 @@ def validate_constraints(constraints):
       die("Compatibility requirements are not formatted properly: %s" % str(e))
 
 
-def matched_interpreters(interpreters, constraints, meet_all_constraints=False):
-  """Given some filters, yield any interpreter that matches at least one of them, or all of them
-     if meet_all_constraints is set to True.
+def matched_interpreters(interpreters, constraints):
+  """Given some filters, yield any interpreter that matches at least one of them.
 
   :param interpreters: a list of PythonInterpreter objects for filtering
   :param constraints: A sequence of strings that constrain the interpreter compatibility for this
-    pex. Each string uses the Requirement-style format, e.g. 'CPython>=3' or '>=2.7,<3' for requirements
-    agnostic to interpreter class. Multiple requirement strings may be combined into a list, such as
-    ['CPython>=2.7,<3', 'CPython>=3.4'], to either OR or AND the requirements depending on `meet_all_constraints`.
-  :param meet_all_constraints: whether to match against all filters (AND).
-    Defaults to matching interpreters that match at least one filter (OR).
+    pex. Each string uses the Requirement-style format, e.g. 'CPython>=3' or '>=2.7,<3' for
+    requirements agnostic to interpreter class. Multiple requirement strings may be combined
+    into a list to OR the constraints, such as ['CPython>=2.7,<3', 'CPython>=3.4'].
   :return interpreter: returns a generator that yields compatible interpreters
   """
-  check = all if meet_all_constraints else any
   for interpreter in interpreters:
-    if check(interpreter.identity.matches(filt) for filt in constraints):
+    if any(interpreter.identity.matches(filt) for filt in constraints):
       TRACER.log("Constraints on interpreters: %s, Matching Interpreter: %s"
                  % (constraints, interpreter.binary), V=3)
       yield interpreter

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -85,8 +85,7 @@ def find_compatible_interpreters(pex_python_path, compatibility_constraints):
       # get all qualifying interpreters found in $PATH
       interpreters = PythonInterpreter.all()
 
-  return list(matched_interpreters(
-    interpreters, compatibility_constraints, meet_all_constraints=True))
+  return list(matched_interpreters(interpreters, compatibility_constraints))
 
 
 def _select_pex_python_interpreter(target_python, compatibility_constraints):
@@ -96,7 +95,7 @@ def _select_pex_python_interpreter(target_python, compatibility_constraints):
     die('Failed to find interpreter specified by PEX_PYTHON: %s' % target)
   if compatibility_constraints:
     pi = PythonInterpreter.from_binary(target)
-    if not list(matched_interpreters([pi], compatibility_constraints, meet_all_constraints=True)):
+    if not list(matched_interpreters([pi], compatibility_constraints)):
       die('Interpreter specified by PEX_PYTHON (%s) is not compatible with specified '
           'interpreter constraints: %s' % (target, str(compatibility_constraints)))
   if not os.path.exists(target):

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -85,7 +85,11 @@ def find_compatible_interpreters(pex_python_path, compatibility_constraints):
       # get all qualifying interpreters found in $PATH
       interpreters = PythonInterpreter.all()
 
-  return list(matched_interpreters(interpreters, compatibility_constraints))
+  return list(
+    matched_interpreters(interpreters, compatibility_constraints)
+    if compatibility_constraints
+    else interpreters
+  )
 
 
 def _select_pex_python_interpreter(target_python, compatibility_constraints):

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -68,8 +68,6 @@ def find_compatible_interpreters(pex_python_path, compatibility_constraints):
      PEX_PYTHON_PATH if it is set. If not, fall back to interpreters on $PATH.
   """
   if pex_python_path:
-    # AND the interpreter constraints
-    meet_all_constraints = True
     interpreters = []
     for binary in pex_python_path.split(os.pathsep):
       try:
@@ -80,8 +78,6 @@ def find_compatible_interpreters(pex_python_path, compatibility_constraints):
     if not interpreters:
       die('PEX_PYTHON_PATH was defined, but no valid interpreters could be identified. Exiting.')
   else:
-    # OR the interpreter constraints
-    meet_all_constraints = False
     if not os.getenv('PATH', ''):
       # no $PATH, use sys.executable
       interpreters = [PythonInterpreter.get()]

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -85,7 +85,8 @@ def find_compatible_interpreters(pex_python_path, compatibility_constraints):
       # get all qualifying interpreters found in $PATH
       interpreters = PythonInterpreter.all()
 
-  return list(matched_interpreters(interpreters, compatibility_constraints))
+  return list(matched_interpreters(
+    interpreters, compatibility_constraints, meet_all_constraints=True))
 
 
 def _select_pex_python_interpreter(target_python, compatibility_constraints):
@@ -95,7 +96,7 @@ def _select_pex_python_interpreter(target_python, compatibility_constraints):
     die('Failed to find interpreter specified by PEX_PYTHON: %s' % target)
   if compatibility_constraints:
     pi = PythonInterpreter.from_binary(target)
-    if not list(matched_interpreters([pi], compatibility_constraints)):
+    if not list(matched_interpreters([pi], compatibility_constraints, meet_all_constraints=True)):
       die('Interpreter specified by PEX_PYTHON (%s) is not compatible with specified '
           'interpreter constraints: %s' % (target, str(compatibility_constraints)))
   if not os.path.exists(target):

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -68,6 +68,8 @@ def find_compatible_interpreters(pex_python_path, compatibility_constraints):
      PEX_PYTHON_PATH if it is set. If not, fall back to interpreters on $PATH.
   """
   if pex_python_path:
+    # AND the interpreter constraints
+    meet_all_constraints = True
     interpreters = []
     for binary in pex_python_path.split(os.pathsep):
       try:
@@ -78,6 +80,8 @@ def find_compatible_interpreters(pex_python_path, compatibility_constraints):
     if not interpreters:
       die('PEX_PYTHON_PATH was defined, but no valid interpreters could be identified. Exiting.')
   else:
+    # OR the interpreter constraints
+    meet_all_constraints = False
     if not os.getenv('PATH', ''):
       # no $PATH, use sys.executable
       interpreters = [PythonInterpreter.get()]
@@ -86,7 +90,7 @@ def find_compatible_interpreters(pex_python_path, compatibility_constraints):
       interpreters = PythonInterpreter.all()
 
   return list(matched_interpreters(
-    interpreters, compatibility_constraints, meet_all_constraints=True))
+    interpreters, compatibility_constraints, meet_all_constraints=meet_all_constraints))
 
 
 def _select_pex_python_interpreter(target_python, compatibility_constraints):
@@ -96,6 +100,7 @@ def _select_pex_python_interpreter(target_python, compatibility_constraints):
     die('Failed to find interpreter specified by PEX_PYTHON: %s' % target)
   if compatibility_constraints:
     pi = PythonInterpreter.from_binary(target)
+    # AND the interpreter constraints
     if not list(matched_interpreters([pi], compatibility_constraints, meet_all_constraints=True)):
       die('Interpreter specified by PEX_PYTHON (%s) is not compatible with specified '
           'interpreter constraints: %s' % (target, str(compatibility_constraints)))

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -89,8 +89,7 @@ def find_compatible_interpreters(pex_python_path, compatibility_constraints):
       # get all qualifying interpreters found in $PATH
       interpreters = PythonInterpreter.all()
 
-  return list(matched_interpreters(
-    interpreters, compatibility_constraints, meet_all_constraints=meet_all_constraints))
+  return list(matched_interpreters(interpreters, compatibility_constraints))
 
 
 def _select_pex_python_interpreter(target_python, compatibility_constraints):
@@ -100,8 +99,7 @@ def _select_pex_python_interpreter(target_python, compatibility_constraints):
     die('Failed to find interpreter specified by PEX_PYTHON: %s' % target)
   if compatibility_constraints:
     pi = PythonInterpreter.from_binary(target)
-    # AND the interpreter constraints
-    if not list(matched_interpreters([pi], compatibility_constraints, meet_all_constraints=True)):
+    if not list(matched_interpreters([pi], compatibility_constraints)):
       die('Interpreter specified by PEX_PYTHON (%s) is not compatible with specified '
           'interpreter constraints: %s' % (target, str(compatibility_constraints)))
   if not os.path.exists(target):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -339,7 +339,7 @@ def test_interpreter_constraints_to_pex_info_py2():
       '-o', pex_out_path])
     res.assert_success()
     pex_info = get_pex_info(pex_out_path)
-    assert ['>=2.7,<3', '>=3.5'] == sorted(pex_info.interpreter_constraints)
+    assert {'>=2.7,<3', '>=3.5'} == set(pex_info.interpreter_constraints)
 
 
 @pytest.mark.skipif(IS_PYPY)
@@ -378,7 +378,7 @@ def test_interpreter_resolution_with_multiple_constraint_options():
       '-o', pex_out_path])
     res.assert_success()
     pex_info = get_pex_info(pex_out_path)
-    assert ['>=2.7,<3', '>=500'] == sorted(pex_info.interpreter_constraints)
+    assert {'>=2.7,<3', '>=500'} == set(pex_info.interpreter_constraints)
     assert pex_info.build_properties['version'][0] < 3
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -334,12 +334,12 @@ def test_interpreter_constraints_to_pex_info_py2():
     # target python 2
     pex_out_path = os.path.join(output_dir, 'pex_py2.pex')
     res = run_pex_command(['--disable-cache',
-      '--interpreter-constraint=>=2.7',
-      '--interpreter-constraint=<3',
+      '--interpreter-constraint=>=2.7,<3',
+      '--interpreter-constraint=>=3.5',
       '-o', pex_out_path])
     res.assert_success()
     pex_info = get_pex_info(pex_out_path)
-    assert set(['>=2.7', '<3']) == set(pex_info.interpreter_constraints)
+    assert ['>=2.7,<3', '>=3.5'] == sorted(pex_info.interpreter_constraints)
 
 
 @pytest.mark.skipif(IS_PYPY)
@@ -359,12 +359,26 @@ def test_interpreter_resolution_with_constraint_option():
   with temporary_dir() as output_dir:
     pex_out_path = os.path.join(output_dir, 'pex1.pex')
     res = run_pex_command(['--disable-cache',
-      '--interpreter-constraint=>=2.7',
-      '--interpreter-constraint=<3',
+      '--interpreter-constraint=>=2.7,<3',
       '-o', pex_out_path])
     res.assert_success()
     pex_info = get_pex_info(pex_out_path)
-    assert set(['>=2.7', '<3']) == set(pex_info.interpreter_constraints)
+    assert ['>=2.7,<3'] == pex_info.interpreter_constraints
+    assert pex_info.build_properties['version'][0] < 3
+
+
+def test_interpreter_resolution_with_multiple_constraint_options():
+  with temporary_dir() as output_dir:
+    pex_out_path = os.path.join(output_dir, 'pex1.pex')
+    res = run_pex_command(['--disable-cache',
+      '--interpreter-constraint=>=2.7,<3',
+      # Add a constraint that's impossible to satisfy. Because multiple
+      # constraints OR, the interpeter should still resolve to Python 2.7.
+      '--interpreter-constraint=>=500',
+      '-o', pex_out_path])
+    res.assert_success()
+    pex_info = get_pex_info(pex_out_path)
+    assert ['>=2.7,<3', '>=500'] == sorted(pex_info.interpreter_constraints)
     assert pex_info.build_properties['version'][0] < 3
 
 
@@ -419,8 +433,7 @@ def test_interpreter_resolution_pex_python_path_precedence_over_pex_python():
     pex_out_path = os.path.join(td, 'pex.pex')
     res = run_pex_command(['--disable-cache',
       '--rcfile=%s' % pexrc_path,
-      '--interpreter-constraint=>3',
-      '--interpreter-constraint=<3.8',
+      '--interpreter-constraint=>3,<3.8',
       '-o', pex_out_path])
     res.assert_success()
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -515,8 +515,7 @@ def test_pex_python():
     pex_out_path = os.path.join(td, 'pex.pex')
     res = run_pex_command(['--disable-cache',
                            '--rcfile=%s' % pexrc_path,
-                           '--interpreter-constraint=>3',
-                           '--interpreter-constraint=<3.8',
+                           '--interpreter-constraint=>3,<3.8',
                            '-o', pex_out_path],
                           env=env)
     res.assert_success()
@@ -536,8 +535,7 @@ def test_pex_python():
     pex_out_path = os.path.join(td, 'pex2.pex')
     res = run_pex_command(['--disable-cache',
                            '--rcfile=%s' % pexrc_path,
-                           '--interpreter-constraint=>3',
-                           '--interpreter-constraint=<3.8',
+                           '--interpreter-constraint=>3,<3.8',
                            '-o', pex_out_path],
                           env=env)
     res.assert_success()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -388,8 +388,7 @@ def test_interpreter_resolution_with_pex_python_path():
     pex_out_path = os.path.join(td, 'pex.pex')
     res = run_pex_command(['--disable-cache',
       '--rcfile=%s' % pexrc_path,
-      '--interpreter-constraint=%s' % interpreter_constraint1,
-      '--interpreter-constraint=%s' % interpreter_constraint2,
+      '--interpreter-constraint=%s,%s' % (interpreter_constraint1, interpreter_constraint2),
       '-o', pex_out_path])
     res.assert_success()
 


### PR DESCRIPTION
## Problem
Resolves https://github.com/pantsbuild/pex/issues/655. 

We would expect a list of constraints, such as `['CPython>=2.7,<3', 'CPython>=3.4']`, to OR the separate list entries, i.e. allow an interpreter that satisfies any of these distinct requirement strings. Instead, we always AND lists of constraints.

## Solution
Always `OR` a list of interpreter constraints. If the user wants `AND`, they may do so within the single requirement string via `,`, e.g. `'CPython>=2.7,<3'`.