### PR TITLE
Pin isort version in CI

### DIFF
--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -8,10 +8,9 @@ import importlib
 import os
 import re
 import sys
-
 import warnings
 import zipfile
-from collections import namedtuple, OrderedDict
+from collections import OrderedDict, namedtuple
 
 
 # NB: All pex imports are performed lazily to play well with the un-imports performed by both the

--- a/pex/vendor/__init__.py
+++ b/pex/vendor/__init__.py
@@ -10,7 +10,6 @@ from pex.common import touch
 from pex.orderedset import OrderedSet
 from pex.tracer import TRACER
 
-
 _PACKAGE_COMPONENTS = __name__.split('.')
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -128,17 +128,19 @@ commands =
 
 [testenv:isort-run]
 basepython = python2.7
-deps = isort
+deps =
+  isort==4.3.10
 commands =
     isort \
-        -rc \
-        -ns __init__.py \
-        -sg {toxinidir}/pex/vendor/_vendored/** \
+        --recursive \
+        --dont-skip __init__.py \
+        --skip-glob {toxinidir}/pex/vendor/_vendored/** \
         {toxinidir}/pex {toxinidir}/tests
 
 [testenv:isort-check]
 basepython = python2.7
-deps = isort
+deps =
+  {[testenv:isort-run]deps}
 commands = {[testenv:isort-run]commands} -c
 
 [testenv:vendor]


### PR DESCRIPTION
## Problem
isort had a regression in 4.3.11 that it no longer respects `skip_glob` as we intended. See https://github.com/timothycrosley/isort/issues/885.

This motivated the problem, although there is reason to pin isort regardless of this regression. Linters and autoformatters often change their behavior with new releases. When this happens, we don't want someone's PR to fail due to an unrelated upstream change in that tool's behavior.

## Solution
Pin isort to 4.3.10, the most recent release that does not have the `skip_glob` issue. Once this issue gets resolved, the version can be upgraded.

Also fix bad imports that weren't caught with our original isort runs.

Finally, convert CLI flags to use long names.