### PR TITLE
Provide control over pex warning behavior.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -477,6 +477,15 @@ def configure_clp():
       help='Turn on logging verbosity, may be specified multiple times.')
 
   parser.add_option(
+      '--emit-warnings', '--no-emit-warnings',
+      dest='emit_warnings',
+      action='callback',
+      callback=parse_bool,
+      default=True,
+      help='Emit runtime UserWarnings on stderr. If false, only emit them when PEX_VERBOSE is set.'
+           'Default: emit user warnings to stderr')
+
+  parser.add_option(
       '--pex-root',
       dest='pex_root',
       default=None,
@@ -559,6 +568,7 @@ def build_pex(args, options, resolver_option_builder):
   pex_info.pex_path = options.pex_path
   pex_info.always_write_cache = options.always_write_cache
   pex_info.ignore_errors = options.ignore_errors
+  pex_info.emit_warnings = options.emit_warnings
   pex_info.inherit_path = options.inherit_path
   if options.interpreter_constraint:
     for ic in options.interpreter_constraint:

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -9,10 +9,9 @@ import os
 import site
 import sys
 import uuid
-import warnings
 import zipfile
 
-from pex import pex_builder
+from pex import pex_builder, pex_warnings
 from pex.bootstrap import Bootstrap
 from pex.common import die, open_zip, rename_if_empty, safe_mkdir, safe_rmtree
 from pex.interpreter import PythonInterpreter
@@ -325,9 +324,10 @@ class PEXEnvironment(Environment):
     # it all down when we hand off from the bootstrap to user code.
     pkg_resources, vendored = _import_pkg_resources()
     if vendored:
-      warnings.warn('The `pkg_resources` package was loaded from a pex vendored version when '
-                    'declaring namespace packages defined by {dist}. The {dist} distribution '
-                    'should fix its `install_requires` to include `setuptools`'.format(dist=dist))
+      pex_warnings.warn('The `pkg_resources` package was loaded from a pex vendored version when '
+                        'declaring namespace packages defined by {dist}. The {dist} distribution '
+                        'should fix its `install_requires` to include `setuptools`'
+                        .format(dist=dist))
 
     for pkg in dist.get_metadata_lines('namespace_packages.txt'):
       if pkg in sys.modules:

--- a/pex/fetcher.py
+++ b/pex/fetcher.py
@@ -4,9 +4,9 @@
 from __future__ import absolute_import
 
 import re
-import warnings
 from abc import abstractmethod
 
+from pex import pex_warnings
 from pex.base import maybe_requirement
 from pex.compatibility import PY3, AbstractClass
 
@@ -51,7 +51,7 @@ class PyPIFetcher(FetcherBase):
 
   def __init__(self, pypi_base=PYPI_BASE, use_mirrors=False):
     if use_mirrors:
-      warnings.warn('use_mirrors is now deprecated.')
+      pex_warnings.warn('use_mirrors is now deprecated.')
 
     if not pypi_base.endswith('/'):
       pypi_base += '/'

--- a/pex/glibc.py
+++ b/pex/glibc.py
@@ -5,7 +5,8 @@ from __future__ import absolute_import
 import ctypes
 import platform
 import re
-import warnings
+
+from pex import pex_warnings
 
 
 def glibc_version_string():
@@ -43,8 +44,8 @@ def check_glibc_version(version_str, required_major, minimum_minor):
   # uses version strings like "2.20-2014.11"). See gh-3588.
   m = re.match(r"(?P<major>[0-9]+)\.(?P<minor>[0-9]+)", version_str)
   if not m:
-    warnings.warn("Expected glibc version with 2 components major.minor,"
-                  " got: %s" % version_str, RuntimeWarning)
+    pex_warnings.warn("Expected glibc version with 2 components major.minor,"
+                      " got: %s" % version_str)
     return False
   return (int(m.group("major")) == required_major and
           int(m.group("minor")) >= minimum_minor)

--- a/pex/pep425tags.py
+++ b/pex/pep425tags.py
@@ -10,7 +10,6 @@ import platform
 import re
 import sys
 import sysconfig
-import warnings
 
 from pex.glibc import have_compatible_glibc
 
@@ -19,11 +18,13 @@ logger = logging.getLogger(__name__)
 _OSX_ARCH_PAT = re.compile(r'(.+)_(\d+)_(\d+)_(.+)')
 
 
+# TODO(John Sirois): Kill this file and use wheel.pep425tags from our vendored wheel instead.
+# The `# Issue #1074` doesn't even refer to a pex issue :/.
 def get_config_var(var):
   try:
     return sysconfig.get_config_var(var)
   except IOError as e:  # Issue #1074
-    warnings.warn("{0}".format(e), RuntimeWarning)
+    logger.warn(str(e))
     return None
 
 

--- a/pex/pep425tags.py
+++ b/pex/pep425tags.py
@@ -1,6 +1,12 @@
 # This file was forked from the pip project master branch on 2016/12/05
 
-"""Generate and work with PEP 425 Compatibility Tags."""
+"""Generate and work with PEP 425 Compatibility Tags.
+
+NB: Several functions here have their code grabbed by `pex.interpreter._generate_identity_source`
+to use in runtime identification of python interpreter platform details. These functions are marked
+here and should maintain reliance on only stdlib support. Even then, any new imports added should
+be checked against those setup in `pex.interpreter.ID_PY_TMPL`.
+"""
 
 from __future__ import absolute_import
 
@@ -19,7 +25,9 @@ _OSX_ARCH_PAT = re.compile(r'(.+)_(\d+)_(\d+)_(.+)')
 
 
 # TODO(John Sirois): Kill this file and use wheel.pep425tags from our vendored wheel instead.
-# The `# Issue #1074` doesn't even refer to a pex issue :/.
+
+# NB: Used in `pex.interpreter.ID_PY_TMPL` and should only rely on stdlib. If imports change,
+# please consult `pex.interpreter.ID_PY_TMPL` and adjust stdlib imports there as needed.
 def get_config_var(var):
   try:
     return sysconfig.get_config_var(var)
@@ -28,6 +36,8 @@ def get_config_var(var):
     return None
 
 
+# NB: Used in `pex.interpreter.ID_PY_TMPL` and should only rely on stdlib. If imports change,
+# please consult `pex.interpreter.ID_PY_TMPL` and adjust stdlib imports there as needed.
 def get_abbr_impl():
   """Return abbreviated implementation name."""
   if hasattr(sys, 'pypy_version_info'):
@@ -41,6 +51,8 @@ def get_abbr_impl():
   return pyimpl
 
 
+# NB: Used in `pex.interpreter.ID_PY_TMPL` and should only rely on stdlib. If imports change,
+# please consult `pex.interpreter.ID_PY_TMPL` and adjust stdlib imports there as needed.
 def get_impl_ver():
   """Return implementation version."""
   impl_ver = get_config_var("py_version_nodot")
@@ -49,6 +61,8 @@ def get_impl_ver():
   return impl_ver
 
 
+# NB: Used in `pex.interpreter.ID_PY_TMPL` and should only rely on stdlib. If imports change,
+# please consult `pex.interpreter.ID_PY_TMPL` and adjust stdlib imports there as needed.
 def get_impl_version_info():
   """Return sys.version_info-like tuple for use in decrementing the minor
   version."""
@@ -60,13 +74,8 @@ def get_impl_version_info():
     return sys.version_info[0], sys.version_info[1]
 
 
-def get_impl_tag():
-  """
-  Returns the Tag for this specific implementation.
-  """
-  return "{0}{1}".format(get_abbr_impl(), get_impl_ver())
-
-
+# NB: Used in `pex.interpreter.ID_PY_TMPL` and should only rely on stdlib. If imports change,
+# please consult `pex.interpreter.ID_PY_TMPL` and adjust stdlib imports there as needed.
 def get_flag(var, fallback, expected=True, warn=True):
   """Use a fallback method for determining SOABI flags if the needed config
   var is unset or unavailable."""
@@ -79,6 +88,8 @@ def get_flag(var, fallback, expected=True, warn=True):
   return val == expected
 
 
+# NB: Used in `pex.interpreter.ID_PY_TMPL` and should only rely on stdlib. If imports change,
+# please consult `pex.interpreter.ID_PY_TMPL` and adjust stdlib imports there as needed.
 def get_abi_tag():
   """Return the ABI tag based on SOABI (if available) or emulate SOABI
   (CPython 2, PyPy)."""

--- a/pex/pep425tags.py
+++ b/pex/pep425tags.py
@@ -26,6 +26,7 @@ _OSX_ARCH_PAT = re.compile(r'(.+)_(\d+)_(\d+)_(.+)')
 
 # TODO(John Sirois): Kill this file and use wheel.pep425tags from our vendored wheel instead.
 
+
 # NB: Used in `pex.interpreter.ID_PY_TMPL` and should only rely on stdlib. If imports change,
 # please consult `pex.interpreter.ID_PY_TMPL` and adjust stdlib imports there as needed.
 def get_config_var(var):

--- a/pex/pep425tags.py
+++ b/pex/pep425tags.py
@@ -1,4 +1,5 @@
 # This file was forked from the pip project master branch on 2016/12/05
+# TODO(John Sirois): Kill this file and use wheel.pep425tags from our vendored wheel instead.
 
 """Generate and work with PEP 425 Compatibility Tags.
 
@@ -22,9 +23,6 @@ from pex.glibc import have_compatible_glibc
 logger = logging.getLogger(__name__)
 
 _OSX_ARCH_PAT = re.compile(r'(.+)_(\d+)_(\d+)_(.+)')
-
-
-# TODO(John Sirois): Kill this file and use wheel.pep425tags from our vendored wheel instead.
 
 
 # NB: Used in `pex.interpreter.ID_PY_TMPL` and should only rely on stdlib. If imports change,

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -5,8 +5,8 @@ from __future__ import absolute_import
 
 import json
 import os
-import warnings
 
+from pex import pex_warnings
 from pex.common import open_zip
 from pex.compatibility import PY2
 from pex.compatibility import string as compatibility_string
@@ -108,7 +108,7 @@ class PexInfo(object):
       if len(requirement_tuple) != 3:
         raise ValueError('Malformed PEX requirement: %r' % (requirement_tuple,))
       # pre 0.8.x requirement type:
-      warnings.warn('Attempting to use deprecated PEX feature.  Please upgrade past PEX 0.8.x.')
+      pex_warnings.warn('Attempting to use deprecated PEX feature.  Please upgrade past PEX 0.8.x.')
       return requirement_tuple[0]
     elif isinstance(requirement_tuple, compatibility_string):
       return requirement_tuple
@@ -225,6 +225,14 @@ class PexInfo(object):
     self._pex_info['ignore_errors'] = bool(value)
 
   @property
+  def emit_warnings(self):
+    return self._pex_info.get('emit_warnings', True)
+
+  @emit_warnings.setter
+  def emit_warnings(self, value):
+    self._pex_info['emit_warnings'] = bool(value)
+
+  @property
   def code_hash(self):
     return self._pex_info.get('code_hash')
 
@@ -315,3 +323,6 @@ class PexInfo(object):
     if not pex_path:
       return
     self.pex_path = ':'.join(merge_split(self.pex_path, pex_path))
+
+  def __repr__(self):
+    return '{}({!r})'.format(type(self).__name__, self._pex_info)

--- a/pex/pex_warnings.py
+++ b/pex/pex_warnings.py
@@ -1,0 +1,30 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import warnings
+
+from pex.variables import ENV
+
+
+class PEXWarning(Warning):
+  """Indicates a warning from PEX about suspect buildtime or runtime configuration."""
+
+
+def configure_warnings(pex_info, env=None):
+  env = env or ENV
+  if env.PEX_VERBOSE > 0:
+    emit_warnings = True
+  elif env.PEX_EMIT_WARNINGS is not None:
+    emit_warnings = env.PEX_EMIT_WARNINGS
+  else:
+    emit_warnings = pex_info.emit_warnings
+
+  action = 'default' if emit_warnings else 'ignore'
+  warnings.filterwarnings(action, category=PEXWarning)
+
+
+def warn(message):
+  warnings.warn(message, category=PEXWarning, stacklevel=2)

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -8,7 +8,6 @@ import importlib
 import os
 import re
 import sys
-import warnings
 import zipfile
 from collections import OrderedDict, namedtuple
 
@@ -258,8 +257,6 @@ class VendorImporter(object):
                           importables=importables,
                           uninstallable=uninstallable,
                           warning=warning)
-    if warning:
-      warnings.filterwarnings('default', category=DeprecationWarning, module=__name__)
     sys.meta_path.insert(0, vendor_importer)
     _tracer().log('Installed {}'.format(vendor_importer), V=3)
     return vendor_importer
@@ -302,8 +299,8 @@ class VendorImporter(object):
       if loader is not None:
         self._loaders.append(loader)
         if self._warning:
-          warnings.warn('Found loader for `import {}`:\n\t{}'.format(fullname, self._warning),
-                        category=DeprecationWarning)
+          from pex import pex_warnings
+          pex_warnings.warn('Found loader for `import {}`:\n\t{}'.format(fullname, self._warning))
         return loader
     return None
 

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -327,6 +327,17 @@ class Variables(object):
     """
     return self._get_bool('PEX_IGNORE_RCFILES', default=False)
 
+  @property
+  def PEX_EMIT_WARNINGS(self):
+    """Boolean
+
+    Emit UserWarnings to stderr. When false, warnings will only be logged at PEX_VERBOSE >= 1. When
+    unset the build-time value of `--emit-warnings` will be used. Default: unset.
+    """
+    return self._get_bool('PEX_EMIT_WARNINGS', default=None)
+
+  def __repr__(self):
+    return '{}({!r})'.format(type(self).__name__, self._environ)
 
 # Global singleton environment
 ENV = Variables()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -338,7 +338,7 @@ def test_interpreter_constraints_to_pex_info_py2():
       '--interpreter-constraint=>=3.5',
       '-o', pex_out_path])
     res.assert_success()
-    PexInfo.from_pex(pex_out_path)
+    pex_info = PexInfo.from_pex(pex_out_path)
     assert {'>=2.7,<3', '>=3.5'} == set(pex_info.interpreter_constraints)
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,7 +13,7 @@ import pytest
 
 from pex.compatibility import WINDOWS, nested, to_bytes
 from pex.installer import EggInstaller
-from pex.pex_bootstrapper import get_pex_info
+from pex.pex_info import PexInfo
 from pex.testing import (
     IS_PYPY,
     NOT_CPYTHON27,
@@ -338,7 +338,7 @@ def test_interpreter_constraints_to_pex_info_py2():
       '--interpreter-constraint=>=3.5',
       '-o', pex_out_path])
     res.assert_success()
-    pex_info = get_pex_info(pex_out_path)
+    PexInfo.from_pex(pex_out_path)
     assert {'>=2.7,<3', '>=3.5'} == set(pex_info.interpreter_constraints)
 
 
@@ -351,7 +351,7 @@ def test_interpreter_constraints_to_pex_info_py3():
     res = run_pex_command(['--disable-cache', '--interpreter-constraint=>3', '-o', pex_out_path],
                           env=make_env(PATH=os.path.dirname(py3_interpreter)))
     res.assert_success()
-    pex_info = get_pex_info(pex_out_path)
+    pex_info = PexInfo.from_pex(pex_out_path)
     assert ['>3'] == pex_info.interpreter_constraints
 
 
@@ -362,7 +362,7 @@ def test_interpreter_resolution_with_constraint_option():
       '--interpreter-constraint=>=2.7,<3',
       '-o', pex_out_path])
     res.assert_success()
-    pex_info = get_pex_info(pex_out_path)
+    pex_info = PexInfo.from_pex(pex_out_path)
     assert ['>=2.7,<3'] == pex_info.interpreter_constraints
     assert pex_info.build_properties['version'][0] < 3
 
@@ -377,7 +377,7 @@ def test_interpreter_resolution_with_multiple_constraint_options():
       '--interpreter-constraint=>=500',
       '-o', pex_out_path])
     res.assert_success()
-    pex_info = get_pex_info(pex_out_path)
+    pex_info = PexInfo.from_pex(pex_out_path)
     assert {'>=2.7,<3', '>=500'} == set(pex_info.interpreter_constraints)
     assert pex_info.build_properties['version'][0] < 3
 
@@ -1228,3 +1228,36 @@ def test_issues_661_devendoring_required():
     res.assert_success()
 
     subprocess.check_call([cryptography_pex, '-c', 'import cryptography'])
+
+
+def build_and_execute_pex_with_warnings(*extra_build_args, **extra_runtime_env):
+  with temporary_dir() as out:
+    tcl_pex = os.path.join(out, 'tcl.pex')
+    run_pex_command(['twitter.common.lang==0.3.10', '-o', tcl_pex] + list(extra_build_args))
+
+    cmd = [tcl_pex, '-c', 'from twitter.common.lang import Singleton']
+    env = os.environ.copy()
+    env.update(**extra_runtime_env)
+    process = subprocess.Popen(cmd, env=env, stderr=subprocess.PIPE)
+    _, stderr = process.communicate()
+    return stderr
+
+
+def test_emit_warnings_default():
+  stderr = build_and_execute_pex_with_warnings()
+  assert stderr
+
+
+def test_no_emit_warnings():
+  stderr = build_and_execute_pex_with_warnings('--no-emit-warnings')
+  assert not stderr
+
+
+def test_no_emit_warnings_emit_env_override():
+  stderr = build_and_execute_pex_with_warnings('--no-emit-warnings', PEX_EMIT_WARNINGS='true')
+  assert stderr
+
+
+def test_no_emit_warnings_verbose_override():
+  stderr = build_and_execute_pex_with_warnings('--no-emit-warnings', PEX_VERBOSE='1')
+  assert stderr

--- a/tests/test_pex_bootstrapper.py
+++ b/tests/test_pex_bootstrapper.py
@@ -1,42 +1,11 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os
-
 import pytest
 
-from pex.common import open_zip
 from pex.interpreter import PythonInterpreter
-from pex.pex_bootstrapper import find_compatible_interpreters, get_pex_info
-from pex.testing import (
-    IS_PYPY,
-    PY27,
-    PY35,
-    PY36,
-    ensure_python_interpreter,
-    temporary_dir,
-    write_simple_pex
-)
-
-
-def test_get_pex_info():
-  with temporary_dir() as td:
-    pb = write_simple_pex(td, 'print("hello world!")')
-    pex_path = os.path.join(td, 'hello_world.pex')
-    pb.build(pex_path)
-
-    # from zip
-    pex_info = get_pex_info(pex_path)
-
-    with temporary_dir() as pex_td:
-      with open_zip(pex_path, 'r') as zf:
-        zf.extractall(pex_td)
-
-      # from dir
-      pex_info_2 = get_pex_info(pex_td)
-
-      # same when encoded
-      assert pex_info.dump() == pex_info_2.dump()
+from pex.pex_bootstrapper import find_compatible_interpreters
+from pex.testing import IS_PYPY, PY27, PY35, PY36, ensure_python_interpreter
 
 
 @pytest.mark.skipif(IS_PYPY)

--- a/tests/test_pex_warnings.py
+++ b/tests/test_pex_warnings.py
@@ -15,7 +15,6 @@ from pex.variables import Variables
 
 def exercise_warnings(pex_info, **env):
   with warnings.catch_warnings(record=True) as events:
-    warnings.resetwarnings()
     pex_warnings.configure_warnings(pex_info, env=Variables(environ=env))
     pex_warnings.warn('test')
     return events
@@ -42,8 +41,8 @@ def pex_info_no_emit_warnings():
 
 skip_py2_warnings = pytest.mark.skipif(PY2,
                                        reason="The warnings.catch_warnings mechanism doesn't work "
-                                              "properly under python 2.7 / pypy2, etc. across "
-                                              "multiple tests")
+                                              "properly under CPython 2.7 / pypy 2.7, etc. across "
+                                              "multiple tests.")
 
 
 @skip_py2_warnings

--- a/tests/test_pex_warnings.py
+++ b/tests/test_pex_warnings.py
@@ -1,0 +1,76 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import warnings
+
+import pytest
+
+from pex import pex_warnings
+from pex.compatibility import PY2
+from pex.pex_info import PexInfo
+from pex.pex_warnings import PEXWarning
+from pex.variables import Variables
+
+
+def exercise_warnings(pex_info, **env):
+  with warnings.catch_warnings(record=True) as events:
+    warnings.resetwarnings()
+    pex_warnings.configure_warnings(pex_info, env=Variables(environ=env))
+    pex_warnings.warn('test')
+    return events
+
+
+def assert_warnings(pex_info, **env):
+  events = exercise_warnings(pex_info, **env)
+  assert 1 == len(events)
+  warning = events[0]
+  assert PEXWarning == warning.category
+  assert 'test' == str(warning.message)
+
+
+def assert_no_warnings(pex_info, **env):
+  events = exercise_warnings(pex_info, **env)
+  assert 0 == len(events)
+
+
+def pex_info_no_emit_warnings():
+  pex_info = PexInfo.default()
+  pex_info.emit_warnings = False
+  return pex_info
+
+
+skip_py2_warnings = pytest.mark.skipif(PY2,
+                                       reason="The warnings.catch_warnings mechanism doesn't work "
+                                              "properly under python 2.7 / pypy2, etc. across "
+                                              "multiple tests")
+
+
+@skip_py2_warnings
+def test_emit_warnings_default_on():
+  assert_warnings(PexInfo.default())
+
+
+@skip_py2_warnings
+def test_emit_warnings_pex_info_off():
+  assert_no_warnings(pex_info_no_emit_warnings())
+
+
+@skip_py2_warnings
+def test_emit_warnings_emit_env_off():
+  assert_no_warnings(PexInfo.default(), PEX_EMIT_WARNINGS='0')
+
+
+@skip_py2_warnings
+def test_emit_warnings_pex_info_off_emit_env_override():
+  assert_warnings(pex_info_no_emit_warnings(), PEX_EMIT_WARNINGS='1')
+
+
+@skip_py2_warnings
+def test_emit_warnings_pex_info_off_verbose_override():
+  assert_warnings(pex_info_no_emit_warnings(), PEX_VERBOSE='1')
+
+
+@skip_py2_warnings
+def test_emit_warnings_pex_info_off_verbose_trumps_emit_env():
+  assert_warnings(pex_info_no_emit_warnings(), PEX_VERBOSE='1', PEX_EMIT_WARNINGS='0')

--- a/tests/test_pex_warnings.py
+++ b/tests/test_pex_warnings.py
@@ -39,10 +39,12 @@ def pex_info_no_emit_warnings():
   return pex_info
 
 
-skip_py2_warnings = pytest.mark.skipif(PY2,
-                                       reason="The warnings.catch_warnings mechanism doesn't work "
-                                              "properly under CPython 2.7 / pypy 2.7, etc. across "
-                                              "multiple tests.")
+skip_py2_warnings = pytest.mark.skipif(
+  PY2,
+  reason="The `warnings.catch_warnings` mechanism doesn't work properly under CPython 2.7 & pypy "
+         "across multiple tests. Since we only use `warnings.catch_warnings` in unit tests and "
+         "the mechanisms tested here are also tested in integration tests under CPython 2.7 & pypy "
+         "we accept that these unit tests appear un-fixable without alot of warnings mocking.")
 
 
 @skip_py2_warnings

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -3,7 +3,7 @@
 
 import sys
 
-from pex.pep425tags import get_abi_tag, get_impl_tag
+from pex.pep425tags import get_abi_tag, get_abbr_impl, get_impl_ver
 from pex.platforms import Platform
 
 EXPECTED_BASE = [('py27', 'none', 'any'), ('py2', 'none', 'any')]
@@ -56,12 +56,13 @@ def test_platform_supported_tags_manylinux():
 
 
 def test_platform_supported_tags_osx_minimal():
+  impl_tag = "{}{}".format(get_abbr_impl(), get_impl_ver())
   assert_tags(
     'macosx-10.4-x86_64',
     [
-      (get_impl_tag(), 'none', 'any'),
+      (impl_tag, 'none', 'any'),
       ('py%s' % sys.version_info[0], 'none', 'any'),
-      (get_impl_tag(), get_abi_tag(), 'macosx_10_4_x86_64')
+      (impl_tag, get_abi_tag(), 'macosx_10_4_x86_64')
     ]
   )
 


### PR DESCRIPTION
Previously warnings were emitted to stderr unconditionally, but now
both build-time and run-time controls are provided. At build-time
--no-emit-warnings can be specified and a pex will be produced that
does not emit warnings. At run-time, PEX_EMIT_WARNINGS and PEX_VERBOSE
can be used to toggle warning behavior.

Fixes #677