### PR TITLE
Correct .travis.yml tox syntax to work for 3.8.1+.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,93 +115,93 @@ matrix:
   include:
     - <<: *x-linux-27-shard
       name: TOXENV=style
-      script: tox -ve style
+      script: tox -v -e style
 
     - <<: *x-linux-27-shard
       name: TOXENV=isort-check
-      script: tox -ve isort-check
+      script: tox -v -e isort-check
 
     - <<: *x-linux-27-shard
       name: TOXENV=vendor-check
-      script: tox -ve vendor-check
+      script: tox -v -e vendor-check
 
     - <<: *x-linux-27-shard
       name: TOXENV=py27
-      script: tox -ve py27
+      script: tox -v -e py27
 
     - <<: *x-linux-27-shard
       name: TOXENV=py27-subprocess
-      script: tox -ve py27-subprocess
+      script: tox -v -e py27-subprocess
 
     - <<: *x-linux-27-shard
       name: TOXENV=py27-requests
-      script: tox -ve py27-requests
+      script: tox -v -e py27-requests
 
     - <<: *x-linux-27-shard
       name: TOXENV=py27-requests-cachecontrol
-      script: tox -ve py27-requests-cachecontrol
+      script: tox -v -e py27-requests-cachecontrol
 
     - <<: *x-linux-shard
       name: TOXENV=py34
       env:
         - *env
         - PYENV_VERSION=3.4.9
-      script: tox -ve py34
+      script: tox -v -e py34
 
     - <<: *x-linux-shard
       name: TOXENV=py35
       env:
         - *env
         - PYENV_VERSION=3.5.6
-      script: tox -ve py35
+      script: tox -v -e py35
 
     - <<: *x-linux-shard
       name: TOXENV=py36
       env:
         - *env
         - PYENV_VERSION=3.6.6
-      script: tox -ve py36
+      script: tox -v -e py36
 
     - <<: *x-linux-37-shard
       name: TOXENV=py37
-      script: tox -ve py37
+      script: tox -v -e py37
 
     - <<: *x-linux-37-shard
       name: TOXENV=py37-requests
-      script: tox -ve py37-requests
+      script: tox -v -e py37-requests
 
     - <<: *x-linux-37-shard
       name: TOXENV=py37-requests-cachecontrol
-      script: tox -ve py37-requests-cachecontrol
+      script: tox -v -e py37-requests-cachecontrol
 
     - <<: *x-linux-pypy-shard
       name: TOXENV=pypy
-      script: tox -ve pypy
+      script: tox -v -e pypy
 
     - <<: *x-linux-27-shard
       name: TOXENV=py27-integration
-      script: tox -ve py27-integration
+      script: tox -v -e py27-integration
 
     - <<: *x-linux-37-shard
       name: TOXENV=py37-integration
-      script: tox -ve py37-integration
+      script: tox -v -e py37-integration
 
     - <<: *x-linux-pypy-shard
       name: TOXENV=pypy-integration
-      script: tox -ve pypy-integration
+      script: tox -v -e pypy-integration
 
     - <<: *x-osx-27-shard
       name: TOXENV=py27-requests
-      script: tox -ve py27-requests
+      script: tox -v -e py27-requests
 
     - <<: *x-osx-37-shard
       name: TOXENV=py37-requests
-      script: tox -ve py37-requests
+      script: tox -v -e py37-requests
 
     - <<: *x-osx-27-shard
       name: TOXENV=py27-integration
-      script: tox -ve py27-integration
+      script: tox -v -e py27-integration
 
     - <<: *x-osx-37-shard
       name: TOXENV=py37-integration
-      script: tox -ve py37-integration
+      script: tox -v -e py37-integration


### PR DESCRIPTION
The tox 3.8.1 release requires `-v` and `-e <env>` be passed as
seperate arguments where, before, `-ve <env>` was accepted. Since we
float our tox dependency in CI to match our lack of a bound on
developer tox installs, update to the new CLI syntax since it is
compatible with old tox too.