### PR TITLE
Don't change indentation for copied glibc.py and pep425tags.py files

### DIFF
--- a/pex/glibc.py
+++ b/pex/glibc.py
@@ -10,52 +10,52 @@ from pex import pex_warnings
 
 
 def glibc_version_string():
-  "Returns glibc version string, or None if not using glibc."
+    "Returns glibc version string, or None if not using glibc."
 
-  # ctypes.CDLL(None) internally calls dlopen(NULL), and as the dlopen
-  # manpage says, "If filename is NULL, then the returned handle is for the
-  # main program". This way we can let the linker do the work to figure out
-  # which libc our process is actually using.
-  process_namespace = ctypes.CDLL(None)
-  try:
-    gnu_get_libc_version = process_namespace.gnu_get_libc_version
-  except AttributeError:
-    # Symbol doesn't exist -> therefore, we are not linked to
-    # glibc.
-    return None
+    # ctypes.CDLL(None) internally calls dlopen(NULL), and as the dlopen
+    # manpage says, "If filename is NULL, then the returned handle is for the
+    # main program". This way we can let the linker do the work to figure out
+    # which libc our process is actually using.
+    process_namespace = ctypes.CDLL(None)
+    try:
+        gnu_get_libc_version = process_namespace.gnu_get_libc_version
+    except AttributeError:
+        # Symbol doesn't exist -> therefore, we are not linked to
+        # glibc.
+        return None
 
-  # Call gnu_get_libc_version, which returns a string like "2.5"
-  gnu_get_libc_version.restype = ctypes.c_char_p
-  version_str = gnu_get_libc_version()
-  # py2 / py3 compatibility:
-  if not isinstance(version_str, str):
-    version_str = version_str.decode("ascii")
+    # Call gnu_get_libc_version, which returns a string like "2.5"
+    gnu_get_libc_version.restype = ctypes.c_char_p
+    version_str = gnu_get_libc_version()
+    # py2 / py3 compatibility:
+    if not isinstance(version_str, str):
+        version_str = version_str.decode("ascii")
 
-  return version_str
+    return version_str
 
 
 # Separated out from have_compatible_glibc for easier unit testing
 def check_glibc_version(version_str, required_major, minimum_minor):
-  # Parse string and check against requested version.
-  #
-  # We use a regexp instead of str.split because we want to discard any
-  # random junk that might come after the minor version -- this might happen
-  # in patched/forked versions of glibc (e.g. Linaro's version of glibc
-  # uses version strings like "2.20-2014.11"). See gh-3588.
-  m = re.match(r"(?P<major>[0-9]+)\.(?P<minor>[0-9]+)", version_str)
-  if not m:
-    pex_warnings.warn("Expected glibc version with 2 components major.minor,"
-                      " got: %s" % version_str)
-    return False
-  return (int(m.group("major")) == required_major and
-          int(m.group("minor")) >= minimum_minor)
+    # Parse string and check against requested version.
+    #
+    # We use a regexp instead of str.split because we want to discard any
+    # random junk that might come after the minor version -- this might happen
+    # in patched/forked versions of glibc (e.g. Linaro's version of glibc
+    # uses version strings like "2.20-2014.11"). See gh-3588.
+    m = re.match(r"(?P<major>[0-9]+)\.(?P<minor>[0-9]+)", version_str)
+    if not m:
+        pex_warnings.warn("Expected glibc version with 2 components major.minor,"
+                          " got: %s" % version_str)
+        return False
+    return (int(m.group("major")) == required_major and
+            int(m.group("minor")) >= minimum_minor)
 
 
 def have_compatible_glibc(required_major, minimum_minor):
-  version_str = glibc_version_string()
-  if version_str is None:
-    return False
-  return check_glibc_version(version_str, required_major, minimum_minor)
+    version_str = glibc_version_string()
+    if version_str is None:
+        return False
+    return check_glibc_version(version_str, required_major, minimum_minor)
 
 
 # platform.libc_ver regularly returns completely nonsensical glibc
@@ -76,9 +76,9 @@ def have_compatible_glibc(required_major, minimum_minor):
 # misleading. Solution: instead of using platform, use our code that actually
 # works.
 def libc_ver():
-  glibc_version = glibc_version_string()
-  if glibc_version is None:
-    # For non-glibc platforms, fall back on platform.libc_ver
-    return platform.libc_ver()
-  else:
-    return ("glibc", glibc_version)
+    glibc_version = glibc_version_string()
+    if glibc_version is None:
+        # For non-glibc platforms, fall back on platform.libc_ver
+        return platform.libc_ver()
+    else:
+        return ("glibc", glibc_version)

--- a/pex/pep425tags.py
+++ b/pex/pep425tags.py
@@ -310,36 +310,36 @@ def get_supported(version=None, noarch=False, platform=None, impl=None, abi=None
                 for m in reversed(range(int(minor) + 1)):
                     for a in get_darwin_arches(int(major), m, actual_arch):
                         arches.append(tpl % (m, a))
-          else:
-              # arch pattern didn't match (?!)
-              arches = [arch]
-      elif (
-          (platform is None and is_manylinux1_compatible()) or
-          # N.B. Here we work around the fact that `is_manylinux1_compatible()` expects
-          # to be running on the target platform being built for with a feature flag approach.
-          (arch.startswith('linux') and force_manylinux)
-      ):
-          arches = [arch.replace('linux', 'manylinux1'), arch]
-      else:
-          arches = [arch]
+            else:
+                # arch pattern didn't match (?!)
+                arches = [arch]
+        elif (
+            (platform is None and is_manylinux1_compatible()) or
+            # N.B. Here we work around the fact that `is_manylinux1_compatible()` expects
+            # to be running on the target platform being built for with a feature flag approach.
+            (arch.startswith('linux') and force_manylinux)
+        ):
+            arches = [arch.replace('linux', 'manylinux1'), arch]
+        else:
+            arches = [arch]
 
-      # Current version, current API (built specifically for our Python):
-      for abi in abis:
-          for arch in arches:
-              supported.append(('%s%s' % (impl, versions[0]), abi, arch))
-
-      # abi3 modules compatible with older version of Python
-      for version in versions[1:]:
-          # abi3 was introduced in Python 3.2
-          if version in ('31', '30'):
-              break
-        for abi in abi3s:   # empty set if not Python 3
+        # Current version, current API (built specifically for our Python):
+        for abi in abis:
             for arch in arches:
-                supported.append(('%s%s' % (impl, version), abi, arch))
+                supported.append(('%s%s' % (impl, versions[0]), abi, arch))
 
-      # Has binaries, does not use the Python API:
-      for arch in arches:
-          supported.append(('py%s' % (versions[0][0]), 'none', arch))
+        # abi3 modules compatible with older version of Python
+        for version in versions[1:]:
+            # abi3 was introduced in Python 3.2
+            if version in ('31', '30'):
+                break
+            for abi in abi3s:   # empty set if not Python 3
+                for arch in arches:
+                    supported.append(('%s%s' % (impl, version), abi, arch))
+
+        # Has binaries, does not use the Python API:
+        for arch in arches:
+            supported.append(('py%s' % (versions[0][0]), 'none', arch))
 
     # No abi / arch, but requires our implementation:
     supported.append(('%s%s' % (impl, versions[0]), 'none', 'any'))

--- a/pex/pep425tags.py
+++ b/pex/pep425tags.py
@@ -28,329 +28,329 @@ _OSX_ARCH_PAT = re.compile(r'(.+)_(\d+)_(\d+)_(.+)')
 # NB: Used in `pex.interpreter.ID_PY_TMPL` and should only rely on stdlib. If imports change,
 # please consult `pex.interpreter.ID_PY_TMPL` and adjust stdlib imports there as needed.
 def get_config_var(var):
-  try:
-    return sysconfig.get_config_var(var)
-  except IOError as e:  # Issue #1074
-    logger.warn(str(e))
-    return None
+    try:
+        return sysconfig.get_config_var(var)
+    except IOError as e:  # Issue #1074
+        logger.warn(str(e))
+        return None
 
 
 # NB: Used in `pex.interpreter.ID_PY_TMPL` and should only rely on stdlib. If imports change,
 # please consult `pex.interpreter.ID_PY_TMPL` and adjust stdlib imports there as needed.
 def get_abbr_impl():
-  """Return abbreviated implementation name."""
-  if hasattr(sys, 'pypy_version_info'):
-    pyimpl = 'pp'
-  elif sys.platform.startswith('java'):
-    pyimpl = 'jy'
-  elif sys.platform == 'cli':
-    pyimpl = 'ip'
-  else:
-    pyimpl = 'cp'
-  return pyimpl
+    """Return abbreviated implementation name."""
+    if hasattr(sys, 'pypy_version_info'):
+        pyimpl = 'pp'
+    elif sys.platform.startswith('java'):
+        pyimpl = 'jy'
+    elif sys.platform == 'cli':
+        pyimpl = 'ip'
+    else:
+        pyimpl = 'cp'
+    return pyimpl
 
 
 # NB: Used in `pex.interpreter.ID_PY_TMPL` and should only rely on stdlib. If imports change,
 # please consult `pex.interpreter.ID_PY_TMPL` and adjust stdlib imports there as needed.
 def get_impl_ver():
-  """Return implementation version."""
-  impl_ver = get_config_var("py_version_nodot")
-  if not impl_ver or get_abbr_impl() == 'pp':
-    impl_ver = ''.join(map(str, get_impl_version_info()))
-  return impl_ver
+    """Return implementation version."""
+    impl_ver = get_config_var("py_version_nodot")
+    if not impl_ver or get_abbr_impl() == 'pp':
+        impl_ver = ''.join(map(str, get_impl_version_info()))
+    return impl_ver
 
 
 # NB: Used in `pex.interpreter.ID_PY_TMPL` and should only rely on stdlib. If imports change,
 # please consult `pex.interpreter.ID_PY_TMPL` and adjust stdlib imports there as needed.
 def get_impl_version_info():
-  """Return sys.version_info-like tuple for use in decrementing the minor
-  version."""
-  if get_abbr_impl() == 'pp':
-    # as per https://github.com/pypa/pip/issues/2882
-    return (sys.version_info[0], sys.pypy_version_info.major,
-            sys.pypy_version_info.minor)
-  else:
-    return sys.version_info[0], sys.version_info[1]
+    """Return sys.version_info-like tuple for use in decrementing the minor
+    version."""
+    if get_abbr_impl() == 'pp':
+        # as per https://github.com/pypa/pip/issues/2882
+        return (sys.version_info[0], sys.pypy_version_info.major,
+                sys.pypy_version_info.minor)
+    else:
+        return sys.version_info[0], sys.version_info[1]
 
 
 # NB: Used in `pex.interpreter.ID_PY_TMPL` and should only rely on stdlib. If imports change,
 # please consult `pex.interpreter.ID_PY_TMPL` and adjust stdlib imports there as needed.
 def get_flag(var, fallback, expected=True, warn=True):
-  """Use a fallback method for determining SOABI flags if the needed config
-  var is unset or unavailable."""
-  val = get_config_var(var)
-  if val is None:
-    if warn:
-      logger.debug("Config variable '%s' is unset, Python ABI tag may "
-                   "be incorrect", var)
-    return fallback()
-  return val == expected
+    """Use a fallback method for determining SOABI flags if the needed config
+    var is unset or unavailable."""
+    val = get_config_var(var)
+    if val is None:
+        if warn:
+            logger.debug("Config variable '%s' is unset, Python ABI tag may "
+                      "be incorrect", var)
+        return fallback()
+    return val == expected
 
 
 # NB: Used in `pex.interpreter.ID_PY_TMPL` and should only rely on stdlib. If imports change,
 # please consult `pex.interpreter.ID_PY_TMPL` and adjust stdlib imports there as needed.
 def get_abi_tag():
-  """Return the ABI tag based on SOABI (if available) or emulate SOABI
-  (CPython 2, PyPy)."""
-  soabi = get_config_var('SOABI')
-  impl = get_abbr_impl()
-  if not soabi and impl in ('cp', 'pp') and hasattr(sys, 'maxunicode'):
-    d = ''
-    m = ''
-    u = ''
-    if get_flag('Py_DEBUG',
-                lambda: hasattr(sys, 'gettotalrefcount'),
-                warn=(impl == 'cp')):
-      d = 'd'
-    if get_flag('WITH_PYMALLOC',
-                lambda: impl == 'cp',
-                warn=(impl == 'cp')):
-      m = 'm'
-    if (get_flag('Py_UNICODE_SIZE',
-                 lambda: sys.maxunicode == 0x10ffff,
-                 expected=4,
-                 warn=(impl == 'cp' and sys.version_info < (3, 3))) and
-        sys.version_info < (3, 3)):
-      u = 'u'
-    abi = '%s%s%s%s%s' % (impl, get_impl_ver(), d, m, u)
-  elif soabi and soabi.startswith('cpython-'):
-    abi = 'cp' + soabi.split('-')[1]
-  elif soabi:
-    abi = soabi.replace('.', '_').replace('-', '_')
-  else:
-    abi = None
-  return abi
+    """Return the ABI tag based on SOABI (if available) or emulate SOABI
+    (CPython 2, PyPy)."""
+    soabi = get_config_var('SOABI')
+    impl = get_abbr_impl()
+    if not soabi and impl in ('cp', 'pp') and hasattr(sys, 'maxunicode'):
+        d = ''
+        m = ''
+        u = ''
+        if get_flag('Py_DEBUG',
+                    lambda: hasattr(sys, 'gettotalrefcount'),
+                    warn=(impl == 'cp')):
+            d = 'd'
+        if get_flag('WITH_PYMALLOC',
+                    lambda: impl == 'cp',
+                    warn=(impl == 'cp')):
+            m = 'm'
+        if (get_flag('Py_UNICODE_SIZE',
+                    lambda: sys.maxunicode == 0x10ffff,
+                    expected=4,
+                    warn=(impl == 'cp' and sys.version_info < (3, 3))) and
+            sys.version_info < (3, 3)):
+            u = 'u'
+        abi = '%s%s%s%s%s' % (impl, get_impl_ver(), d, m, u)
+    elif soabi and soabi.startswith('cpython-'):
+        abi = 'cp' + soabi.split('-')[1]
+    elif soabi:
+        abi = soabi.replace('.', '_').replace('-', '_')
+    else:
+        abi = None
+    return abi
 
 
 def _is_running_32bit():
-  return sys.maxsize == 2147483647
+    return sys.maxsize == 2147483647
 
 
 def get_platform():
-  """Return our platform name 'win32', 'linux_x86_64'"""
-  if sys.platform == 'darwin':
-    # distutils.util.get_platform() returns the release based on the value
-    # of MACOSX_DEPLOYMENT_TARGET on which Python was built, which may
-    # be significantly older than the user's current machine.
-    release, _, machine = platform.mac_ver()
-    split_ver = release.split('.')
+    """Return our platform name 'win32', 'linux_x86_64'"""
+    if sys.platform == 'darwin':
+        # distutils.util.get_platform() returns the release based on the value
+        # of MACOSX_DEPLOYMENT_TARGET on which Python was built, which may
+        # be significantly older than the user's current machine.
+        release, _, machine = platform.mac_ver()
+        split_ver = release.split('.')
 
-    if machine == 'x86_64' and _is_running_32bit():
-      machine = 'i386'
-    elif machine == 'ppc64' and _is_running_32bit():
-      machine = 'ppc'
+        if machine == 'x86_64' and _is_running_32bit():
+            machine = 'i386'
+        elif machine == 'ppc64' and _is_running_32bit():
+            machine = 'ppc'
 
-    return 'macosx_{0}_{1}_{2}'.format(split_ver[0], split_ver[1], machine)
+        return 'macosx_{0}_{1}_{2}'.format(split_ver[0], split_ver[1], machine)
 
-  # XXX remove distutils dependency
-  result = distutils.util.get_platform().replace('.', '_').replace('-', '_')
-  if result == 'linux_x86_64' and _is_running_32bit():
-    # 32 bit Python program (running on a 64 bit Linux): pip should only
-    # install and run 32 bit compiled extensions in that case.
-    result = 'linux_i686'
+    # XXX remove distutils dependency
+    result = distutils.util.get_platform().replace('.', '_').replace('-', '_')
+    if result == 'linux_x86_64' and _is_running_32bit():
+        # 32 bit Python program (running on a 64 bit Linux): pip should only
+        # install and run 32 bit compiled extensions in that case.
+        result = 'linux_i686'
 
-  return result
+    return result
 
 
 def is_manylinux1_compatible():
-  # Only Linux, and only x86-64 / i686
-  if get_platform() not in ('linux_x86_64', 'linux_i686'):
-    return False
+    # Only Linux, and only x86-64 / i686
+    if get_platform() not in ('linux_x86_64', 'linux_i686'):
+        return False
 
-  # Check for presence of _manylinux module
-  try:
-    import _manylinux
-    return bool(_manylinux.manylinux1_compatible)
-  except (ImportError, AttributeError):
-    # Fall through to heuristic check below
-    pass
+    # Check for presence of _manylinux module
+    try:
+        import _manylinux
+        return bool(_manylinux.manylinux1_compatible)
+    except (ImportError, AttributeError):
+        # Fall through to heuristic check below
+        pass
 
-  # Check glibc version. CentOS 5 uses glibc 2.5.
-  return have_compatible_glibc(2, 5)
+    # Check glibc version. CentOS 5 uses glibc 2.5.
+    return have_compatible_glibc(2, 5)
 
 
 def get_darwin_arches(major, minor, machine):
-  """Return a list of supported arches (including group arches) for
-  the given major, minor and machine architecture of an macOS machine.
-  """
-  arches = []
+    """Return a list of supported arches (including group arches) for
+    the given major, minor and machine architecture of an macOS machine.
+    """
+    arches = []
 
-  def _supports_arch(major, minor, arch):
-    # Looking at the application support for macOS versions in the chart
-    # provided by https://en.wikipedia.org/wiki/OS_X#Versions it appears
-    # our timeline looks roughly like:
-    #
-    # 10.0 - Introduces ppc support.
-    # 10.4 - Introduces ppc64, i386, and x86_64 support, however the ppc64
-    #    and x86_64 support is CLI only, and cannot be used for GUI
-    #    applications.
-    # 10.5 - Extends ppc64 and x86_64 support to cover GUI applications.
-    # 10.6 - Drops support for ppc64
-    # 10.7 - Drops support for ppc
-    #
-    # Note: The above information is taken from the "Application support"
-    #     column in the chart not the "Processor support" since I believe
-    #     that we care about what instruction sets an application can use
-    #     not which processors the OS supports.
-    if arch == 'ppc':
-      return (major, minor) <= (10, 5)
-    if arch == 'ppc64':
-      return (major, minor) == (10, 5)
-    if arch == 'i386':
-      return (major, minor) >= (10, 4)
-    if arch == 'x86_64':
-      return (major, minor) >= (10, 4)
-    if arch in groups:
-      for garch in groups_dict[arch]:
-        if _supports_arch(major, minor, garch):
-          return True
-    return False
+    def _supports_arch(major, minor, arch):
+        # Looking at the application support for macOS versions in the chart
+        # provided by https://en.wikipedia.org/wiki/OS_X#Versions it appears
+        # our timeline looks roughly like:
+        #
+        # 10.0 - Introduces ppc support.
+        # 10.4 - Introduces ppc64, i386, and x86_64 support, however the ppc64
+        #    and x86_64 support is CLI only, and cannot be used for GUI
+        #    applications.
+        # 10.5 - Extends ppc64 and x86_64 support to cover GUI applications.
+        # 10.6 - Drops support for ppc64
+        # 10.7 - Drops support for ppc
+        #
+        # Note: The above information is taken from the "Application support"
+        #     column in the chart not the "Processor support" since I believe
+        #     that we care about what instruction sets an application can use
+        #     not which processors the OS supports.
+        if arch == 'ppc':
+            return (major, minor) <= (10, 5)
+        if arch == 'ppc64':
+            return (major, minor) == (10, 5)
+        if arch == 'i386':
+            return (major, minor) >= (10, 4)
+        if arch == 'x86_64':
+            return (major, minor) >= (10, 4)
+        if arch in groups:
+            for garch in groups_dict[arch]:
+                if _supports_arch(major, minor, garch):
+                    return True
+        return False
 
-  groups = ('fat', 'intel', 'fat64', 'fat32')
-  groups_dict = {'fat': ('i386', 'ppc'),
-                 'intel': ('x86_64', 'i386'),
-                 'fat64': ('x86_64', 'ppc64'),
-                 'fat32': ('x86_64', 'i386', 'ppc')}
+    groups = ('fat', 'intel', 'fat64', 'fat32')
+    groups_dict = {'fat': ('i386', 'ppc'),
+                  'intel': ('x86_64', 'i386'),
+                  'fat64': ('x86_64', 'ppc64'),
+                  'fat32': ('x86_64', 'i386', 'ppc')}
 
-  if _supports_arch(major, minor, machine):
-    arches.append(machine)
+    if _supports_arch(major, minor, machine):
+        arches.append(machine)
 
-  for garch in groups:
-    if machine in groups_dict[garch] and _supports_arch(major, minor, garch):
-      arches.append(garch)
+    for garch in groups:
+        if machine in groups_dict[garch] and _supports_arch(major, minor, garch):
+            arches.append(garch)
 
-  arches.append('universal')
+    arches.append('universal')
 
-  return arches
+    return arches
 
 
 def _gen_all_abis(impl, version):
-  def tmpl_abi(impl, version, suffix):
-    return ''.join((impl, version, suffix))
-  yield tmpl_abi(impl, version, 'd')
-  yield tmpl_abi(impl, version, 'dm')
-  yield tmpl_abi(impl, version, 'dmu')
-  yield tmpl_abi(impl, version, 'm')
-  yield tmpl_abi(impl, version, 'mu')
-  yield tmpl_abi(impl, version, 'u')
+    def tmpl_abi(impl, version, suffix):
+        return ''.join((impl, version, suffix))
+    yield tmpl_abi(impl, version, 'd')
+    yield tmpl_abi(impl, version, 'dm')
+    yield tmpl_abi(impl, version, 'dmu')
+    yield tmpl_abi(impl, version, 'm')
+    yield tmpl_abi(impl, version, 'mu')
+    yield tmpl_abi(impl, version, 'u')
 
 
 def get_supported_for_any_abi(version=None, noarch=False, platform=None, impl=None,
                               force_manylinux=False):
-  """Generates supported tags for unspecified ABI types to support more intuitive cross-platform
-     resolution."""
-  unique_tags = {
-    tag for abi in _gen_all_abis(impl, version)
-    for tag in get_supported(version=version,
-                             noarch=noarch,
-                             platform=platform,
-                             impl=impl,
-                             abi=abi,
-                             force_manylinux=force_manylinux)
-  }
-  return list(unique_tags)
+    """Generates supported tags for unspecified ABI types to support more intuitive cross-platform
+      resolution."""
+    unique_tags = {
+        tag for abi in _gen_all_abis(impl, version)
+        for tag in get_supported(version=version,
+                                noarch=noarch,
+                                platform=platform,
+                                impl=impl,
+                                abi=abi,
+                                force_manylinux=force_manylinux)
+    }
+    return list(unique_tags)
 
 
 def get_supported(version=None, noarch=False, platform=None, impl=None, abi=None,
                   force_manylinux=False):
-  """Return a list of supported tags for each version specified in
-  `version`.
+    """Return a list of supported tags for each version specified in
+    `version`.
 
-  :param version: string version (e.g., "33", "32") or None.
-    If None, use local system Python version.
-  :param platform: specify the exact platform you want valid
-    tags for, or None. If None, use the local system platform.
-  :param impl: specify the exact implementation you want valid
-    tags for, or None. If None, use the local interpreter impl.
-  :param abi: specify the exact abi you want valid
-    tags for, or None. If None, use the local interpreter abi.
-  :param force_manylinux: Whether or not to force manylinux support. This is useful
-                          when resolving for different target platform than current.
-  """
-  supported = []
+    :param version: string version (e.g., "33", "32") or None.
+      If None, use local system Python version.
+    :param platform: specify the exact platform you want valid
+      tags for, or None. If None, use the local system platform.
+    :param impl: specify the exact implementation you want valid
+      tags for, or None. If None, use the local interpreter impl.
+    :param abi: specify the exact abi you want valid
+      tags for, or None. If None, use the local interpreter abi.
+    :param force_manylinux: Whether or not to force manylinux support. This is useful
+                            when resolving for different target platform than current.
+    """
+    supported = []
 
-  # Versions must be given with respect to the preference
-  if version is None:
-    versions = []
-    version_info = get_impl_version_info()
-    major = version_info[:-1]
-    # Support all previous minor Python versions.
-    for minor in range(version_info[-1], -1, -1):
-      versions.append(''.join(map(str, major + (minor,))))
-  else:
-    versions = [version]
-
-  impl = impl or get_abbr_impl()
-
-  abis = []
-
-  abi = abi or get_abi_tag()
-  if abi:
-    abis[0:0] = [abi]
-
-  abi3s = set()
-  import imp
-  for suffix in imp.get_suffixes():
-    if suffix[0].startswith('.abi'):
-      abi3s.add(suffix[0].split('.', 2)[1])
-
-  abis.extend(sorted(list(abi3s)))
-
-  abis.append('none')
-
-  if not noarch:
-    arch = platform or get_platform()
-    if arch.startswith('macosx'):
-      # support macosx-10.6-intel on macosx-10.9-x86_64
-      match = _OSX_ARCH_PAT.match(arch)
-      if match:
-        name, major, minor, actual_arch = match.groups()
-        tpl = '{0}_{1}_%i_%s'.format(name, major)
-        arches = []
-        for m in reversed(range(int(minor) + 1)):
-          for a in get_darwin_arches(int(major), m, actual_arch):
-            arches.append(tpl % (m, a))
-      else:
-        # arch pattern didn't match (?!)
-        arches = [arch]
-    elif (
-      (platform is None and is_manylinux1_compatible()) or
-      # N.B. Here we work around the fact that `is_manylinux1_compatible()` expects
-      # to be running on the target platform being built for with a feature flag approach.
-      (arch.startswith('linux') and force_manylinux)
-    ):
-      arches = [arch.replace('linux', 'manylinux1'), arch]
+    # Versions must be given with respect to the preference
+    if version is None:
+        versions = []
+        version_info = get_impl_version_info()
+        major = version_info[:-1]
+        # Support all previous minor Python versions.
+        for minor in range(version_info[-1], -1, -1):
+            versions.append(''.join(map(str, major + (minor,))))
     else:
-      arches = [arch]
+        versions = [version]
 
-    # Current version, current API (built specifically for our Python):
-    for abi in abis:
+    impl = impl or get_abbr_impl()
+
+    abis = []
+
+    abi = abi or get_abi_tag()
+    if abi:
+        abis[0:0] = [abi]
+
+    abi3s = set()
+    import imp
+    for suffix in imp.get_suffixes():
+        if suffix[0].startswith('.abi'):
+            abi3s.add(suffix[0].split('.', 2)[1])
+
+    abis.extend(sorted(list(abi3s)))
+
+    abis.append('none')
+
+    if not noarch:
+        arch = platform or get_platform()
+        if arch.startswith('macosx'):
+            # support macosx-10.6-intel on macosx-10.9-x86_64
+            match = _OSX_ARCH_PAT.match(arch)
+            if match:
+                name, major, minor, actual_arch = match.groups()
+                tpl = '{0}_{1}_%i_%s'.format(name, major)
+                arches = []
+                for m in reversed(range(int(minor) + 1)):
+                    for a in get_darwin_arches(int(major), m, actual_arch):
+                        arches.append(tpl % (m, a))
+          else:
+              # arch pattern didn't match (?!)
+              arches = [arch]
+      elif (
+          (platform is None and is_manylinux1_compatible()) or
+          # N.B. Here we work around the fact that `is_manylinux1_compatible()` expects
+          # to be running on the target platform being built for with a feature flag approach.
+          (arch.startswith('linux') and force_manylinux)
+      ):
+          arches = [arch.replace('linux', 'manylinux1'), arch]
+      else:
+          arches = [arch]
+
+      # Current version, current API (built specifically for our Python):
+      for abi in abis:
+          for arch in arches:
+              supported.append(('%s%s' % (impl, versions[0]), abi, arch))
+
+      # abi3 modules compatible with older version of Python
+      for version in versions[1:]:
+          # abi3 was introduced in Python 3.2
+          if version in ('31', '30'):
+              break
+        for abi in abi3s:   # empty set if not Python 3
+            for arch in arches:
+                supported.append(('%s%s' % (impl, version), abi, arch))
+
+      # Has binaries, does not use the Python API:
       for arch in arches:
-        supported.append(('%s%s' % (impl, versions[0]), abi, arch))
+          supported.append(('py%s' % (versions[0][0]), 'none', arch))
 
-    # abi3 modules compatible with older version of Python
-    for version in versions[1:]:
-      # abi3 was introduced in Python 3.2
-      if version in ('31', '30'):
-        break
-      for abi in abi3s:   # empty set if not Python 3
-        for arch in arches:
-          supported.append(('%s%s' % (impl, version), abi, arch))
+    # No abi / arch, but requires our implementation:
+    supported.append(('%s%s' % (impl, versions[0]), 'none', 'any'))
+    # Tagged specifically as being cross-version compatible
+    # (with just the major version specified)
+    supported.append(('%s%s' % (impl, versions[0][0]), 'none', 'any'))
 
-    # Has binaries, does not use the Python API:
-    for arch in arches:
-      supported.append(('py%s' % (versions[0][0]), 'none', arch))
+    # No abi / arch, generic Python
+    for i, version in enumerate(versions):
+        supported.append(('py%s' % (version,), 'none', 'any'))
+        if i == 0:
+            supported.append(('py%s' % (version[0]), 'none', 'any'))
 
-  # No abi / arch, but requires our implementation:
-  supported.append(('%s%s' % (impl, versions[0]), 'none', 'any'))
-  # Tagged specifically as being cross-version compatible
-  # (with just the major version specified)
-  supported.append(('%s%s' % (impl, versions[0][0]), 'none', 'any'))
-
-  # No abi / arch, generic Python
-  for i, version in enumerate(versions):
-    supported.append(('py%s' % (version,), 'none', 'any'))
-    if i == 0:
-      supported.append(('py%s' % (version[0]), 'none', 'any'))
-
-  return supported
+    return supported

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -3,5 +3,9 @@
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 
 twitterstyle -n ImportOrder "${ROOT_DIR}/tests" $(
-  find "${ROOT_DIR}/pex" -path "${ROOT_DIR}/pex/vendor/_vendored" -prune , -name "*.py"
+  find "${ROOT_DIR}/pex" -name "*.py" | \
+    grep -v \
+      -e "${ROOT_DIR}/pex/vendor/_vendored/" \
+      -e "${ROOT_DIR}/pex/glibc.py" \
+      -e "${ROOT_DIR}/pex/pep425tags.py"
 )

--- a/tox.ini
+++ b/tox.ini
@@ -135,6 +135,8 @@ commands =
         --recursive \
         --dont-skip __init__.py \
         --skip-glob {toxinidir}/pex/vendor/_vendored/** \
+        --skip {toxinidir}/pex/glibc.py \
+        --skip {toxinidir}/pex/pep425tags.py \
         {toxinidir}/pex {toxinidir}/tests
 
 [testenv:isort-check]


### PR DESCRIPTION
Since these files are copied, we want to keep the original styling so that we can more easily copy over updates to the files and have a smaller diff when seeing how we've diverged from the originals.

Prework for https://github.com/pantsbuild/pex/pull/692.