### PR TITLE
[fix] python 2 with None value in _pex_info

### DIFF
--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -137,7 +137,7 @@ class PexInfo(object):
     if key not in self._pex_info:
       return None
     value = self._pex_info[key]
-    return value.encode('utf-8') if PY2 else value
+    return value.encode('utf-8') if PY2 and value is not None else value
 
   @property
   def build_properties(self):


### PR DESCRIPTION
A valid key might exit in _pex_info with a value of `None`. Under Python 2 this is guaranteed to crash.
This PR fixes that by checking for a None value to avoid calling `value.encode()`