### PR TITLE
Make sure `PexInfo` is isolated from `os.environ`.

### DIFF
--- a/pex/variables.py
+++ b/pex/variables.py
@@ -66,7 +66,7 @@ class Variables(object):
 
   def __init__(self, environ=None, rc=None, use_defaults=True):
     self._use_defaults = use_defaults
-    self._environ = environ.copy() if environ else os.environ
+    self._environ = (environ if environ is not None else os.environ).copy()
     if not self.PEX_IGNORE_RCFILES:
       rc_values = self.from_rc(rc).copy()
       rc_values.update(self._environ)


### PR DESCRIPTION
Before this change a `PexInfo` constructed with pexrc files ignored
would be subject to mutation through the side-effects of later
`os.environ` mutation. Guard against this by consistently copying the
environment the `PexInfo` is constructed with and add tests that ensure
the guard works.

Noticed working #710.