### PR TITLE
Delay importing pkg_resources until sys.path is ready.

### DIFF
--- a/pex/environment.py
+++ b/pex/environment.py
@@ -368,6 +368,9 @@ class PEXEnvironment(Environment):
         with TRACER.timed('Adding sitedir', V=2):
           site.addsitedir(dist.location)
 
-        self._declare_namespace_packages(dist)
+    # Delay calling 'self._declare_namespace_packages' until 'sys.path' contains all of the
+    # resolved dists.
+    for dist in resolved:
+      self._declare_namespace_packages(dist)
 
     return working_set


### PR DESCRIPTION
Otherwise the master working set will be built upon the first namespace package, instead of when sys.path is fully ready.