### PR TITLE
Add failing acceptance tests for reproducible Pex builds

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -166,8 +166,11 @@ def safe_sleep(seconds):
     time.sleep(seconds)
   else:
     start_time = time.time()
-    while time.time() - start_time < seconds:
-      pass
+    current_time = time.time()
+    while current_time - start_time < seconds:
+      remaining_time = seconds - (current_time - start_time)
+      time.sleep(remaining_time)
+      current_time = time.time()
 
 
 def rename_if_empty(src, dest, allowable_errors=(errno.EEXIST, errno.ENOTEMPTY)):

--- a/pex/common.py
+++ b/pex/common.py
@@ -11,6 +11,7 @@ import shutil
 import stat
 import sys
 import tempfile
+import time
 import threading
 import zipfile
 from collections import defaultdict
@@ -154,6 +155,19 @@ def safe_rmtree(directory):
   """Delete a directory if it's present. If it's not present, no-op."""
   if os.path.exists(directory):
     shutil.rmtree(directory, True)
+
+
+def safe_sleep(seconds):
+  """Ensure that the thread sleeps at a minimum the requested seconds.
+
+  Until Python 3.5, there was no guarantee that time.sleep() would actually sleep the requested
+  time. See https://docs.python.org/3/library/time.html#time.sleep."""
+  if sys.version_info[0:2] >= (3, 5):
+    time.sleep(seconds)
+  else:
+    start_time = time.time()
+    while time.time() - start_time < seconds:
+      pass
 
 
 def rename_if_empty(src, dest, allowable_errors=(errno.EEXIST, errno.ENOTEMPTY)):

--- a/pex/common.py
+++ b/pex/common.py
@@ -165,8 +165,7 @@ def safe_sleep(seconds):
   if sys.version_info[0:2] >= (3, 5):
     time.sleep(seconds)
   else:
-    start_time = time.time()
-    current_time = time.time()
+    start_time = current_time = time.time()
     while current_time - start_time < seconds:
       remaining_time = seconds - (current_time - start_time)
       time.sleep(remaining_time)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1375,29 +1375,29 @@ def test_reproducible_build_no_args():
 @pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
 def test_reproducible_build_bdist_requirements():
   # We test both a pure Python wheel (six) and a platform-specific wheel (cryptography).
-  assert_reproducible(['six==1.12.0', 'cryptography==2.6.1'])
+  assert_reproducible_build(['six==1.12.0', 'cryptography==2.6.1'])
 
 
 @pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
 def test_reproducible_build_sdist_requirements():
-  assert_reproducible(['pycparser==2.19', '--no-build'])
+  assert_reproducible_build(['pycparser==2.19', '--no-build'])
 
 
 @pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
 def test_reproducible_m_flag():
-  assert_reproducible(['-m', 'pydoc'])
+  assert_reproducible_build(['-m', 'pydoc'])
 
 
 @pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
 def test_reproducible_c_flag():
-  assert_reproducible(['black==19.3b0', '-c', 'black'])
+  assert_reproducible_build(['black==19.3b0', '-c', 'black'])
 
 
 @pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
 def test_reproducible_python_flag():
-  assert_reproducible(['--python=python2.7'])
+  assert_reproducible_build(['--python=python2.7'])
 
 
 @pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
 def test_reproducible_python_shebang_flag():
-  assert_reproducible(['--python-shebang=/usr/bin/python'])
+  assert_reproducible_build(['--python-shebang=/usr/bin/python'])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1346,8 +1346,11 @@ def assert_reproducible_build(args):
   with temporary_dir() as td:
     pex1 = os.path.join(td, '1.pex')
     pex2 = os.path.join(td, '2.pex')
-    run_pex_command(args + ['-o', pex1])
-    run_pex_command(args + ['-o', pex2])
+    # Note that we change the `PYTHONHASHSEED` to ensure that there are no issues resulting
+    # from the random seed, such as data structures, as Tox sets this value by default.
+    # See https://tox.readthedocs.io/en/latest/example/basic.html#special-handling-of-pythonhashseed.
+    run_pex_command(args + ['-o', pex1], env=make_env(PYTHONHASHSEED=111))
+    run_pex_command(args + ['-o', pex2], env=make_env(PYTHONHASHSEED=22222))
     # First explode the PEXes to compare file-by-file for easier debugging.
     with ZipFile(pex1) as zf1, ZipFile(pex2) as zf2:
       unzipped1 = os.path.join(td, "pex1")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,7 +7,6 @@ import os
 import platform
 import subprocess
 import sys
-import time
 from contextlib import contextmanager
 from textwrap import dedent
 from zipfile import ZipFile

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,6 +7,7 @@ import os
 import platform
 import subprocess
 import sys
+import time
 from contextlib import contextmanager
 from textwrap import dedent
 from zipfile import ZipFile
@@ -1349,8 +1350,11 @@ def assert_reproducible_build(args):
     # Note that we change the `PYTHONHASHSEED` to ensure that there are no issues resulting
     # from the random seed, such as data structures, as Tox sets this value by default. See
     # https://tox.readthedocs.io/en/latest/example/basic.html#special-handling-of-pythonhashseed.
-    run_pex_command(args + ['-o', pex1], env=make_env(PYTHONHASHSEED=111))
-    run_pex_command(args + ['-o', pex2], env=make_env(PYTHONHASHSEED=22222))
+    def create_pex(path, seed):
+      run_pex_command(args + ['-o', path], env=make_env(PYTHONHASHSEED=seed))
+    create_pex(pex1, seed=111)
+    time.sleep(2)
+    create_pex(pex2, seed=22222)
     # First explode the PEXes to compare file-by-file for easier debugging.
     with ZipFile(pex1) as zf1, ZipFile(pex2) as zf2:
       unzipped1 = os.path.join(td, "pex1")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1390,7 +1390,16 @@ def test_reproducible_build_m_flag():
 
 @pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
 def test_reproducible_build_c_flag():
-  assert_reproducible_build(['black==19.3b0', '-c', 'black'])
+  setup_py = dedent("""
+    from setuptools import setup
+
+    setup(
+      name='my_app',
+      entry_points={'console_scripts': ['my_app = my_app:do_something']},
+    )
+  """)
+  with temporary_content({'setup.py': setup_py}) as project_dir:
+    assert_reproducible_build([project_dir, '-c', 'my_app'])
 
 
 @pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1357,7 +1357,7 @@ def assert_reproducible_build(args):
       unzipped2 = os.path.join(td, "pex2")
       zf1.extractall(path=unzipped1)
       zf2.extractall(path=unzipped2)
-      for member1, member2 in zip(zf1.namelist(), zf2.namelist()):
+      for member1, member2 in zip(sorted(zf1.namelist()), sorted(zf2.namelist())):
         assert filecmp.cmp(
           os.path.join(unzipped1, member1),
           os.path.join(unzipped2, member2),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1384,20 +1384,20 @@ def test_reproducible_build_sdist_requirements():
 
 
 @pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
-def test_reproducible_m_flag():
+def test_reproducible_build_m_flag():
   assert_reproducible_build(['-m', 'pydoc'])
 
 
 @pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
-def test_reproducible_c_flag():
+def test_reproducible_build_c_flag():
   assert_reproducible_build(['black==19.3b0', '-c', 'black'])
 
 
 @pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
-def test_reproducible_python_flag():
+def test_reproducible_build_python_flag():
   assert_reproducible_build(['--python=python2.7'])
 
 
 @pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
-def test_reproducible_python_shebang_flag():
+def test_reproducible_build_python_shebang_flag():
   assert_reproducible_build(['--python-shebang=/usr/bin/python'])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1350,12 +1350,14 @@ def assert_reproducible_build(args):
     run_pex_command(args + ['-o', pex2])
     # First explode the PEXes to compare file-by-file for easier debugging.
     with ZipFile(pex1) as zf1, ZipFile(pex2) as zf2:
-      zf1.extractall(path=os.path.join(td, "pex1"))
-      zf2.extractall(path=os.path.join(td, "pex2"))
+      unzipped1 = os.path.join(td, "pex1")
+      unzipped2 = os.path.join(td, "pex2")
+      zf1.extractall(path=unzipped1)
+      zf2.extractall(path=unzipped2)
       for member1, member2 in zip(zf1.namelist(), zf2.namelist()):
         assert filecmp.cmp(
-          os.path.join(td, "pex1", member1),
-          os.path.join(td, "pex2", member2),
+          os.path.join(unzipped1, member1),
+          os.path.join(unzipped2, member2),
           shallow=False
         )
     # Then compare the original .pex files. This is the assertion we truly care about.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,6 +14,7 @@ from zipfile import ZipFile
 
 import pytest
 
+from pex.common import safe_sleep
 from pex.compatibility import WINDOWS, nested, to_bytes
 from pex.installer import EggInstaller
 from pex.pex_info import PexInfo
@@ -1353,7 +1354,11 @@ def assert_reproducible_build(args):
     def create_pex(path, seed):
       run_pex_command(args + ['-o', path], env=make_env(PYTHONHASHSEED=seed))
     create_pex(pex1, seed=111)
-    time.sleep(2)
+    # We sleep to ensure that there is no non-reproducibility from timestamps or
+    # anything that may depend on the system time. Note that we must sleep for at least
+    # 2 seconds, because the zip format uses 2 second precision per section 4.4.6 of
+    # https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT.
+    safe_sleep(2)
     create_pex(pex2, seed=22222)
     # First explode the PEXes to compare file-by-file for easier debugging.
     with ZipFile(pex1) as zf1, ZipFile(pex2) as zf2:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1347,8 +1347,8 @@ def assert_reproducible_build(args):
     pex1 = os.path.join(td, '1.pex')
     pex2 = os.path.join(td, '2.pex')
     # Note that we change the `PYTHONHASHSEED` to ensure that there are no issues resulting
-    # from the random seed, such as data structures, as Tox sets this value by default.
-    # See https://tox.readthedocs.io/en/latest/example/basic.html#special-handling-of-pythonhashseed.
+    # from the random seed, such as data structures, as Tox sets this value by default. See
+    # https://tox.readthedocs.io/en/latest/example/basic.html#special-handling-of-pythonhashseed.
     run_pex_command(args + ['-o', pex1], env=make_env(PYTHONHASHSEED=111))
     run_pex_command(args + ['-o', pex2], env=make_env(PYTHONHASHSEED=22222))
     # First explode the PEXes to compare file-by-file for easier debugging.


### PR DESCRIPTION
Per https://github.com/pantsbuild/pex/issues/716, we want to make Pex builds reproducible / deterministic.

As the first step in that process, we add failing acceptance tests that will act as the indicator of whether the issue is complete or not. As we get tests passing, such as the base test of no args, we will unskip those tests to avoid any regressions.

Here, we test the major permutations of building a Pex via `-o my-name.pex`, per https://pex.readthedocs.io/en/stable/buildingpex.html#saving-pex-files. We use Python's [`filecmp`](https://docs.python.org/3/library/filecmp.html) for a byte-by-byte comparison.

We must also add a `safe_sleep()` function to ensure Python 2 is not flaky, as `time.sleep()` is not guaranteed to run for the specified time until Python 3.5.