### PR TITLE
Introduce new `--no-compile` flag to not include .pyc in built Pex due to its non-determinism

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -292,11 +292,10 @@ def configure_clp_pex_options(parser):
            '[Default: %default]')
 
   group.add_option(
-      '--reproducible', '--not-reproducible',
+      '--reproducible',
       dest='reproducible',
       default=False,
-      action='callback',
-      callback=parse_bool,
+      action='store_true',
       help='Ensure that the generated Pex file is completely reproducible, i.e. if you were '
            'to run the same command again, the new PEX would be byte-for-byte equivalent '
            'to the original. This means that the generated Pex will not have .pyc files '

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -294,7 +294,7 @@ def configure_clp_pex_options(parser):
   group.add_option(
       '--reproducible', '--not-reproducible',
       dest='reproducible',
-      default=True,
+      default=False,
       action='callback',
       callback=parse_bool,
       help='Ensure that the generated Pex file is completely reproducible, i.e. if you were '

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -298,8 +298,7 @@ def configure_clp_pex_options(parser):
       action='store_true',
       help='Ensure that the generated Pex file is completely reproducible, i.e. if you were '
            'to run the same command again, the new PEX would be byte-for-byte equivalent '
-           'to the original. This means that the generated Pex will not have .pyc files '
-           'included, which results in a slight startup performance hit.')
+           'to the original. This may result in a slight startup performance hit.')
 
   parser.add_option_group(group)
 

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -292,15 +292,15 @@ def configure_clp_pex_options(parser):
            '[Default: %default]')
 
   group.add_option(
-      '--include-pyc', '--no-include-pyc',
-      dest='include_pyc',
+      '--compile', '--no-compile',
+      dest='compile',
       default=True,
       action='callback',
       callback=parse_bool,
-      help='Including .pyc files will result in slightly faster startup performance, but at the '
-           'expense of making the generated pex not be reproducible, meaning that if you were to '
-           'run `./pex -o` with the same inputs then the new pex would not be byte-for-byte '
-           'identical to the original.')
+      help='Compiling means that the built pex will include .pyc files, which will result in '
+           'slightly faster startup performance. However, compiling means that the generated pex '
+           'likely will not be reproducible, meaning that if you were to run `./pex -o` with the '
+           'same inputs then the new pex would not be byte-for-byte identical to the original.')
 
   parser.add_option_group(group)
 
@@ -685,7 +685,7 @@ def main(args=None):
     with TRACER.timed('Building pex'):
       pex_builder = build_pex(reqs, options, resolver_options_builder)
 
-    pex_builder.freeze(bytecode_compile=options.include_pyc)
+    pex_builder.freeze(bytecode_compile=options.compile)
     pex = PEX(pex_builder.path(),
               interpreter=pex_builder.interpreter,
               verify_entry_point=options.validate_ep)
@@ -694,7 +694,7 @@ def main(args=None):
       log('Saving PEX file to %s' % options.pex_name, V=options.verbosity)
       tmp_name = options.pex_name + '~'
       safe_delete(tmp_name)
-      pex_builder.build(tmp_name, bytecode_compile=options.include_pyc)
+      pex_builder.build(tmp_name, bytecode_compile=options.compile)
       os.rename(tmp_name, options.pex_name)
     else:
       if not _compatible_with_current_platform(options.platforms):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1351,7 +1351,7 @@ def assert_reproducible_build(args):
     # from the random seed, such as data structures, as Tox sets this value by default. See
     # https://tox.readthedocs.io/en/latest/example/basic.html#special-handling-of-pythonhashseed.
     def create_pex(path, seed):
-      run_pex_command(args + ['-o', path], env=make_env(PYTHONHASHSEED=seed))
+      run_pex_command(args + ['-o', path, '--reproducible'], env=make_env(PYTHONHASHSEED=seed))
     create_pex(pex1, seed=111)
     # We sleep to ensure that there is no non-reproducibility from timestamps or
     # anything that may depend on the system time. Note that we must sleep for at least

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1351,7 +1351,7 @@ def assert_reproducible_build(args):
     # from the random seed, such as data structures, as Tox sets this value by default. See
     # https://tox.readthedocs.io/en/latest/example/basic.html#special-handling-of-pythonhashseed.
     def create_pex(path, seed):
-      run_pex_command(args + ['-o', path, '--reproducible'], env=make_env(PYTHONHASHSEED=seed))
+      run_pex_command(args + ['-o', path, '--no-include-pyc'], env=make_env(PYTHONHASHSEED=seed))
     create_pex(pex1, seed=111)
     # We sleep to ensure that there is no non-reproducibility from timestamps or
     # anything that may depend on the system time. Note that we must sleep for at least

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1351,7 +1351,7 @@ def assert_reproducible_build(args):
     # from the random seed, such as data structures, as Tox sets this value by default. See
     # https://tox.readthedocs.io/en/latest/example/basic.html#special-handling-of-pythonhashseed.
     def create_pex(path, seed):
-      run_pex_command(args + ['-o', path, '--no-include-pyc'], env=make_env(PYTHONHASHSEED=seed))
+      run_pex_command(args + ['-o', path, '--no-compile'], env=make_env(PYTHONHASHSEED=seed))
     create_pex(pex1, seed=111)
     # We sleep to ensure that there is no non-reproducibility from timestamps or
     # anything that may depend on the system time. Note that we must sleep for at least


### PR DESCRIPTION
### Problem
Until Python 3.7 via https://www.python.org/dev/peps/pep-0552/, `.pyc` files were never reproducible because they included the timestamp. See the discussion at https://github.com/pantsbuild/pex/issues/716#issuecomment-487821354.

We are aiming to ensure reproducible builds a la https://github.com/pantsbuild/pex/issues/716 so that we can safely remote PEXes in CI. Reproducible builds also play an important role in security, per https://reproducible-builds.org.

### Solution
Allow users to toggle on and off `.pyc` files via the new `--compile` / `--no-compile` flag.

We currently default to including `.pyc`, because this has been the precedent for 9 years. In a future release, e.g. 1.70, we will change the default to not include `.pyc` so that builds are reproducible by default, but people can still opt into including the files if they'd like via the flag.

#### Alternative flag considered: `--reproducible`
Originally, we were going to use `--reproducible` to toggle on multiple behaviors like not including `.pyc` and using a hardcoded timestamp instead of system time. However, after deciding that in a future release we are going to default to reproducible, it doesn't make sense for people to ever call `--not-reproducible`, but it does make sense to opt out of specific behaviors like wanting to use `--include-pyc`. So, we use behavior-specific flags instead of a universal flag.

#### Alternative solution: ensure our own `.pyc` timestamp
It may be possible to still include `.pyc` _and_ have their timestamp be deterministic https://github.com/pantsbuild/pex/pull/718#issuecomment-488202220. This is not pursued for now because it is more complex than necessary, especially because currently we do not ship `.pyc` files if multiple platforms are used in the PEX. But it could be a followup PR if deemed worth it.

### Result
When `--no-compile` is set, PEXes will no longer include `.pyc`. This results in all of the [reproducible build acceptance tests](https://github.com/pantsbuild/pex/blob/master/tests/test_integration.py#L1378) passing the exploded pex portion of their tests, excluding the `bdist_wheel` test.

#### Impact on performance
Not using `.pyc` has a slight speedup of ~0.2 seconds to the _creation_ of simple PEXes.

* `time python -m pex -o normal.pex --compile` averaged around 0.49 seconds
* `time python -m pex -o repro.pex --no-compile` averaged around 0.31 seconds

Not using `.pyc` has a slight slowdown of ~0.06 seconds to the startup time of simple PEXes.

* `time ./normal.pex --version` averaged around 0.26 seconds
* `time ./repro.pex --version` averaged around 0.32 seconds

`python -m pex -m pydoc -o pydoc.pex` likewise ran 0.07 seconds slower when not including `.pyc`.

Note that the inclusion of `.pyc` only impacts startup time, not actual runtime performance. See https://stackoverflow.com/questions/2998215/if-python-is-interpreted-what-are-pyc-files for what `.pyc` files do / why they exist.
