### PR TITLE
Document how Pex developers can run specific tests and run Pex from source

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,8 +146,8 @@ running ``tox --listenvs-all``, then invoke like this:
 
     $ tox -e style
 
-All of our tox environments allow passthrough arguments, which can be helpful to run specific
-tests:
+All of our tox test environments allow passthrough arguments, which can be helpful to run
+specific tests:
 
 .. code-block::
 

--- a/README.rst
+++ b/README.rst
@@ -134,17 +134,22 @@ If you don't have tox, you can generate a pex of tox:
 
     $ pex tox -c tox -o ~/bin/tox
 
+Tox provides many useful commands and options, explained at https://testrun.org/tox/en/latest/.
+Below, we provide some of the most commonly used commands used when working on Pex, but the
+docs are worth acquainting yourself with to better understand how Tox works and how to do more
+advanced commmands.
+
 To run a specific test command, look in `tox.ini` for the name and run like this:
 
 .. code-block::
 
-    $ pex tox -v -e style
+    $ tox -e style
 
 Tox allows passthrough arguments, which can be helpful to run specific tests:
 
 .. code-block::
 
-    $ pex tox -v -e py37-integration -- -k test_reproducible_build
+    $ tox -e py37-integration -- -k test_reproducible_build
 
 To run Pex from source, rather than through what is on your PATH, invoke via Python:
 

--- a/README.rst
+++ b/README.rst
@@ -140,7 +140,7 @@ docs are worth acquainting yourself with to better understand how Tox works and 
 advanced commmands.
 
 To run a specific environment, identify the name of the environment you'd like to invoke by
-running ``tox --listenvs-all`, then invoke like this:
+running ``tox --listenvs-all``, then invoke like this:
 
 .. code-block::
 

--- a/README.rst
+++ b/README.rst
@@ -114,14 +114,14 @@ that you can copy to staging or production environments.
 Documentation
 =============
 
-More documentation about pex, building .pex files, and how .pex files work
+More documentation about Pex, building .pex files, and how .pex files work
 is available at https://pex.readthedocs.io.
 
 
 Development
 ===========
 
-pex uses `tox <https://testrun.org/tox/en/latest/>`_ for test and development automation.  To run
+Pex uses `tox <https://testrun.org/tox/en/latest/>`_ for test and development automation. To run
 the test suite, just invoke tox:
 
 .. code-block:: bash
@@ -134,6 +134,23 @@ If you don't have tox, you can generate a pex of tox:
 
     $ pex tox -c tox -o ~/bin/tox
 
+To run a specific test command, look in `tox.ini` for the name and run like this:
+
+.. code-block::
+
+    $ pex tox -v -e style
+
+Tox allows passthrough arguments, which can be helpful to run specific tests:
+
+.. code-block::
+
+    $ pex tox -v -e py37-integration -- -k test_reproducible_build
+
+To run Pex from source, rather than through what is on your PATH, invoke via Python:
+
+.. code-block::
+
+    $ python -m pex
 
 Contributing
 ============

--- a/README.rst
+++ b/README.rst
@@ -139,13 +139,15 @@ Below, we provide some of the most commonly used commands used when working on P
 docs are worth acquainting yourself with to better understand how Tox works and how to do more
 advanced commmands.
 
-To run a specific test command, look in `tox.ini` for the name and run like this:
+To run a specific environment, identify the name of the environment you'd like to invoke by
+running ``tox --listenvs-all`, then invoke like this:
 
 .. code-block::
 
     $ tox -e style
 
-Tox allows passthrough arguments, which can be helpful to run specific tests:
+All of our tox environments allow passthrough arguments, which can be helpful to run specific
+tests:
 
 .. code-block::
 


### PR DESCRIPTION
These newly documented commands are highly useful for Pants developers, and not immediately obvious for people who have no worked with Pex or used tox before.

However, we also want people reading the Tox docs and not solely relying on our guide, so we try to strike a balance between the two.