### PR TITLE
Add new `--no-use-system-time` flag to use a deterministic timestamp in built PEX

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -307,7 +307,7 @@ def configure_clp_pex_options(parser):
       dest='use_system_time',
       # TODO: set this to True. It's only False for now to test what happens in CI if we
       # always use deterministic timestamps.
-      default=False,
+      default=True,
       action='callback',
       callback=parse_bool,
       help='Use the current system time to generate timestamps for the new pex. Otherwise, Pex '

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -307,7 +307,7 @@ def configure_clp_pex_options(parser):
       dest='use_system_time',
       # TODO: set this to True. It's only False for now to test what happens in CI if we
       # always use deterministic timestamps.
-      default=True,
+      default=False,
       action='callback',
       callback=parse_bool,
       help='Use the current system time to generate timestamps for the new pex. Otherwise, Pex '

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -312,7 +312,9 @@ def configure_clp_pex_options(parser):
       callback=parse_bool,
       help='Use the current system time to generate timestamps for the new pex. Otherwise, Pex '
            'will first try to read the time from the environment variable SOURCE_DATE_EPOCH and '
-           'will fallback to midnight on January 1, 1980. TODO: explain reproducibility.')
+           'will fallback to midnight on January 1, 1980. By using system time, the generated pex '
+           'will not be reproducible, meaning that if you were to run `./pex -o` with the '
+           'same inputs then the new pex would not be byte-for-byte identical to the original.')
 
   parser.add_option_group(group)
 

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -309,7 +309,6 @@ def configure_clp_pex_options(parser):
       action='callback',
       callback=parse_bool,
       help='Use the current system time to generate timestamps for the new pex. Otherwise, Pex '
-           'will first try to read the time from the environment variable SOURCE_DATE_EPOCH and '
            'will fallback to midnight on January 1, 1980. By using system time, the generated pex '
            'will not be reproducible, meaning that if you were to run `./pex -o` with the '
            'same inputs then the new pex would not be byte-for-byte identical to the original.')

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -309,7 +309,7 @@ def configure_clp_pex_options(parser):
       action='callback',
       callback=parse_bool,
       help='Use the current system time to generate timestamps for the new pex. Otherwise, Pex '
-           'will fallback to midnight on January 1, 1980. By using system time, the generated pex '
+           'will use midnight on January 1, 1980. By using system time, the generated pex '
            'will not be reproducible, meaning that if you were to run `./pex -o` with the '
            'same inputs then the new pex would not be byte-for-byte identical to the original.')
 

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -305,9 +305,7 @@ def configure_clp_pex_options(parser):
   group.add_option(
       '--use-system-time', '--no-use-system-time',
       dest='use_system_time',
-      # TODO: set this to True. It's only False for now to test what happens in CI if we
-      # always use deterministic timestamps.
-      default=False,
+      default=True,
       action='callback',
       callback=parse_bool,
       help='Use the current system time to generate timestamps for the new pex. Otherwise, Pex '

--- a/pex/common.py
+++ b/pex/common.py
@@ -20,11 +20,10 @@ from uuid import uuid4
 
 
 # We use the start of MS-DOS time, which is what zipfiles use (see section 4.4.6 of
-# https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT). Note that ZipInfo expects a
-# time.struct_time, which we set here.
+# https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT).
 DETERMINISTIC_DATETIME = datetime(
   year=1980, month=1, day=1, hour=0, minute=0, second=0, tzinfo=None
-).timetuple()
+)
 
 
 def die(msg, exit_code=1):
@@ -407,7 +406,7 @@ class Chroot(object):
         zinfo = zf.zip_info_from_file(
             filename=full_path,
             arcname=f,
-            date_time=DETERMINISTIC_DATETIME if deterministic_timestamp else None
+            date_time=DETERMINISTIC_DATETIME.timetuple() if deterministic_timestamp else None
         )
         with open(full_path, 'rb') as open_f:
           data = open_f.read()

--- a/pex/common.py
+++ b/pex/common.py
@@ -175,11 +175,11 @@ class DeterministicTimestampZipFile(PermPreservingZipFile):
 
 
 @contextlib.contextmanager
-def open_zip(path, *args, use_deterministic_timestamp=False, **kwargs):
+def open_zip(path, *args, deterministic_timestamp=False, **kwargs):
   """A contextmanager for zip files. Passes through positional and kwargs to zipfile.ZipFile."""
   zf = (
     DeterministicTimestampZipFile(path, *args, **kwargs)
-    if use_deterministic_timestamp
+    if deterministic_timestamp
     else PermPreservingZipFile(path, *args, **kwargs)
   )
   with contextlib.closing(zf) as zip:
@@ -446,8 +446,8 @@ class Chroot(object):
   def delete(self):
     shutil.rmtree(self.chroot)
 
-  def zip(self, filename, mode='w', use_deterministic_timestamp=False):
-    with open_zip(filename, mode, use_deterministic_timestamp=use_deterministic_timestamp) as zf:
+  def zip(self, filename, mode='w', deterministic_timestamp=False):
+    with open_zip(filename, mode, deterministic_timestamp=deterministic_timestamp) as zf:
       for f in sorted(self.files()):
         zf.write(
           os.path.join(self.chroot, f),

--- a/pex/common.py
+++ b/pex/common.py
@@ -405,19 +405,13 @@ class Chroot(object):
     with open_zip(filename, mode) as zf:
       for f in sorted(self.files()):
         full_path = os.path.join(self.chroot, f)
-        if not deterministic_timestamp:
-          zf.write(
-            full_path,
-            arcname=f,
-            compress_type=zipfile.ZIP_DEFLATED
-          )
-        else:
-          zinfo = zf.zip_info_from_file(
+        zinfo = zf.zip_info_from_file(
             filename=full_path,
             arcname=f,
-            # NB: the constructor expects a six tuple of year-month-day-hour-minute-second.
-            date_time=DETERMINISTIC_DATETIME.timetuple()[:6]
-          )
-          with open(full_path, 'rb') as open_f:
-            data = open_f.read()
-          zf.writestr(zinfo, data, compress_type=zipfile.ZIP_DEFLATED)
+            date_time=(
+              None if not deterministic_timestamp else DETERMINISTIC_DATETIME.timetuple()[:6]
+            )
+        )
+        with open(full_path, 'rb') as open_f:
+          data = open_f.read()
+        zf.writestr(zinfo, data, compress_type=zipfile.ZIP_DEFLATED)

--- a/pex/common.py
+++ b/pex/common.py
@@ -408,7 +408,7 @@ class Chroot(object):
         zinfo = zf.zip_info_from_file(
             filename=full_path,
             arcname=f,
-            date_time=None if not deterministic_timestamp else DETERMINISTIC_DATETIME
+            date_time=DETERMINISTIC_DATETIME if deterministic_timestamp else None
         )
         with open(full_path, 'rb') as open_f:
           data = open_f.read()

--- a/pex/common.py
+++ b/pex/common.py
@@ -24,7 +24,7 @@ def deterministic_datetime():
 
   First try to read from the standard $SOURCE_DATE_EPOCH, then default to midnight January 1,
   1980, which is the start of time for MS-DOS time. Per section 4.4.6 of the zip spec at
-  https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TX, Zipfiles use MS-DOS time. So, we
+  https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT, Zipfiles use MS-DOS time. So, we
   use this default to ensure no issues with Zipfiles.
 
   Even though we use MS-DOS to inform the default value, note that we still return a normal UTC

--- a/pex/common.py
+++ b/pex/common.py
@@ -391,7 +391,11 @@ class Chroot(object):
       for f in sorted(self.files()):
         full_path = os.path.join(self.chroot, f)
         if not deterministic_timestamp:
-          zf.write(full_path, compress_type=zipfile.ZIP_DEFLATED)
+          zf.write(
+            full_path,
+            arcname=f,
+            compress_type=zipfile.ZIP_DEFLATED
+          )
         else:
           # This code mostly reimplements ZipInfo.from_file(), which is not available in Python
           # 2.7. See https://github.com/python/cpython/blob/master/Lib/zipfile.py#L495.

--- a/pex/common.py
+++ b/pex/common.py
@@ -19,26 +19,21 @@ from datetime import datetime
 from uuid import uuid4
 
 
-def deterministic_datetime():
-  """Return a deterministic UTC datetime object that does not depend on the system time.
-
-  First try to read from the standard $SOURCE_DATE_EPOCH, then default to midnight January 1,
-  1980, which is the start of time for MS-DOS time. Per section 4.4.6 of the zip spec at
-  https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT, Zipfiles use MS-DOS time. So, we
-  use this default to ensure no issues with Zipfiles.
-
-  Even though we use MS-DOS to inform the default value, note that we still return a normal UTC
-  datetime object for flexibility with how the result is used.
-
-  For more information on $SOURCE_DATE_EPOCH, refer to
-  https://reproducible-builds.org/docs/source-date-epoch/."""
-  return (
-    datetime.utcfromtimestamp(int(os.environ['SOURCE_DATE_EPOCH']))
-    if "SOURCE_DATE_EPOCH" in os.environ
-    else datetime(
-      year=1980, month=1, day=1, hour=0, minute=0, second=0, microsecond=0, tzinfo=None
-    )
+# We resolve a deterministic UTC datetime object that does not depend on the system time.
+# * First try to read from the standard $SOURCE_DATE_EPOCH. See
+#   https://reproducible-builds.org/docs/source-date-epoch/.
+# * Fallback to midnight January 1, 1980, which is the start of MS-DOS time. Per section
+#   4.4.6 of the zip spec at https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT,
+#   Zipfiles use MS-DOS time.
+# * Even though we use MS-DOS to inform the default value, note that we still return a normal
+#   UTC datetime object for flexibility with how the result is used.
+DETERMINISTIC_DATETIME = (
+  datetime.utcfromtimestamp(int(os.environ['SOURCE_DATE_EPOCH']))
+  if "SOURCE_DATE_EPOCH" in os.environ
+  else datetime(
+    year=1980, month=1, day=1, hour=0, minute=0, second=0, microsecond=0, tzinfo=None
   )
+)
 
 
 def die(msg, exit_code=1):
@@ -412,7 +407,7 @@ class Chroot(object):
           zinfo = zipfile.ZipInfo(
             filename=arcname,
             # NB: the constructor expects a six tuple of year-month-day-hour-minute-second.
-            date_time=deterministic_datetime().timetuple()[:6]
+            date_time=DETERMINISTIC_DATETIME.timetuple()[:6]
           )
           zinfo.external_attr = (st.st_mode & 0xFFFF) << 16
           if isdir:

--- a/pex/common.py
+++ b/pex/common.py
@@ -108,7 +108,7 @@ class PermPreservingZipFile(zipfile.ZipFile, object):
     if isdir:
       arcname += '/'
     if date_time is None:
-      datetime = time.localtime(st.st_mtime)
+      date_time = time.localtime(st.st_mtime)
     zinfo = zipfile.ZipInfo(filename=arcname, date_time=date_time[:6])
     zinfo.external_attr = (st.st_mode & 0xFFFF) << 16  # Unix attributes
     if isdir:

--- a/pex/common.py
+++ b/pex/common.py
@@ -19,16 +19,8 @@ from datetime import datetime
 from uuid import uuid4
 
 
-# We hardcode the datetime to January 1, 1980, which is the start of MS-DOS time. Per section 
-# 4.4.6 of the zip spec at https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT, 
-# Zipfiles use MS-DOS time.
-# NB: We do not respect the standard env var $SOURCE_DATE_EPOCH often used by tools for
-# deterministic timestamps, as doing so risks reducing the reproducibility of built pexes across
-# different platforms, e.g. if two platforms set the env var differently. Usually, this is
-# supposed to be set for the sake of security to check that a shipped binary was not tampered
-# with, but that is not our primary use case, so we do not respect it both for simplicity of
-# our codebase and to avoid this potential reduction in reproducibility. Refer to
-# https://reproducible-builds.org/docs/source-date-epoch/ for more information.
+# We use the start of MS-DOS time, which is what zipfiles use (see section 4.4.6 of
+# https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT).
 DETERMINISTIC_DATETIME = datetime(
   year=1980, month=1, day=1, hour=0, minute=0, second=0, microsecond=0, tzinfo=None
 )

--- a/pex/common.py
+++ b/pex/common.py
@@ -24,7 +24,7 @@ from uuid import uuid4
 # year-month-day-hour-minute-second, which we use here.
 DETERMINISTIC_DATETIME = datetime(
   year=1980, month=1, day=1, hour=0, minute=0, second=0, tzinfo=None
-).timetuple[:6]
+).timetuple()[:6]
 
 
 def die(msg, exit_code=1):

--- a/pex/common.py
+++ b/pex/common.py
@@ -399,7 +399,7 @@ class Chroot(object):
         else:
           # This code mostly reimplements ZipInfo.from_file(), which is not available in Python
           # 2.7. See https://github.com/python/cpython/blob/master/Lib/zipfile.py#L495.
-          st = os.stat(filename)
+          st = os.stat(full_path)
           isdir = stat.S_ISDIR(st.st_mode)
           # Determine arcname, i.e. the archive name.
           arcname = f

--- a/pex/common.py
+++ b/pex/common.py
@@ -22,11 +22,11 @@ from uuid import uuid4
 # We hardcode the datetime to January 1, 1980, which is the start of MS-DOS time. Per section 
 # 4.4.6 of the zip spec at https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT, 
 # Zipfiles use MS-DOS time.
-# NB: we do not respect the standard env var $SOURCE_DATE_EPOCH often used by tools for
-# deterministic timestamps, as the intended use case is security by checking if the binary was
-# tampered with; we do not have a compelling use case for respecing this env var, and it only
-# complicates the code, but this decision can be revisited if a user has a compelling use
-# case for it.
+# NB: We do not respect the standard env var $SOURCE_DATE_EPOCH often used by tools for
+# deterministic timestamps, as the intended use case is for security by checking if the binary
+# was tampered with. We do not have a compelling use case for respecting this env var, and it
+# only complicates the code, so we do not use it. However, this decision can be revisited if a
+# user has a compelling use case for it.
 DETERMINISTIC_DATETIME = datetime(
   year=1980, month=1, day=1, hour=0, minute=0, second=0, microsecond=0, tzinfo=None
 )

--- a/pex/common.py
+++ b/pex/common.py
@@ -386,7 +386,7 @@ class Chroot(object):
   def delete(self):
     shutil.rmtree(self.chroot)
 
-  def zip(self, filename, mode='w', deterministic_timestamp=True):
+  def zip(self, filename, mode='w', deterministic_timestamp=False):
     with open_zip(filename, mode) as zf:
       for f in sorted(self.files()):
         full_path = os.path.join(self.chroot, f)

--- a/pex/common.py
+++ b/pex/common.py
@@ -20,10 +20,11 @@ from uuid import uuid4
 
 
 # We use the start of MS-DOS time, which is what zipfiles use (see section 4.4.6 of
-# https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT).
+# https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT). ZipInfo expects a 6-tuple of
+# year-month-day-hour-minute-second, which we use here.
 DETERMINISTIC_DATETIME = datetime(
-  year=1980, month=1, day=1, hour=0, minute=0, second=0, microsecond=0, tzinfo=None
-)
+  year=1980, month=1, day=1, hour=0, minute=0, second=0, tzinfo=None
+).timetuple[:6]
 
 
 def die(msg, exit_code=1):
@@ -407,9 +408,7 @@ class Chroot(object):
         zinfo = zf.zip_info_from_file(
             filename=full_path,
             arcname=f,
-            date_time=(
-              None if not deterministic_timestamp else DETERMINISTIC_DATETIME.timetuple()[:6]
-            )
+            date_time=None if not deterministic_timestamp else DETERMINISTIC_DATETIME
         )
         with open(full_path, 'rb') as open_f:
           data = open_f.read()

--- a/pex/common.py
+++ b/pex/common.py
@@ -23,10 +23,12 @@ from uuid import uuid4
 # 4.4.6 of the zip spec at https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT, 
 # Zipfiles use MS-DOS time.
 # NB: We do not respect the standard env var $SOURCE_DATE_EPOCH often used by tools for
-# deterministic timestamps, as the intended use case is for security by checking if the binary
-# was tampered with. We do not have a compelling use case for respecting this env var, and it
-# only complicates the code, so we do not use it. However, this decision can be revisited if a
-# user has a compelling use case for it.
+# deterministic timestamps, as doing so risks reducing the reproducibility of built pexes across
+# different platforms, e.g. if two platforms set the env var differently. Usually, this is
+# supposed to be set for the sake of security to check that a shipped binary was not tampered
+# with, but that is not our primary use case, so we do not respect it both for simplicity of
+# our codebase and to avoid this potential reduction in reproducibility. Refer to
+# https://reproducible-builds.org/docs/source-date-epoch/ for more information.
 DETERMINISTIC_DATETIME = datetime(
   year=1980, month=1, day=1, hour=0, minute=0, second=0, microsecond=0, tzinfo=None
 )

--- a/pex/common.py
+++ b/pex/common.py
@@ -386,7 +386,7 @@ class Chroot(object):
   def delete(self):
     shutil.rmtree(self.chroot)
 
-  def zip(self, filename, mode='w', deterministic_timestamp=False):
+  def zip(self, filename, mode='w', deterministic_timestamp=True):
     with open_zip(filename, mode) as zf:
       for f in sorted(self.files()):
         full_path = os.path.join(self.chroot, f)

--- a/pex/common.py
+++ b/pex/common.py
@@ -133,7 +133,6 @@ class PermPreservingZipFile(zipfile.ZipFile, object):
     os.chmod(path, attr)
 
 
-
 @contextlib.contextmanager
 def open_zip(path, *args, **kwargs):
   """A contextmanager for zip files. Passes through positional and kwargs to zipfile.ZipFile."""

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -428,7 +428,7 @@ class PEXBuilder(object):
       self._precompile_source()
     self._frozen = True
 
-  def build(self, filename, bytecode_compile=True, deterministic_timestamp=True):
+  def build(self, filename, bytecode_compile=True, deterministic_timestamp=False):
     """Package the PEX into a zipfile.
 
     :param filename: The filename where the PEX should be stored.

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -433,7 +433,7 @@ class PEXBuilder(object):
 
     :param filename: The filename where the PEX should be stored.
     :param bytecode_compile: If True, precompile .py files into .pyc files.
-    :param deterministic_timestamp: If True, will not use system time for the zipfile timestamps.
+    :param deterministic_timestamp: If True, will use our hardcoded time for zipfile timestamps.
 
     If the PEXBuilder is not yet frozen, it will be frozen by ``build``.  This renders the
     PEXBuilder immutable.

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -428,11 +428,12 @@ class PEXBuilder(object):
       self._precompile_source()
     self._frozen = True
 
-  def build(self, filename, bytecode_compile=True):
+  def build(self, filename, bytecode_compile=True, deterministic_timestamp=False):
     """Package the PEX into a zipfile.
 
     :param filename: The filename where the PEX should be stored.
     :param bytecode_compile: If True, precompile .py files into .pyc files.
+    :param deterministic_timestamp: If True, will not use system time for the zipfile timestamps.
 
     If the PEXBuilder is not yet frozen, it will be frozen by ``build``.  This renders the
     PEXBuilder immutable.
@@ -450,7 +451,7 @@ class PEXBuilder(object):
     with open(filename + '~', 'ab') as pexfile:
       assert os.path.getsize(pexfile.name) == 0
       pexfile.write(to_bytes('%s\n' % self._shebang))
-    self._chroot.zip(filename + '~', mode='a')
+    self._chroot.zip(filename + '~', mode='a', deterministic_timestamp=deterministic_timestamp)
     if os.path.exists(filename):
       os.unlink(filename)
     os.rename(filename + '~', filename)

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -428,7 +428,7 @@ class PEXBuilder(object):
       self._precompile_source()
     self._frozen = True
 
-  def build(self, filename, bytecode_compile=True, deterministic_timestamp=False):
+  def build(self, filename, bytecode_compile=True, deterministic_timestamp=True):
     """Package the PEX into a zipfile.
 
     :param filename: The filename where the PEX should be stored.

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -105,7 +105,7 @@ def assert_chroot_perms(copyfn):
       assert extract_perms(two) == extract_perms(os.path.join(chroot.path(), 'two'))
 
       zip_path = os.path.join(src, 'chroot.zip')
-      chroot.zip(zip_path, deterministic_timestamp=True)
+      chroot.zip(zip_path)
       with temporary_dir() as extract_dir:
         with contextlib.closing(PermPreservingZipFile(zip_path)) as zf:
           zf.extractall(extract_dir)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -105,7 +105,7 @@ def assert_chroot_perms(copyfn):
       assert extract_perms(two) == extract_perms(os.path.join(chroot.path(), 'two'))
 
       zip_path = os.path.join(src, 'chroot.zip')
-      chroot.zip(zip_path)
+      chroot.zip(zip_path, deterministic_timestamp=True)
       with temporary_dir() as extract_dir:
         with contextlib.closing(PermPreservingZipFile(zip_path)) as zf:
           zf.extractall(extract_dir)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1351,7 +1351,10 @@ def assert_reproducible_build(args):
     # from the random seed, such as data structures, as Tox sets this value by default. See
     # https://tox.readthedocs.io/en/latest/example/basic.html#special-handling-of-pythonhashseed.
     def create_pex(path, seed):
-      run_pex_command(args + ['-o', path, '--no-compile'], env=make_env(PYTHONHASHSEED=seed))
+      run_pex_command(
+        args + ['-o', path, '--no-compile', '--no-use-system-time'],
+        env=make_env(PYTHONHASHSEED=seed)
+      )
     create_pex(pex1, seed=111)
     # We sleep to ensure that there is no non-reproducibility from timestamps or
     # anything that may depend on the system time. Note that we must sleep for at least

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1388,6 +1388,7 @@ def test_reproducible_build_bdist_requirements():
   assert_reproducible_build(['six==1.12.0', 'cryptography==2.6.1'])
 
 
+@pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
 def test_reproducible_build_sdist_requirements():
   assert_reproducible_build(['pycparser==2.19', '--no-build'])
 
@@ -1396,6 +1397,7 @@ def test_reproducible_build_m_flag():
   assert_reproducible_build(['-m', 'pydoc'])
 
 
+@pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
 def test_reproducible_build_c_flag():
   setup_py = dedent("""
     from setuptools import setup

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1375,7 +1375,6 @@ def assert_reproducible_build(args):
     assert filecmp.cmp(pex1, pex2, shallow=False)
 
 
-@pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
 def test_reproducible_build_no_args():
   assert_reproducible_build([])
 
@@ -1386,17 +1385,14 @@ def test_reproducible_build_bdist_requirements():
   assert_reproducible_build(['six==1.12.0', 'cryptography==2.6.1'])
 
 
-@pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
 def test_reproducible_build_sdist_requirements():
   assert_reproducible_build(['pycparser==2.19', '--no-build'])
 
 
-@pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
 def test_reproducible_build_m_flag():
   assert_reproducible_build(['-m', 'pydoc'])
 
 
-@pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
 def test_reproducible_build_c_flag():
   setup_py = dedent("""
     from setuptools import setup
@@ -1410,11 +1406,9 @@ def test_reproducible_build_c_flag():
     assert_reproducible_build([project_dir, '-c', 'my_app'])
 
 
-@pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
 def test_reproducible_build_python_flag():
   assert_reproducible_build(['--python=python2.7'])
 
 
-@pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
 def test_reproducible_build_python_shebang_flag():
   assert_reproducible_build(['--python-shebang=/usr/bin/python'])

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -1,7 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import datetime
 import os
 import stat
 import zipfile
@@ -182,22 +181,9 @@ def test_pex_builder_copy_or_link():
 
 
 def test_pex_builder_deterministic_timestamp():
-  def assert_all_files_have_timestamp(timestamp):
-    pb = PEXBuilder()
-    with temporary_dir() as td:
-      target = os.path.join(td, 'foo.pex')
-      pb.build(target, deterministic_timestamp=True)
-      with zipfile.ZipFile(target) as zf:
-        assert all(zinfo.date_time == timestamp for zinfo in zf.infolist())
-
-  assert_all_files_have_timestamp((1980, 1, 1, 0, 0, 0))
-  # Also test that $SOURCE_DATE_EPOCH is respected.
-  requested_date = (2019, 5, 1, 10, 10, 10)
-  utc_timestamp = int((
-    datetime.datetime(*requested_date) - datetime.datetime(1970, 1, 1)
-  ).total_seconds())
-  os.environ["SOURCE_DATE_EPOCH"] = str(utc_timestamp)
-  try:
-    assert_all_files_have_timestamp(requested_date)
-  finally:
-    os.environ.pop("SOURCE_DATE_EPOCH")
+  pb = PEXBuilder()
+  with temporary_dir() as td:
+    target = os.path.join(td, 'foo.pex')
+    pb.build(target, deterministic_timestamp=True)
+    with zipfile.ZipFile(target) as zf:
+      assert all(zinfo.date_time == (1980, 1, 1, 0, 0, 0) for zinfo in zf.infolist())

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -197,5 +197,7 @@ def test_pex_builder_deterministic_timestamp():
     datetime.datetime(*requested_date) - datetime.datetime(1970, 1, 1)
   ).total_seconds())
   os.environ["SOURCE_DATE_EPOCH"] = str(utc_timestamp)
-  assert_all_files_have_timestamp(requested_date)
-  os.environ.pop("SOURCE_DATE_EPOCH")
+  try:
+    assert_all_files_have_timestamp(requested_date)
+  finally:
+    os.environ.pop("SOURCE_DATE_EPOCH")


### PR DESCRIPTION
### Problem
Part of https://github.com/pantsbuild/pex/issues/716 to make built PEXes be reproducible.

One of the major sources of unreproducibility is timestamps embedded into the zipfile. Python's `zipfile.py` uses the current system time when creating a new zipfile, per https://github.com/python/cpython/blob/45e92fc02d57a7219f4f4922179929f19b3d1c28/Lib/zipfile.py#L509. So, the Pex cannot be reproducible if built after the original run.

### Solution
Introduce a new flag `--use-system-time` / `--no-use-system-time` that will toggle whether we use a deterministic timestamp or keep the default behavior of using the current system time. We will default to `--use-system-time` for now to keep prior behavior, and then in a future release like 1.70 will switch over to default to reproducible builds.

If `--no-use-system-time` is specified, we use midnight at January 1, 1980, which is the start of the MS-DOS time used by Zipfiles. We then use this value to construct a `ZipInfo` with the desired date.


#### Not respecting `SOURCE_DATE_EPOCH`
We do not respect the standard env var `$SOURCE_DATE_EPOCH` often used by tools for deterministic timestamps, as doing so risks reducing the reproducibility of built pexes across different platforms, e.g. if two platforms set the env var differently. Usually, this is supposed to be set for the sake of security to check that a shipped binary was not tampered with, but that is not our primary use case, so we do not respect it both for simplicity of our codebase and to avoid this potential reduction in reproducibility. Refer to https://reproducible-builds.org/docs/source-date-epoch/ for more information.

### Result
4 / 7 of the acceptance tests for reproducibility now pass consistently!

When setting CI to always use a deterministic timestamp, [CI was green](https://travis-ci.org/pantsbuild/pex/builds/527997029) so things will work as expected when we change the default to deterministic timestamps.