### PR TITLE
Fix PexInfo requirements using a non-deterministic data structure

### DIFF
--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -117,7 +117,7 @@ class PexInfo(object):
     raise ValueError('Malformed PEX requirement: %r' % (requirement_tuple,))
 
   def __init__(self, info=None):
-    """Construct a new PexInfo.  This should not be used directly."""
+    """Construct a new PexInfo. This should not be used directly."""
 
     if info is not None and not isinstance(info, dict):
       raise ValueError('PexInfo can only be seeded with a dict, got: '
@@ -310,8 +310,8 @@ class PexInfo(object):
 
   def dump(self, **kwargs):
     pex_info_copy = self._pex_info.copy()
-    pex_info_copy['requirements'] = list(self._requirements)
-    pex_info_copy['interpreter_constraints'] = list(self._interpreter_constraints)
+    pex_info_copy['requirements'] = sorted(self._requirements)
+    pex_info_copy['interpreter_constraints'] = sorted(self._interpreter_constraints)
     pex_info_copy['distributions'] = self._distributions.copy()
     return json.dumps(pex_info_copy, **kwargs)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1385,7 +1385,6 @@ def test_reproducible_build_no_args():
   assert_reproducible_build([])
 
 
-@pytest.mark.skip("Acceptance test for landing https://github.com/pantsbuild/pex/issues/716.")
 def test_reproducible_build_bdist_requirements():
   # We test both a pure Python wheel (six) and a platform-specific wheel (cryptography).
   assert_reproducible_build(['six==1.12.0', 'cryptography==2.6.1'])


### PR DESCRIPTION
## Problem
Even though `PexInfo` stores its requirements as an `OrderedSet`, when getting converted into a `list` in the `dump()` function, the requirements were losing their deterministic order for an unclear reason.

Specifically, the acceptance test diverged with `PEX-INFO`, with both files having different orders for their requirements. 

```
# pex1
"requirements": ["six==1.12.0", "cryptography==2.6.1", "cffi!=1.11.3,>=1.8", "asn1crypto>=0.21.0", "pycparser"]

# pex2
["six==1.12.0", "cryptography==2.6.1", "asn1crypto>=0.21.0", "cffi!=1.11.3,>=1.8", "pycparser"]
```

## Solution
Sort the requirements when being dumped to ensure we always have a consistent result.

We also make `interpreter_constraints`'s output always be sorted, as it is internally stored as a set so by definition is not deterministic in ordering.