### PR TITLE
Add timeout when using requests.

### DIFF
--- a/pex/http.py
+++ b/pex/http.py
@@ -231,6 +231,7 @@ class RequestsContext(Context):
       raise ValueError('max_retries may not be negative.')
 
     self._max_retries = max_retries
+    self._timeout = env.PEX_HTTP_TIMEOUT
     self._session = session or self._create_session(self._max_retries)
 
   def open(self, link):
@@ -240,7 +241,8 @@ class RequestsContext(Context):
     for attempt in range(self._max_retries + 1):
       try:
         return StreamFilelike(self._session.get(
-            link.url, verify=self._verify, stream=True, headers={'User-Agent': self.USER_AGENT}),
+            link.url, verify=self._verify, stream=True, headers={'User-Agent': self.USER_AGENT},
+            timeout=self._timeout),
             link)
       except requests.exceptions.ReadTimeout:
         # Connect timeouts are handled by the HTTPAdapter, unfortunately read timeouts are not
@@ -267,7 +269,7 @@ class RequestsContext(Context):
   def resolve(self, link):
     return link.wrap(self._session.head(
         link.url, verify=self._verify, allow_redirects=True,
-        headers={'User-Agent': self.USER_AGENT}
+        headers={'User-Agent': self.USER_AGENT}, timeout=self._timeout
     ).url)
 
 

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -309,7 +309,7 @@ class Variables(object):
     """
     return self._get_int('PEX_VERBOSE', default=0)
 
-  # TODO(wickman) Remove and push into --flags.  #94
+  # TODO(#94) Remove and push into --flags.
   @property
   def PEX_HTTP_RETRIES(self):
     """Integer
@@ -318,6 +318,17 @@ class Variables(object):
     Default: 5.
     """
     return self._get_int('PEX_HTTP_RETRIES', default=5)
+
+  # TODO(#94) Remove and push into --flags.
+  @property
+  def PEX_HTTP_TIMEOUT(self):
+    """Integer
+
+    When built with the `requests` HTTP library, a timeout to apply for HTTP connect attempts and
+    read attempts. See the `requests` docis for more information.
+    Default: 15.
+    """
+    return self._get_int('PEX_HTTP_TIMEOUT', default=15)
 
   @property
   def PEX_IGNORE_RCFILES(self):

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -325,7 +325,8 @@ class Variables(object):
     """Integer
 
     When built with the `requests` HTTP library, a timeout to apply for HTTP connect attempts and
-    read attempts. See the `requests` docis for more information.
+    read attempts. See the `requests` docs (https://2.python-requests.org/en/master/user/quickstart/#timeouts)
+    for more information.
     Default: 15.
     """
     return self._get_int('PEX_HTTP_TIMEOUT', default=15)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -146,6 +146,13 @@ def test_requests_context_retries_from_environment():
   assert RequestsContext(verify=False, env=env)._max_retries == int(retry_count)
 
 
+@pytest.mark.skipif(NO_REQUESTS)
+def test_requests_context_timeout_from_environment():
+  timeout = '42'
+  env = Variables({'PEX_HTTP_TIMEOUT': timeout})
+  assert RequestsContext(verify=False, env=env)._timeout == int(timeout)
+
+
 def timeout_side_effect(timeout_error=None, num_timeouts=1):
   timeout_error = timeout_error or requests.packages.urllib3.exceptions.ConnectTimeoutError
   url = 'http://pypi.org/foo.tar.gz'


### PR DESCRIPTION
By default, `requests` does not use a connect/read timeout. See https://2.python-requests.org/en/master/user/quickstart/#timeouts and https://github.com/pantsbuild/pants/pull/7659.

Fixes #26.