### PR TITLE
add delayed pkg_resources import fix from #713, with an integration test

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ You can also build pex in a git clone using tox:
 
 .. code-block:: bash
 
-    $ tox -e py27-package
+    $ tox -e package
     $ cp dist/pex ~/bin
 
 This builds a pex binary in ``dist/pex`` that can be copied onto your ``$PATH``.

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -368,6 +368,9 @@ class PEXEnvironment(Environment):
         with TRACER.timed('Adding sitedir', V=2):
           site.addsitedir(dist.location)
 
-        self._declare_namespace_packages(dist)
+    # Delay calling 'self._declare_namespace_packages' until 'sys.path' contains all of the
+    # resolved dists.
+    for dist in resolved:
+      self._declare_namespace_packages(dist)
 
     return working_set

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -368,8 +368,9 @@ class PEXEnvironment(Environment):
         with TRACER.timed('Adding sitedir', V=2):
           site.addsitedir(dist.location)
 
-    # Delay calling 'self._declare_namespace_packages' until 'sys.path' contains all of the
-    # resolved dists.
+    # NB: we use this loop, rather than putting the below line in the prior loop, to ensure that
+    # 'sys.path' contains all of the resolved dists before calling
+    # 'self._declare_namespace_packages'.
     for dist in resolved:
       self._declare_namespace_packages(dist)
 


### PR DESCRIPTION
This is a fix to the way we load pkg_resources, along with an integration test which fails on master since the setuptools vendoring in #624, but is fixed by the change in #713. This can be merged before that one to fix the failures induced in several 3rdparty packages, while #713 can be left to understanding and testing the separate but related problem that this change also happens to fix.