### PR TITLE
Fixup pex re-exec during bootstrap.

### DIFF
--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -116,12 +116,12 @@ def maybe_reexec_pex(compatibility_constraints=None):
 
   current_interpreter = PythonInterpreter.get()
 
-  # NB: Used only for debugging and tests.
-  pex_exec_chain = []
+  # NB: Used only for tests.
   if '_PEX_EXEC_CHAIN' in os.environ:
-    pex_exec_chain.extend(os.environ['_PEX_EXEC_CHAIN'].split(os.pathsep))
-  pex_exec_chain.append(current_interpreter.binary)
-  os.environ['_PEX_EXEC_CHAIN'] = os.pathsep.join(pex_exec_chain)
+    flag_or_chain = os.environ.pop('_PEX_EXEC_CHAIN')
+    pex_exec_chain = [] if flag_or_chain == '1' else flag_or_chain.split(os.pathsep)
+    pex_exec_chain.append(current_interpreter.binary)
+    os.environ['_PEX_EXEC_CHAIN'] = os.pathsep.join(pex_exec_chain)
 
   current_interpreter_blessed_env_var = '_PEX_SHOULD_EXIT_BOOTSTRAP_REEXEC'
   if os.environ.pop(current_interpreter_blessed_env_var, None):

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -20,12 +20,10 @@ __all__ = ('bootstrap_pex',)
 
 def _find_pex_python(pex_python):
   def try_create(try_path):
-    if os.path.exists(try_path):
-      try:
-        return PythonInterpreter.from_binary(try_path)
-      except Executor.ExecutionError:
-        pass
-    return None
+    try:
+      return PythonInterpreter.from_binary(try_path)
+    except Executor.ExecutionError:
+      return None
 
   interpreter = try_create(pex_python)
   if interpreter:

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -75,9 +75,6 @@ class Variables(object):
   def copy(self):
     return self._environ.copy()
 
-  def delete(self, variable):
-    self._environ.pop(variable, None)
-
   def set(self, variable, value):
     self._environ[variable] = str(value)
 
@@ -350,6 +347,7 @@ class Variables(object):
 
   def __repr__(self):
     return '{}({!r})'.format(type(self).__name__, self._environ)
+
 
 # Global singleton environment
 ENV = Variables()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -603,7 +603,8 @@ def test_pex_python():
     stdin_payload = b'import sys; print(sys.executable); sys.exit(0)'
     stdout, rc = run_simple_pex(pex_out_path, stdin=stdin_payload, env=env)
     assert rc == 1
-    fail_str = 'not compatible with specified interpreter constraints'.encode()
+    fail_str = ('Failed to find a compatible PEX_PYTHON={} for constraints'
+                .format(pex_python)).encode()
     assert fail_str in stdout
 
     # test PEX_PYTHON with no constraints

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,6 +3,7 @@
 
 import filecmp
 import functools
+import json
 import os
 import platform
 import subprocess
@@ -43,7 +44,10 @@ from pex.util import DistributionHelper, named_temporary_file
 
 def make_env(**kwargs):
   env = os.environ.copy()
-  env.update((k, str(v)) for k, v in kwargs.items())
+  env.update((k, str(v)) for k, v in kwargs.items() if v is not None)
+  for k, v in kwargs.items():
+    if v is None:
+      env.pop(k, None)
   return env
 
 
@@ -1483,3 +1487,83 @@ def test_issues_736_requirement_setup_py_with_extras():
         env=make_env(PEX_INTERPRETER='1')
       )
       assert output.decode('utf-8').strip() == u'hello world!'
+
+
+def _assert_exec_chain(exec_chain=None,
+                       pex_python=None,
+                       pex_python_path=None,
+                       interpreter_constraints=None):
+
+  with temporary_dir() as td:
+    test_pex = os.path.join(td, 'test.pex')
+
+    args = ['-o', test_pex]
+    if interpreter_constraints:
+      args.extend('--interpreter-constraint={}'.format(ic) for ic in interpreter_constraints)
+
+    env = os.environ.copy()
+    PATH = env.get('PATH').split(os.pathsep)
+
+    def add_to_path(path):
+      if os.path.isfile(path):
+        path = os.path.dirname(path)
+      PATH.append(path)
+
+    if pex_python:
+      add_to_path(pex_python)
+    if pex_python_path:
+      for path in pex_python_path:
+        add_to_path(path)
+
+    env['PATH'] = os.pathsep.join(PATH)
+    result = run_pex_command(args, env=env)
+    result.assert_success()
+
+    env = make_env(PEX_INTERPRETER=1,
+                   PEX_PYTHON=pex_python,
+                   PEX_PYTHON_PATH=os.pathsep.join(pex_python_path) if pex_python_path else None)
+
+    output = subprocess.check_output(
+      [sys.executable, test_pex, '-c', 'import json, os; print(json.dumps(os.environ.copy()))'],
+      env=env
+    )
+    final_env = json.loads(output.decode('utf-8'))
+
+    assert 'PEX_PYTHON' not in final_env
+    assert 'PEX_PYTHON_PATH' not in final_env
+    assert '_PEX_SHOULD_EXIT_BOOTSTRAP_REEXEC' not in final_env
+
+    expected_exec_chain = [os.path.realpath(i) for i in [sys.executable] + (exec_chain or [])]
+    assert expected_exec_chain == final_env['_PEX_EXEC_CHAIN'].split(os.pathsep)
+
+
+def test_pex_no_reexec_no_constraints():
+  _assert_exec_chain()
+
+
+def test_pex_no_reexec_constraints_match_current():
+  current_version = '.'.join(str(component) for component in sys.version_info[0:3])
+  _assert_exec_chain(interpreter_constraints=['=={}'.format(current_version)])
+
+
+def test_pex_reexec_constraints_dont_match_current_pex_python_path():
+  py36_interpreter = ensure_python_interpreter(PY36)
+  py27_interpreter = ensure_python_interpreter(PY27)
+  _assert_exec_chain(exec_chain=[py36_interpreter],
+                     pex_python_path=[py27_interpreter, py36_interpreter],
+                     interpreter_constraints=['=={}'.format(PY36)])
+
+
+def test_pex_reexec_constraints_dont_match_current_pex_python_path_min():
+  py36_interpreter = ensure_python_interpreter(PY36)
+  py27_interpreter = ensure_python_interpreter(PY27)
+  _assert_exec_chain(exec_chain=[py27_interpreter],
+                     pex_python_path=[py36_interpreter, py27_interpreter])
+
+
+def test_pex_reexec_constraints_dont_match_current_pex_python():
+  version = PY27 if sys.version_info[0:2] == (3, 6) else PY36
+  interpreter = ensure_python_interpreter(version)
+  _assert_exec_chain(exec_chain=[interpreter],
+                     pex_python=interpreter,
+                     interpreter_constraints=['=={}'.format(version)])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1504,10 +1504,10 @@ def _assert_exec_chain(exec_chain=None,
     env = os.environ.copy()
     PATH = env.get('PATH').split(os.pathsep)
 
-    def add_to_path(path):
-      if os.path.isfile(path):
-        path = os.path.dirname(path)
-      PATH.append(path)
+    def add_to_path(entry):
+      if os.path.isfile(entry):
+        entry = os.path.dirname(entry)
+      PATH.append(entry)
 
     if pex_python:
       add_to_path(pex_python)
@@ -1554,7 +1554,7 @@ def test_pex_reexec_constraints_dont_match_current_pex_python_path():
                      interpreter_constraints=['=={}'.format(PY36)])
 
 
-def test_pex_reexec_constraints_dont_match_current_pex_python_path_min():
+def test_pex_reexec_constraints_dont_match_current_pex_python_path_min_py_version_selected():
   py36_interpreter = ensure_python_interpreter(PY36)
   py27_interpreter = ensure_python_interpreter(PY27)
   _assert_exec_chain(exec_chain=[py27_interpreter],

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1519,7 +1519,8 @@ def _assert_exec_chain(exec_chain=None,
     result = run_pex_command(args, env=env)
     result.assert_success()
 
-    env = make_env(PEX_INTERPRETER=1,
+    env = make_env(_PEX_EXEC_CHAIN=1,
+                   PEX_INTERPRETER=1,
                    PEX_PYTHON=pex_python,
                    PEX_PYTHON_PATH=os.pathsep.join(pex_python_path) if pex_python_path else None)
 

--- a/tests/test_pex_bootstrapper.py
+++ b/tests/test_pex_bootstrapper.py
@@ -17,7 +17,7 @@ def test_find_compatible_interpreters():
 
   def find_interpreters(*constraints):
     return [interp.binary for interp in
-            find_compatible_interpreters(pex_python_path=pex_python_path,
+            find_compatible_interpreters(path=pex_python_path,
                                          compatibility_constraints=constraints)]
 
   assert [py35, py36] == find_interpreters('>3')

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -110,11 +110,10 @@ def test_pex_vars_hermetic():
 
 def test_pex_vars_set():
   v = Variables(environ={})
+  assert v._get_int('HELLO') is None
   v.set('HELLO', '42')
   assert v._get_int('HELLO') == 42
-  v.delete('HELLO')
-  assert v._get_int('HELLO') is None
-  assert {} == v.copy()
+  assert {'HELLO': '42'} == v.copy()
 
 
 def test_pex_get_kv():


### PR DESCRIPTION
Ensure `PEX_PYTHON` and `PEX_PYTHON_PATH` are actually scrubbed from the
environment of the pex process when re-exec'd fixing #710. Also
uniformize re-exec interpreter selection to ensure that the current
interpreter is preferred when it meets any constraints fixing #709.

Fixes #709
Fixes #710