### PR TITLE
Fix pkg resource early import

### DIFF
--- a/pex/environment.py
+++ b/pex/environment.py
@@ -307,7 +307,7 @@ class PEXEnvironment(Environment):
     return resolveds
 
   @staticmethod
-  def _declare_namespace_packages(resolved_dists):
+  def declare_namespace_packages(resolved_dists):
     namespace_package_dists = [dist for dist in resolved_dists
                                if dist.has_metadata('namespace_packages.txt')]
     if not namespace_package_dists:
@@ -381,7 +381,5 @@ class PEXEnvironment(Environment):
 
         with TRACER.timed('Adding sitedir', V=2):
           site.addsitedir(dist.location)
-
-    self._declare_namespace_packages(resolved)
 
     return working_set

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -24,7 +24,7 @@ from pex.orderedset import OrderedSet
 from pex.pex_info import PexInfo
 from pex.third_party.pkg_resources import EntryPoint, WorkingSet, find_distributions
 from pex.tracer import TRACER
-from pex.util import iter_pth_paths, merge_split, named_temporary_file
+from pex.util import iter_pth_paths, named_temporary_file
 from pex.variables import ENV
 
 
@@ -93,9 +93,9 @@ class PEX(object):  # noqa: T000
         for dist in env.activate():
           working_set.add(dist)
 
-      # Ensure that pkg_resources is not imported until at least every pex environment 
+      # Ensure that pkg_resources is not imported until at least every pex environment
       # (i.e. PEX_PATH) has been merged into the environment
-      PEXEnvironment.declare_namespace_packages(working_set.by_key.values())
+      PEXEnvironment.declare_namespace_packages(working_set)
       self._working_set = working_set
 
     return self._working_set
@@ -277,8 +277,6 @@ class PEX(object):  # noqa: T000
       patch_dict(sys.modules, modules)
 
     new_sys_path, new_sys_path_importer_cache, new_sys_modules = self.minimum_sys(inherit_path)
-
-    new_sys_path.extend(merge_split(self._pex_info.pex_path, self._vars.PEX_PATH))
 
     patch_all(new_sys_path, new_sys_path_importer_cache, new_sys_modules)
 

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -93,6 +93,9 @@ class PEX(object):  # noqa: T000
         for dist in env.activate():
           working_set.add(dist)
 
+      # Ensure that the pkg_resources is not imported until at least every pex environment (i.e. PEX_PATH)
+      # has been merged into the environment
+      PEXEnvironment.declare_namespace_packages(working_set.by_key.values())
       self._working_set = working_set
 
     return self._working_set

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -93,8 +93,8 @@ class PEX(object):  # noqa: T000
         for dist in env.activate():
           working_set.add(dist)
 
-      # Ensure that the pkg_resources is not imported until at least every pex environment (i.e. PEX_PATH)
-      # has been merged into the environment
+      # Ensure that pkg_resources is not imported until at least every pex environment 
+      # (i.e. PEX_PATH) has been merged into the environment
       PEXEnvironment.declare_namespace_packages(working_set.by_key.values())
       self._working_set = working_set
 

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -11,7 +11,6 @@ from pex.common import open_zip
 from pex.compatibility import PY2
 from pex.compatibility import string as compatibility_string
 from pex.orderedset import OrderedSet
-from pex.util import merge_split
 from pex.variables import ENV
 from pex.version import __version__ as pex_version
 

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -318,13 +318,19 @@ class PexInfo(object):
   def copy(self):
     return self.from_json(self.dump())
 
+  @staticmethod
+  def _merge_split(*paths):
+    filtered_paths = filter(None, paths)
+    return [p for p in ':'.join(filtered_paths).split(':') if p]
+
   def merge_pex_path(self, pex_path):
     """Merges a new PEX_PATH definition into the existing one (if any).
-    :param string pex_path: The PEX_PATH to merge.
+
+    :param str pex_path: The PEX_PATH to merge.
     """
     if not pex_path:
       return
-    self.pex_path = ':'.join(merge_split(self.pex_path, pex_path))
+    self.pex_path = ':'.join(self._merge_split(self.pex_path, pex_path))
 
   def __repr__(self):
     return '{}({!r})'.format(type(self).__name__, self._pex_info)

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -212,24 +212,28 @@ except ImportError:
 """
 
 
-def write_simple_pex(td, exe_contents, dists=None, sources=None, coverage=False, interpreter=None):
-  """Write a pex file that contains an executable entry point
+def write_simple_pex(td,
+                     exe_contents=None,
+                     dists=None,
+                     sources=None,
+                     coverage=False,
+                     interpreter=None):
+  """Write a pex file that optionally contains an executable entry point.
 
-  :param td: temporary directory path
-  :param exe_contents: entry point python file
-  :type exe_contents: string
+  :param str td: temporary directory path
+  :param str exe_contents: entry point python file
   :param dists: distributions to include, typically sdists or bdists
+  :type: list of :class:`pex.third_party.pkg_resources.Distribution`
   :param sources: sources to include, as a list of pairs (env_filename, contents)
-  :param coverage: include coverage header
+  :type sources: list of (str, str)
+  :param bool coverage: include coverage header
   :param interpreter: a custom interpreter to use to build the pex
+  :type interpreter: :class:`pex.interpreter.PythonInterpreter`
   """
   dists = dists or []
   sources = sources or []
 
   safe_mkdir(td)
-
-  with open(os.path.join(td, 'exe.py'), 'w') as fp:
-    fp.write(exe_contents)
 
   pb = PEXBuilder(path=td,
                   preamble=COVERAGE_PREAMBLE if coverage else None,
@@ -245,7 +249,11 @@ def write_simple_pex(td, exe_contents, dists=None, sources=None, coverage=False,
       fp.write(contents)
     pb.add_source(src_path, env_filename)
 
-  pb.set_executable(os.path.join(td, 'exe.py'))
+  if exe_contents:
+    with open(os.path.join(td, 'exe.py'), 'w') as fp:
+      fp.write(exe_contents)
+    pb.set_executable(os.path.join(td, 'exe.py'))
+
   pb.freeze()
 
   return pb

--- a/pex/util.py
+++ b/pex/util.py
@@ -250,14 +250,3 @@ def iter_pth_paths(filename):
         if extras_dir_case_insensitive not in known_paths and os.path.exists(extras_dir):
           yield extras_dir
           known_paths.add(extras_dir_case_insensitive)
-
-
-def merge_split(*paths):
-  """Merge paths into a single path delimited by colons and split on colons to return
-  a list of paths.
-
-  :param paths: a variable length list of path strings
-  :return: a list of paths from the merged path list split by colons
-  """
-  filtered_paths = filter(None, paths)
-  return [p for p in ':'.join(filtered_paths).split(':') if p]

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -48,14 +48,14 @@ def test_force_local():
     pb.info.pex_root = pex_root
     pb.build(pex_file)
 
-    code_cache = PEXEnvironment.force_local(pex_file, pb.info)
+    code_cache = PEXEnvironment._force_local(pex_file, pb.info)
     assert os.path.exists(pb.info.zip_unsafe_cache)
     assert len(os.listdir(pb.info.zip_unsafe_cache)) == 1
     assert [os.path.basename(code_cache)] == os.listdir(pb.info.zip_unsafe_cache)
     assert set(os.listdir(code_cache)) == set([PexInfo.PATH, '__main__.py', '__main__.pyc'])
 
     # idempotence
-    assert PEXEnvironment.force_local(pex_file, pb.info) == code_cache
+    assert PEXEnvironment._force_local(pex_file, pb.info) == code_cache
 
 
 def assert_force_local_implicit_ns_packages_issues_598(interpreter=None,
@@ -206,7 +206,7 @@ def test_write_zipped_internal_cache():
     pb.info.pex_root = pex_root
     pb.build(pex_file)
 
-    existing, new, zip_safe = PEXEnvironment.write_zipped_internal_cache(pex_file, pb.info)
+    existing, new, zip_safe = PEXEnvironment._write_zipped_internal_cache(pex_file, pb.info)
     assert len(zip_safe) == 1
     assert normalize(zip_safe[0].location).startswith(
         normalize(os.path.join(pex_file, pb.info.internal_cache))), (
@@ -215,12 +215,12 @@ def test_write_zipped_internal_cache():
                 normalize(os.path.join(pex_file, pb.info.internal_cache))))
 
     pb.info.always_write_cache = True
-    existing, new, zip_safe = PEXEnvironment.write_zipped_internal_cache(pex_file, pb.info)
+    existing, new, zip_safe = PEXEnvironment._write_zipped_internal_cache(pex_file, pb.info)
     assert len(new) == 1
     assert normalize(new[0].location).startswith(normalize(pb.info.install_cache))
 
     # Check that we can read from the cache
-    existing, new, zip_safe = PEXEnvironment.write_zipped_internal_cache(pex_file, pb.info)
+    existing, new, zip_safe = PEXEnvironment._write_zipped_internal_cache(pex_file, pb.info)
     assert len(existing) == 1
     assert normalize(existing[0].location).startswith(normalize(pb.info.install_cache))
 
@@ -231,13 +231,13 @@ def test_write_zipped_internal_cache():
     pb.info.pex_root = pex_root
     pb.build(pex_file)
 
-    existing, new, zip_safe = PEXEnvironment.write_zipped_internal_cache(pex_file, pb.info)
+    existing, new, zip_safe = PEXEnvironment._write_zipped_internal_cache(pex_file, pb.info)
     assert len(new) == 1
     assert normalize(new[0].location).startswith(normalize(pb.info.install_cache))
     original_location = normalize(new[0].location)
 
     # do the second time to validate idempotence of caching
-    existing, new, zip_safe = PEXEnvironment.write_zipped_internal_cache(pex_file, pb.info)
+    existing, new, zip_safe = PEXEnvironment._write_zipped_internal_cache(pex_file, pb.info)
     assert len(existing) == 1
     assert normalize(existing[0].location) == original_location
 
@@ -248,7 +248,7 @@ def test_load_internal_cache_unzipped():
     pb.info.pex_root = pex_root
     pb.freeze()
 
-    dists = list(PEXEnvironment.load_internal_cache(pb.path(), pb.info))
+    dists = list(PEXEnvironment._load_internal_cache(pb.path(), pb.info))
     assert len(dists) == 1
     assert normalize(dists[0].location).startswith(
         normalize(os.path.join(pb.path(), pb.info.internal_cache)))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1357,6 +1357,7 @@ def test_undeclared_setuptools_import_on_pex_path():
     res.assert_success()
     assert res.output.strip() == 'bigquery version: 1.10.0'
 
+
 def test_pkg_resource_early_import_on_pex_path():
   """Test that packages which access pkg_resources at import time can be found with pkg_resources.
 
@@ -1383,7 +1384,8 @@ def test_pkg_resource_early_import_on_pex_path():
         """))
 
     setuptools_pex = os.path.join(td, 'autopep8.pex')
-    run_pex_command(['autopep8', 'setuptools', '-D', src_dir, '--entry-point', 'execute_import', '-o', setuptools_pex]).assert_success()
+    run_pex_command(['autopep8', 'setuptools', '-D', src_dir, '--entry-point',
+      'execute_import', '-o', setuptools_pex]).assert_success()
     _, return_code = run_simple_pex(setuptools_pex, env=make_env(PEX_PATH=six_pex))
     assert return_code == 0
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1357,6 +1357,36 @@ def test_undeclared_setuptools_import_on_pex_path():
     res.assert_success()
     assert res.output.strip() == 'bigquery version: 1.10.0'
 
+def test_pkg_resource_early_import_on_pex_path():
+  """Test that packages which access pkg_resources at import time can be found with pkg_resources.
+
+  See https://github.com/pantsbuild/pex/issues/749 for context. We only declare
+  namespace packages once all environments have been resolved including ones passed in
+  via PEX_PATH. This avoids importing pkg_resources too early which is potentially impactful
+  with packages interacting with pkg_resources at import time.
+  """
+  with temporary_dir() as td:
+
+    six_pex = os.path.join(td, 'six.pex')
+    run_pex_command(['six', '-o', six_pex]).assert_success()
+
+    src_dir = os.path.join(td, 'src')
+    os.mkdir(src_dir)
+
+    src_file = os.path.join(src_dir, 'execute_import.py')
+    with open(src_file, 'w') as fp:
+      fp.write(dedent("""\
+        import pkg_resources
+        import sys
+
+        pkg_resources.get_distribution('six')
+        """))
+
+    setuptools_pex = os.path.join(td, 'autopep8.pex')
+    run_pex_command(['autopep8', 'setuptools', '-D', src_dir, '--entry-point', 'execute_import', '-o', setuptools_pex]).assert_success()
+    _, return_code = run_simple_pex(setuptools_pex, env=make_env(PEX_PATH=six_pex))
+    assert return_code == 0
+
 
 @pytest.mark.skipif(IS_PYPY)
 def test_issues_539_abi3_resolution():

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -296,7 +296,6 @@ def test_pex_paths():
       pex1_path = os.path.join(temp_dir, 'pex1')
       write_simple_pex(
         pex1_path,
-        exe_contents='',
         sources=[
           ('foo_pkg/__init__.py', ''),
           ('foo_pkg/foo_module.py', 'def foo_func():\n  return "42"')

--- a/tests/test_pex_info.py
+++ b/tests/test_pex_info.py
@@ -80,3 +80,23 @@ def test_from_env():
 
 def test_build_properties():
   assert pex_version == PexInfo.default().build_properties['pex_version']
+
+
+def test_merge_split():
+  path_1, path_2 = '/pex/path/1:/pex/path/2', '/pex/path/3:/pex/path/4'
+  result = PexInfo._merge_split(path_1, path_2)
+  assert result == ['/pex/path/1', '/pex/path/2', '/pex/path/3', '/pex/path/4']
+
+  path_1, path_2 = '/pex/path/1:', '/pex/path/3:/pex/path/4'
+  result = PexInfo._merge_split(path_1, path_2)
+  assert result == ['/pex/path/1', '/pex/path/3', '/pex/path/4']
+
+  path_1, path_2 = '/pex/path/1::/pex/path/2', '/pex/path/3:/pex/path/4'
+  result = PexInfo._merge_split(path_1, path_2)
+  assert result == ['/pex/path/1', '/pex/path/2', '/pex/path/3', '/pex/path/4']
+
+  path_1, path_2 = '/pex/path/1::/pex/path/2', '/pex/path/3:/pex/path/4'
+  result = PexInfo._merge_split(path_1, None)
+  assert result == ['/pex/path/1', '/pex/path/2']
+  result = PexInfo._merge_split(None, path_2)
+  assert result == ['/pex/path/3', '/pex/path/4']

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -13,13 +13,7 @@ from pex.installer import EggInstaller, WheelInstaller
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.testing import make_bdist, temporary_content, temporary_dir, write_zipfile
-from pex.util import (
-    CacheHelper,
-    DistributionHelper,
-    iter_pth_paths,
-    merge_split,
-    named_temporary_file
-)
+from pex.util import CacheHelper, DistributionHelper, iter_pth_paths, named_temporary_file
 
 try:
   from unittest import mock
@@ -222,17 +216,3 @@ def test_iter_pth_paths(mock_exists):
       with open(pth_tmp_path, 'wb') as f:
         f.write(to_bytes(pth_content))
       assert sorted(PTH_TEST_MAPPING[pth_content]) == sorted(list(iter_pth_paths(pth_tmp_path)))
-
-
-def test_merge_split():
-  path_1, path_2 = '/pex/path/1:/pex/path/2', '/pex/path/3:/pex/path/4'
-  result = merge_split(path_1, path_2)
-  assert result == ['/pex/path/1', '/pex/path/2', '/pex/path/3', '/pex/path/4']
-
-  path_1, path_2 = '/pex/path/1:', '/pex/path/3:/pex/path/4'
-  result = merge_split(path_1, path_2)
-  assert result == ['/pex/path/1', '/pex/path/3', '/pex/path/4']
-
-  path_1, path_2 = '/pex/path/1::/pex/path/2', '/pex/path/3:/pex/path/4'
-  result = merge_split(path_1, path_2)
-  assert result == ['/pex/path/1', '/pex/path/2', '/pex/path/3', '/pex/path/4']


### PR DESCRIPTION
As referenced in #749 , I ran into a situation where `pkg_resources` was imported too early before `sys.path` was finalized, occurring in the situation where a pex in my `PEX_PATH` needed to invoke: `pkg_resources.get_distribution`.  This was failing because a namespace package caused `pkg_resources` to be imported before the other pexes were merged into the environment 

Therefore, wait until all deps from all pexes (i.e. pexes in `PEX_PATH`) have been resolved before attempting to declare the namespace packages. This ensures `sys.path` is finalized before `pkg_resources` is possibly imported.