### PR TITLE
Fix `sys.path` scrubbing of pex extras modules.

### DIFF
--- a/pex/testing.py
+++ b/pex/testing.py
@@ -270,14 +270,14 @@ class IntegResults(namedtuple('results', ['output', 'error', 'return_code'])):
     assert self.return_code != 0
 
 
-def run_pex_command(args, env=None):
+def run_pex_command(args, env=None, python=sys.executable):
   """Simulate running pex command for integration testing.
 
   This is different from run_simple_pex in that it calls the pex command rather
   than running a generated pex.  This is useful for testing end to end runs
   with specific command line arguments or env options.
   """
-  cmd = [sys.executable, '-mpex', '-vvvvv'] + list(args)
+  cmd = [python, '-mpex', '-vvvvv'] + list(args)
   process = Executor.open_process(cmd=cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
   output, error = process.communicate()
   return IntegResults(output.decode('utf-8'), error.decode('utf-8'), process.returncode)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1634,7 +1634,7 @@ def test_issues_745_extras_isolation():
 
     # But if the pex has a declared dependency on subprocess32 we should be able to find the
     # subprocess32 bundled into the pex.
-    pex_root = os.path.join(td, 'pex_root')
+    pex_root = os.path.realpath(os.path.join(td, 'pex_root'))
     run_pex_command(['subprocess32',
                      '--sources-directory={}'.format(src_dir),
                      '--entry-point=test_issues_745',
@@ -1643,5 +1643,5 @@ def test_issues_745_extras_isolation():
 
     output = subprocess.check_output([python, pex_file], env=make_env(PEX_ROOT=pex_root))
 
-    subprocess32_location = output.decode('utf-8').strip()
+    subprocess32_location = os.path.realpath(output.decode('utf-8').strip())
     assert subprocess32_location.startswith(pex_root)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,7 +14,7 @@ from zipfile import ZipFile
 
 import pytest
 
-from pex.common import safe_copy, safe_sleep
+from pex.common import safe_copy, safe_open, safe_sleep
 from pex.compatibility import WINDOWS, nested, to_bytes
 from pex.installer import EggInstaller
 from pex.pex_info import PexInfo
@@ -29,6 +29,7 @@ from pex.testing import (
     PY27,
     PY35,
     PY36,
+    ensure_python_distribution,
     ensure_python_interpreter,
     get_dep_dist_names_from_pex,
     make_sdist,
@@ -1600,3 +1601,47 @@ def test_pex_reexec_constraints_dont_match_current_pex_python():
   _assert_exec_chain(exec_chain=[interpreter],
                      pex_python=interpreter,
                      interpreter_constraints=['=={}'.format(version)])
+
+
+@pytest.mark.skipif(IS_PYPY,
+                    reason='Our pyenv interpreter setup fails under pypy: '
+                           'https://github.com/pantsbuild/pex/issues/477')
+def test_issues_745_extras_isolation():
+  # Here we ensure one of our extras, `subprocess32`, is properly isolated in the transition from
+  # pex bootstrapping where it is imported by `pex.executor` to execution of user code.
+  python, pip = ensure_python_distribution(PY27)
+  subprocess.check_call([pip, 'install', 'subprocess32'])
+  with temporary_dir() as td:
+    src_dir = os.path.join(td, 'src')
+    with safe_open(os.path.join(src_dir, 'test_issues_745.py'), 'w') as fp:
+      fp.write(dedent("""
+        import subprocess32
+
+        print(subprocess32.__file__)
+      """))
+
+    pex_file = os.path.join(td, 'test.pex')
+
+    run_pex_command(['--sources-directory={}'.format(src_dir),
+                     '--entry-point=test_issues_745',
+                     '-o', pex_file],
+                    python=python)
+
+    # The pex runtime should scrub subprocess32 since it comes from site-packages and so we should
+    # not have access to it.
+    with pytest.raises(subprocess.CalledProcessError):
+      subprocess.check_call([python, pex_file])
+
+    # But if the pex has a declared dependency on subprocess32 we should be able to find the
+    # subprocess32 bundled into the pex.
+    pex_root = os.path.join(td, 'pex_root')
+    run_pex_command(['subprocess32',
+                     '--sources-directory={}'.format(src_dir),
+                     '--entry-point=test_issues_745',
+                     '-o', pex_file],
+                    python=python)
+
+    output = subprocess.check_output([python, pex_file], env=make_env(PEX_ROOT=pex_root))
+
+    subprocess32_location = output.decode('utf-8').strip()
+    assert subprocess32_location.startswith(pex_root)


### PR DESCRIPTION
Previously we would fail to scrub any extras modules imported by the pex
bootstrapping code. Add failing unit and integration tests and fix this
with a missing scrub step to check modules (previously only packages
were scrubbed).

Fixes #745