### PR TITLE
imp is deperecated, using importlib.machinery instead.

### DIFF
--- a/pex/pep425tags.py
+++ b/pex/pep425tags.py
@@ -271,10 +271,16 @@ def get_supported(versions=None, noarch=False, platform=None,
         abis[0:0] = [abi]
 
     abi3s = set()
-    import imp
-    for suffix in imp.get_suffixes():
-        if suffix[0].startswith('.abi'):
-            abi3s.add(suffix[0].split('.', 2)[1])
+    if sys.version_info[0] == 2:
+        import imp
+        suffixes = [sfx[0] for sfx in imp.get_suffixes()]
+    else:
+        import importlib
+        suffixes = importlib.machinery.all_suffixes()
+
+    for suffix in suffixes:
+        if suffix.startswith('.abi'):
+            abi3s.add(suffix.split('.', 2)[1])
 
     abis.extend(sorted(list(abi3s)))
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -102,6 +102,7 @@ def test_pypy_abi_prefix():
 # NB: Having to patch here is a symptom of https://github.com/pantsbuild/pex/issues/694
 # Kill when the Platform API is fixed to not need to consult the local interpreter.
 @patch('imp.get_suffixes', lambda: [('.abi3.so', 'rb', 3)])
+@patch(' importlib.machinery.all_suffixes', lambda: ['.abi3.so'])
 def test_platform_supported_tags_abi3():
   tags = Platform.create('linux-x86_64-cp-37-m').supported_tags()
   expected_tags = [
@@ -141,6 +142,7 @@ def test_platform_supported_tags_abi3():
 # NB: Having to patch here is a symptom of https://github.com/pantsbuild/pex/issues/694
 # Kill when the Platform API is fixed to not need to consult the local interpreter.
 @patch('imp.get_suffixes', lambda: [])
+@patch(' importlib.machinery.all_suffixes', lambda: [])
 def test_platform_supported_tags_no_abi3():
   tags = Platform.create('linux-x86_64-cp-37-m').supported_tags()
   expected_tags = [


### PR DESCRIPTION
https://docs.python.org/3/library/imp.html#imp.get_suffixes

```
In [10]: import imp
src/python/toolchain/service/buildstats/api/manage.py:1: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  #! /usr/bin/env ./python3

In [11]: import importlib

In [12]: imp.get_suffixes()
Out[12]:
[('.cpython-37m-darwin.so', 'rb', 3),
 ('.abi3.so', 'rb', 3),
 ('.so', 'rb', 3),
 ('.py', 'r', 1),
 ('.pyc', 'rb', 2)]

In [13]: importlib.machinery.all_suffixes()
Out[13]: ['.py', '.pyc', '.cpython-37m-darwin.so', '.abi3.so', '.so']

```

<img width="1456" alt="Screenshot 2019-08-09 14 35 10" src="https://user-images.githubusercontent.com/1268088/62810462-e7f44080-bab2-11e9-93d3-ee6054ae2ef5.png">
