### PR TITLE
Guard against modules with a `__file__` of `None`.

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -175,8 +175,8 @@ class PEX(object):  # noqa: T000
 
     for module_name, module in modules.items():
       # Tainted modules should be dropped.
-      module_file = getattr(module, '__file__', os.devnull)
-      if cls._tainted_path(module_file, site_libs):
+      module_file = getattr(module, '__file__', None)
+      if module_file and cls._tainted_path(module_file, site_libs):
         TRACER.log('Dropping %s' % (module_name,), V=3)
         continue
 

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -173,6 +173,13 @@ def test_minimum_sys_modules():
   new_modules = PEX.minimum_sys_modules(site_libs=['bad_path'], modules=modules)
   assert new_modules == {}
 
+  # If __file__ is explicitly None we should gracefully proceed to __path__ checks.
+  tainted_module = ModuleType('tainted_module')
+  tainted_module.__file__ = None
+  modules = {'tainted_module': tainted_module}
+  new_modules = PEX.minimum_sys_modules(site_libs=[], modules=modules)
+  assert new_modules == modules
+
 
 def test_site_libs():
   with nested(mock.patch.object(PEX, '_get_site_packages'), temporary_dir()) as (


### PR DESCRIPTION
Fixes #756