### PR TITLE
Avoid reordering of equivalent packages from multiple fetchers

### DIFF
--- a/pex/sorter.py
+++ b/pex/sorter.py
@@ -37,7 +37,9 @@ class Sorter(object):
         package.version,  # highest version
         cls.package_type_precedence(package, precedence=precedence),  # type preference
         cls.package_platform_tag_precedence(package),  # platform preference
-        package.local)  # prefer not fetching over the wire
+        package.local,  # prefer not fetching over the wire
+        package.url,  # otherwise equivalent files should deterministically sort
+    )
 
   def __init__(self, precedence=None):
     self._precedence = precedence or self.DEFAULT_PACKAGE_PRECEDENCE

--- a/tests/test_sorter.py
+++ b/tests/test_sorter.py
@@ -28,7 +28,7 @@ def test_package_precedence():
   # overridden precedence
   PRECEDENCE = (EggPackage, WheelPackage)
   assert Sorter.package_precedence(source, PRECEDENCE) == (
-      source.version, -1, 0, True)  # unknown rank
+      source.version, -1, 0, True, source.url)  # unknown rank
   assert Sorter.package_precedence(whl, PRECEDENCE) > Sorter.package_precedence(
       source, PRECEDENCE)
   assert Sorter.package_precedence(egg, PRECEDENCE) > Sorter.package_precedence(


### PR DESCRIPTION
`Iterator.iter()` iterates over the set of links returned from `Crawler.crawl()`. This means the hash seed randomization potentially changes the order, when there are two packages equivalent in both version, package type (wheel, etc), platform tags, and they're both remote.

Ideally, these would not be any different, so it's not really a correctness issue, but I am using pex's resolver internals to store the actual URLs used, and they flap over time between different-but-equivalent ones.

(And in case it's relevant: to be honest I tried running the integration tests locally, but they were failing before this change, and it didn't look related. Are they known to fail on macOS (10.14)?)