### PR TITLE
Add an --intransitive option.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -121,6 +121,12 @@ def process_precedence(option, option_str, option_value, parser, builder):
   elif option_str in ('--no-manylinux', '--no-use-manylinux'):
     setattr(parser.values, option.dest, False)
     builder.no_use_manylinux()
+  elif option_str == '--transitive':
+    setattr(parser.values, option.dest, True)
+    builder.transitive()
+  elif option_str in ('--no-transitive', '--intransitive'):
+    setattr(parser.values, option.dest, False)
+    builder.intransitive()
   else:
     raise OptionValueError
 
@@ -239,6 +245,15 @@ def configure_clp_pex_resolution(parser, builder):
       callback_args=(builder,),
       help=('Whether to allow resolution of manylinux dists for linux target '
             'platforms; Default: allow manylinux'))
+
+  group.add_option(
+    '--transitive', '--no-transitive', '--intransitive',
+    dest='transitive',
+    default=True,
+    action='callback',
+    callback=process_precedence,
+    callback_args=(builder,),
+    help=('Whether to transitively resolve requirements. Default: True'))
 
   # Set the pex tool to fetch from PyPI by default if nothing is specified.
   parser.set_default('repos', [PyPIFetcher()])
@@ -621,7 +636,8 @@ def build_pex(args, options, resolver_option_builder):
                                 cache=options.cache_dir,
                                 cache_ttl=options.cache_ttl,
                                 allow_prereleases=resolver_option_builder.prereleases_allowed,
-                                use_manylinux=options.use_manylinux)
+                                use_manylinux=options.use_manylinux,
+                                transitive=options.transitive)
 
       for resolved_dist in resolveds:
         log('  %s -> %s' % (resolved_dist.requirement, resolved_dist.distribution),

--- a/pex/resolver_options.py
+++ b/pex/resolver_options.py
@@ -44,6 +44,7 @@ class ResolverOptionsBuilder(object):
                allow_unverified=None,
                allow_prereleases=None,
                use_manylinux=None,
+               transitive=True,
                precedence=None,
                context=None):
     self._fetchers = fetchers if fetchers is not None else [PyPIFetcher()]
@@ -54,6 +55,7 @@ class ResolverOptionsBuilder(object):
     self._precedence = precedence if precedence is not None else Sorter.DEFAULT_PACKAGE_PRECEDENCE
     self._context = context or Context.get()
     self._use_manylinux = use_manylinux
+    self._transitive = transitive
 
   def clone(self):
     return ResolverOptionsBuilder(
@@ -63,6 +65,7 @@ class ResolverOptionsBuilder(object):
         allow_unverified=self._allow_unverified.copy(),
         allow_prereleases=self._allow_prereleases,
         use_manylinux=self._use_manylinux,
+        transitive=self._transitive,
         precedence=self._precedence[:],
         context=self._context,
     )
@@ -117,6 +120,14 @@ class ResolverOptionsBuilder(object):
     self._use_manylinux = False
     return self
 
+  def transitive(self):
+    self._transitive = True
+    return self
+
+  def intransitive(self):
+    self._transitive = False
+    return self
+
   def allow_builds(self):
     if SourcePackage not in self._precedence:
       self._precedence = self._precedence + (SourcePackage,)
@@ -163,6 +174,7 @@ class ResolverOptionsBuilder(object):
         allow_unverified=key in self._allow_unverified,
         allow_prereleases=self._allow_prereleases,
         use_manylinux=self._use_manylinux,
+        transitive=self._transitive,
         precedence=self._precedence,
         context=self._context,
     )
@@ -175,6 +187,7 @@ class ResolverOptions(ResolverOptionsInterface):
                allow_unverified=False,
                allow_prereleases=None,
                use_manylinux=None,
+               transitive=True,
                precedence=None,
                context=None):
     self._fetchers = fetchers if fetchers is not None else [PyPIFetcher()]
@@ -182,6 +195,7 @@ class ResolverOptions(ResolverOptionsInterface):
     self._allow_unverified = allow_unverified
     self._allow_prereleases = allow_prereleases
     self._use_manylinux = use_manylinux
+    self._transitive = transitive
     self._precedence = precedence if precedence is not None else Sorter.DEFAULT_PACKAGE_PRECEDENCE
     self._context = context or Context.get()
 

--- a/tests/test_pex_binary.py
+++ b/tests/test_pex_binary.py
@@ -160,6 +160,7 @@ def test_clp_prereleases_resolver():
                    allow_unverified=None,
                    allow_prereleases=None,
                    use_manylinux=None,
+                   transitive=True,
                    precedence=None,
                    context=None
                    ):
@@ -169,6 +170,7 @@ def test_clp_prereleases_resolver():
                                                  allow_unverified=allow_unverified,
                                                  allow_prereleases=allow_prereleases,
                                                  use_manylinux=use_manylinux,
+                                                 transitive=transitive,
                                                  precedence=precedence,
                                                  context=context)
         self._fetchers.insert(0, fetcher)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -117,6 +117,23 @@ def test_ambiguous_transitive_resolvable():
       assert resolved_dists[0].distribution.version == '1.0.0'
 
 
+def test_intransitive():
+  foo1_0 = make_sdist(name='foo', version='1.0.0')
+  # The nonexistent req ensures that we are actually not acting transitively (as that would fail).
+  bar1_0 = make_sdist(name='bar', version='1.0.0', install_reqs=['nonexistent==1.0.0'])
+  with temporary_dir() as td:
+    for sdist in (foo1_0, bar1_0):
+      safe_copy(sdist, os.path.join(td, os.path.basename(sdist)))
+    fetchers = [Fetcher([td])]
+    with temporary_dir() as cd:
+      resolved_dists = do_resolve_multi(['foo', 'bar'],
+                                        fetchers=fetchers,
+                                        cache=cd,
+                                        cache_ttl=1000,
+                                        transitive=False)
+      assert len(resolved_dists) == 2
+
+
 def test_resolve_prereleases():
   stable_dep = make_sdist(name='dep', version='2.0.0')
   prerelease_dep = make_sdist(name='dep', version='3.0.0rc3')


### PR DESCRIPTION
If specified, only the explicitly provided requirements are
resolved.  Their transitive requirements are not.

Since pex checks that all requirements are satisfied, this means
that a complete transitive set must be provided explicitly in
order to use this flag.

This is useful if you have a lockfile from some other source
and want pex to just apply it.