### PR TITLE
Add manylinux2010 to list of supported platforms

### DIFF
--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -54,6 +54,7 @@ def _get_supported(version=None, platform=None, impl=None, abi=None, force_manyl
       python_tag, abi_tag, platform_tag = supported
       if platform_tag.startswith('linux') and force_manylinux:
         yield python_tag, abi_tag, platform_tag.replace('linux', 'manylinux1')
+        yield python_tag, abi_tag, platform_tag.replace('linux', 'manylinux2010')
 
   return list(OrderedSet(iter_all_supported()))
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -107,22 +107,31 @@ def test_platform_supported_tags_abi3():
   expected_tags = [
     ('cp37', 'cp37m', 'linux_x86_64'),
     ('cp37', 'cp37m', 'manylinux1_x86_64'),
+    ('cp37', 'cp37m', 'manylinux2010_x86_64'),
     ('cp37', 'abi3', 'linux_x86_64'),
     ('cp37', 'abi3', 'manylinux1_x86_64'),
+    ('cp37', 'abi3', 'manylinux2010_x86_64'),
     ('cp37', 'none', 'linux_x86_64'),
     ('cp37', 'none', 'manylinux1_x86_64'),
+    ('cp37', 'none', 'manylinux2010_x86_64'),
     ('cp36', 'abi3', 'linux_x86_64'),
     ('cp36', 'abi3', 'manylinux1_x86_64'),
+    ('cp36', 'abi3', 'manylinux2010_x86_64'),
     ('cp35', 'abi3', 'linux_x86_64'),
     ('cp35', 'abi3', 'manylinux1_x86_64'),
+    ('cp35', 'abi3', 'manylinux2010_x86_64'),
     ('cp34', 'abi3', 'linux_x86_64'),
     ('cp34', 'abi3', 'manylinux1_x86_64'),
+    ('cp34', 'abi3', 'manylinux2010_x86_64'),
     ('cp33', 'abi3', 'linux_x86_64'),
     ('cp33', 'abi3', 'manylinux1_x86_64'),
+    ('cp33', 'abi3', 'manylinux2010_x86_64'),
     ('cp32', 'abi3', 'linux_x86_64'),
     ('cp32', 'abi3', 'manylinux1_x86_64'),
+    ('cp32', 'abi3', 'manylinux2010_x86_64'),
     ('py3', 'none', 'linux_x86_64'),
     ('py3', 'none', 'manylinux1_x86_64'),
+    ('py3', 'none', 'manylinux2010_x86_64'),
     ('cp37', 'none', 'any'),
     ('cp3', 'none', 'any'),
     ('py37', 'none', 'any'),
@@ -135,6 +144,7 @@ def test_platform_supported_tags_abi3():
     ('py31', 'none', 'any'),
     ('py30', 'none', 'any'),
   ]
+
   assert expected_tags == tags
 
 
@@ -146,10 +156,13 @@ def test_platform_supported_tags_no_abi3():
   expected_tags = [
     ('cp37', 'cp37m', 'linux_x86_64'),
     ('cp37', 'cp37m', 'manylinux1_x86_64'),
+    ('cp37', 'cp37m', 'manylinux2010_x86_64'),
     ('cp37', 'none', 'linux_x86_64'),
     ('cp37', 'none', 'manylinux1_x86_64'),
+    ('cp37', 'none', 'manylinux2010_x86_64'),
     ('py3', 'none', 'linux_x86_64'),
     ('py3', 'none', 'manylinux1_x86_64'),
+    ('py3', 'none', 'manylinux2010_x86_64'),
     ('cp37', 'none', 'any'),
     ('cp3', 'none', 'any'),
     ('py37', 'none', 'any'),


### PR DESCRIPTION
Proposal to to fix https://github.com/pantsbuild/pex/issues/763 as we are also blocked by this issue.

I investigated this problem and in reality it is complicated.

Pex has forked https://github.com/pantsbuild/pex/blob/master/pex/pep425tags.py from setuptools which handles the supported tags. The last pep425tags version from setuptools also handles manylinux2010 & manylinux2014 support but there is currently a [PR](https://github.com/pypa/setuptools/pull/1829 ) to replace this by pypa/packaging.tags. So I suppose the real fix would be waiting this to be merged, update vendor/setuptools and then reapply the changes. This looks like a lot of work.

In the meantime (waiting for a proper fix) I suggest just adding manylinux2010 to the list of supported platforms. In reality I think having people publish linux_x86_64 and manylinux1 wheels at the same time already doesn't work very well. So this fix should not be much worse.