### PR TITLE
Adding `--runtime-pex-root` option.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -612,6 +612,9 @@ def build_pex(reqs, options):
   elif options.script:
     pex_builder.set_script(options.script)
 
+  if options.pex_root:
+    pex_builder.set_pex_root(options.pex_root)
+
   if options.python_shebang:
     pex_builder.set_shebang(options.python_shebang)
 

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -619,9 +619,6 @@ def build_pex(reqs, options):
   elif options.script:
     pex_builder.set_script(options.script)
 
-  if options.pex_root:
-    pex_builder.set_pex_root(options.pex_root)
-
   if options.python_shebang:
     pex_builder.set_shebang(options.python_shebang)
 

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -298,6 +298,13 @@ def configure_clp_pex_options(parser):
            'will not be reproducible, meaning that if you were to run `./pex -o` with the '
            'same inputs then the new pex would not be byte-for-byte identical to the original.')
 
+  group.add_option(
+      '--pex-root',
+      dest='pex_root',
+      default=None,
+      help='Specify the pex root to be used in the generated .pex file. [Default: ~/.pex]'
+  )
+
   parser.add_option_group(group)
 
 

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -299,8 +299,8 @@ def configure_clp_pex_options(parser):
            'same inputs then the new pex would not be byte-for-byte identical to the original.')
 
   group.add_option(
-      '--pex-root',
-      dest='pex_root',
+      '--runtime=pex-root',
+      dest='runtime_pex_root',
       default=None,
       help='Specify the pex root to be used in the generated .pex file. [Default: ~/.pex]'
   )
@@ -575,6 +575,7 @@ def build_pex(reqs, options):
   pex_info.ignore_errors = options.ignore_errors
   pex_info.emit_warnings = options.emit_warnings
   pex_info.inherit_path = options.inherit_path
+  pex_info.pex_root = options.runtime_pex_root
   if options.interpreter_constraint:
     for ic in options.interpreter_constraint:
       pex_builder.add_interpreter_constraint(ic)

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -299,7 +299,7 @@ def configure_clp_pex_options(parser):
            'same inputs then the new pex would not be byte-for-byte identical to the original.')
 
   group.add_option(
-      '--runtime=pex-root',
+      '--runtime-pex-root',
       dest='runtime_pex_root',
       default=None,
       help='Specify the pex root to be used in the generated .pex file. [Default: ~/.pex]'

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -255,6 +255,16 @@ class PEXBuilder(object):
     self._ensure_unfrozen('Setting an entry point')
     self._pex_info.entry_point = entry_point
 
+  def set_pex_root(self, pex_root):
+    """Set the root directory for this PEX environment.
+
+    :param pex_root: The root directory of the PEX.
+
+    By default the root directory is ~/.pex.
+    """
+    self._ensure_unfrozen('Setting pex root')
+    self._pex_info.pex_root = pex_root
+
   def set_shebang(self, shebang):
     """Set the exact shebang line for the PEX file.
 

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -255,16 +255,6 @@ class PEXBuilder(object):
     self._ensure_unfrozen('Setting an entry point')
     self._pex_info.entry_point = entry_point
 
-  def set_pex_root(self, pex_root):
-    """Set the root directory for this PEX environment.
-
-    :param pex_root: The root directory of the PEX.
-
-    By default the root directory is ~/.pex.
-    """
-    self._ensure_unfrozen('Setting pex root')
-    self._pex_info.pex_root = pex_root
-
   def set_shebang(self, shebang):
     """Set the exact shebang line for the PEX file.
 

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -286,7 +286,10 @@ class PexInfo(object):
 
   @pex_root.setter
   def pex_root(self, value):
-    self._pex_info['pex_root'] = value
+    if value is None:
+      self._pex_info.pop('pex_root', None)
+    else:
+      self._pex_info['pex_root'] = value
 
   @property
   def internal_cache(self):


### PR DESCRIPTION
Adding the option to set the PEX root in in built PEXes.

The option already existed for use from the PexInfo API but was not
exposed to the CLI.

Work towards #746
Work towards #926