### PR TITLE
Bias selecting the current interpreter.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -18,7 +18,7 @@ from pex.fetcher import Fetcher, PyPIFetcher
 from pex.interpreter import PythonInterpreter
 from pex.interpreter_constraints import validate_constraints
 from pex.pex import PEX
-from pex.pex_bootstrapper import find_compatible_interpreters
+from pex.pex_bootstrapper import iter_compatible_interpreters
 from pex.pex_builder import PEXBuilder
 from pex.platforms import Platform
 from pex.requirements import requirements_from_file
@@ -574,7 +574,7 @@ def build_pex(args, options, resolver_option_builder):
       pex_python_path = rc_variables.get('PEX_PYTHON_PATH', '')
     else:
       pex_python_path = ""
-    interpreters = find_compatible_interpreters(pex_python_path, constraints)
+    interpreters = list(iter_compatible_interpreters(pex_python_path, constraints))
 
   if not interpreters:
     die('Could not find compatible interpreter', CANNOT_SETUP_INTERPRETER)

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -287,10 +287,23 @@ class PythonInterpreter(object):
     return cls.from_binary(sys.executable)
 
   @classmethod
-  def all(cls, paths=None):
+  def iter(cls, paths=None):
+    """Iterate all interpreters found in `paths`.
+
+    NB: The paths can either be directories to search for python binaries or the paths of python
+    binaries themselves.
+
+    :param paths: The paths to look for python interpreters; by default the `PATH`.
+    :type paths: list str
+    """
     if paths is None:
       paths = os.getenv('PATH', '').split(os.pathsep)
-    return cls.filter(cls.find(paths))
+    for interpreter in cls._filter(cls._find(paths)):
+      yield interpreter
+
+  @classmethod
+  def all(cls, paths=None):
+    return list(cls.iter(paths=paths))
 
   @classmethod
   def _from_binary_internal(cls):
@@ -353,53 +366,40 @@ class PythonInterpreter(object):
     return any(matcher.match(basefile) is not None for matcher in cls.REGEXEN)
 
   @classmethod
-  def find(cls, paths):
+  def _find(cls, paths):
     """
       Given a list of files or directories, try to detect python interpreters amongst them.
-      Returns a list of PythonInterpreter objects.
+      Returns an iterator over PythonInterpreter objects.
     """
-    pythons = []
     for path in paths:
       for fn in cls.expand_path(path):
         basefile = os.path.basename(fn)
         if cls._matches_binary_name(basefile):
           try:
-            pythons.append(cls.from_binary(fn))
+            yield cls.from_binary(fn)
           except Exception as e:
             TRACER.log('Could not identify %s: %s' % (fn, e))
             continue
-    return pythons
 
   @classmethod
-  def filter(cls, pythons):
+  def _filter(cls, pythons):
     """
-      Given a map of python interpreters in the format provided by PythonInterpreter.find(),
-      filter out duplicate versions and versions we would prefer not to use.
+      Given an iterator over python interpreters filter out duplicate versions and versions we would
+      prefer not to use.
 
-      Returns a map in the same format as find.
+      Returns an iterator over PythonInterpreters.
     """
-    good = []
-
     MAJOR, MINOR, SUBMINOR = range(3)
     def version_filter(version):
       return (version[MAJOR] == 2 and version[MINOR] >= 7 or
               version[MAJOR] == 3 and version[MINOR] >= 4)
 
-    all_versions = OrderedSet(interpreter.identity.version for interpreter in pythons)
-    good_versions = filter(version_filter, all_versions)
-
-    for version in good_versions:
-      # For each candidate, use the latest version we find on the filesystem.
-      candidates = defaultdict(list)
-      for interp in pythons:
-        if interp.identity.version == version:
-          candidates[interp.identity.interpreter].append(interp)
-      for interp_class in candidates:
-        candidates[interp_class].sort(
-            key=lambda interp: os.path.getmtime(interp.binary), reverse=True)
-        good.append(candidates[interp_class].pop(0))
-
-    return good
+    seen = set()
+    for interp in pythons:
+      version = interp.identity.version
+      if version not in seen and version_filter(version):
+        seen.add(version)
+        yield interp
 
   @classmethod
   def sanitized_environment(cls):

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -8,12 +8,10 @@ from __future__ import absolute_import
 import os
 import re
 import sys
-from collections import defaultdict
 from inspect import getsource
 
 from pex.compatibility import string
 from pex.executor import Executor
-from pex.orderedset import OrderedSet
 from pex.pep425tags import (
     get_abbr_impl,
     get_abi_tag,

--- a/pex/interpreter_constraints.py
+++ b/pex/interpreter_constraints.py
@@ -21,17 +21,17 @@ def validate_constraints(constraints):
       die("Compatibility requirements are not formatted properly: %s" % str(e))
 
 
-def matched_interpreters(interpreters, constraints):
+def matched_interpreters_iter(interpreters_iter, constraints):
   """Given some filters, yield any interpreter that matches at least one of them.
 
-  :param interpreters: a list of PythonInterpreter objects for filtering
+  :param interpreters_iter: A `PythonInterpreter` iterable for filtering.
   :param constraints: A sequence of strings that constrain the interpreter compatibility for this
     pex. Each string uses the Requirement-style format, e.g. 'CPython>=3' or '>=2.7,<3' for
     requirements agnostic to interpreter class. Multiple requirement strings may be combined
     into a list to OR the constraints, such as ['CPython>=2.7,<3', 'CPython>=3.4'].
   :return interpreter: returns a generator that yields compatible interpreters
   """
-  for interpreter in interpreters:
+  for interpreter in interpreters_iter:
     if any(interpreter.identity.matches(filt) for filt in constraints):
       TRACER.log("Constraints on interpreters: %s, Matching Interpreter: %s"
                  % (constraints, interpreter.binary), V=3)

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -6,13 +6,12 @@ from __future__ import absolute_import, print_function
 import os
 import sys
 
-from pex.orderedset import OrderedSet
-
 from pex import pex_warnings
 from pex.common import die
 from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
 from pex.interpreter_constraints import matched_interpreters_iter
+from pex.orderedset import OrderedSet
 from pex.tracer import TRACER
 from pex.variables import ENV
 

--- a/tests/test_pex_bootstrapper.py
+++ b/tests/test_pex_bootstrapper.py
@@ -4,7 +4,7 @@
 import pytest
 
 from pex.interpreter import PythonInterpreter
-from pex.pex_bootstrapper import find_compatible_interpreters
+from pex.pex_bootstrapper import iter_compatible_interpreters
 from pex.testing import IS_PYPY, PY27, PY35, PY36, ensure_python_interpreter
 
 
@@ -17,7 +17,7 @@ def test_find_compatible_interpreters():
 
   def find_interpreters(*constraints):
     return [interp.binary for interp in
-            find_compatible_interpreters(path=pex_python_path,
+            iter_compatible_interpreters(path=pex_python_path,
                                          compatibility_constraints=constraints)]
 
   assert [py35, py36] == find_interpreters('>3')
@@ -35,5 +35,5 @@ def test_find_compatible_interpreters():
   all_known_interpreters = set(PythonInterpreter.all())
   all_known_interpreters.add(PythonInterpreter.get())
 
-  interpreters = find_compatible_interpreters(compatibility_constraints=['<3'])
+  interpreters = iter_compatible_interpreters(compatibility_constraints=['<3'])
   assert set(interpreters).issubset(all_known_interpreters)


### PR DESCRIPTION
Preiously we made some effort towards this, but were not thorough.
Fix all interpreter selection logic to be both lazy and bias towards
re-using the current interpreter, only falling back to picking the
minimum version compatible interpreter from all possible compatibile
interpreters as the very last step.

Addresses item 1 in #782.