### PR TITLE
Add a --dehydrated option to dump requirements to PEX-INFO, then resolve them at bootstrap time.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -660,7 +660,7 @@ def build_pex(args, options, resolver_option_builder):
             V=options.verbosity)
 
         if options.dehydrated:
-          pex_info.add_dehydrated_requirement(resolved_dist.requirement)
+          pex_info.add_dehydrated_requirement(resolved_dist.distribution.as_requirement())
         else:
           pex_builder.add_distribution(resolved_dist.distribution)
           pex_builder.add_requirement(resolved_dist.requirement)

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -269,6 +269,7 @@ class PexInfo(object):
 
   def add_dehydrated_requirement(self, requirement):
     self._dehydrated_requirements.add(str(requirement))
+    self.add_requirement(requirement)
 
   @property
   def requirements(self):

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -430,14 +430,8 @@ def resolve(requirements,
     unspecified, the default is to look for packages on PyPI.
   :keyword interpreter: (optional) A :class:`PythonInterpreter` object to use for building
     distributions and for testing distribution compatibility.
-  :keyword versions: (optional) a list of string versions, of the form ["33", "32"],
-    or None. The first version will be assumed to support our ABI.
   :keyword platform: (optional) specify the exact platform you want valid
     tags for, or None. If None, use the local system platform.
-  :keyword impl: (optional) specify the exact implementation you want valid
-    tags for, or None. If None, use the local interpreter impl.
-  :keyword abi: (optional) specify the exact abi you want valid
-    tags for, or None. If None, use the local interpreter abi.
   :keyword context: (optional) A :class:`Context` object to use for network access.  If
     unspecified, the resolver will attempt to use the best available network context.
   :keyword precedence: (optional) An ordered list of allowable :class:`Package` classes

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -109,6 +109,11 @@ class Variables(object):
     except KeyError:
       return self._defaulted(default)
 
+  def _get_comma_separated(self, variable, default=None):
+    value = self._get_string(variable, default=default)
+    if value is not None:
+      return value.split(',')
+
   def strip_defaults(self):
     """Returns a copy of these variables but with defaults stripped.
 
@@ -310,6 +315,15 @@ class Variables(object):
     environment issues.  Default: 0
     """
     return self._get_int('PEX_VERBOSE', default=0)
+
+  @property
+  def PEX_BOOTSTRAP_HYDRATION_INDICES(self):
+    """List
+
+    ,-separated strings for cheeseshop indices.
+    """
+    return self._get_comma_separated('PEX_BOOTSTRAP_HYDRATION_INDICES', default='https://pypi.org/simple/')
+
 
   # TODO(#94) Remove and push into --flags.
   @property

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = '1.6.12'
+__version__ = '1.6.12+dehydration'


### PR DESCRIPTION
### TODO
- [ ] Fix this PR to perform the resolve process by installing into PEX_ROOT upon the first run, instead of during pex bootstrap.
- [ ] Validate internally that this solution results in the expected latency improvement for redeploying large ML applications within our datacenter.
  - Consider parallelizing the bootstrap resolve and investigating other caching solutions if not.
- [ ] Add testing.
- [ ] Wait for review (or, if this change isn't compatible with the pex project, we can just externalize the "hydration" process using something like virtualenv internally and close this PR).

### Problem

Redeploying pex files full of many extremely large 3rdparty requirements (tensorflow, etc) into our datacenter at Twitter currently takes a very long time, since we upload them all at once into an internal artifact resolution utility, and then pull down the entire pex file before executing it. This slowness to redeploy then also affects multiple of our internal python development workflows and tooling for machine learning (including a Jupyter wrapper developed by @kwlzn, who was not consulted before making this PR) which depend on executing a pex file within the datacenter -- in that case, modifying any python source files in our monorepo currently requires waiting several minutes for changes to be usable within that Jupyter notebook.

As far as we are aware, other users of pex who package large machine learning applications also suffer from this issue and do not have an easy workaround.

### Solution

We would like to be able to ship around "dehydrated" pex files without 3rdparty requirements embedded in the pex, and resolve ("hydrate") them before executing the pex. This removes one half of the current process of synchronously waiting to upload and download 3rdparty requirements, and moves the remaining download part off the critical path of the entire redeploy process. Because the requirements to hydrate were already resolved when building the pex, we know all the exact versions of all the transitive dependencies to resolve at bootstrap time.

There are many ways we could potentially make the bootstrap resolve process faster -- this PR just uses a `CachingResolver`, with the idea that the machines that execute our pex files will eventually have most of the large distributions cached and won't need to redownload them on every redeploy (or that we can provision machines to have these requirements already contained within their local pex cache).

An alternative implementation of "hydration" that was considered was to use a virtualenv to hydrate requirements before running the pex with `PEX_INHERIT_PATH=fallback`, but it would be extremely helpful for us to avoid having to maintain separate tooling with virtualenv, and it would be really nice if pex could do that itself at bootstrap.

### Implementation

- Add `dehydrated_requirements` field to `PexInfo`.
- Add `--dehydrated` command line option, which resolves all requirements, then dumps the transitive requirements into `dehydrated_requirements` in PEX-INFO.
- Add `PEX_BOOTSTRAP_HYDRATION_INDICES` to `variables.py`, which determines which PyPI-compatible package indices to resolve against at bootstrap.
- At bootstrap time when executing the pex, check for `dehydrated_requirements` in PEX-INFO and perform a resolve against `PEX_BOOTSTRAP_HYDRATION_INDICES`. The locations of the downloaded distributions are then appended to `scrubbed_sys_path` when `sys.path` is patched.