### PR TITLE
Pex defaults to reproduceable builds.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -242,7 +242,7 @@ def configure_clp_pex_options(parser):
   group.add_option(
       '--compile', '--no-compile',
       dest='compile',
-      default=True,
+      default=False,
       action='callback',
       callback=parse_bool,
       help='Compiling means that the built pex will include .pyc files, which will result in '
@@ -253,7 +253,7 @@ def configure_clp_pex_options(parser):
   group.add_option(
       '--use-system-time', '--no-use-system-time',
       dest='use_system_time',
-      default=True,
+      default=False,
       action='callback',
       callback=parse_bool,
       help='Use the current system time to generate timestamps for the new pex. Otherwise, Pex '

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1371,10 +1371,7 @@ def assert_reproducible_build(args):
     # from the random seed, such as data structures, as Tox sets this value by default. See
     # https://tox.readthedocs.io/en/latest/example/basic.html#special-handling-of-pythonhashseed.
     def create_pex(path, seed):
-      result = run_pex_command(
-        args + ['-o', path, '--no-compile', '--no-use-system-time'],
-        env=make_env(PYTHONHASHSEED=seed)
-      )
+      result = run_pex_command(args + ['-o', path], env=make_env(PYTHONHASHSEED=seed))
       result.assert_success()
 
     create_pex(pex1, seed=111)


### PR DESCRIPTION
This follows up on the decision to switch Pex defaults to do so made
in #718.