### PR TITLE
Fix `iter_compatible_interpreters` path biasing.

### DIFF
--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -61,8 +61,9 @@ def iter_compatible_interpreters(path=None, compatibility_constraints=None):
       # Prefer the current interpreter if present on the `path`.
       candidate_paths = frozenset((current_interpreter.binary,
                                    os.path.dirname(current_interpreter.binary)))
-      if candidate_paths.intersection(paths):
-        for p in candidate_paths:
+      candidate_paths_in_path = candidate_paths.intersection(paths)
+      if candidate_paths_in_path:
+        for p in candidate_paths_in_path:
           paths.remove(p)
         seen.add(current_interpreter)
         yield current_interpreter

--- a/tests/test_pex_bootstrapper.py
+++ b/tests/test_pex_bootstrapper.py
@@ -1,6 +1,9 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
+import sys
+
 import pytest
 
 from pex.interpreter import PythonInterpreter
@@ -8,28 +11,29 @@ from pex.pex_bootstrapper import iter_compatible_interpreters
 from pex.testing import IS_PYPY, PY27, PY35, PY36, ensure_python_interpreter
 
 
+def find_interpreters(path, *constraints):
+  return [interp.binary for interp in
+          iter_compatible_interpreters(path=os.pathsep.join(path),
+                                       compatibility_constraints=constraints)]
+
+
 @pytest.mark.skipif(IS_PYPY)
 def test_find_compatible_interpreters():
   py27 = ensure_python_interpreter(PY27)
   py35 = ensure_python_interpreter(PY35)
   py36 = ensure_python_interpreter(PY36)
-  pex_python_path = ':'.join([py27, py35, py36])
+  path = [py27, py35, py36]
 
-  def find_interpreters(*constraints):
-    return [interp.binary for interp in
-            iter_compatible_interpreters(path=pex_python_path,
-                                         compatibility_constraints=constraints)]
+  assert [py35, py36] == find_interpreters(path, '>3')
+  assert [py27] == find_interpreters(path, '<3')
 
-  assert [py35, py36] == find_interpreters('>3')
-  assert [py27] == find_interpreters('<3')
+  assert [py36] == find_interpreters(path, '>{}'.format(PY35))
+  assert [py35] == find_interpreters(path, '>{}, <{}'.format(PY27, PY36))
+  assert [py36] == find_interpreters(path, '>=3.6')
 
-  assert [py36] == find_interpreters('>{}'.format(PY35))
-  assert [py35] == find_interpreters('>{}, <{}'.format(PY27, PY36))
-  assert [py36] == find_interpreters('>=3.6')
-
-  assert [] == find_interpreters('<2')
-  assert [] == find_interpreters('>4')
-  assert [] == find_interpreters('>{}, <{}'.format(PY27, PY35))
+  assert [] == find_interpreters(path, '<2')
+  assert [] == find_interpreters(path, '>4')
+  assert [] == find_interpreters(path, '>{}, <{}'.format(PY27, PY35))
 
   # All interpreters on PATH including whatever interpreter is currently running.
   all_known_interpreters = set(PythonInterpreter.all())
@@ -37,3 +41,10 @@ def test_find_compatible_interpreters():
 
   interpreters = iter_compatible_interpreters(compatibility_constraints=['<3'])
   assert set(interpreters).issubset(all_known_interpreters)
+
+
+@pytest.mark.skipif(IS_PYPY)
+def test_find_compatible_interpreters_bias_current():
+  py36 = ensure_python_interpreter(PY36)
+  assert [os.path.realpath(sys.executable), py36] == find_interpreters([py36, sys.executable])
+  assert [os.path.realpath(sys.executable), py36] == find_interpreters([sys.executable, py36])


### PR DESCRIPTION
Biasing interpreter selection towards the current interpreter was
implemented in #783 but not test was added. Add a test that fails due to
a bug in path trimming logic and fix the bug.