### PR TITLE
Fix current platform handling.

### DIFF
--- a/pex/variables.py
+++ b/pex/variables.py
@@ -122,7 +122,7 @@ class Variables(object):
     old_environ = self._environ
     self._environ = self._environ.copy()
     self._environ.update(kw)
-    yield
+    yield self._environ
     self._environ = old_environ
 
   @property

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,7 +22,6 @@ from pex.testing import (
     IS_PYPY,
     NOT_CPYTHON27,
     NOT_CPYTHON27_OR_OSX,
-    NOT_CPYTHON36,
     NOT_CPYTHON36_OR_LINUX,
     PY27,
     PY35,
@@ -36,6 +35,7 @@ from pex.testing import (
     run_pex_command,
     run_simple_pex,
     run_simple_pex_test,
+    skip_for_pyenv_use_under_pypy,
     temporary_content
 )
 from pex.util import DistributionHelper, named_temporary_file
@@ -352,7 +352,7 @@ def test_interpreter_constraints_to_pex_info_py2():
     assert {'>=2.7,<3', '>=3.5'} == set(pex_info.interpreter_constraints)
 
 
-@pytest.mark.skipif(IS_PYPY)
+@skip_for_pyenv_use_under_pypy
 def test_interpreter_constraints_to_pex_info_py3():
   py3_interpreter = ensure_python_interpreter(PY36)
   with temporary_dir() as output_dir:
@@ -392,7 +392,7 @@ def test_interpreter_resolution_with_multiple_constraint_options():
     assert pex_info.build_properties['version'][0] < 3
 
 
-@pytest.mark.skipif(IS_PYPY)
+@skip_for_pyenv_use_under_pypy
 def test_interpreter_resolution_with_pex_python_path():
   with temporary_dir() as td:
     pexrc_path = os.path.join(td, '.pexrc')
@@ -426,7 +426,7 @@ def test_interpreter_resolution_with_pex_python_path():
       assert str(pex_python_path.split(':')[0]).encode() in stdout
 
 
-@pytest.mark.skipif(IS_PYPY)
+@skip_for_pyenv_use_under_pypy
 def test_interpreter_constraints_honored_without_ppp_or_pp():
   # Create a pex with interpreter constraints, but for not the default interpreter in the path.
   with temporary_dir() as td:
@@ -460,7 +460,7 @@ def test_interpreter_constraints_honored_without_ppp_or_pp():
     assert str(py36_path).encode() in stdout
 
 
-@pytest.mark.skipif(NOT_CPYTHON36)
+@skip_for_pyenv_use_under_pypy
 def test_interpreter_resolution_pex_python_path_precedence_over_pex_python():
   with temporary_dir() as td:
     pexrc_path = os.path.join(td, '.pexrc')
@@ -508,7 +508,7 @@ def test_plain_pex_exec_no_ppp_no_pp_no_constraints():
     assert os.path.realpath(sys.executable).encode() in stdout
 
 
-@pytest.mark.skipif(IS_PYPY)
+@skip_for_pyenv_use_under_pypy
 def test_pex_exec_with_pex_python_path_only():
   with temporary_dir() as td:
     pexrc_path = os.path.join(td, '.pexrc')
@@ -534,7 +534,7 @@ def test_pex_exec_with_pex_python_path_only():
     assert str(pex_python_path.split(':')[0]).encode() in stdout
 
 
-@pytest.mark.skipif(IS_PYPY)
+@skip_for_pyenv_use_under_pypy
 def test_pex_exec_with_pex_python_path_and_pex_python_but_no_constraints():
   with temporary_dir() as td:
     pexrc_path = os.path.join(td, '.pexrc')
@@ -562,7 +562,7 @@ def test_pex_exec_with_pex_python_path_and_pex_python_but_no_constraints():
     assert str(pex_python_path.split(':')[0]).encode() in stdout
 
 
-@pytest.mark.skipif(IS_PYPY)
+@skip_for_pyenv_use_under_pypy
 def test_pex_python():
   py2_path_interpreter = ensure_python_interpreter(PY27)
   py3_path_interpreter = ensure_python_interpreter(PY36)
@@ -623,7 +623,7 @@ def test_pex_python():
     assert correct_interpreter_path in stdout
 
 
-@pytest.mark.skipif(IS_PYPY)
+@skip_for_pyenv_use_under_pypy
 def test_entry_point_targeting():
   """Test bugfix for https://github.com/pantsbuild/pex/issues/434"""
   with temporary_dir() as td:
@@ -644,7 +644,7 @@ def test_entry_point_targeting():
     assert 'usage: autopep8'.encode() in stdout
 
 
-@pytest.mark.skipif(IS_PYPY)
+@skip_for_pyenv_use_under_pypy
 def test_interpreter_selection_using_os_environ_for_bootstrap_reexec():
   """
   This is a test for verifying the proper function of the
@@ -829,7 +829,7 @@ def pex_manylinux_and_tag_selection_context():
     yield test_resolve, ensure_failure
 
 
-@pytest.mark.skipif(IS_PYPY)
+@skip_for_pyenv_use_under_pypy
 def test_pex_manylinux_and_tag_selection_linux_msgpack():
   """Tests resolver manylinux support and tag targeting."""
   with pex_manylinux_and_tag_selection_context() as (test_resolve, ensure_failure):
@@ -869,7 +869,7 @@ def test_pex_manylinux_and_tag_selection_lxml_osx():
     test_resolve('lxml', '3.8.0', 'macosx-10.6-x86_64-cp-36-m', 'lxml-3.8.0-cp36-cp36m-macosx')
 
 
-@pytest.mark.skipif(NOT_CPYTHON27_OR_OSX)
+@pytest.mark.skipif(NOT_CPYTHON27_OR_OSX, reason="Relies on a pre-built wheel for linux 2.7")
 def test_pex_manylinux_runtime():
   """Tests resolver manylinux support and runtime resolution (and --platform=current)."""
   test_stub = dedent(
@@ -913,7 +913,7 @@ def test_pex_exit_code_propagation():
     assert subprocess.call([pex_path, os.path.realpath(tester_path)]) == 1
 
 
-@pytest.mark.skipif(NOT_CPYTHON27)
+@pytest.mark.skipif(NOT_CPYTHON27, reason='Tests environment markers that select for python 2.7.')
 def test_ipython_appnope_env_markers():
   res = run_pex_command(['--disable-cache',
                          'ipython==5.8.0',
@@ -923,7 +923,6 @@ def test_ipython_appnope_env_markers():
   res.assert_success()
 
 
-@pytest.mark.skipif(NOT_CPYTHON27)
 def test_cross_platform_abi_targeting_behavior_exact():
   with temporary_dir() as td:
     pex_out_path = os.path.join(td, 'pex.pex')
@@ -987,7 +986,7 @@ def test_pex_resource_bundling():
       assert stdout == b'hello\n'
 
 
-@pytest.mark.skipif(IS_PYPY)
+@skip_for_pyenv_use_under_pypy
 def test_entry_point_verification_3rdparty():
   with temporary_dir() as td:
     pex_out_path = os.path.join(td, 'pex.pex')
@@ -998,7 +997,7 @@ def test_entry_point_verification_3rdparty():
     res.assert_success()
 
 
-@pytest.mark.skipif(IS_PYPY)
+@skip_for_pyenv_use_under_pypy
 def test_invalid_entry_point_verification_3rdparty():
   with temporary_dir() as td:
     pex_out_path = os.path.join(td, 'pex.pex')
@@ -1009,7 +1008,7 @@ def test_invalid_entry_point_verification_3rdparty():
     res.assert_failure()
 
 
-@pytest.mark.skipif(IS_PYPY)
+@skip_for_pyenv_use_under_pypy
 def test_multiplatform_entrypoint():
   with temporary_dir() as td:
     pex_out_path = os.path.join(td, 'p537.pex')
@@ -1332,7 +1331,7 @@ def test_pkg_resource_early_import_on_pex_path():
     assert return_code == 0
 
 
-@pytest.mark.skipif(IS_PYPY)
+@skip_for_pyenv_use_under_pypy
 def test_issues_539_abi3_resolution():
   # The cryptography team releases the following relevant pre-built wheels for version 2.6.1:
   # cryptography-2.6.1-cp27-cp27m-macosx_10_6_intel.whl

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -7,7 +7,7 @@ import pytest
 
 from pex import interpreter
 from pex.compatibility import PY3
-from pex.testing import IS_PYPY, PY27, PY35, ensure_python_interpreter
+from pex.testing import PY27, PY35, ensure_python_interpreter, skip_for_pyenv_use_under_pypy
 
 try:
   from mock import patch
@@ -44,12 +44,12 @@ class TestPythonInterpreter(object):
   def test_interpreter2(self):
     return ensure_python_interpreter(self.TEST_INTERPRETER2_VERSION)
 
-  @pytest.mark.skipif(IS_PYPY)
+  @skip_for_pyenv_use_under_pypy
   def test_interpreter_versioning(self, test_interpreter1):
     py_interpreter = interpreter.PythonInterpreter.from_binary(test_interpreter1)
     assert py_interpreter.identity.version == self.TEST_INTERPRETER1_VERSION_TUPLE
 
-  @pytest.mark.skipif(IS_PYPY)
+  @skip_for_pyenv_use_under_pypy
   def test_interpreter_caching(self, test_interpreter1, test_interpreter2):
     py_interpreter1 = interpreter.PythonInterpreter.from_binary(test_interpreter1)
     py_interpreter2 = interpreter.PythonInterpreter.from_binary(test_interpreter2)

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -20,7 +20,6 @@ from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
 from pex.resolver import resolve
 from pex.testing import (
-    IS_PYPY,
     PY27,
     PY36,
     WheelBuilder,
@@ -31,6 +30,7 @@ from pex.testing import (
     run_simple_pex,
     run_simple_pex_test,
     safe_mkdir,
+    skip_for_pyenv_use_under_pypy,
     temporary_content,
     write_simple_pex
 )
@@ -42,7 +42,6 @@ except ImportError:
   import mock
 
 
-@pytest.mark.skipif('sys.version_info > (3,)')
 def test_pex_uncaught_exceptions():
   body = "raise Exception('This is an exception')"
   so, rc = run_simple_pex_test(body)
@@ -96,7 +95,6 @@ def test_pex_sys_exit_prints_objects():
   _test_sys_exit('Exception("derp")', to_bytes('derp\n'), 1)
 
 
-@pytest.mark.skipif('hasattr(sys, "pypy_version_info")')
 def test_pex_atexit_swallowing():
   body = textwrap.dedent("""
   import atexit
@@ -484,7 +482,7 @@ def test_pex_verify_entry_point_module_should_fail():
           verify_entry_point=True)
 
 
-@pytest.mark.skipif(IS_PYPY)
+@skip_for_pyenv_use_under_pypy
 def test_activate_interpreter_different_from_current():
   with temporary_dir() as pex_root:
     interp_version = PY36 if PY2 else PY27

--- a/tests/test_pex_bootstrapper.py
+++ b/tests/test_pex_bootstrapper.py
@@ -4,11 +4,9 @@
 import os
 import sys
 
-import pytest
-
 from pex.interpreter import PythonInterpreter
 from pex.pex_bootstrapper import iter_compatible_interpreters
-from pex.testing import IS_PYPY, PY27, PY35, PY36, ensure_python_interpreter
+from pex.testing import PY27, PY35, PY36, ensure_python_interpreter, skip_for_pyenv_use_under_pypy
 
 
 def find_interpreters(path, *constraints):
@@ -17,7 +15,7 @@ def find_interpreters(path, *constraints):
                                        compatibility_constraints=constraints)]
 
 
-@pytest.mark.skipif(IS_PYPY)
+@skip_for_pyenv_use_under_pypy
 def test_find_compatible_interpreters():
   py27 = ensure_python_interpreter(PY27)
   py35 = ensure_python_interpreter(PY35)
@@ -43,7 +41,7 @@ def test_find_compatible_interpreters():
   assert set(interpreters).issubset(all_known_interpreters)
 
 
-@pytest.mark.skipif(IS_PYPY)
+@skip_for_pyenv_use_under_pypy
 def test_find_compatible_interpreters_bias_current():
   py36 = ensure_python_interpreter(PY36)
   assert [os.path.realpath(sys.executable), py36] == find_interpreters([py36, sys.executable])

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -3,6 +3,8 @@
 
 import sys
 
+import pytest
+
 from pex.pep425tags import get_abbr_impl, get_abi_tag, get_impl_ver
 from pex.platforms import Platform
 
@@ -20,28 +22,38 @@ def test_platform():
   assert str(
     Platform('linux-x86_64', 'cp', '27', 'm')
   ) == 'linux_x86_64-cp-27-cp27m'
-  assert str(Platform('linux-x86_64')) == 'linux_x86_64'
 
 
 def test_platform_create():
-  assert Platform.create('linux-x86_64') == ('linux_x86_64', None, None, None)
   assert Platform.create('linux-x86_64-cp-27-cp27mu') == ('linux_x86_64', 'cp', '27', 'cp27mu')
   assert Platform.create('linux-x86_64-cp-27-mu') == ('linux_x86_64', 'cp', '27', 'cp27mu')
   assert Platform.create(
     'macosx-10.4-x86_64-cp-27-m') == ('macosx_10_4_x86_64', 'cp', '27', 'cp27m')
 
 
+def test_platform_create_bad_platform_missing_fields():
+  with pytest.raises(Platform.InvalidPlatformError):
+    Platform.create('linux-x86_64')
+
+
+def test_platform_create_bad_platform_empty_fields():
+  with pytest.raises(Platform.InvalidPlatformError):
+    Platform.create('linux-x86_64-cp--cp27mu')
+
+
 def test_platform_create_noop():
-  existing = Platform.create('linux-x86_64')
+  existing = Platform.create('linux-x86_64-cp-27-mu')
   assert Platform.create(existing) == existing
 
 
-def test_platform_current():
-  assert Platform.create('current') == Platform.current()
+def assert_tags(platform, expected_tags):
+  maybe_foreign_platform = Platform.create(platform)
+  if Platform.current() == maybe_foreign_platform:
+    # We can only assert tags when we know the local interpreter is not being consulted, since local
+    # consults will pick up things that may vary, like manylinux{1,2010,2014} support.
+    pytest.skip('Skipping test of supported tags on local platform {}'.format(platform))
 
-
-def assert_tags(platform, expected_tags, manylinux=None):
-  tags = Platform.create(platform).supported_tags(force_manylinux=manylinux)
+  tags = maybe_foreign_platform.supported_tags()
   for expected_tag in expected_tags:
     assert expected_tag in tags
 
@@ -53,18 +65,10 @@ def test_platform_supported_tags_linux():
   )
 
 
-def test_platform_supported_tags_manylinux():
-  assert_tags(
-    'linux-x86_64-cp-27-mu',
-    EXPECTED_BASE + [('cp27', 'cp27mu', 'manylinux1_x86_64')],
-    True
-  )
-
-
 def test_platform_supported_tags_osx_minimal():
   impl_tag = "{}{}".format(get_abbr_impl(), get_impl_ver())
   assert_tags(
-    'macosx-10.5-x86_64',
+    'macosx-10.5-x86_64-{}-{}-{}'.format(get_abbr_impl(), get_impl_ver(), get_abi_tag()),
     [
       (impl_tag, 'none', 'any'),
       ('py%s' % sys.version_info[0], 'none', 'any'),
@@ -99,67 +103,58 @@ def test_pypy_abi_prefix():
   )
 
 
-# NB: Having to patch here is a symptom of https://github.com/pantsbuild/pex/issues/694
-# Kill when the Platform API is fixed to not need to consult the local interpreter.
 @patch('pex.pep425tags.get_extension_suffixes', lambda: ['.abi3.so'])
 def test_platform_supported_tags_abi3():
-  tags = Platform.create('linux-x86_64-cp-37-m').supported_tags()
-  expected_tags = [
-    ('cp37', 'cp37m', 'linux_x86_64'),
-    ('cp37', 'cp37m', 'manylinux1_x86_64'),
-    ('cp37', 'abi3', 'linux_x86_64'),
-    ('cp37', 'abi3', 'manylinux1_x86_64'),
-    ('cp37', 'none', 'linux_x86_64'),
-    ('cp37', 'none', 'manylinux1_x86_64'),
-    ('cp36', 'abi3', 'linux_x86_64'),
-    ('cp36', 'abi3', 'manylinux1_x86_64'),
-    ('cp35', 'abi3', 'linux_x86_64'),
-    ('cp35', 'abi3', 'manylinux1_x86_64'),
-    ('cp34', 'abi3', 'linux_x86_64'),
-    ('cp34', 'abi3', 'manylinux1_x86_64'),
-    ('cp33', 'abi3', 'linux_x86_64'),
-    ('cp33', 'abi3', 'manylinux1_x86_64'),
-    ('cp32', 'abi3', 'linux_x86_64'),
-    ('cp32', 'abi3', 'manylinux1_x86_64'),
-    ('py3', 'none', 'linux_x86_64'),
-    ('py3', 'none', 'manylinux1_x86_64'),
-    ('cp37', 'none', 'any'),
-    ('cp3', 'none', 'any'),
-    ('py37', 'none', 'any'),
-    ('py3', 'none', 'any'),
-    ('py36', 'none', 'any'),
-    ('py35', 'none', 'any'),
-    ('py34', 'none', 'any'),
-    ('py33', 'none', 'any'),
-    ('py32', 'none', 'any'),
-    ('py31', 'none', 'any'),
-    ('py30', 'none', 'any'),
-  ]
-  assert expected_tags == tags
+  assert_tags(
+    'linux-x86_64-cp-37-m',
+    [
+      ('cp37', 'cp37m', 'linux_x86_64'),
+      ('cp37', 'abi3', 'linux_x86_64'),
+      ('cp37', 'none', 'linux_x86_64'),
+      ('cp36', 'abi3', 'linux_x86_64'),
+      ('cp35', 'abi3', 'linux_x86_64'),
+      ('cp34', 'abi3', 'linux_x86_64'),
+      ('cp33', 'abi3', 'linux_x86_64'),
+      ('cp32', 'abi3', 'linux_x86_64'),
+      ('py3', 'none', 'linux_x86_64'),
+      ('cp37', 'none', 'any'),
+      ('cp3', 'none', 'any'),
+      ('py37', 'none', 'any'),
+      ('py3', 'none', 'any'),
+      ('py36', 'none', 'any'),
+      ('py35', 'none', 'any'),
+      ('py34', 'none', 'any'),
+      ('py33', 'none', 'any'),
+      ('py32', 'none', 'any'),
+      ('py31', 'none', 'any'),
+      ('py30', 'none', 'any'),
+    ]
+  )
 
 
-# NB: Having to patch here is a symptom of https://github.com/pantsbuild/pex/issues/694
-# Kill when the Platform API is fixed to not need to consult the local interpreter.
 @patch('pex.pep425tags.get_extension_suffixes', lambda: [])
 def test_platform_supported_tags_no_abi3():
-  tags = Platform.create('linux-x86_64-cp-37-m').supported_tags()
-  expected_tags = [
-    ('cp37', 'cp37m', 'linux_x86_64'),
-    ('cp37', 'cp37m', 'manylinux1_x86_64'),
-    ('cp37', 'none', 'linux_x86_64'),
-    ('cp37', 'none', 'manylinux1_x86_64'),
-    ('py3', 'none', 'linux_x86_64'),
-    ('py3', 'none', 'manylinux1_x86_64'),
-    ('cp37', 'none', 'any'),
-    ('cp3', 'none', 'any'),
-    ('py37', 'none', 'any'),
-    ('py3', 'none', 'any'),
-    ('py36', 'none', 'any'),
-    ('py35', 'none', 'any'),
-    ('py34', 'none', 'any'),
-    ('py33', 'none', 'any'),
-    ('py32', 'none', 'any'),
-    ('py31', 'none', 'any'),
-    ('py30', 'none', 'any'),
-  ]
-  assert expected_tags == tags
+  assert_tags(
+    'linux-x86_64-cp-37-m',
+    [
+      ('cp37', 'cp37m', 'linux_x86_64'),
+      ('cp37', 'none', 'linux_x86_64'),
+      ('py3', 'none', 'linux_x86_64'),
+      ('cp37', 'none', 'any'),
+      ('cp3', 'none', 'any'),
+      ('py37', 'none', 'any'),
+      ('py3', 'none', 'any'),
+      ('py36', 'none', 'any'),
+      ('py35', 'none', 'any'),
+      ('py34', 'none', 'any'),
+      ('py33', 'none', 'any'),
+      ('py32', 'none', 'any'),
+      ('py31', 'none', 'any'),
+      ('py30', 'none', 'any'),
+    ]
+  )
+
+
+def test_platform_current_tags():
+  local_platform = str(Platform.current())
+  assert Platform.current().supported_tags() == Platform.create(local_platform).supported_tags()


### PR DESCRIPTION
Three aspects of current platform handling are fixed:

1. Ensure that `Platform.supported_tags` returns the full range of tags
when the platform is current. This uses the special no-arg form of
`pep425tags.get_supported` which consults the local interpreter to
return the broadest possible set of tags. Also ensure that we always
pass all compatible versions when the platform is not current to
generate the broadest possible set of tags for the foreign platform.

2. Ensure that the resolver interprets 'current' to mean any local
interpreter instead of just the current runtime interpreter. This is
faithful to prior behavior where a PEX built for the 'current' platform
would always work on the current machine.

3. Fix the PEX cli when run with a fully foreign set of `--platform`s.
Previously the attempt to warn the user would error on an invalid log
call that was missing a `V` argument.

Tests of all of the above are added and platform parsing is pushed up to
the CLI and resolver API layers for cleaner code under those layers and
earlier failures for invalid platform specifiers.
