### PR TITLE
Use the resolve cache to skip installs.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -538,7 +538,7 @@ def build_pex(reqs, options):
   if options.indexes != [_PYPI] and options.indexes is not None:
     indexes = [str(index) for index in options.indexes]
 
-  with TRACER.timed('Resolving distributions ({})'.format(reqs)):
+  with TRACER.timed('Resolving distributions ({})'.format(reqs + options.requirement_files)):
     try:
       resolveds = resolve_multi(requirements=reqs,
                                 requirement_files=options.requirement_files,

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -330,7 +330,7 @@ class PythonInterpreter(object):
     rendered_command = ' '.join(cmd)
     if pythonpath:
       rendered_command = 'PYTHONPATH={} {}'.format(env['PYTHONPATH'], rendered_command)
-    TRACER.log('Executing: {}'.format(rendered_command))
+    TRACER.log('Executing: {}'.format(rendered_command), V=3)
 
     return cmd, env
 

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -252,7 +252,7 @@ def resolve(requirements=None,
                         cache=cache,
                         interpreter=interpreter)
         except PipError as e:
-          raise Untranslateable('Failed to install {}:\n\t{}'.format(wheel_file_path, str(e)))
+          raise Untranslateable('Failed to install {}:\n\t{}'.format(wheel_file_path, e))
         os.rename(tmp_chroot, chroot)
 
       environment = Environment(search_path=[chroot])


### PR DESCRIPTION
Previously the cache was only used by pip for http queries. Now we also
use the cache to skill wheel installs in their isolated chroots.

Fixes #809
Fixes #811