### PR TITLE
Parallelize resolve.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -191,13 +191,15 @@ def configure_clp_pex_resolution(parser):
     help='Whether to transitively resolve requirements. Default: True')
 
   group.add_option(
-    '-j', '--parallel',
+    '-j', '--jobs',
     metavar='JOBS',
     dest='max_parallel_jobs',
     type=int,
     default=DEFAULT_MAX_JOBS,
     help='The maximum number of parallel jobs to use when resolving, building and installing '
-         'distributions. [Default: %default]')
+         'distributions. You might want to increase the maximum number of parallel jobs to '
+         'potentially improve the latency of the pex creation process at the expense of other'
+         'processes on your system. [Default: %default]')
 
   parser.add_option_group(group)
 

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -16,6 +16,7 @@ from textwrap import TextWrapper
 from pex.common import die, safe_delete, safe_mkdtemp
 from pex.interpreter import PythonInterpreter
 from pex.interpreter_constraints import validate_constraints
+from pex.jobs import DEFAULT_MAX_JOBS
 from pex.pex import PEX
 from pex.pex_bootstrapper import iter_compatible_interpreters
 from pex.pex_builder import PEXBuilder
@@ -188,6 +189,15 @@ def configure_clp_pex_resolution(parser):
     action='callback',
     callback=process_transitive,
     help='Whether to transitively resolve requirements. Default: True')
+
+  group.add_option(
+    '-j', '--parallel',
+    metavar='JOBS',
+    dest='max_parallel_jobs',
+    type=int,
+    default=DEFAULT_MAX_JOBS,
+    help='The maximum number of parallel jobs to use when resolving, building and installing '
+         'distributions. [Default: %default]')
 
   parser.add_option_group(group)
 
@@ -552,7 +562,8 @@ def build_pex(reqs, options):
                                 cache=options.cache_dir,
                                 build=options.build,
                                 use_wheel=options.use_wheel,
-                                compile=options.compile)
+                                compile=options.compile,
+                                max_parallel_jobs=options.max_parallel_jobs)
 
       for resolved_dist in resolveds:
         log('  %s -> %s' % (resolved_dist.requirement, resolved_dist.distribution),

--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -102,4 +102,17 @@ else:
   from urllib import pathname2url, url2pathname
 
 
+if PY3:
+  from queue import Queue
+
+  def cpu_count():
+    from os import sched_getaffinity
+    # The set of CPUs accessible to the current process (pid 0).
+    cpu_set = os.sched_getaffinity(0)
+    return len(cpu_set)
+else:
+  from Queue import Queue
+  from multiprocessing import cpu_count
+
+
 WINDOWS = os.name == 'nt'

--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -105,11 +105,14 @@ else:
 if PY3:
   from queue import Queue
 
-  def cpu_count():
-    from os import sched_getaffinity
-    # The set of CPUs accessible to the current process (pid 0).
-    cpu_set = os.sched_getaffinity(0)
-    return len(cpu_set)
+  # The `os.sched_getaffinity` function appears to be supported on Linux but not OSX.
+  if not hasattr(os, 'sched_getaffinity'):
+    os.cpu_count
+  else:
+    def cpu_count():
+      # The set of CPUs accessible to the current process (pid 0).
+      cpu_set = os.sched_getaffinity(0)
+      return len(cpu_set)
 else:
   from Queue import Queue
   from multiprocessing import cpu_count

--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -107,7 +107,7 @@ if PY3:
 
   # The `os.sched_getaffinity` function appears to be supported on Linux but not OSX.
   if not hasattr(os, 'sched_getaffinity'):
-    os.cpu_count
+    from os import cpu_count
   else:
     def cpu_count():
       # The set of CPUs accessible to the current process (pid 0).

--- a/pex/distribution_target.py
+++ b/pex/distribution_target.py
@@ -1,0 +1,71 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from pex.interpreter import PythonInterpreter
+from pex.platforms import Platform
+
+
+class DistributionTarget(object):
+  """Represents the target of a python distribution."""
+
+  @classmethod
+  def current(cls):
+    return cls(interpreter=None, platform=None)
+
+  @classmethod
+  def for_interpreter(cls, interpreter):
+    return cls(interpreter=interpreter, platform=None)
+
+  @classmethod
+  def for_platform(cls, platform):
+    return cls(interpreter=None, platform=platform)
+
+  def __init__(self, interpreter=None, platform=None):
+    self._interpreter = interpreter
+    self._platform = platform
+
+  @property
+  def is_foreign(self):
+    if self._platform is None:
+      return False
+    return self._platform != Platform.of_interpreter(self._interpreter)
+
+  def get_interpreter(self):
+    return self._interpreter or PythonInterpreter.get()
+
+  def get_platform(self):
+    return self._platform or Platform.current()
+
+  @property
+  def id(self):
+    """A unique id for a resolve target suitable as a path name component.
+
+    :rtype: str
+    """
+    if self._platform is None:
+      interpreter = self.get_interpreter()
+      return '{impl}-{ver}-{abi}'.format(impl=interpreter.identity.abbr_impl,
+                                         ver=interpreter.identity.impl_ver,
+                                         abi=interpreter.identity.abi_tag)
+    else:
+      return str(self._platform)
+
+  def __repr__(self):
+    if self._platform is None:
+      return 'Target(interpreter={!r})'.format(self.get_interpreter())
+    else:
+      return 'Target(platform={!r})'.format(self._platform)
+
+  def _tup(self):
+    return self._interpreter, self._platform
+
+  def __eq__(self, other):
+    return type(self) == type(other) and self._tup() == other._tup()
+
+  def __ne__(self, other):
+    return not self.__eq__(other)
+
+  def __hash__(self):
+    return hash(self._tup())

--- a/pex/distribution_target.py
+++ b/pex/distribution_target.py
@@ -62,10 +62,9 @@ class DistributionTarget(object):
     return self._interpreter, self._platform
 
   def __eq__(self, other):
-    return type(self) == type(other) and self._tup() == other._tup()
-
-  def __ne__(self, other):
-    return not self.__eq__(other)
+    if type(other) is not type(self):
+      return NotImplemented
+    return self._tup() == other._tup()
 
   def __hash__(self):
     return hash(self._tup())

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -318,6 +318,7 @@ class PythonInterpreter(object):
     cmd.append('-s')
 
     env = cls.sanitized_environment(env=env)
+    pythonpath = list(pythonpath or ())
     if pythonpath:
       env['PYTHONPATH'] = os.pathsep.join(pythonpath)
     else:

--- a/pex/jobs.py
+++ b/pex/jobs.py
@@ -161,6 +161,9 @@ class SpawnedJob(object):
     """Terminates the spawned job if it's not already complete."""
     self._job.kill()
 
+  def __str__(self):
+    return str(self._job)
+
 
 _CPU_COUNT = cpu_count()
 _ABSOLUTE_MAX_JOBS = _CPU_COUNT * 2
@@ -235,6 +238,6 @@ def execute_parallel(max_jobs, inputs, spawn_func, raise_type):
           yield item.await_result()
         except Job.Error as e:
           stop.set()
-          error = raise_type('Job {} raised {}'.format(item.job, e))
+          error = raise_type('{} raised {}'.format(item, e))
     finally:
       job_slots.release()

--- a/pex/jobs.py
+++ b/pex/jobs.py
@@ -119,8 +119,8 @@ class SpawnedJob(object):
     :param job: The spawned job.
     :type job: :class:`Job`
     :param result: The fixed success result.
-    :return: A spawned job that whose result is a side effect of the job (a written file, a
-             populated directory, etc.).
+    :return: A spawned job whose result is a side effect of the job (a written file, a populated
+             directory, etc.).
     :rtype: :class:`SpawnedJob`
     """
     def wait_result_func():
@@ -139,7 +139,7 @@ class SpawnedJob(object):
                         returning the desired result.
     :param input: Optional input stream data to pass to the process as per the
                   `subprocess.Popen.communicate` API.
-    :return: A spawned job that whose result is derived from stdout contents.
+    :return: A spawned job whose result is derived from stdout contents.
     :rtype: :class:`SpawnedJob`
     """
     def stdout_result_func():

--- a/pex/jobs.py
+++ b/pex/jobs.py
@@ -1,0 +1,207 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import errno
+import os
+from collections import namedtuple
+from threading import BoundedSemaphore, Event, Thread
+
+from pex import third_party
+from pex.compatibility import Queue, cpu_count
+from pex.interpreter import PythonInterpreter
+from pex.tracer import TRACER
+
+
+class Job(object):
+  """Represents a job spawned as a subprocess."""
+
+  class Error(Exception):
+    """Indicates that a Job exited non-zero."""
+
+  def __init__(self, command, process):
+    self._command = command
+    self._process = process
+
+  def wait(self):
+    """Waits for the job to complete.
+
+    N.B.: This method is idempotent.
+
+    :raises: :class:`Job.Error` if the job exited non-zero.
+    """
+    self._process.wait()
+    self._check_returncode()
+
+  def communicate(self, input=None):
+    """communicates with the job sending any input data to stdin and collecting stdout and stderr.
+
+    N.B.: This method is not idempotent.
+
+    :param input: Data to send to stdin of the job as per the `subprocess` API.
+    :return: A tuple of the job's stdout and stderr as per the `subprocess` API.
+    :raises: :class:`Job.Error` if the job exited non-zero.
+    """
+    stdout, stderr = self._process.communicate(input=input)
+    self._check_returncode()
+    return stdout, stderr
+
+  def kill(self):
+    """Terminates the job if it is still running.
+
+    N.B.: This method is idempotent.
+    """
+    try:
+      self._process.kill()
+    except OSError as e:
+      if e.errno != errno.ESRCH:
+        raise e
+
+  def _check_returncode(self):
+    if self._process.returncode != 0:
+      raise self.Error('Executing {} failed with {}'
+                       .format(' '.join(self._command), self._process.returncode))
+
+  def __str__(self):
+    return 'pid: {pid} -> {command}'.format(pid=self._process.pid, command=' '.join(self._command))
+
+
+def spawn_python_job(args, env=None, interpreter=None, expose=None, **subprocess_kwargs):
+  """Spawns a python job.
+
+  :param args: The arguments to pass to the python interpreter.
+  :type args: list of str
+  :param env: The environment to spawn the python interpreter process in. Defaults to the ambient
+              environment.
+  :type env: dict of (str, str)
+  :param interpreter: The interpreter to use to spawn the python job. Defaults to the current
+                      interpreter.
+  :type interpreter: :class:`PythonInterpreter`
+  :param expose: The names of any vendored distributions to expose to the spawned python process.
+  :type expose: list of str
+  :param subprocess_kwargs: Any additional :class:`subprocess.Popen` kwargs to pass through.
+  :returns: A job handle to the spawned python process.
+  :rtype: :class:`Job`
+  """
+  if expose:
+    subprocess_env = (env or os.environ).copy()
+    subprocess_env['__PEX_UNVENDORED__'] = '1'
+
+    pythonpath = third_party.expose(expose)
+  else:
+    subprocess_env = env
+    pythonpath = None
+
+  interpreter = interpreter or PythonInterpreter.get()
+  cmd, process = interpreter.open_process(
+    args=args,
+    pythonpath=pythonpath,
+    env=subprocess_env,
+    **subprocess_kwargs
+  )
+  return Job(command=cmd, process=process)
+
+
+class SpawnedJob(namedtuple('SpawnedJob', ['job', 'result_func'])):
+  """A handle to a spawned :class:`Job` and its associated result."""
+
+  @classmethod
+  def wait(cls, job, result):
+    def wait_result_func():
+      job.wait()
+      return result
+
+    return cls(job=job, result_func=wait_result_func)
+
+  @classmethod
+  def stdout(cls, job, result_func, input=None):
+    def stdout_result_func():
+      stdout, _ = job.communicate(input=input)
+      return result_func(stdout)
+
+    return cls(job=job, result_func=stdout_result_func)
+
+  def await_result(self):
+    """Waits for the spawned job to complete and returns its result."""
+    return self.result_func()
+
+  def kill(self):
+    """Terminates the spawned job if it's not already complete."""
+    self.job.kill()
+
+
+_CPU_COUNT = cpu_count()
+_ABSOLUTE_MAX_JOBS = _CPU_COUNT * 2
+
+
+DEFAULT_MAX_JOBS = _CPU_COUNT
+"""The default maximum number of parallel jobs PEX should use."""
+
+
+def _sanitize_max_jobs(max_jobs=None):
+  assert max_jobs is None or isinstance(max_jobs, int)
+  if max_jobs is None or max_jobs <= 0:
+    return DEFAULT_MAX_JOBS
+  else:
+    return min(max_jobs, _ABSOLUTE_MAX_JOBS)
+
+
+def execute_parallel(max_jobs, inputs, spawn_func, raise_type):
+  """Execute jobs for the given inputs in parallel.
+
+  :param int max_jobs: The maximum number of parallel jobs to spawn.
+  :param inputs: An iterable of the data to parallelize over `spawn_func`.
+  :param spawn_func: A function taking a single input and returning a :class:`SpawnedJob`.
+  :param raise_type: A type that takes a single string argument and will be used to construct a
+                     raiseable value when any of the spawned jobs errors.
+  :returns: An iterator over the spawned job results as they come in.
+  :raises: A `raise_type` exception if any individual job errors.
+  """
+  size = _sanitize_max_jobs(max_jobs)
+  TRACER.log('Spawning a maximum of {} parallel jobs to process:\n  {}'
+             .format(size, '\n  '.join(map(str, inputs))),
+             V=9)
+
+  stop = Event()
+  job_slots = BoundedSemaphore(value=size)
+  spawned_job_queue = Queue()
+  queue_done_sentinel = object()
+
+  def spawn_jobs():
+    for input in inputs:
+      if not stop.is_set():
+        job_slots.acquire()
+        try:
+          item = spawn_func(input)
+        except Exception as e:
+          item = e
+        finally:
+          spawned_job_queue.put(item)
+    spawned_job_queue.put(queue_done_sentinel)
+
+  spawner = Thread(name='PEX Parallel Job Spawner', target=spawn_jobs)
+  spawner.daemon = True
+  spawner.start()
+
+  error = None
+  while True:
+    item = spawned_job_queue.get()
+    if item is queue_done_sentinel:
+      if error:
+        raise error
+      return
+
+    try:
+      if isinstance(item, Exception):
+        error = item
+      elif error is not None:
+        item.job.kill()
+      else:
+        try:
+          yield item.await_result()
+        except Job.Error as e:
+          stop.set()
+          error = raise_type('Job {} raised {}'.format(item.job, e))
+    finally:
+      job_slots.release()

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -9,10 +9,11 @@ import os
 from pex.common import Chroot, chmod_plus_x, open_zip, safe_mkdir, safe_mkdtemp
 from pex.compatibility import to_bytes
 from pex.compiler import Compiler
+from pex.distribution_target import DistributionTarget
 from pex.finders import get_entry_point_from_console_script, get_script_from_distributions
 from pex.interpreter import PythonInterpreter
 from pex.pex_info import PexInfo
-from pex.pip import install_wheel
+from pex.pip import spawn_install_wheel
 from pex.third_party.pkg_resources import DefaultProvider, ZipProvider, get_provider
 from pex.tracer import TRACER
 from pex.util import CacheHelper, DistributionHelper
@@ -285,7 +286,12 @@ class PEXBuilder(object):
       tmp = safe_mkdtemp()
       whltmp = os.path.join(tmp, dist_name)
       os.mkdir(whltmp)
-      install_wheel(wheel=path, target=whltmp, overwrite=True, interpreter=self.interpreter)
+      install_job = spawn_install_wheel(
+        wheel=path,
+        install_dir=whltmp,
+        target=DistributionTarget.for_interpreter(self.interpreter)
+      )
+      install_job.wait()
       for root, _, files in os.walk(whltmp):
         pruned_dir = os.path.relpath(root, tmp)
         for f in files:

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -165,7 +165,8 @@ def spawn_install_wheel(wheel,
   interpreter = target.get_interpreter()
   if target.is_foreign:
     if compile:
-      raise ValueError('Cannot compile bytecode for {} using {}.'.format(wheel, interpreter))
+      raise ValueError('Cannot compile bytecode for {} using {} because the wheel has a foreign '
+                       'platform.'.format(wheel, interpreter))
 
     # We're installing a wheel for a foreign platform. This is just an unpacking operation though;
     # so we don't actually need to perform it with a target platform compatible interpreter.

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -58,7 +58,7 @@ class Platform(namedtuple('Platform', ['platform', 'impl', 'version', 'abi'])):
       )
     platform = platform.replace('-', '_').replace('.', '_')
     abi = cls._maybe_prefix_abi(impl, version, abi)
-    return super(cls, Platform).__new__(cls, platform, impl, version, abi)
+    return super(Platform, cls).__new__(cls, platform, impl, version, abi)
 
   def __str__(self):
     return self.SEP.join(self)

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -3,23 +3,25 @@
 
 from __future__ import absolute_import
 
+import errno
 import functools
 import json
 import os
 import subprocess
-from collections import defaultdict, namedtuple
+from collections import OrderedDict, defaultdict, namedtuple
 from textwrap import dedent
 from uuid import uuid4
 
-from pex import third_party
 from pex.common import safe_mkdtemp
-from pex.interpreter import PythonInterpreter
+from pex.distribution_target import DistributionTarget
+from pex.jobs import SpawnedJob, execute_parallel, spawn_python_job
 from pex.orderedset import OrderedSet
-from pex.pip import PipError, build_wheels, download_distributions, install_wheel
+from pex.pip import spawn_build_wheels, spawn_download_distributions, spawn_install_wheel
 from pex.platforms import Platform
 from pex.requirements import local_project_from_requirement, local_projects_from_requirement_file
 from pex.third_party.pkg_resources import Distribution, Environment, Requirement
 from pex.tracer import TRACER
+from pex.util import CacheHelper
 
 
 class Untranslateable(Exception):
@@ -39,45 +41,42 @@ class ResolvedDistribution(namedtuple('ResolvedDistribution', ['requirement', 'd
     return super(ResolvedDistribution, cls).__new__(cls, requirement, distribution)
 
 
-def _calculate_dependency_markers(distributions, interpreter=None):
-  search_path = [dist.location for dist in distributions]
-  program = dedent("""
-    import json
-    import sys
-    from collections import defaultdict
-    from pkg_resources import Environment
-    
-    
-    env = Environment(search_path={search_path!r})
-    dependency_requirements = []
-    for key in env:
-      for dist in env[key]:
-        dependency_requirements.extend(str(req) for req in dist.requires())
-    json.dump(dependency_requirements, sys.stdout)
-  """.format(search_path=search_path))
+class DistributionMarkers(object):
+  @staticmethod
+  def spawn_calculation(distributions, interpreter=None):
+    search_path = [dist.location for dist in distributions]
 
-  env = os.environ.copy()
-  env['__PEX_UNVENDORED__'] = '1'
+    program = dedent("""
+      import json
+      import sys
+      from collections import defaultdict
+      from pkg_resources import Environment
+      
+      
+      env = Environment(search_path={search_path!r})
+      dependency_requirements = []
+      for key in env:
+        for dist in env[key]:
+          dependency_requirements.extend(str(req) for req in dist.requires())
+      json.dump(dependency_requirements, sys.stdout)
+    """.format(search_path=search_path))
 
-  pythonpath = third_party.expose(['setuptools'])
+    return spawn_python_job(
+      args=['-c', program],
+      stdout=subprocess.PIPE,
+      interpreter=interpreter,
+      expose=['setuptools']
+    )
 
-  interpreter = interpreter or PythonInterpreter.get()
-  _, process = interpreter.open_process(args=['-c', program],
-                                        stdout=subprocess.PIPE,
-                                        pythonpath=pythonpath,
-                                        env=env)
-  stdout, _ = process.communicate()
-  if process.returncode != 0:
-    raise Untranslateable('Could not determine dependency environment markers for {}'
-                          .format(distributions))
-
-  dependency_requirements = json.loads(stdout.decode('utf-8'))
-  markers_by_req_key = defaultdict(OrderedSet)
-  for requirement in dependency_requirements:
-    req = Requirement.parse(requirement)
-    if req.marker:
-      markers_by_req_key[req.key].add(req.marker)
-  return markers_by_req_key
+  @staticmethod
+  def markers_by_requirement(stdout):
+    dependency_requirements = json.loads(stdout.decode('utf-8'))
+    markers_by_req_key = defaultdict(OrderedSet)
+    for requirement in dependency_requirements:
+      req = Requirement.parse(requirement)
+      if req.marker:
+        markers_by_req_key[req.key].add(req.marker)
+    return markers_by_req_key
 
 
 def parsed_platform(platform=None):
@@ -95,6 +94,394 @@ def parsed_platform(platform=None):
   return Platform.create(platform) if platform and platform != 'current' else None
 
 
+class AtomicDirectory(namedtuple('AtomicDirectory', ['work_dir', 'target_dir'])):
+  @classmethod
+  def for_target_dir(cls, target_dir):
+    return cls(work_dir='{}.{}'.format(target_dir, uuid4().hex), target_dir=target_dir)
+
+  @property
+  def is_finalized(self):
+    return os.path.exists(self.target_dir)
+
+  def finalize(self):
+    try:
+      os.rename(self.work_dir, self.target_dir)
+    except OSError as e:
+      if e.errno != errno.ENOTEMPTY:
+        raise e
+
+
+class ResolveResult(namedtuple('ResolveResult', ['target', 'download_dir'])):
+  @staticmethod
+  def _is_wheel(path):
+    return os.path.isfile(path) and path.endswith('.whl')
+
+  def _iter_distribution_paths(self):
+    if os.path.exists(self.download_dir):
+      for distribution in os.listdir(self.download_dir):
+        yield os.path.join(self.download_dir, distribution)
+
+  def build_requests(self):
+    for distribution_path in self._iter_distribution_paths():
+      if not self._is_wheel(distribution_path):
+        yield BuildRequest.create(target=self.target, source_path=distribution_path)
+
+  def install_requests(self):
+    for distribution_path in self._iter_distribution_paths():
+      if self._is_wheel(distribution_path):
+        yield InstallRequest.create(target=self.target, wheel_path=distribution_path)
+
+
+class BuildRequest(namedtuple('BuildRequest', ['target', 'source_path', 'fingerprint'])):
+  @classmethod
+  def create(cls, target, source_path):
+    hasher = CacheHelper.dir_hash if os.path.isdir(source_path) else CacheHelper.hash
+    fingerprint = hasher(source_path)
+    return cls(target=target, source_path=source_path, fingerprint=fingerprint)
+
+  def result(self, dist_root):
+    return BuildResult.from_request(self, dist_root=dist_root)
+
+
+class BuildResult(namedtuple('BuildResult', ['request', 'atomic_dir'])):
+  @classmethod
+  def from_request(cls, build_request, dist_root):
+    dist_dir = os.path.join(
+      dist_root,
+      'sdists' if os.path.isfile(build_request.source_path) else 'local_projects',
+      os.path.basename(build_request.source_path),
+      build_request.fingerprint,
+      build_request.target.id
+    )
+    return cls(request=build_request, atomic_dir=AtomicDirectory.for_target_dir(dist_dir))
+
+  @property
+  def is_built(self):
+    return self.atomic_dir.is_finalized
+
+  @property
+  def build_dir(self):
+    return self.atomic_dir.work_dir
+
+  @property
+  def dist_dir(self):
+    return self.atomic_dir.target_dir
+
+  def install_requests(self):
+    for wheel in os.listdir(self.dist_dir):
+      yield InstallRequest.create(self.request.target, os.path.join(self.dist_dir, wheel))
+
+  def finalize_build(self):
+    self.atomic_dir.finalize()
+    for install_request in self.install_requests():
+      yield install_request
+
+
+class InstallRequest(namedtuple('InstallRequest', ['target', 'wheel_path', 'fingerprint'])):
+  @classmethod
+  def create(cls, target, wheel_path):
+    fingerprint = CacheHelper.hash(wheel_path)
+    return cls(target=target, wheel_path=wheel_path, fingerprint=fingerprint)
+
+  @property
+  def wheel_file(self):
+    return os.path.basename(self.wheel_path)
+
+  def result(self, installation_root):
+    return InstallResult.from_request(self, installation_root=installation_root)
+
+
+class InstallResult(namedtuple('InstallResult', ['request', 'atomic_dir'])):
+  @classmethod
+  def from_request(cls, install_request, installation_root):
+    install_chroot = os.path.join(
+      installation_root,
+      install_request.fingerprint,
+      install_request.wheel_file
+    )
+    return cls(request=install_request, atomic_dir=AtomicDirectory.for_target_dir(install_chroot))
+
+  @property
+  def is_installed(self):
+    return self.atomic_dir.is_finalized
+
+  @property
+  def build_chroot(self):
+    return self.atomic_dir.work_dir
+
+  @property
+  def install_chroot(self):
+    return self.atomic_dir.target_dir
+
+  def find_distributions(self):
+    if self.is_installed:
+      # N.B.: Direct snip from the Environment docs:
+      #
+      #  You may explicitly set `platform` (and/or `python`) to ``None`` if you
+      #  wish to map *all* distributions, not just those compatible with the
+      #  running platform or Python version.
+      #
+      # Since our requested target may be foreign, we make sure find all distributions installed by
+      # explicitly setting both `python` and `platform` to `None`.
+      environment = Environment(search_path=[self.install_chroot], python=None, platform=None)
+
+      for dist_project_name in environment:
+        for dist in environment[dist_project_name]:
+          yield dist
+
+  def finalize_install(self):
+    self.atomic_dir.finalize()
+    for distribution in self.find_distributions():
+      yield distribution
+
+
+MarkersRequest = namedtuple('MarkersRequest', ['target', 'distributions'])
+
+
+class ResolveRequest(object):
+  def __init__(self,
+               targets,
+               requirements=None,
+               requirement_files=None,
+               constraint_files=None,
+               allow_prereleases=False,
+               transitive=True,
+               indexes=None,
+               find_links=None,
+               cache=None,
+               build=True,
+               use_wheel=True,
+               compile=False,
+               max_parallel_jobs=None):
+
+    self._targets = targets
+    self._requirements = requirements
+    self._requirement_files = requirement_files
+    self._constraint_files = constraint_files
+    self._allow_prereleases = allow_prereleases
+    self._transitive = transitive
+    self._indexes = indexes
+    self._find_links = find_links
+    self._cache = cache
+    self._build = build
+    self._use_wheel = use_wheel
+    self._compile = compile
+    self._max_parallel_jobs = max_parallel_jobs
+
+  def _run_parallel(self, inputs, spawn_func, raise_type):
+    for result in execute_parallel(self._max_parallel_jobs, inputs, spawn_func, raise_type):
+      yield result
+
+  def _spawn_resolve(self, resolved_dists_dir, target):
+    download_dir = os.path.join(resolved_dists_dir, target.id)
+    download_job = spawn_download_distributions(
+      download_dir=download_dir,
+      requirements=self._requirements,
+      requirement_files=self._requirement_files,
+      constraint_files=self._constraint_files,
+      allow_prereleases=self._allow_prereleases,
+      transitive=self._transitive,
+      target=target,
+      indexes=self._indexes,
+      find_links=self._find_links,
+      cache=self._cache,
+      build=self._build,
+      use_wheel=self._use_wheel
+    )
+    return SpawnedJob.wait(job=download_job, result=ResolveResult(target, download_dir))
+
+  def _spawn_wheel_build(self, built_wheels_dir, build_request):
+    build_result = build_request.result(built_wheels_dir)
+    build_job = spawn_build_wheels(
+      distributions=[build_request.source_path],
+      wheel_dir=build_result.build_dir,
+      cache=self._cache,
+      interpreter=build_request.target.get_interpreter()
+    )
+    return SpawnedJob.wait(job=build_job, result=build_result)
+
+  def _spawn_install(self, installed_wheels_dir, install_request):
+    install_result = install_request.result(installed_wheels_dir)
+    install_job = spawn_install_wheel(
+      wheel=install_request.wheel_path,
+      install_dir=install_result.build_chroot,
+      compile=self._compile,
+      overwrite=True,
+      cache=self._cache,
+      target=install_request.target
+    )
+    return SpawnedJob.wait(job=install_job, result=install_result)
+
+  def _spawn_calculate_markers(self, markers_request):
+    markers_calculation_job = DistributionMarkers.spawn_calculation(
+      distributions=markers_request.distributions,
+      interpreter=markers_request.target.get_interpreter()
+    )
+    return SpawnedJob.stdout(
+      job=markers_calculation_job,
+      result_func=DistributionMarkers.markers_by_requirement
+    )
+
+  def resolve_distributions(self):
+    # This method has three stages: 1) resolve, 2) build, and 3) install.
+    #
+    # You'd think we might be able to just pip install all the requirements, but pexes can be
+    # multi-platform / multi-interpreter, in which case only a subset of distributions resolved into
+    # the PEX should be activated for the runtime interpreter. Sometimes there are platform specific
+    # wheels and sometimes python version specific dists (backports being the common case). As such,
+    # we need to be able to add each resolved distribution to the `sys.path` individually
+    # (`PEXEnvironment` handles this selective activation at runtime). Since pip install only
+    # accepts a single location to install all resolved dists, that won't work.
+    #
+    # This means we need to seperately resolve all distributions, then install each in their own
+    # chroot. To do this we use `pip download` for the resolve and download of all needed
+    # distributions and then `pip install` to install each distribution in its own chroot.
+    #
+    # As a complicating factor, the runtime activation scheme relies on PEP 425 tags; i.e.: wheel
+    # names. Some requirements are only available or applicable in source form - either via sdist,
+    # VCS URL or local projects. As such we need to insert a `pip wheel` step to generate wheels for
+    # all requirements resolved in source form via `pip download` / inspection of requirements to
+    # discover those that are local directories (local setup.py or pyproject.toml python projects).
+
+    if not self._requirements and not self._requirement_files:
+      # Nothing to resolve.
+      return []
+
+    workspace = safe_mkdtemp()
+    cache = self._cache or workspace
+
+    resolved_dists_dir = os.path.join(workspace, 'resolved_dists')
+    spawn_resolve = functools.partial(self._spawn_resolve, resolved_dists_dir)
+    to_resolve = self._targets
+
+    built_wheels_dir = os.path.join(cache, 'built_wheels')
+    spawn_wheel_build = functools.partial(self._spawn_wheel_build, built_wheels_dir)
+    to_build = []
+    if self._requirements:
+      for req in self._requirements:
+        local_project = local_project_from_requirement(req)
+        if local_project:
+          to_build.extend(BuildRequest.create(target=target, source_path=local_project)
+                          for target in self._targets)
+    if self._requirement_files:
+      for requirement_file in self._requirement_files:
+        for local_project in local_projects_from_requirement_file(requirement_file):
+          to_build.extend(BuildRequest.create(target=target, source_path=local_project)
+                          for target in self._targets)
+
+    installed_wheels_dir = os.path.join(cache, 'installed_wheels')
+    spawn_install = functools.partial(self._spawn_install, installed_wheels_dir)
+    to_install = []
+
+    # 1. Resolve
+    with TRACER.timed('Resolving for:\n  '.format('\n  '.join(map(str, to_resolve)))):
+      for resolve_result in self._run_parallel(inputs=to_resolve,
+                                               spawn_func=spawn_resolve,
+                                               raise_type=Unsatisfiable):
+        to_build.extend(resolve_result.build_requests())
+        to_install.extend(resolve_result.install_requests())
+
+    if not any((to_build, to_install)):
+      # Nothing to build or install.
+      return []
+
+    # 2. Build
+    if to_build:
+      with TRACER.timed('Building distributions for:\n  {}'
+                        .format('\n  '.join(map(str, to_build)))):
+        unsatisfied_build_requests = []
+        for build_request in to_build:
+          build_result = build_request.result(built_wheels_dir)
+          if not build_result.is_built:
+            TRACER.log('Building {} to {}'
+                       .format(build_request.source_path, build_result.dist_dir))
+            unsatisfied_build_requests.append(build_request)
+          else:
+            TRACER.log('Using cached build of {} at {}'
+                       .format(build_request.source_path, build_result.dist_dir))
+            to_install.extend(build_result.install_requests())
+
+        for build_result in self._run_parallel(inputs=unsatisfied_build_requests,
+                                               spawn_func=spawn_wheel_build,
+                                               raise_type=Untranslateable):
+          to_install.extend(build_result.finalize_build())
+
+    # 3. Install
+    installed_distributions_by_target = OrderedDict()
+    def add_distributions(target, dists):
+      installed_distributions_by_target.setdefault(target, []).extend(dists)
+
+    with TRACER.timed('Installing:\n  {}'.format('\n  '.join(map(str, to_install)))):
+      # Dedup by wheel name; e.g.: only install universal wheels once even though they'll get
+      # downloaded / built for each interpreter or platform.
+      install_requests_by_wheel_file = OrderedDict()
+      for install_request in to_install:
+        install_requests = install_requests_by_wheel_file.setdefault(install_request.wheel_file, [])
+        install_requests.append(install_request)
+
+      unsatisfied_install_requests = OrderedDict()
+      for install_requests in install_requests_by_wheel_file.values():
+        representative_install_request = install_requests[0]
+        install_result = representative_install_request.result(installed_wheels_dir)
+        if not install_result.is_installed:
+          TRACER.log('Installing {} in {}'
+                     .format(representative_install_request.wheel_path,
+                             install_result.install_chroot))
+          unsatisfied_install_requests[representative_install_request] = install_requests
+        else:
+          TRACER.log('Using cached installation of {} at {}'
+                     .format(representative_install_request.wheel_file,
+                             install_result.install_chroot))
+          distributions = list(install_result.find_distributions())
+          for install_request in install_requests:
+            add_distributions(install_request.target, distributions)
+
+      for install_result in self._run_parallel(inputs=unsatisfied_install_requests.keys(),
+                                               spawn_func=spawn_install,
+                                               raise_type=Untranslateable):
+        distributions = list(install_result.finalize_install())
+        for install_request in unsatisfied_install_requests[install_result.request]:
+          add_distributions(install_request.target, distributions)
+
+    # And, finally, calculate environment markers for the resolved distributions.
+    markers_requests = [MarkersRequest(target=target, distributions=distributions)
+                        for target, distributions in installed_distributions_by_target.items()]
+    markers_by_req_key = defaultdict(OrderedSet)
+    with TRACER.timed('Determining environment markers of installed distributions:\n  {}'
+                      .format('\n  '.join(map(str, markers_requests)))):
+      for distribution_markers in self._run_parallel(inputs=markers_requests,
+                                                     spawn_func=self._spawn_calculate_markers,
+                                                     raise_type=Untranslateable):
+        for requirement, markers in distribution_markers.items():
+          markers_by_req_key[requirement].update(markers)
+
+    def to_requirement(dist):
+      req = dist.as_requirement()
+      markers = markers_by_req_key.get(req.key)
+      if not markers:
+        return req
+
+      if len(markers) == 1:
+        marker = next(iter(markers))
+        req.marker = marker
+        return req
+
+      # Here we have a resolve with multiple paths to the dependency represented by dist. At least
+      # two of those paths had (different) conditional requirements for dist based on environment
+      # marker predicates. Since the pip resolve succeeded, the implication is that the environment
+      # markers are compatible; i.e.: their intersection selects the target interpreter. Here we
+      # make that intersection explicit.
+      # See: https://www.python.org/dev/peps/pep-0496/#micro-language
+      marker = ' and '.join('({})'.format(marker) for marker in markers)
+      return Requirement.parse('{}; {}'.format(req, marker))
+
+    resolved_distributions = OrderedSet()
+    for dists in installed_distributions_by_target.values():
+      resolved_distributions.update(ResolvedDistribution(to_requirement(dist), dist)
+                                    for dist in dists)
+    return resolved_distributions
+
+
 def resolve(requirements=None,
             requirement_files=None,
             constraint_files=None,
@@ -107,7 +494,8 @@ def resolve(requirements=None,
             cache=None,
             build=True,
             use_wheel=True,
-            compile=False):
+            compile=False,
+            max_parallel_jobs=None):
   """Produce all distributions needed to meet all specified requirements.
 
   :keyword requirements: A sequence of requirement strings.
@@ -141,152 +529,31 @@ def resolve(requirements=None,
     Defaults to ``True``.
   :keyword bool compile: Whether to pre-compile resolved distribution python sources.
     Defaults to ``False``.
+  :keyword int max_parallel_jobs: The maximum number of parallel jobs to use when resolving,
+    building and installing distributions in a resolve. Defaults to the number of CPUs available.
   :returns: List of :class:`ResolvedDistribution` instances meeting ``requirements``.
   :raises Unsatisfiable: If ``requirements`` is not transitively satisfiable.
   :raises Untranslateable: If no compatible distributions could be acquired for
     a particular requirement.
   """
 
-  # This function has three stages: 1) resolve, 2) build, and 3) chroot.
-  #
-  # You'd think we might be able to just pip install all the requirements, but pexes can be
-  # multi-platform / multi-interpreter, in which case only a subset of distributions resolved into
-  # the PEX should be activated for the runtime interpreter. Sometimes there are platform specific
-  # wheels and sometimes python version specific dists (backports being the common case). As such,
-  # we need to be able to add each resolved distribution to the `sys.path` individually
-  # (`PEXEnvironment` handles this selective activation at runtime). Since pip install only accepts
-  # a single location to install all resolved dists, that won't work.
-  #
-  # This means we need to seperately resolve all distributions, then install each in their own
-  # chroot. To do this we use `pip download` for the resolve and download of all needed
-  # distributions and then `pip install` to install each distribution in its own chroot.
-  #
-  # As a complicating factor, the runtime activation scheme relies on PEP 425 tags; i.e.: wheel
-  # names. Some requirements are only available or applicable in source form - either via sdist, VCS
-  # URL or local projects. As such we need to insert a `pip wheel` step to generate wheels for all
-  # requirements resolved in source form via `pip download` / inspection of requirements to
-  # discover those that are local directories (local setup.py or pyproject.toml python projects).
+  target = DistributionTarget(interpreter=interpreter, platform=parsed_platform(platform))
 
-  if not requirements and not requirement_files:
-    # Nothing to resolve.
-    return []
+  resolve_request = ResolveRequest(targets=[target],
+                                   requirements=requirements,
+                                   requirement_files=requirement_files,
+                                   constraint_files=constraint_files,
+                                   allow_prereleases=allow_prereleases,
+                                   transitive=transitive,
+                                   indexes=indexes,
+                                   find_links=find_links,
+                                   cache=cache,
+                                   build=build,
+                                   use_wheel=use_wheel,
+                                   compile=compile,
+                                   max_parallel_jobs=max_parallel_jobs)
 
-  workspace = safe_mkdtemp()
-  cache = cache or workspace
-  resolved_dists = os.path.join(workspace, 'resolved')
-  built_wheels = os.path.join(workspace, 'wheels')
-  installed_chroots = os.path.join(cache, 'chroots')
-
-  # 1. Resolve
-  with TRACER.timed('Resolving and downloading distributions'):
-    try:
-      download_distributions(target=resolved_dists,
-                             requirements=requirements,
-                             requirement_files=requirement_files,
-                             constraint_files=constraint_files,
-                             allow_prereleases=allow_prereleases,
-                             transitive=transitive,
-                             interpreter=interpreter,
-                             platform=parsed_platform(platform),
-                             indexes=indexes,
-                             find_links=find_links,
-                             cache=cache,
-                             build=build,
-                             use_wheel=use_wheel)
-    except PipError as e:
-      raise Unsatisfiable(str(e))
-
-  # 2. Build
-  to_build = []
-  if requirements:
-    for req in requirements:
-      local_project = local_project_from_requirement(req)
-      if local_project:
-        to_build.append(local_project)
-  if requirement_files:
-    for requirement_file in requirement_files:
-      to_build.extend(local_projects_from_requirement_file(requirement_file))
-
-  to_install = []
-  if os.path.exists(resolved_dists):
-    for distribution in os.listdir(resolved_dists):
-      path = os.path.join(resolved_dists, distribution)
-      if os.path.isfile(path) and path.endswith('.whl'):
-        to_install.append(path)
-      else:
-        to_build.append(path)
-
-  if not any((to_build, to_install)):
-    # Nothing to build or install.
-    return []
-
-  if to_build:
-    with TRACER.timed('Building distributions:\n  {}'.format('\n  '.join(to_build))):
-      try:
-        build_wheels(distributions=to_build,
-                     target=built_wheels,
-                     cache=cache,
-                     interpreter=interpreter)
-      except PipError as e:
-        raise Untranslateable('Failed to build at least one of {}:\n  {}'
-                              .format(', '.join(to_build), str(e)))
-      to_install.extend(os.path.join(built_wheels, wheel) for wheel in os.listdir(built_wheels))
-
-  # 3. Chroot
-  resolved_distributions = []
-
-  with TRACER.timed('Installing distributions:\n  {}'.format('\n  '.join(to_install))):
-    for wheel_file_path in to_install:
-      wheel_file = os.path.basename(wheel_file_path)
-      chroot = os.path.join(installed_chroots, wheel_file)
-      if os.path.exists(chroot):
-        TRACER.log('Using cached installation of {} at {}'.format(wheel_file, chroot))
-      else:
-        TRACER.log('Installing {} in {}'.format(wheel_file_path, chroot))
-        tmp_chroot = '{}.{}'.format(chroot, uuid4().hex)
-        try:
-          install_wheel(wheel=wheel_file_path,
-                        target=tmp_chroot,
-                        compile=compile,
-                        overwrite=True,
-                        cache=cache,
-                        interpreter=interpreter)
-        except PipError as e:
-          raise Untranslateable('Failed to install {}:\n\t{}'.format(wheel_file_path, e))
-        os.rename(tmp_chroot, chroot)
-
-      environment = Environment(search_path=[chroot])
-      for dist_project_name in environment:
-        resolved_distributions.extend(environment[dist_project_name])
-
-  with TRACER.timed('Determining environment markers of installed distributions:\n  {}'
-                    .format('\n  '.join(map(str, resolved_distributions)))):
-    markers_by_req_key = _calculate_dependency_markers(
-      resolved_distributions,
-      interpreter=interpreter
-    )
-
-  def to_requirement(dist):
-    req = dist.as_requirement()
-    markers = markers_by_req_key.get(req.key)
-    if not markers:
-      return req
-
-    if len(markers) == 1:
-      marker = next(iter(markers))
-      req.marker = marker
-      return req
-
-    # Here we have a resolve with multiple paths to the dependency represented by dist. At least
-    # two of those paths had (different) conditional requirements for dist based on environment
-    # marker predicates. Since the pip resolve succeeded, the implication is that the environment
-    # markers are compatible; i.e.: their intersection selects the target interpreter. Here we
-    # make that intersection explicit.
-    # See: https://www.python.org/dev/peps/pep-0496/#micro-language
-    marker = ' and '.join('({})'.format(marker) for marker in markers)
-    return Requirement.parse('{}; {}'.format(req, marker))
-
-  return [ResolvedDistribution(to_requirement(dist), dist) for dist in resolved_distributions]
+  return list(resolve_request.resolve_distributions())
 
 
 def resolve_multi(requirements=None,
@@ -301,7 +568,8 @@ def resolve_multi(requirements=None,
                   cache=None,
                   build=True,
                   use_wheel=True,
-                  compile=True):
+                  compile=False,
+                  max_parallel_jobs=None):
   """A generator function that produces all distributions needed to meet `requirements`
   for multiple interpreters and/or platforms.
 
@@ -338,38 +606,26 @@ def resolve_multi(requirements=None,
     Defaults to ``True``.
   :keyword bool compile: Whether to pre-compile resolved distribution python sources.
     Defaults to ``False``.
-  :yields: All :class:`ResolvedDistribution` instances meeting ``requirements`` for all
-    specifed interpreters and platforms.
+  :keyword int max_parallel_jobs: The maximum number of parallel jobs to use when resolving,
+    building and installing distributions in a resolve. Defaults to the number of CPUs available.
+  :returns: List of :class:`ResolvedDistribution` instances meeting ``requirements``.
   :raises Unsatisfiable: If ``requirements`` is not transitively satisfiable.
   :raises Untranslateable: If no compatible distributions could be acquired for
     a particular requirement.
   """
 
-  curried_resolve = functools.partial(resolve,
-                                      requirements=requirements,
-                                      requirement_files=requirement_files,
-                                      constraint_files=constraint_files,
-                                      allow_prereleases=allow_prereleases,
-                                      transitive=transitive,
-                                      indexes=indexes,
-                                      find_links=find_links,
-                                      cache=cache,
-                                      build=build,
-                                      use_wheel=use_wheel,
-                                      compile=compile)
-
   parsed_platforms = [parsed_platform(platform) for platform in platforms] if platforms else []
 
-  def iter_kwargs():
+  def iter_targets():
     if not interpreters and not parsed_platforms:
       # No specified targets, so just build for the current interpreter (on the current platform).
-      yield dict(interpreter=None, platform=None)
+      yield DistributionTarget.current()
       return
 
     if interpreters:
       for interpreter in interpreters:
         # Build for the specified local interpreters (on the current platform).
-        yield dict(interpreter=interpreter, platform=None)
+        yield DistributionTarget.for_interpreter(interpreter)
 
     if parsed_platforms:
       for platform in parsed_platforms:
@@ -377,13 +633,20 @@ def resolve_multi(requirements=None,
           # 1. Build for specific platforms.
           # 2. Build for the current platform (None) only if not done already (ie: no intepreters
           #    were specified).
-          yield dict(interpreter=None, platform=platform)
+          yield DistributionTarget.for_platform(platform)
 
-  seen = set()
-  for kwargs in iter_kwargs():
-    for resolved_distribution in curried_resolve(**kwargs):
-      # The resolved wheel name is a suitable multi-platform distinguishing key.
-      key = os.path.basename(resolved_distribution.distribution.location)
-      if key not in seen:
-        seen.add(key)
-        yield resolved_distribution
+  resolve_request = ResolveRequest(targets=list(iter_targets()),
+                                   requirements=requirements,
+                                   requirement_files=requirement_files,
+                                   constraint_files=constraint_files,
+                                   allow_prereleases=allow_prereleases,
+                                   transitive=transitive,
+                                   indexes=indexes,
+                                   find_links=find_links,
+                                   cache=cache,
+                                   build=build,
+                                   use_wheel=use_wheel,
+                                   compile=compile,
+                                   max_parallel_jobs=max_parallel_jobs)
+
+  return list(resolve_request.resolve_distributions())

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -413,7 +413,7 @@ class ResolveRequest(object):
     # (`PEXEnvironment` handles this selective activation at runtime). Since pip install only
     # accepts a single location to install all resolved dists, that won't work.
     #
-    # This means we need to seperately resolve all distributions, then install each in their own
+    # This means we need to separately resolve all distributions, then install each in their own
     # chroot. To do this we use `pip download` for the resolve and download of all needed
     # distributions and then `pip install` to install each distribution in its own chroot.
     #

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -20,7 +20,7 @@ from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
-from pex.pip import build_wheels
+from pex.pip import spawn_build_wheels
 from pex.util import DistributionHelper, named_temporary_file
 
 PY_VER = sys.version_info[:2]
@@ -156,11 +156,11 @@ class WheelBuilder(object):
     self._interpreter = interpreter or PythonInterpreter.get()
 
   def bdist(self):
-    build_wheels(
+    spawn_build_wheels(
       distributions=[self._source_dir],
-      target=self._wheel_dir,
+      wheel_dir=self._wheel_dir,
       interpreter=self._interpreter
-    )
+    ).wait()
     dists = os.listdir(self._wheel_dir)
     if len(dists) == 0:
       raise self.BuildFailure('No distributions were produced!')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,7 +17,7 @@ import pytest
 from pex.common import safe_copy, safe_open, safe_sleep, temporary_dir
 from pex.compatibility import WINDOWS, nested, to_bytes
 from pex.pex_info import PexInfo
-from pex.pip import build_wheels, download_distributions
+from pex.pip import spawn_build_wheels, spawn_download_distributions
 from pex.testing import (
     NOT_CPYTHON27,
     NOT_CPYTHON27_OR_OSX,
@@ -1342,9 +1342,15 @@ def test_issues_539_abi3_resolution():
     # sdist. Since we want to test in --no-build, we pre-resolve/build the pycparser wheel here and
     # add the resulting wheelhouse to the --no-build pex command.
     download_dir = os.path.join(td, '.downloads')
-    download_distributions(target=download_dir, requirements=['pycparser'])
+    spawn_download_distributions(
+      download_dir=download_dir,
+      requirements=['pycparser']
+    ).wait()
     wheel_dir = os.path.join(td, '.wheels')
-    build_wheels(target=wheel_dir, distributions=glob.glob(os.path.join(download_dir, '*')))
+    spawn_build_wheels(
+      wheel_dir=wheel_dir,
+      distributions=glob.glob(os.path.join(download_dir, '*'))
+    ).wait()
 
     cryptography_pex = os.path.join(td, 'cryptography.pex')
     res = run_pex_command(['-f', wheel_dir,

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,24 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pex.jobs import _ABSOLUTE_MAX_JOBS, DEFAULT_MAX_JOBS, _sanitize_max_jobs
+
+
+def test_sanitize_max_jobs_none():
+  assert DEFAULT_MAX_JOBS == _sanitize_max_jobs(None)
+
+
+def test_sanitize_max_jobs_less_then_one():
+  assert DEFAULT_MAX_JOBS == _sanitize_max_jobs(0)
+  assert DEFAULT_MAX_JOBS == _sanitize_max_jobs(-1)
+  assert DEFAULT_MAX_JOBS == _sanitize_max_jobs(-5)
+
+
+def test_sanitize_max_jobs_nominal():
+  assert 1 == _sanitize_max_jobs(1)
+
+
+def test_sanitize_max_jobs_too_large():
+  assert _ABSOLUTE_MAX_JOBS == _sanitize_max_jobs(_ABSOLUTE_MAX_JOBS)
+  assert _ABSOLUTE_MAX_JOBS == _sanitize_max_jobs(_ABSOLUTE_MAX_JOBS + 1)
+  assert _ABSOLUTE_MAX_JOBS == _sanitize_max_jobs(_ABSOLUTE_MAX_JOBS + 5)


### PR DESCRIPTION
The three major phases of a pex resolve: download, build and install,
are delegated to pip subprocesses. As such, we can easily parallelize
these operations only needing to take care of shared portions of the
filesystem the processes might mutate. In the end this is only relevant
to the build and install phases which are natural points to cache
results in a shared filesystem cache. The install phase is already
cached in this way (#815) and we add caching for the build phase as
well, both utilizing (posix in the end) guarantees around `os.rename`.

The atomic shared directory updates are achieved with `AtomicDirectory`
and the subprocess parallelization is acheived using the new `jobs`
module and request / response data object pairs to coordinate parallel
pip jobs.

Example speedups:

+ PEX build using prebuilt wheels (the #811 case):
  ```
  pex \
    --platform=manylinux1-x86_64-cp-35-m \
    --platform=manylinux1-x86_64-cp-36-m \
    --platform=manylinux1-x86_64-cp-37-m \
    --platform=macosx-10.9-x86_64-cp-35-m \
    --platform=macosx-10.9-x86_64-cp-36-m \
    --platform=macosx-10.9-x86_64-cp-37-m \
    numpy==1.17.4 \
    --python-shebang "/usr/bin/env python3" \
    -o numpy-pex1.6.2.pex
  ```
  pex version | cold      | warm
  ------------|-----------|----------
  1.6.12      | 0m41.313s | 0m20.759s
  2.0.2       | 0m53.236s | 0m27.217s
  HEAD        | 0m32.336s | 0m17.596s

+ PEX build including sdists (wheel builds):
  ```
  pex \
    pantsbuild.pants==1.22.0 \
    -o pantsbuild.pants.pex
  ```
  pex version | cold      | warm
  ------------|-----------|----------
  1.6.12      | 0m49.101s | 0m11.788s
  2.0.2       | 1m15.602s | 1m2.476s
  HEAD        | 0m47.174s | 0m15.309s

Fixes #811
Fixes #817
Fixes #818