### PR TITLE
Unify PEX buildtime and runtime wheel caches.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -162,9 +162,9 @@ def configure_clp_pex_resolution(parser):
   group.add_option(
       '--cache-dir',
       dest='cache_dir',
-      default='{pex_root}/build',
+      default='{pex_root}',
       help='The local cache directory to use for speeding up requirement '
-           'lookups. [Default: ~/.pex/build]')
+           'lookups. [Default: ~/.pex]')
 
   group.add_option(
       '--wheel', '--no-wheel', '--no-use-wheel',
@@ -458,7 +458,7 @@ def configure_clp():
   parser.add_option(
       '--pex-root',
       dest='pex_root',
-      default=None,
+      default=ENV.PEX_ROOT,
       help='Specify the pex root used in this invocation of pex. [Default: ~/.pex]'
   )
 
@@ -625,16 +625,13 @@ def main(args=None):
   if options.python and options.interpreter_constraint:
     die('The "--python" and "--interpreter-constraint" options cannot be used together.')
 
-  if options.pex_root:
-    ENV.set('PEX_ROOT', options.pex_root)
-  else:
-    options.pex_root = ENV.PEX_ROOT  # If option not specified fallback to env variable.
+  with ENV.patch(PEX_VERBOSE=str(options.verbosity),
+                 PEX_ROOT=options.pex_root) as patched_env:
 
-  # Don't alter cache if it is disabled.
-  if options.cache_dir:
-    options.cache_dir = make_relative_to_root(options.cache_dir)
+    # Don't alter cache if it is disabled.
+    if options.cache_dir:
+      options.cache_dir = make_relative_to_root(options.cache_dir)
 
-  with ENV.patch(PEX_VERBOSE=str(options.verbosity)) as patched_env:
     with TRACER.timed('Building pex'):
       pex_builder = build_pex(reqs, options)
 

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -305,7 +305,7 @@ class PEXBuilder(object):
     elif dist.location.endswith('.whl'):
       dist_hash = self._add_dist_wheel_file(dist.location, dist_name)
     else:
-      raise self.InvalidDistribution('Unsupported distribution type: {}'.format(dist))
+      raise self.InvalidDistribution('Unsupported distribution type: {}. pex can accept dist dirs and wheels.'.format(dist))
 
     # add dependency key so that it can rapidly be retrieved from cache
     self._pex_info.add_distribution(dist_name, dist_hash)

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -305,7 +305,8 @@ class PEXBuilder(object):
     elif dist.location.endswith('.whl'):
       dist_hash = self._add_dist_wheel_file(dist.location, dist_name)
     else:
-      raise self.InvalidDistribution('Unsupported distribution type: {}. pex can accept dist dirs and wheels.'.format(dist))
+      raise self.InvalidDistribution('Unsupported distribution type: {}, pex can only accept dist '
+                                     'dirs and wheels.'.format(dist))
 
     # add dependency key so that it can rapidly be retrieved from cache
     self._pex_info.add_distribution(dist_name, dist_hash)

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -11,6 +11,7 @@ from pex.common import open_zip
 from pex.compatibility import PY2
 from pex.compatibility import string as compatibility_string
 from pex.orderedset import OrderedSet
+from pex.util import CacheHelper
 from pex.variables import ENV
 from pex.version import __version__ as pex_version
 
@@ -46,7 +47,7 @@ class PexInfo(object):
   """
 
   PATH = 'PEX-INFO'
-  INTERNAL_CACHE = '.deps'
+  INSTALL_CACHE = 'installed_wheels'
 
   @classmethod
   def make_build_properties(cls, interpreter=None):
@@ -290,11 +291,11 @@ class PexInfo(object):
 
   @property
   def internal_cache(self):
-    return self.INTERNAL_CACHE
+    return '.deps'
 
   @property
   def install_cache(self):
-    return os.path.join(self.pex_root, 'install')
+    return os.path.join(self.pex_root, self.INSTALL_CACHE)
 
   @property
   def zip_unsafe_cache(self):

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -11,7 +11,6 @@ from pex.common import open_zip
 from pex.compatibility import PY2
 from pex.compatibility import string as compatibility_string
 from pex.orderedset import OrderedSet
-from pex.util import CacheHelper
 from pex.variables import ENV
 from pex.version import __version__ as pex_version
 

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -1,18 +1,19 @@
+# coding=utf-8
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import absolute_import
 
-import errno
 import functools
 import json
 import os
 import subprocess
 from collections import OrderedDict, defaultdict, namedtuple
 from textwrap import dedent
-from uuid import uuid4
 
-from pex.common import safe_mkdtemp
+from pex.pex_info import PexInfo
+
+from pex.common import AtomicDirectory, atomic_directory, safe_mkdtemp
 from pex.distribution_target import DistributionTarget
 from pex.jobs import SpawnedJob, execute_parallel, spawn_python_job
 from pex.orderedset import OrderedSet
@@ -126,35 +127,6 @@ def parsed_platform(platform=None):
   return Platform.create(platform) if platform and platform != 'current' else None
 
 
-class AtomicDirectory(namedtuple('AtomicDirectory', ['work_dir', 'target_dir'])):
-  @classmethod
-  def for_target_dir(cls, target_dir):
-    return cls(work_dir='{}.{}'.format(target_dir, uuid4().hex), target_dir=target_dir)
-
-  @property
-  def is_finalized(self):
-    return os.path.exists(self.target_dir)
-
-  def finalize(self):
-    if self.is_finalized:
-      return
-
-    try:
-      # Perform an atomic rename.
-      #
-      # Per the docs: https://docs.python.org/2.7/library/os.html#os.rename
-      #
-      #   The operation may fail on some Unix flavors if src and dst are on different filesystems.
-      #   If successful, the renaming will be an atomic operation (this is a POSIX requirement).
-      #
-      # We have satisfied the single filesystem constraint by arranging the `work_dir` to be a
-      # sibling of the `target_dir`.
-      os.rename(self.work_dir, self.target_dir)
-    except OSError as e:
-      if e.errno != errno.ENOTEMPTY:
-        raise e
-
-
 class ResolveResult(namedtuple('ResolveResult', ['target', 'download_dir'])):
   @staticmethod
   def _is_wheel(path):
@@ -198,7 +170,7 @@ class BuildResult(namedtuple('BuildResult', ['request', 'atomic_dir'])):
       build_request.fingerprint,
       build_request.target.id
     )
-    return cls(request=build_request, atomic_dir=AtomicDirectory.for_target_dir(dist_dir))
+    return cls(request=build_request, atomic_dir=AtomicDirectory(dist_dir))
 
   @property
   def is_built(self):
@@ -232,7 +204,7 @@ class InstallRequest(namedtuple('InstallRequest', ['target', 'wheel_path', 'fing
     return InstallResult.from_request(self, installation_root=installation_root)
 
 
-class InstallResult(namedtuple('InstallResult', ['request', 'atomic_dir'])):
+class InstallResult(namedtuple('InstallResult', ['request', 'installation_root', 'atomic_dir'])):
   @classmethod
   def from_request(cls, install_request, installation_root):
     install_chroot = os.path.join(
@@ -240,7 +212,11 @@ class InstallResult(namedtuple('InstallResult', ['request', 'atomic_dir'])):
       install_request.fingerprint,
       install_request.wheel_file
     )
-    return cls(request=install_request, atomic_dir=AtomicDirectory.for_target_dir(install_chroot))
+    return cls(
+      request=install_request,
+      installation_root=installation_root,
+      atomic_dir=AtomicDirectory(install_chroot)
+    )
 
   @property
   def is_installed(self):
@@ -256,6 +232,63 @@ class InstallResult(namedtuple('InstallResult', ['request', 'atomic_dir'])):
 
   def finalize_install(self, install_requests):
     self.atomic_dir.finalize()
+
+    # The install_chroot is keyed by the hash of the wheel file (zip) we installed. Here we add a
+    # key by the hash of the exploded wheel dir (the install_chroot). This latter key is used by
+    # zipped PEXes at runtime to explode their wheel chroots to the filesystem. By adding the key
+    # here we short-circuit the explode process for PEXes created and run on the same machine.
+    #
+    # From a clean cache after building a simple pex this looks like:
+    # $ rm -rf ~/.pex
+    # $ python -mpex -c pex -o /tmp/pex.pex .
+    # $ tree -L 4 ~/.pex/
+    # /home/jsirois/.pex/
+    # ├── built_wheels
+    # │   └── 1003685de2c3604dc6daab9540a66201c1d1f718
+    # │       └── cp-38-cp38
+    # │           └── pex-2.0.2-py2.py3-none-any.whl
+    # └── installed_wheels
+    #     ├── 2a594cef34d2e9109bad847358d57ac4615f81f4
+    #     │   └── pex-2.0.2-py2.py3-none-any.whl
+    #     │       ├── bin
+    #     │       ├── pex
+    #     │       └── pex-2.0.2.dist-info
+    #     └── ae13cba3a8e50262f4d730699a11a5b79536e3e1
+    #         └── pex-2.0.2-py2.py3-none-any.whl -> /home/jsirois/.pex/installed_wheels/2a594cef34d2e9109bad847358d57ac4615f81f4/pex-2.0.2-py2.py3-none-any.whl  # noqa
+    #
+    # 11 directories, 1 file
+    #
+    # And we see in the created pex, the runtime key that the layout above satisfies:
+    # $ unzip -qc /tmp/pex.pex PEX-INFO | jq .distributions
+    # {
+    #   "pex-2.0.2-py2.py3-none-any.whl": "ae13cba3a8e50262f4d730699a11a5b79536e3e1"
+    # }
+    #
+    # When the pex is run, the runtime key is followed to the build time key, avoiding re-unpacking
+    # the wheel:
+    # $ PEX_VERBOSE=1 /tmp/pex.pex --version
+    # pex: Found site-library: /usr/lib/python3.8/site-packages
+    # pex: Tainted path element: /usr/lib/python3.8/site-packages
+    # pex: Scrubbing from user site: /home/jsirois/.local/lib/python3.8/site-packages
+    # pex: Scrubbing from site-packages: /usr/lib/python3.8/site-packages
+    # pex: Activating PEX virtual environment from /tmp/pex.pex: 9.1ms
+    # pex: Bootstrap complete, performing final sys.path modifications...
+    # pex: PYTHONPATH contains:
+    # pex:     /tmp/pex.pex
+    # pex:   * /usr/lib/python38.zip
+    # pex:     /usr/lib/python3.8
+    # pex:     /usr/lib/python3.8/lib-dynload
+    # pex:     /home/jsirois/.pex/installed_wheels/2a594cef34d2e9109bad847358d57ac4615f81f4/pex-2.0.2-py2.py3-none-any.whl  # noqa
+    # pex:   * /tmp/pex.pex/.bootstrap
+    # pex:   * - paths that do not exist or will be imported via zipimport
+    # pex.pex 2.0.2
+    #
+    wheel_dir_hash = CacheHelper.dir_hash(self.install_chroot)
+    runtime_key_dir = os.path.join(self.installation_root, wheel_dir_hash)
+    with atomic_directory(runtime_key_dir) as work_dir:
+      if work_dir:
+        os.symlink(self.install_chroot, os.path.join(work_dir, self.request.wheel_file))
+
     return self._iter_requirements_requests(install_requests)
 
   def _iter_requirements_requests(self, install_requests):
@@ -442,7 +475,7 @@ class ResolveRequest(object):
     spawn_wheel_build = functools.partial(self._spawn_wheel_build, built_wheels_dir)
     to_build = list(self._iter_local_projects())
 
-    installed_wheels_dir = os.path.join(cache, 'installed_wheels')
+    installed_wheels_dir = os.path.join(cache, PexInfo.INSTALL_CACHE)
     spawn_install = functools.partial(self._spawn_install, installed_wheels_dir)
     to_install = []
 

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -11,12 +11,11 @@ import subprocess
 from collections import OrderedDict, defaultdict, namedtuple
 from textwrap import dedent
 
-from pex.pex_info import PexInfo
-
 from pex.common import AtomicDirectory, atomic_directory, safe_mkdtemp
 from pex.distribution_target import DistributionTarget
 from pex.jobs import SpawnedJob, execute_parallel, spawn_python_job
 from pex.orderedset import OrderedSet
+from pex.pex_info import PexInfo
 from pex.pip import spawn_build_wheels, spawn_download_distributions, spawn_install_wheel
 from pex.platforms import Platform
 from pex.requirements import local_project_from_requirement, local_projects_from_requirement_file

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -75,9 +75,6 @@ class Variables(object):
   def copy(self):
     return self._environ.copy()
 
-  def set(self, variable, value):
-    self._environ[variable] = str(value)
-
   def _defaulted(self, default):
     return default if self._use_defaults else None
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -69,7 +69,6 @@ def test_pex_root():
     results.assert_success()
     assert ['pex.pex'] == os.listdir(output_dir), 'Expected built pex file.'
     assert [] == os.listdir(tmp_home), 'Expected empty temp home dir.'
-    assert 'build' in os.listdir(td), 'Expected build directory in tmp pex root.'
 
 
 def test_cache_disable():

--- a/tests/test_unified_install_cache.py
+++ b/tests/test_unified_install_cache.py
@@ -10,7 +10,7 @@ from textwrap import dedent
 import pytest
 
 from pex import pip
-from pex.common import safe_rmtree, safe_open, safe_mkdir
+from pex.common import safe_mkdir, safe_open, safe_rmtree, safe_mkdtemp
 from pex.pex_info import PexInfo
 from pex.testing import run_pex_command
 
@@ -20,7 +20,9 @@ def pex_project_dir():
   return subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).decode('utf-8').strip()
 
 
-def test_issues_789_demo(pex_project_dir, tmpdir):
+def test_issues_789_demo(pex_project_dir):
+  tmpdir = safe_mkdtemp()
+
   # 1. Imagine we've pre-resolved the requirements needed in our wheel house.
   requirements = [
     'ansicolors',
@@ -37,7 +39,7 @@ def test_issues_789_demo(pex_project_dir, tmpdir):
   # 2. Also imagine this configuration is passed to a tool (PEX or a wrapper as in this test
   # example) via the CLI or other configuration data sources. For example, Pants has a `PythonSetup`
   # that combines with BUILD target data to get you this sort of configuration info outside pex.
-  resolver_settings=dict(
+  resolver_settings = dict(
     indexes=[],  # Turn off pypi.
     find_links=[wheelhouse],  # Use our wheel house.
     build=False,  # Use only pre-built wheels.

--- a/tests/test_unified_install_cache.py
+++ b/tests/test_unified_install_cache.py
@@ -1,0 +1,206 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import json
+import os
+import subprocess
+from subprocess import CalledProcessError
+from textwrap import dedent
+
+import pytest
+
+from pex import pip
+from pex.common import safe_rmtree, safe_open, safe_mkdir
+from pex.pex_info import PexInfo
+from pex.testing import run_pex_command
+
+
+@pytest.fixture(scope='module')
+def pex_project_dir():
+  return subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).decode('utf-8').strip()
+
+
+def test_issues_789_demo(pex_project_dir, tmpdir):
+  # 1. Imagine we've pre-resolved the requirements needed in our wheel house.
+  requirements = [
+    'ansicolors',
+    'isort',
+    'setuptools'  # N.B.: isort doesn't declare its setuptools dependency.
+  ]
+
+  wheelhouse = os.path.join(tmpdir, 'wheelhouse')
+  pip.spawn_download_distributions(
+    download_dir=wheelhouse,
+    requirements=requirements
+  ).wait()
+
+  # 2. Also imagine this configuration is passed to a tool (PEX or a wrapper as in this test
+  # example) via the CLI or other configuration data sources. For example, Pants has a `PythonSetup`
+  # that combines with BUILD target data to get you this sort of configuration info outside pex.
+  resolver_settings=dict(
+    indexes=[],  # Turn off pypi.
+    find_links=[wheelhouse],  # Use our wheel house.
+    build=False,  # Use only pre-built wheels.
+  )
+
+  # 3. That same configuration was used to build a standard pex:
+  resolver_args = []
+  if len(resolver_settings['find_links']) == 0:
+    resolver_args.append('--no-index')
+  else:
+    for index in resolver_settings['indexes']:
+      resolver_args.extend(['--index', index])
+
+  for repo in resolver_settings['find_links']:
+    resolver_args.extend(['--find-links', repo])
+
+  resolver_args.append('--build' if resolver_settings['build'] else '--no-build')
+
+  project_code_dir = os.path.join(tmpdir, 'project_code_dir')
+  with safe_open(os.path.join(project_code_dir, 'colorized_isort.py'), 'w') as fp:
+    fp.write(dedent("""\
+      import colors
+      import os
+      import subprocess
+      import sys
+
+
+      def run():
+        env = os.environ.copy()
+        env.update(PEX_INTERPRETER='1')
+        isort_process = subprocess.Popen(
+          [sys.argv[0], '-m', 'isort'] + sys.argv[1:],
+          env=env,
+          stdout = subprocess.PIPE,
+          stderr = subprocess.PIPE
+        )
+        stdout, stderr = isort_process.communicate()
+        print(colors.green(stdout.decode('utf-8')))
+        print(colors.red(stderr.decode('utf-8')))
+        sys.exit(isort_process.returncode)
+    """))
+
+  colorized_isort_pex = os.path.join(tmpdir, 'colorized_isort.pex')
+  args = [
+    '--sources-directory', project_code_dir,
+    '--entry-point', 'colorized_isort:run',
+    '--output-file', colorized_isort_pex
+  ]
+  result = run_pex_command(args + resolver_args + requirements)
+  result.assert_success()
+
+  # 4. Now the tool builds a "dehydrated" PEX using the standard pex + resolve settings as the
+  # template.
+  ptex_cache = os.path.join(tmpdir, '.ptex')
+
+  colorized_isort_pex_info = PexInfo.from_pex(colorized_isort_pex)
+  colorized_isort_pex_info.pex_root = ptex_cache
+
+  # Force the standard pex to extract its code. An external tool like Pants would already know the
+  # orignal source code file paths, but we need to discover here.
+  colorized_isort_pex_code_dir = os.path.join(
+    colorized_isort_pex_info.zip_unsafe_cache,
+    colorized_isort_pex_info.code_hash
+  )
+  env = os.environ.copy()
+  env.update(PEX_ROOT=ptex_cache, PEX_INTERPRETER='1', PEX_FORCE_LOCAL='1')
+  subprocess.check_call([colorized_isort_pex, '-c', ''], env=env)
+
+  colorized_isort_ptex_code_dir = os.path.join(tmpdir, 'colorized_isort_ptex_code_dir')
+  safe_mkdir(colorized_isort_ptex_code_dir)
+
+  code = []
+  for root, dirs, files in os.walk(colorized_isort_pex_code_dir):
+    rel_root = os.path.relpath(root, colorized_isort_pex_code_dir)
+    for f in files:
+      # Don't ship compiled python from the code extract above, the target interpreter will not
+      # match ours in general.
+      if f.endswith('.pyc'):
+        continue
+      rel_path = os.path.normpath(os.path.join(rel_root, f))
+      # The root __main__.py is special for any zipapp including pex, let it write its own
+      # __main__.py bootstrap. Similarly. PEX-INFO is special to pex and we want the PEX-INFO for
+      # The ptex pex, not the pex being ptexed.
+      if rel_path in ('__main__.py', PexInfo.PATH):
+        continue
+      os.symlink(os.path.join(root, f), os.path.join(colorized_isort_ptex_code_dir, rel_path))
+      code.append(rel_path)
+
+  ptex_code_dir = os.path.join(tmpdir, 'ptex_code_dir')
+
+  ptex_info = dict(code=code, resolver_settings=resolver_settings)
+  with safe_open(os.path.join(ptex_code_dir, 'PTEX-INFO'), 'w') as fp:
+    json.dump(ptex_info, fp)
+
+  with safe_open(os.path.join(ptex_code_dir, 'IPEX-INFO'), 'w') as fp:
+    fp.write(colorized_isort_pex_info.dump())
+
+  with safe_open(os.path.join(ptex_code_dir, 'ptex.py'), 'w') as fp:
+    fp.write(dedent("""\
+      import json
+      import os
+      import sys
+
+      from pex import resolver
+      from pex.common import open_zip
+      from pex.pex_builder import PEXBuilder
+      from pex.pex_info import PexInfo
+      from pex.util import CacheHelper
+      from pex.variables import ENV
+
+      self = sys.argv[0]
+      ipex_file = '{}.ipex'.format(os.path.splitext(self)[0])
+
+      if not os.path.isfile(ipex_file):
+        print('Hydrating {} to {}'.format(self, ipex_file))
+
+        ptex_pex_info = PexInfo.from_pex(self)
+        code_root = os.path.join(ptex_pex_info.zip_unsafe_cache, ptex_pex_info.code_hash)
+        with open_zip(self) as zf:
+          # Populate the pex with the pinned requirements and distribution names & hashes.
+          ipex_info = PexInfo.from_json(zf.read('IPEX-INFO'))
+          ipex_builder = PEXBuilder(pex_info=ipex_info)
+
+          # Populate the pex with the needed code.
+          ptex_info = json.load(zf.open('PTEX-INFO'))
+          for path in ptex_info['code']:
+            ipex_builder.add_source(os.path.join(code_root, path), path)
+
+        # Perform a fully pinned intransitive resolve to hydrate the install cache (not the
+        # pex!).
+        resolver_settings = ptex_info['resolver_settings']
+        resolved_distributions = resolver.resolve(
+          requirements=[str(req) for req in ipex_info.requirements],
+          cache=ipex_info.pex_root,
+          transitive=False,
+          **resolver_settings
+        )
+
+        ipex_builder.build(ipex_file)
+
+      os.execv(ipex_file, [ipex_file] + sys.argv[1:])
+    """))
+
+  colorized_isort_ptex = os.path.join(tmpdir, 'colorized_isort.ptex')
+
+  result = run_pex_command([
+    '--not-zip-safe',
+    '--always-write-cache',
+    '--pex-root', ptex_cache,
+    pex_project_dir,
+    '--sources-directory', ptex_code_dir,
+    '--sources-directory', colorized_isort_ptex_code_dir,
+    '--entry-point', 'ptex',
+    '--output-file', colorized_isort_ptex
+  ])
+  result.assert_success()
+
+  subprocess.check_call([colorized_isort_ptex, '--version'])
+  with pytest.raises(CalledProcessError):
+    subprocess.check_call([colorized_isort_ptex, '--not-a-flag'])
+
+  safe_rmtree(ptex_cache)
+
+  # The dehydrated pex now fails since it lost its hydration from the cache.
+  with pytest.raises(CalledProcessError):
+    subprocess.check_call([colorized_isort_ptex, '--version'])

--- a/tests/test_unified_install_cache.py
+++ b/tests/test_unified_install_cache.py
@@ -69,9 +69,9 @@ def test_issues_789_demo(pex_project_dir):
 
       def run():
         env = os.environ.copy()
-        env.update(PEX_INTERPRETER='1')
+        env.update(PEX_MODULE='isort')
         isort_process = subprocess.Popen(
-          [sys.argv[0], '-m', 'isort'] + sys.argv[1:],
+          sys.argv,
           env=env,
           stdout = subprocess.PIPE,
           stderr = subprocess.PIPE
@@ -164,7 +164,7 @@ def test_issues_789_demo(pex_project_dir):
           ipex_builder = PEXBuilder(pex_info=ipex_info)
 
           # Populate the pex with the needed code.
-          ptex_info = json.load(zf.open('PTEX-INFO'))
+          ptex_info = json.loads(zf.read('PTEX-INFO').decode('utf-8'))
           for path in ptex_info['code']:
             ipex_builder.add_source(os.path.join(code_root, path), path)
 

--- a/tests/test_unified_install_cache.py
+++ b/tests/test_unified_install_cache.py
@@ -10,7 +10,7 @@ from textwrap import dedent
 import pytest
 
 from pex import pip
-from pex.common import safe_mkdir, safe_open, safe_rmtree, safe_mkdtemp
+from pex.common import safe_mkdir, safe_mkdtemp, safe_open, safe_rmtree
 from pex.pex_info import PexInfo
 from pex.testing import run_pex_command
 

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -108,14 +108,6 @@ def test_pex_vars_hermetic():
     assert_pex_vars_hermetic()
 
 
-def test_pex_vars_set():
-  v = Variables(environ={})
-  assert v._get_int('HELLO') is None
-  v.set('HELLO', '42')
-  assert v._get_int('HELLO') == 42
-  assert {'HELLO': '42'} == v.copy()
-
-
 def test_pex_get_kv():
   v = Variables(environ={})
   assert v._get_kv('HELLO') is None


### PR DESCRIPTION
Previously these caches were seperate. Downloaded wheels and sdists were
cached in `~/.pex/build` and wheels unzipped from zipped pexes at
runtime were cached to `~/.pex/install`.

Now the caches are unified by the resolver such that any wheel installs
performed by it can be seen by zipped PEXes on the same machine when
they go to potentially unzip wheel distributions stored within at PEX
boot time.

N.B.: The cache is not unified in the other direction. If a zipped PEX
is executed on the same machine a PEX build resolve later happens on,
any intersecting wheels will be re-downloaded, built and installed by
the resolve finally unifying the caches from that point forward.

Fixes #820