### PR TITLE
Kill `pkg_resources` finders monkey-patching.

### DIFF
--- a/pex/finders.py
+++ b/pex/finders.py
@@ -1,268 +1,28 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-"""The finders we wish we had in setuptools.
-
-As of setuptools 3.3, the only finder for zip-based distributions is for eggs.  The path-based
-finder only searches paths ending in .egg and not in .whl (zipped or unzipped.)
-
-pex.finders augments pkg_resources with additional finders to achieve functional
-parity between wheels and eggs in terms of findability with find_distributions.
-
-To use:
-   >>> from pex.finders import register_finders
-   >>> register_finders()
-"""
-
 from __future__ import absolute_import
 
 import os
-import pkgutil
-import re
-import sys
-import zipimport
-
-import pex.third_party.pkg_resources as pkg_resources
-
-if sys.version_info >= (3, 3) and sys.implementation.name == "cpython":
-  import importlib.machinery as importlib_machinery
-else:
-  importlib_machinery = None
+from collections import namedtuple
 
 
-class ChainedFinder(object):
-  """A utility to chain together multiple pkg_resources finders."""
-
+class DistributionScript(namedtuple('DistributionScript', ['dist', 'path'])):
   @classmethod
-  def of(cls, *chained_finder_or_finder):
-    finders = []
-    for finder in chained_finder_or_finder:
-      if isinstance(finder, cls):
-        finders.extend(finder.finders)
-      else:
-        finders.append(finder)
-    return cls(finders)
+  def find(cls, dist, name):
+    script_path = os.path.join(dist.location, 'bin', name)
+    return cls(dist=dist, path=script_path) if os.path.isfile(script_path) else None
 
-  def __init__(self, finders):
-    self.finders = finders
-
-  def __call__(self, importer, path_item, only=False):
-    for finder in self.finders:
-      for dist in finder(importer, path_item, only=only):
-        yield dist
-
-  def __eq__(self, other):
-    if not isinstance(other, ChainedFinder):
-      return False
-    return self.finders == other.finders
-
-
-# The following methods are somewhat dangerous as pkg_resources._distribution_finders is not an
-# exposed API.  As it stands, pkg_resources doesn't provide an API to chain multiple distribution
-# finders together.  This is probably possible using importlib but that does us no good as the
-# importlib machinery supporting this is only available in Python >= 3.1.
-def _get_finder(importer):
-  return pkg_resources._distribution_finders.get(importer)
-
-
-def _add_finder(importer, finder):
-  """Register a new pkg_resources path finder that does not replace the existing finder."""
-
-  existing_finder = _get_finder(importer)
-
-  if not existing_finder:
-    pkg_resources.register_finder(importer, finder)
-  else:
-    pkg_resources.register_finder(importer, ChainedFinder.of(existing_finder, finder))
-
-
-def _remove_finder(importer, finder):
-  """Remove an existing finder from pkg_resources."""
-
-  existing_finder = _get_finder(importer)
-
-  if not existing_finder:
-    return
-
-  if isinstance(existing_finder, ChainedFinder):
-    try:
-      existing_finder.finders.remove(finder)
-    except ValueError:
-      return
-    if len(existing_finder.finders) == 1:
-      pkg_resources.register_finder(importer, existing_finder.finders[0])
-    elif len(existing_finder.finders) == 0:
-      pkg_resources.register_finder(importer, pkg_resources.find_nothing)
-  else:
-    pkg_resources.register_finder(importer, pkg_resources.find_nothing)
-
-
-class WheelMetadata(pkg_resources.EggMetadata):
-  """Metadata provider for zipped wheels."""
-
-  @classmethod
-  def _escape(cls, filename_component):
-    # See: https://www.python.org/dev/peps/pep-0427/#escaping-and-unicode
-    return re.sub(r"[^\w\d.]+", "_", filename_component, re.UNICODE)
-
-  @classmethod
-  def _split_wheelname(cls, wheelname):
-    # See: https://www.python.org/dev/peps/pep-0427/#file-name-convention
-    assert wheelname.endswith('.whl'), 'invalid wheel name: %s' % wheelname
-    split_wheelname = wheelname.rsplit('-', 5)
-    assert len(split_wheelname) in (5, 6), 'invalid wheel name: %s' % wheelname
-    distribution, version = split_wheelname[:2]
-    return '%s-%s' % (distribution, version)
-
-  @classmethod
-  def data_dir(cls, wheel_path):
-    """Returns the internal path of the data dir for the given wheel.
-
-    As defined https://www.python.org/dev/peps/pep-0427/#the-data-directory
-
-    :rtype: str
-    """
-    return '%s.data' % cls._split_wheelname(os.path.basename(wheel_path))
-
-  @classmethod
-  def dist_info_dir(cls, wheel_path):
-    """Returns the internal path of the dist-info dir for the given wheel.
-
-    As defined here: https://www.python.org/dev/peps/pep-0427/#the-dist-info-directory
-
-    :rtype: str
-    """
-    return '%s.dist-info' % cls._split_wheelname(os.path.basename(wheel_path))
-
-  def _setup_prefix(self):
-    path = self.module_path
-    old = None
-    while path != old:
-      if path.lower().endswith('.whl'):
-        self.egg_name = os.path.basename(path)
-        # TODO(wickman) Test the regression where we have both upper and lower cased package
-        # names.
-        self.egg_info = os.path.join(path, self.dist_info_dir(self.egg_name))
-        self.egg_root = path
-        break
-      old = path
-      path, base = os.path.split(path)
-
-
-def wheel_from_metadata(location, metadata):
-  if not metadata.has_metadata(pkg_resources.DistInfoDistribution.PKG_INFO):
-    return None
-
-  from email.parser import Parser
-  pkg_info = Parser().parsestr(metadata.get_metadata(pkg_resources.DistInfoDistribution.PKG_INFO))
-  return pkg_resources.DistInfoDistribution(
-      location=location,
-      metadata=metadata,
-      # TODO(wickman) Is this necessary or will they get picked up correctly?
-      project_name=pkg_info.get('Name'),
-      version=pkg_info.get('Version'),
-      platform=None)
-
-
-def find_wheels_on_path(importer, path_item, only=False):
-  if not os.path.isdir(path_item) or not os.access(path_item, os.R_OK):
-    return
-  if not only:
-    for entry in os.listdir(path_item):
-      if entry.lower().endswith('.whl'):
-        for dist in pkg_resources.find_distributions(os.path.join(path_item, entry)):
-          yield dist
-
-
-def find_wheels_in_zip(importer, path_item, only=False):
-  metadata = WheelMetadata(importer)
-  dist = wheel_from_metadata(path_item, metadata)
-  if dist:
-    yield dist
-
-
-__PREVIOUS_FINDER = None
-
-
-def register_finders():
-  """Register finders necessary for PEX to function properly."""
-
-  # If the previous finder is set, then we've already monkeypatched, so skip.
-  global __PREVIOUS_FINDER
-  if __PREVIOUS_FINDER:
-    return
-
-  # save previous finder so that it can be restored
-  previous_finder = _get_finder(zipimport.zipimporter)
-  assert previous_finder, 'This appears to be using an incompatible setuptools.'
-
-  # Enable finding zipped wheels.
-  pkg_resources.register_finder(
-      zipimport.zipimporter, ChainedFinder.of(pkg_resources.find_eggs_in_zip, find_wheels_in_zip))
-
-  # append the wheel finder
-  _add_finder(pkgutil.ImpImporter, find_wheels_on_path)
-
-  if importlib_machinery is not None:
-    _add_finder(importlib_machinery.FileFinder, find_wheels_on_path)
-
-  __PREVIOUS_FINDER = previous_finder
-
-
-def unregister_finders():
-  """Unregister finders necessary for PEX to function properly."""
-
-  global __PREVIOUS_FINDER
-  if not __PREVIOUS_FINDER:
-    return
-
-  pkg_resources.register_finder(zipimport.zipimporter, __PREVIOUS_FINDER)
-  _remove_finder(pkgutil.ImpImporter, find_wheels_on_path)
-
-  if importlib_machinery is not None:
-    _remove_finder(importlib_machinery.FileFinder, find_wheels_on_path)
-
-  __PREVIOUS_FINDER = None
-
-
-def get_script_from_whl(name, dist):
-  # This can get called in different contexts; in some, it looks for files in the
-  # wheel archives being used to produce a pex; in others, it looks for files in the
-  # install wheel directory included in the pex. So we need to look at both locations.
-  datadir_name = WheelMetadata.data_dir(dist.location)
-  wheel_scripts_dirs = ['bin', 'scripts',
-                         os.path.join(datadir_name, "bin"),
-                         os.path.join(datadir_name, "scripts")]
-  for wheel_scripts_dir in wheel_scripts_dirs:
-    if (dist.resource_isdir(wheel_scripts_dir) and
-        name in dist.resource_listdir(wheel_scripts_dir)):
-      # We always install wheel scripts into bin
-      script_path = os.path.join(wheel_scripts_dir, name)
-      return (
-          os.path.join(dist.location, script_path),
-          dist.get_resource_string('', script_path).replace(b'\r\n', b'\n').replace(b'\r', b'\n'))
-  return None, None
-
-
-def get_script_from_distribution(name, dist):
-  # PathMetadata: exploded distribution on disk.
-  if isinstance(dist._provider, pkg_resources.PathMetadata):
-    if dist.egg_info.endswith('.dist-info'):
-      return get_script_from_whl(name, dist)
-    else:
-      return None, None
-  # WheelMetadata: Zipped whl (in theory should not experience this at runtime.)
-  elif isinstance(dist._provider, WheelMetadata):
-    return get_script_from_whl(name, dist)
-  return None, None
+  def read_contents(self):
+    with open(self.path) as fp:
+      return fp.read()
 
 
 def get_script_from_distributions(name, dists):
   for dist in dists:
-    script_path, script_content = get_script_from_distribution(name, dist)
-    if script_path:
-      return dist, script_path, script_content
-  return None, None, None
+    distribution_script = DistributionScript.find(dist, name)
+    if distribution_script:
+      return distribution_script
 
 
 def get_entry_point_from_console_script(script, dists):

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -14,11 +14,7 @@ from pex.bootstrap import Bootstrap
 from pex.common import die
 from pex.environment import PEXEnvironment
 from pex.executor import Executor
-from pex.finders import (
-    get_entry_point_from_console_script,
-    get_script_from_distributions,
-    unregister_finders
-)
+from pex.finders import get_entry_point_from_console_script, get_script_from_distributions
 from pex.interpreter import PythonInterpreter
 from pex.orderedset import OrderedSet
 from pex.pex_info import PexInfo
@@ -457,7 +453,6 @@ class PEX(object):  # noqa: T000
     # Remove the third party resources pex uses and demote pex bootstrap code to the end of
     # sys.path for the duration of the run to allow conflicting versions supplied by user
     # dependencies to win during the course of the execution of user code.
-    unregister_finders()
     third_party.uninstall()
 
     bootstrap = Bootstrap.locate()
@@ -511,11 +506,11 @@ class PEX(object):  # noqa: T000
       TRACER.log('Found console_script %r in %r' % (entry_point, dist))
       sys.exit(self.execute_entry(entry_point))
 
-    dist, script_path, script_content = get_script_from_distributions(script_name, dists)
-    if not dist:
+    dist_script = get_script_from_distributions(script_name, dists)
+    if not dist_script:
       raise self.NotFound('Could not find script %r in pex!' % script_name)
     TRACER.log('Found script %r in %r' % (script_name, dist))
-    return self.execute_content(script_path, script_content, argv0=script_name)
+    return self.execute_content(dist_script.path, dist_script.read_contents(), argv0=script_name)
 
   @classmethod
   def execute_content(cls, name, content, argv0=None):

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -231,10 +231,6 @@ def _bootstrap(entry_point):
   from .pex_info import PexInfo
   pex_info = PexInfo.from_pex(entry_point)
   pex_warnings.configure_warnings(pex_info)
-
-  from .finders import register_finders
-  register_finders()
-
   return pex_info
 
 

--- a/pex/util.py
+++ b/pex/util.py
@@ -11,7 +11,6 @@ from site import makepath
 
 from pex.common import atomic_directory, safe_mkdir, safe_mkdtemp
 from pex.compatibility import exec_function
-from pex.finders import register_finders
 from pex.third_party.pkg_resources import (
     find_distributions,
     resource_isdir,
@@ -79,8 +78,6 @@ class DistributionHelper(object):
     return None.  If name is not provided and there is unambiguously a single
     distribution, return that distribution otherwise None.
     """
-    # Monkeypatch pkg_resources finders should it not already be so.
-    register_finders()
     if name is None:
       distributions = set(find_distributions(path))
       if len(distributions) == 1:

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -31,10 +31,7 @@ from pex.testing import (
 @contextmanager
 def yield_pex_builder(zip_safe=True, interpreter=None):
   with nested(temporary_dir(),
-              make_bdist('p1',
-                         zipped=True,
-                         zip_safe=zip_safe,
-                         interpreter=interpreter)) as (td, p1):
+              make_bdist('p1', zip_safe=zip_safe, interpreter=interpreter)) as (td, p1):
     pb = PEXBuilder(path=td, interpreter=interpreter)
     pb.add_dist_location(p1.location)
     yield pb

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -2,127 +2,33 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import zipimport
 
 import pytest
 
-import pex.third_party.pkg_resources as pkg_resources
-from pex.compatibility import to_bytes
-from pex.finders import ChainedFinder
-from pex.finders import _add_finder as add_finder
-from pex.finders import _remove_finder as remove_finder
-from pex.finders import find_wheels_in_zip, get_entry_point_from_console_script, get_script_from_whl
-
-try:
-  import mock
-except ImportError:
-  from unittest import mock
-
-
-def test_chained_finder():
-  def finder1(importer, path_item, only=False):
-    for foo in ('foo', 'bar'):
-      yield foo
-
-  def finder2(importer, path_item, only=False):
-    yield 'baz'
-
-  cf = ChainedFinder([finder1])
-  assert list(cf(None, None)) == ['foo', 'bar']
-
-  cf = ChainedFinder([finder1, finder2])
-  assert list(cf(None, None)) == ['foo', 'bar', 'baz']
-
-
-GET_FINDER = 'pex.finders._get_finder'
-REGISTER_FINDER = 'pex.finders.pkg_resources.register_finder'
-
-
-def test_add_new_finder():
-  with mock.patch(GET_FINDER) as mock_get_finder:
-    with mock.patch(REGISTER_FINDER) as mock_register_finder:
-      mock_get_finder.return_value = None
-      add_finder('foo', 'bar')
-      mock_register_finder.assert_called_with('foo', 'bar')
-
-
-def test_append_finder():
-  with mock.patch(GET_FINDER) as mock_get_finder:
-    with mock.patch(REGISTER_FINDER) as mock_register_finder:
-      mock_get_finder.return_value = 'bar'
-      add_finder('foo', 'baz')
-      mock_register_finder.assert_called_with('foo', ChainedFinder(['bar', 'baz']))
-
-  with mock.patch(GET_FINDER) as mock_get_finder:
-    with mock.patch(REGISTER_FINDER) as mock_register_finder:
-      mock_get_finder.return_value = ChainedFinder(['bar'])
-      add_finder('foo', 'baz')
-      mock_register_finder.assert_called_with('foo', ChainedFinder(['bar', 'baz']))
-
-
-def test_remove_finder():
-  # wasn't registered
-  with mock.patch(GET_FINDER) as mock_get_finder:
-    with mock.patch(REGISTER_FINDER) as mock_register_finder:
-      mock_get_finder.return_value = None
-      remove_finder('foo', 'baz')
-      assert not mock_register_finder.called
-
-  # was registered but we're asking for the wrong one
-  with mock.patch(GET_FINDER) as mock_get_finder:
-    with mock.patch(REGISTER_FINDER) as mock_register_finder:
-      mock_get_finder.return_value = ChainedFinder(['bar'])
-      remove_finder('foo', 'baz')
-      assert not mock_register_finder.called
-
-  # was registered but we're asking for the wrong one
-  with mock.patch(GET_FINDER) as mock_get_finder:
-    with mock.patch(REGISTER_FINDER) as mock_register_finder:
-      cf = ChainedFinder(['bar', 'baz', 'bak'])
-      mock_get_finder.return_value = cf
-      remove_finder('foo', 'baz')
-      assert cf.finders == ['bar', 'bak']
-      assert not mock_register_finder.called
-
-  # was registered but we're asking for the wrong one
-  with mock.patch(GET_FINDER) as mock_get_finder:
-    with mock.patch(REGISTER_FINDER) as mock_register_finder:
-      cf = ChainedFinder(['bar', 'baz'])
-      mock_get_finder.return_value = cf
-      remove_finder('foo', 'baz')
-      mock_register_finder.assert_called_with('foo', 'bar')
-
-  # was registered but we're asking for the wrong one
-  with mock.patch(GET_FINDER) as mock_get_finder:
-    with mock.patch(REGISTER_FINDER) as mock_register_finder:
-      mock_get_finder.return_value = 'bar'
-      remove_finder('foo', 'bar')
-      mock_register_finder.assert_called_with('foo', pkg_resources.find_nothing)
-
-  # was registered but we're asking for the wrong one
-  with mock.patch(GET_FINDER) as mock_get_finder:
-    with mock.patch(REGISTER_FINDER) as mock_register_finder:
-      mock_get_finder.return_value = ChainedFinder(['bar'])
-      remove_finder('foo', 'bar')
-      mock_register_finder.assert_called_with('foo', pkg_resources.find_nothing)
+from pex.finders import get_entry_point_from_console_script, get_script_from_distributions
+from pex.pip import spawn_install_wheel
+from pex.util import DistributionHelper
 
 
 # In-part, tests a bug where the wheel distribution name has dashes as reported in:
 #   https://github.com/pantsbuild/pex/issues/443
 #   https://github.com/pantsbuild/pex/issues/551
-def test_get_script_from_whl():
+def test_get_script_from_distributions(tmpdir):
   whl_path = './tests/example_packages/aws_cfn_bootstrap-1.4-py2-none-any.whl'
-  dists = list(find_wheels_in_zip(zipimport.zipimporter(whl_path), whl_path))
-  assert len(dists) == 1
+  install_dir = os.path.join(str(tmpdir), os.path.basename(whl_path))
+  spawn_install_wheel(wheel=whl_path, install_dir=install_dir).wait()
 
-  dist = dists[0]
+  dist = DistributionHelper.distribution_from_path(install_dir)
   assert 'aws-cfn-bootstrap' == dist.project_name
 
-  script_path, script_content = get_script_from_whl('cfn-signal', dist)
-  assert os.path.join(whl_path, 'aws_cfn_bootstrap-1.4.data/scripts/cfn-signal') == script_path
-  assert script_content.startswith(to_bytes('#!')), 'Expected a `scripts`-style script w/shebang.'
+  dist_script = get_script_from_distributions('cfn-signal', [dist])
+  assert dist_script.dist is dist
+  assert os.path.join(install_dir, 'bin/cfn-signal') == dist_script.path
+  assert dist_script.read_contents().startswith('#!'), (
+    'Expected a `scripts`-style script w/shebang.'
+  )
 
-  assert (None, None) == get_script_from_whl('non_existent_script', dist)
+  assert None is get_script_from_distributions('non_existent_script', [dist])
 
 
 class FakeDist(object):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -38,7 +38,7 @@ from pex.testing import (
     temporary_content
 )
 from pex.third_party import pkg_resources
-from pex.util import DistributionHelper, named_temporary_file
+from pex.util import named_temporary_file
 
 
 def make_env(**kwargs):
@@ -171,7 +171,7 @@ def test_entry_point_exit_code():
 
   with temporary_content({'setup.py': setup_py, 'my_app.py': my_app}) as project_dir:
     installer = WheelBuilder(project_dir)
-    dist = DistributionHelper.distribution_from_path(installer.bdist())
+    dist = installer.bdist()
     so, rc = run_simple_pex_test('', env=make_env(PEX_SCRIPT='my_app'), dists=[dist])
     assert so.decode('utf-8').strip() == error_msg
     assert rc == 1

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -7,13 +7,12 @@ import zipfile
 
 import pytest
 
-from pex.common import open_zip, temporary_dir
+from pex.common import temporary_dir
 from pex.compatibility import WINDOWS, nested
 from pex.pex import PEX
 from pex.pex_builder import BOOTSTRAP_DIR, PEXBuilder
-from pex.testing import make_bdist, safe_mkdir
+from pex.testing import make_bdist
 from pex.testing import write_simple_pex as write_pex
-from pex.util import DistributionHelper
 
 exe_main = """
 import sys
@@ -37,7 +36,7 @@ with open(sys.argv[1], 'w') as fp:
 
 def test_pex_builder():
   # test w/ and w/o zipfile dists
-  with nested(temporary_dir(), make_bdist('p1', zipped=True)) as (td, p1):
+  with nested(temporary_dir(), make_bdist('p1')) as (td, p1):
     pb = write_pex(td, exe_main, dists=[p1])
 
     success_txt = os.path.join(td, 'success.txt')
@@ -47,14 +46,7 @@ def test_pex_builder():
       assert fp.read() == 'success'
 
   # test w/ and w/o zipfile dists
-  with nested(temporary_dir(), temporary_dir(), make_bdist('p1', zipped=True)) as (
-      td1, td2, p1):
-    target_egg_dir = os.path.join(td2, os.path.basename(p1.location))
-    safe_mkdir(target_egg_dir)
-    with open_zip(p1.location, 'r') as zf:
-      zf.extractall(target_egg_dir)
-    p1 = DistributionHelper.distribution_from_path(target_egg_dir)
-
+  with nested(temporary_dir(), temporary_dir(), make_bdist('p1')) as (td1, td2, p1):
     pb = write_pex(td1, exe_main, dists=[p1])
 
     success_txt = os.path.join(td1, 'success.txt')
@@ -68,10 +60,9 @@ def test_pex_builder_wheeldep():
   """Repeat the pex_builder test, but this time include an import of
   something from a wheel that doesn't come in importable form.
   """
-  with nested(temporary_dir(), make_bdist('p1', zipped=True)) as (td, p1):
+  with nested(temporary_dir(), make_bdist('p1')) as (td, p1):
     pyparsing_path = "./tests/example_packages/pyparsing-2.1.10-py2.py3-none-any.whl"
-    dist = DistributionHelper.distribution_from_path(pyparsing_path)
-    pb = write_pex(td, wheeldeps_exe_main, dists=[p1, dist])
+    pb = write_pex(td, wheeldeps_exe_main, dists=[p1, pyparsing_path])
     success_txt = os.path.join(td, 'success.txt')
     PEX(td, interpreter=pb.interpreter).run(args=[success_txt])
     assert os.path.exists(success_txt)


### PR DESCRIPTION
We no longer used any of this in production except for one `PEXBuilder`
API which is converted to use `pex.pip` to install zipped wheels when
encountered so that they can be found by standard `pkg_resources`
finders.

Tests that use zipped wheels are similarly updated.