### PR TITLE
Fix pex resolution to respect --ignore-errors.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -234,8 +234,8 @@ def configure_clp_pex_options(parser):
       dest='ignore_errors',
       default=False,
       action='store_true',
-      help='Ignore run-time requirement resolution errors when invoking the pex. '
-           '[Default: %default]')
+      help='Ignore requirement resolution solver errors when building pexes and later invoking '
+           'them. [Default: %default]')
 
   group.add_option(
       '--inherit-path',
@@ -565,7 +565,8 @@ def build_pex(reqs, options):
                                 build=options.build,
                                 use_wheel=options.use_wheel,
                                 compile=options.compile,
-                                max_parallel_jobs=options.max_parallel_jobs)
+                                max_parallel_jobs=options.max_parallel_jobs,
+                                ignore_errors=options.ignore_errors)
 
       for resolved_dist in resolveds:
         log('  %s -> %s' % (resolved_dist.requirement, resolved_dist.distribution),

--- a/pex/package.py
+++ b/pex/package.py
@@ -15,12 +15,18 @@ def distribution_compatible(dist, supported_tags=None):
     by the platform in question; defaults to the current interpreter's supported tags.
   :returns: True if the distribution is compatible, False if it is unrecognized or incompatible.
   """
-  if supported_tags is None:
-    supported_tags = get_supported()
 
   filename, ext = os.path.splitext(os.path.basename(dist.location))
   if ext.lower() != '.whl':
-    return False
+    # This supports resolving pex's own vendored distributions which are vendored in directory
+    # directory with the project name (`pip/` for pip) and not the corresponding wheel name
+    # (`pip-19.3.1-py2.py3-none-any.whl/` for pip). Pes only vendors universal wheels for all
+    # platforms it supports at buildtime and runtime so this is always safe.
+    return True
+
+  if supported_tags is None:
+    supported_tags = get_supported()
+
   try:
     name_, raw_version_, py_tag, abi_tag, arch_tag = filename.rsplit('-', 4)
   except ValueError:

--- a/pex/package.py
+++ b/pex/package.py
@@ -20,7 +20,7 @@ def distribution_compatible(dist, supported_tags=None):
   if ext.lower() != '.whl':
     # This supports resolving pex's own vendored distributions which are vendored in directory
     # directory with the project name (`pip/` for pip) and not the corresponding wheel name
-    # (`pip-19.3.1-py2.py3-none-any.whl/` for pip). Pes only vendors universal wheels for all
+    # (`pip-19.3.1-py2.py3-none-any.whl/` for pip). Pex only vendors universal wheels for all
     # platforms it supports at buildtime and runtime so this is always safe.
     return True
 

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -13,7 +13,7 @@ from pex.distribution_target import DistributionTarget
 from pex.finders import get_entry_point_from_console_script, get_script_from_distributions
 from pex.interpreter import PythonInterpreter
 from pex.pex_info import PexInfo
-from pex.pip import spawn_install_wheel
+from pex.pip import get_pip
 from pex.third_party.pkg_resources import DefaultProvider, ZipProvider, get_provider
 from pex.tracer import TRACER
 from pex.util import CacheHelper, DistributionHelper
@@ -278,7 +278,7 @@ class PEXBuilder(object):
 
   def _add_dist_wheel_file(self, path, dist_name):
     with temporary_dir() as install_dir:
-      spawn_install_wheel(
+      get_pip().spawn_install_wheel(
         wheel=path,
         install_dir=install_dir,
         target=DistributionTarget.for_interpreter(self.interpreter)
@@ -327,7 +327,7 @@ class PEXBuilder(object):
     dist_path = dist
     if os.path.isfile(dist_path) and dist_path.endswith('.whl'):
       dist_path = os.path.join(safe_mkdtemp(), os.path.basename(dist))
-      spawn_install_wheel(
+      get_pip().spawn_install_wheel(
         wheel=dist,
         install_dir=dist_path,
         target=DistributionTarget.for_interpreter(self.interpreter)

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -20,7 +20,7 @@ class Pip(object):
   def create(cls, path=None):
     """Creates a pip tool with PEX isolation at path.
 
-    :param str path: The path to build the pip tool pex at; A temporary directory by default.
+    :param str path: The path to build the pip tool pex at; a temporary directory by default.
     """
     from pex.pex_builder import PEXBuilder
 

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -4,176 +4,238 @@
 
 from __future__ import absolute_import, print_function
 
+import os
 from collections import deque
+from textwrap import dedent
 
+from pex import third_party
 from pex.compatibility import urlparse
 from pex.distribution_target import DistributionTarget
-from pex.jobs import spawn_python_job
+from pex.jobs import Job
 from pex.variables import ENV
 
 
-def _spawn_pip_isolated(args, cache=None, interpreter=None):
-  pip_args = ['-m', 'pip', '--disable-pip-version-check', '--isolated', '--exists-action', 'i']
+class Pip(object):
+  @classmethod
+  def create(cls, path=None):
+    """Creates a pip tool with PEX isolation at path.
 
-  # The max pip verbosity is -vvv and for pex it's -vvvvvvvvv; so we scale down by a factor of 3.
-  verbosity = ENV.PEX_VERBOSE // 3
-  if verbosity > 0:
-    pip_args.append('-{}'.format('v' * verbosity))
-  else:
-    pip_args.append('-q')
+    :param str path: The path to build the pip tool pex at; A temporary directory by default.
+    """
+    from pex.pex_builder import PEXBuilder
 
-  if cache:
-    pip_args.extend(['--cache-dir', cache])
-  else:
-    pip_args.append('--no-cache-dir')
-
-  return spawn_python_job(
-    args=pip_args + args,
-    interpreter=interpreter,
-    expose=['pip', 'setuptools', 'wheel']
-  )
+    isolated_pip_builder = PEXBuilder(path=path)
+    pythonpath = third_party.expose(['pip', 'setuptools', 'wheel'])
+    isolated_pip_environment = third_party.pkg_resources.Environment(search_path=pythonpath)
+    for dist_name in isolated_pip_environment:
+      for dist in isolated_pip_environment[dist_name]:
+        isolated_pip_builder.add_dist_location(dist=dist.location)
+    with open(os.path.join(isolated_pip_builder.path(), 'run_pip.py'), 'w') as fp:
+      fp.write(dedent("""\
+        import os
+        import runpy
+        import sys
 
 
-def _calculate_package_index_options(indexes=None, find_links=None):
-  trusted_hosts = []
+        # Propagate un-vendored setuptools and wheel to pip for any legacy setup.py builds it needs
+        # to perform.
+        os.environ['__PEX_UNVENDORED__'] = '1'
+        os.environ['PYTHONPATH'] = os.pathsep.join(sys.path)
 
-  def maybe_trust_insecure_host(url):
-    url_info = urlparse.urlparse(url)
-    if 'http' == url_info.scheme:
-      # Implicitly trust explicitly asked for http indexes and find_links repos instead of requiring
-      # seperate trust configuration.
-      trusted_hosts.append(url_info.netloc)
-    return url
+        runpy.run_module('pip', run_name='__main__')
+      """))
+    isolated_pip_builder.set_executable(fp.name)
+    isolated_pip_builder.freeze()
 
-  # N.B.: We interpret None to mean accept pip index defaults, [] to mean turn off all index use.
-  if indexes is not None:
-    if len(indexes) == 0:
-      yield '--no-index'
+    return cls(isolated_pip_builder.path())
+
+  def __init__(self, pip_pex_path):
+    self._pip_pex_path = pip_pex_path
+
+  def _spawn_pip_isolated(self, args, cache=None, interpreter=None):
+    pip_args = ['--disable-pip-version-check', '--isolated', '--exists-action', 'i']
+
+    # The max pip verbosity is -vvv and for pex it's -vvvvvvvvv; so we scale down by a factor of 3.
+    pex_verbosity = ENV.PEX_VERBOSE
+    pip_verbosity = pex_verbosity // 3
+    if pip_verbosity > 0:
+      pip_args.append('-{}'.format('v' * pip_verbosity))
     else:
-      all_indexes = deque(indexes)
-      yield '--index-url'
-      yield maybe_trust_insecure_host(all_indexes.popleft())
-      if all_indexes:
-        for extra_index in all_indexes:
-          yield '--extra-index-url'
-          yield maybe_trust_insecure_host(extra_index)
+      pip_args.append('-q')
 
-  if find_links:
-    for find_link_url in find_links:
-      yield '--find-links'
-      yield maybe_trust_insecure_host(find_link_url)
+    if cache:
+      pip_args.extend(['--cache-dir', cache])
+    else:
+      pip_args.append('--no-cache-dir')
 
-  for trusted_host in trusted_hosts:
-    yield '--trusted-host'
-    yield trusted_host
+    command = pip_args + args
+    with ENV.strip().patch(PEX_ROOT=ENV.PEX_ROOT, PEX_VERBOSE=str(pex_verbosity)) as env:
+      from pex.pex import PEX
+      pip = PEX(pex=self._pip_pex_path, interpreter=interpreter)
+      return Job(
+        command=pip.cmdline(command),
+        process=pip.run(
+          args=command,
+          env=env,
+          blocking=False
+        )
+      )
+
+  def _calculate_package_index_options(self, indexes=None, find_links=None):
+    trusted_hosts = []
+
+    def maybe_trust_insecure_host(url):
+      url_info = urlparse.urlparse(url)
+      if 'http' == url_info.scheme:
+        # Implicitly trust explicitly asked for http indexes and find_links repos instead of
+        # requiring seperate trust configuration.
+        trusted_hosts.append(url_info.netloc)
+      return url
+
+    # N.B.: We interpret None to mean accept pip index defaults, [] to mean turn off all index use.
+    if indexes is not None:
+      if len(indexes) == 0:
+        yield '--no-index'
+      else:
+        all_indexes = deque(indexes)
+        yield '--index-url'
+        yield maybe_trust_insecure_host(all_indexes.popleft())
+        if all_indexes:
+          for extra_index in all_indexes:
+            yield '--extra-index-url'
+            yield maybe_trust_insecure_host(extra_index)
+
+    if find_links:
+      for find_link_url in find_links:
+        yield '--find-links'
+        yield maybe_trust_insecure_host(find_link_url)
+
+    for trusted_host in trusted_hosts:
+      yield '--trusted-host'
+      yield trusted_host
+
+  def spawn_download_distributions(self,
+                                   download_dir,
+                                   requirements=None,
+                                   requirement_files=None,
+                                   constraint_files=None,
+                                   allow_prereleases=False,
+                                   transitive=True,
+                                   target=None,
+                                   indexes=None,
+                                   find_links=None,
+                                   cache=None,
+                                   build=True,
+                                   use_wheel=True):
+
+    target = target or DistributionTarget.current()
+
+    platform = target.get_platform()
+    if not use_wheel:
+      if not build:
+        raise ValueError('Cannot both ignore wheels (use_wheel=False) and refrain from building '
+                         'distributions (build=False).')
+      elif target.is_foreign:
+        raise ValueError('Cannot ignore wheels (use_wheel=False) when resolving for a foreign '
+                         'platform: {}'.format(platform))
+
+    download_cmd = ['download', '--dest', download_dir]
+    package_index_options = self._calculate_package_index_options(
+      indexes=indexes,
+      find_links=find_links
+    )
+    download_cmd.extend(package_index_options)
+
+    if target.is_foreign:
+      # We're either resolving for a different host / platform or a different interpreter for the
+      # current platform that we have no access to; so we need to let pip know and not otherwise
+      # pickup platform info from the interpreter we execute pip with.
+      download_cmd.extend(['--platform', platform.platform])
+      download_cmd.extend(['--implementation', platform.impl])
+      download_cmd.extend(['--python-version', platform.version])
+      download_cmd.extend(['--abi', platform.abi])
+
+    if target.is_foreign or not build:
+      download_cmd.extend(['--only-binary', ':all:'])
+
+    if not use_wheel:
+      download_cmd.extend(['--no-binary', ':all:'])
+
+    if allow_prereleases:
+      download_cmd.append('--pre')
+
+    if not transitive:
+      download_cmd.append('--no-deps')
+
+    if requirement_files:
+      for requirement_file in requirement_files:
+        download_cmd.extend(['--requirement', requirement_file])
+
+    if constraint_files:
+      for constraint_file in constraint_files:
+        download_cmd.extend(['--constraint', constraint_file])
+
+    download_cmd.extend(requirements)
+
+    return self._spawn_pip_isolated(download_cmd, cache=cache, interpreter=target.get_interpreter())
+
+  def spawn_build_wheels(self,
+                         distributions,
+                         wheel_dir,
+                         interpreter=None,
+                         indexes=None,
+                         find_links=None,
+                         cache=None):
+
+    wheel_cmd = ['wheel', '--no-deps', '--wheel-dir', wheel_dir]
+
+    # If the build is PEP-517 compliant it may need to resolve build requirements.
+    wheel_cmd.extend(self._calculate_package_index_options(indexes=indexes, find_links=find_links))
+
+    wheel_cmd.extend(distributions)
+    return self._spawn_pip_isolated(wheel_cmd, cache=cache, interpreter=interpreter)
+
+  def spawn_install_wheel(self,
+                          wheel,
+                          install_dir,
+                          compile=False,
+                          overwrite=False,
+                          cache=None,
+                          target=None):
+
+    target = target or DistributionTarget.current()
+
+    install_cmd = [
+      'install',
+      '--no-deps',
+      '--no-index',
+      '--only-binary', ':all:',
+      '--target', install_dir
+    ]
+
+    interpreter = target.get_interpreter()
+    if target.is_foreign:
+      if compile:
+        raise ValueError('Cannot compile bytecode for {} using {} because the wheel has a foreign '
+                         'platform.'.format(wheel, interpreter))
+
+      # We're installing a wheel for a foreign platform. This is just an unpacking operation though;
+      # so we don't actually need to perform it with a target platform compatible interpreter.
+      install_cmd.append('--ignore-requires-python')
+
+    install_cmd.append('--compile' if compile else '--no-compile')
+    if overwrite:
+      install_cmd.extend(['--upgrade', '--force-reinstall'])
+    install_cmd.append(wheel)
+    return self._spawn_pip_isolated(install_cmd, cache=cache, interpreter=interpreter)
 
 
-def spawn_download_distributions(download_dir,
-                                 requirements=None,
-                                 requirement_files=None,
-                                 constraint_files=None,
-                                 allow_prereleases=False,
-                                 transitive=True,
-                                 target=None,
-                                 indexes=None,
-                                 find_links=None,
-                                 cache=None,
-                                 build=True,
-                                 use_wheel=True):
-
-  target = target or DistributionTarget.current()
-
-  platform = target.get_platform()
-  if not use_wheel:
-    if not build:
-      raise ValueError('Cannot both ignore wheels (use_wheel=False) and refrain from building '
-                       'distributions (build=False).')
-    elif target.is_foreign:
-      raise ValueError('Cannot ignore wheels (use_wheel=False) when resolving for a foreign '
-                       'platform: {}'.format(platform))
-
-  download_cmd = ['download', '--dest', download_dir]
-  download_cmd.extend(_calculate_package_index_options(indexes=indexes, find_links=find_links))
-
-  if target.is_foreign:
-    # We're either resolving for a different host / platform or a different interpreter for the
-    # current platform that we have no access to; so we need to let pip know and not otherwise
-    # pickup platform info from the interpreter we execute pip with.
-    download_cmd.extend(['--platform', platform.platform])
-    download_cmd.extend(['--implementation', platform.impl])
-    download_cmd.extend(['--python-version', platform.version])
-    download_cmd.extend(['--abi', platform.abi])
-
-  if target.is_foreign or not build:
-    download_cmd.extend(['--only-binary', ':all:'])
-
-  if not use_wheel:
-    download_cmd.extend(['--no-binary', ':all:'])
-
-  if allow_prereleases:
-    download_cmd.append('--pre')
-
-  if not transitive:
-    download_cmd.append('--no-deps')
-
-  if requirement_files:
-    for requirement_file in requirement_files:
-      download_cmd.extend(['--requirement', requirement_file])
-
-  if constraint_files:
-    for constraint_file in constraint_files:
-      download_cmd.extend(['--constraint', constraint_file])
-
-  download_cmd.extend(requirements)
-
-  return _spawn_pip_isolated(download_cmd, cache=cache, interpreter=target.get_interpreter())
+_PIP = None
 
 
-def spawn_build_wheels(distributions,
-                       wheel_dir,
-                       interpreter=None,
-                       indexes=None,
-                       find_links=None,
-                       cache=None):
-
-  wheel_cmd = ['wheel', '--no-deps', '--wheel-dir', wheel_dir]
-
-  # If the build is PEP-517 compliant it may need to resolve build requirements.
-  wheel_cmd.extend(_calculate_package_index_options(indexes=indexes, find_links=find_links))
-
-  wheel_cmd.extend(distributions)
-  return _spawn_pip_isolated(wheel_cmd, cache=cache, interpreter=interpreter)
-
-
-def spawn_install_wheel(wheel,
-                        install_dir,
-                        compile=False,
-                        overwrite=False,
-                        cache=None,
-                        target=None):
-
-  target = target or DistributionTarget.current()
-
-  install_cmd = [
-    'install',
-    '--no-deps',
-    '--no-index',
-    '--only-binary', ':all:',
-    '--target', install_dir
-  ]
-
-  interpreter = target.get_interpreter()
-  if target.is_foreign:
-    if compile:
-      raise ValueError('Cannot compile bytecode for {} using {} because the wheel has a foreign '
-                       'platform.'.format(wheel, interpreter))
-
-    # We're installing a wheel for a foreign platform. This is just an unpacking operation though;
-    # so we don't actually need to perform it with a target platform compatible interpreter.
-    install_cmd.append('--ignore-requires-python')
-
-  install_cmd.append('--compile' if compile else '--no-compile')
-  if overwrite:
-    install_cmd.extend(['--upgrade', '--force-reinstall'])
-  install_cmd.append(wheel)
-  return _spawn_pip_isolated(install_cmd, cache=cache, interpreter=interpreter)
+def get_pip():
+  """Returns a lazily instantiated global Pip object that is safe for un-coordinated use."""
+  global _PIP
+  if _PIP is None:
+    _PIP = Pip.create()
+  return _PIP

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -21,7 +21,7 @@ from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
-from pex.pip import spawn_build_wheels, spawn_install_wheel
+from pex.pip import get_pip
 from pex.third_party.pkg_resources import Distribution
 from pex.util import DistributionHelper, named_temporary_file
 
@@ -161,7 +161,7 @@ class WheelBuilder(object):
     self._interpreter = interpreter or PythonInterpreter.get()
 
   def bdist(self):
-    spawn_build_wheels(
+    get_pip().spawn_build_wheels(
       distributions=[self._source_dir],
       wheel_dir=self._wheel_dir,
       interpreter=self._interpreter
@@ -211,7 +211,7 @@ def make_bdist(name='my_project', version='0.0.0', zip_safe=True, interpreter=No
                    **kwargs) as dist_location:
 
     install_dir = os.path.join(safe_mkdtemp(), os.path.basename(dist_location))
-    spawn_install_wheel(
+    get_pip().spawn_install_wheel(
       wheel=dist_location,
       install_dir=install_dir,
       target=DistributionTarget.for_interpreter(interpreter)

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -106,6 +106,11 @@ class Variables(object):
     except KeyError:
       return self._defaulted(default)
 
+  def strip(self):
+    stripped_environ = {k: v
+                        for k, v in self.copy().items() if not k.startswith(('PEX_', '__PEX_'))}
+    return Variables(environ=stripped_environ)
+
   def strip_defaults(self):
     """Returns a copy of these variables but with defaults stripped.
 

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 from pex.finders import get_entry_point_from_console_script, get_script_from_distributions
-from pex.pip import spawn_install_wheel
+from pex.pip import get_pip
 from pex.util import DistributionHelper
 
 
@@ -16,7 +16,7 @@ from pex.util import DistributionHelper
 def test_get_script_from_distributions(tmpdir):
   whl_path = './tests/example_packages/aws_cfn_bootstrap-1.4-py2-none-any.whl'
   install_dir = os.path.join(str(tmpdir), os.path.basename(whl_path))
-  spawn_install_wheel(wheel=whl_path, install_dir=install_dir).wait()
+  get_pip().spawn_install_wheel(wheel=whl_path, install_dir=install_dir).wait()
 
   dist = DistributionHelper.distribution_from_path(install_dir)
   assert 'aws-cfn-bootstrap' == dist.project_name

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,7 +17,7 @@ import pytest
 from pex.common import safe_copy, safe_open, safe_sleep, temporary_dir
 from pex.compatibility import WINDOWS, nested, to_bytes
 from pex.pex_info import PexInfo
-from pex.pip import spawn_build_wheels, spawn_download_distributions
+from pex.pip import get_pip
 from pex.testing import (
     NOT_CPYTHON27,
     NOT_CPYTHON27_OR_OSX,
@@ -1341,12 +1341,12 @@ def test_issues_539_abi3_resolution():
     # sdist. Since we want to test in --no-build, we pre-resolve/build the pycparser wheel here and
     # add the resulting wheelhouse to the --no-build pex command.
     download_dir = os.path.join(td, '.downloads')
-    spawn_download_distributions(
+    get_pip().spawn_download_distributions(
       download_dir=download_dir,
       requirements=['pycparser']
     ).wait()
     wheel_dir = os.path.join(td, '.wheels')
-    spawn_build_wheels(
+    get_pip().spawn_build_wheels(
       wheel_dir=wheel_dir,
       distributions=glob.glob(os.path.join(download_dir, '*'))
     ).wait()

--- a/tests/test_unified_install_cache.py
+++ b/tests/test_unified_install_cache.py
@@ -9,9 +9,9 @@ from textwrap import dedent
 
 import pytest
 
-from pex import pip
 from pex.common import safe_mkdir, safe_mkdtemp, safe_open, safe_rmtree
 from pex.pex_info import PexInfo
+from pex.pip import get_pip
 from pex.testing import run_pex_command
 
 
@@ -31,7 +31,7 @@ def test_issues_789_demo(pex_project_dir):
   ]
 
   wheelhouse = os.path.join(tmpdir, 'wheelhouse')
-  pip.spawn_download_distributions(
+  get_pip().spawn_download_distributions(
     download_dir=wheelhouse,
     requirements=requirements
   ).wait()


### PR DESCRIPTION
Previously, pip might warn in red that versions were mismatched but
we would get no failure until pex runtime resolution. Improve pex
runtime resolution error messages and implement pex buildtime
resolution sanity checks when --no-ignore-errors.

At buildtime we now get:
```
$ python -mpex wheel pantsbuild.pants==1.24.0.dev2
Failed to resolve compatible distributions:
1: pantsbuild.pants==1.24.0.dev2 requires wheel==0.31.1 but wheel==0.33.6 was resolved
```

And the corresponding runtime error is now:
```
$ PEX_IGNORE_ERRORS=false python -mpex wheel pantsbuild.pants==1.24.0.dev2 --ignore-errors
Failed to execute PEX file. Needed linux_x86_64-cp-38-cp38 compatible dependencies for:
 1: wheel==0.31.1
    Required by:
      pantsbuild.pants==1.24.0.dev2
    But this pex only contains:
      wheel-0.33.6-py2.py3-none-any.whl
```