### PR TITLE
De-vendor pex just once per version.

### DIFF
--- a/tests/test_third_party.py
+++ b/tests/test_third_party.py
@@ -1,0 +1,43 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import subprocess
+import sys
+from contextlib import contextmanager
+
+from pex import third_party
+from pex.common import temporary_dir
+from pex.variables import ENV
+
+
+@contextmanager
+def temporary_pex_root():
+  with temporary_dir() as pex_root, ENV.patch(PEX_ROOT=pex_root) as env:
+    original_isolated = third_party._ISOLATED
+    try:
+      third_party._ISOLATED = None
+      yield pex_root, env
+    finally:
+      third_party._ISOLATED = original_isolated
+
+
+def test_isolated_pex_root():
+  with temporary_pex_root() as (pex_root, _):
+    devendored_chroot = third_party.isolated()
+    assert pex_root == os.path.commonprefix([pex_root, devendored_chroot])
+
+
+def test_isolated_idempotent_inprocess():
+  with temporary_pex_root():
+    assert third_party.isolated() == third_party.isolated()
+
+
+def test_isolated_idempotent_subprocess():
+  with temporary_pex_root() as (_, env):
+    devendored_chroot = third_party.isolated()
+    stdout = subprocess.check_output(
+      args=[sys.executable, '-c', 'from pex.third_party import isolated; print(isolated())'],
+      env=env
+    )
+    assert devendored_chroot == stdout.decode('utf-8').strip()

--- a/tests/test_third_party.py
+++ b/tests/test_third_party.py
@@ -13,31 +13,31 @@ from pex.variables import ENV
 
 @contextmanager
 def temporary_pex_root():
-  with temporary_dir() as pex_root, ENV.patch(PEX_ROOT=pex_root) as env:
+  with temporary_dir() as pex_root, ENV.patch(PEX_ROOT=os.path.realpath(pex_root)) as env:
     original_isolated = third_party._ISOLATED
     try:
       third_party._ISOLATED = None
-      yield pex_root, env
+      yield os.path.realpath(pex_root), env
     finally:
       third_party._ISOLATED = original_isolated
 
 
 def test_isolated_pex_root():
   with temporary_pex_root() as (pex_root, _):
-    devendored_chroot = third_party.isolated()
+    devendored_chroot = os.path.realpath(third_party.isolated())
     assert pex_root == os.path.commonprefix([pex_root, devendored_chroot])
 
 
 def test_isolated_idempotent_inprocess():
   with temporary_pex_root():
-    assert third_party.isolated() == third_party.isolated()
+    assert os.path.realpath(third_party.isolated()) == os.path.realpath(third_party.isolated())
 
 
 def test_isolated_idempotent_subprocess():
   with temporary_pex_root() as (_, env):
-    devendored_chroot = third_party.isolated()
+    devendored_chroot = os.path.realpath(third_party.isolated())
     stdout = subprocess.check_output(
       args=[sys.executable, '-c', 'from pex.third_party import isolated; print(isolated())'],
       env=env
     )
-    assert devendored_chroot == stdout.decode('utf-8').strip()
+    assert devendored_chroot == os.path.realpath(stdout.decode('utf-8').strip())


### PR DESCRIPTION
Previously we would de-vendor pex once per CLI invocation in a new
temporary directory. Now we de-vendor once per pex version under the
pex root (~/.pex/isolated/...) by leveraging existing hashing and atomic
directory creation tools.