### PR TITLE
Support VCS urls for vendoring.

### DIFF
--- a/pex/vendor/__main__.py
+++ b/pex/vendor/__main__.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import, print_function
 
+import glob
 import os
 import pkgutil
 import subprocess
@@ -201,8 +202,8 @@ def vendorize(root_dir, vendor_specs, prefix):
     # The RECORD contains file hashes of all installed files and is unfortunately unstable in the
     # case of scripts which get a shebang added with a system-specific path to the python
     # interpreter to execute.
-    safe_delete(os.path.join(vendor_spec.target_dir,
-                             '{}-{}.dist-info/RECORD'.format(vendor_spec.key, vendor_spec.version)))
+    for record_file in glob.glob(os.path.join(vendor_spec.target_dir, '*-*.dist-info/RECORD')):
+      safe_delete(record_file)
 
     vendor_spec.create_packages()
 

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -1,0 +1,28 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import pytest
+
+from pex.vendor import VendorSpec
+
+
+def test_pinned():
+  vendor_spec = VendorSpec.pinned('foo', '1.2.3')
+  assert 'foo' == vendor_spec.key
+  assert 'foo==1.2.3' == vendor_spec.requirement
+
+
+def test_vcs_valid():
+  vendor_spec = VendorSpec.vcs('git+https://github.com/foo.git@da39a3ee#egg=bar')
+  assert 'bar' == vendor_spec.key
+  assert 'git+https://github.com/foo.git@da39a3ee#egg=bar' == vendor_spec.requirement
+
+
+def test_vcs_invalid_no_egg():
+  with pytest.raises(ValueError):
+    VendorSpec.vcs('git+https://github.com/foo.git@da39a3ee')
+
+
+def test_vcs_invalid_multiple_egg():
+  with pytest.raises(ValueError):
+    VendorSpec.vcs('git+https://github.com/foo.git@da39a3ee#egg=bar&egg=foo')


### PR DESCRIPTION
This will support using a patched version of pip pending acceptance
of patches upstream.

Work towards #823.