### PR TITLE
Parallelize interpreter discovery.

### DIFF
--- a/pex/jobs.py
+++ b/pex/jobs.py
@@ -229,7 +229,7 @@ def execute_parallel(inputs, spawn_func, raise_type=None, max_jobs=None):
                      .format(item.item, spawn_func, item.error))
       elif error is not None:  # I.E.: `item` is not an exception, but there was a prior exception.
         item.kill()
-      elif isinstance(item, SpawnedJob):
+      else:
         try:
           yield item.await_result()
         except Job.Error as e:
@@ -240,8 +240,5 @@ def execute_parallel(inputs, spawn_func, raise_type=None, max_jobs=None):
           else:
             # Otherwise, if we were given no `raise_type`, we continue on and just log the failure.
             TRACER.log('{} raised {}'.format(item, e))
-      else:
-        raise AssertionError('Unexpected item on spawned job queue {} of type {}'
-                             .format(item, type(item)))
     finally:
       job_slots.release()

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -13,7 +13,8 @@ from textwrap import dedent
 
 from pex.common import AtomicDirectory, atomic_directory, safe_mkdtemp
 from pex.distribution_target import DistributionTarget
-from pex.jobs import SpawnedJob, execute_parallel, spawn_python_job
+from pex.interpreter import spawn_python_job
+from pex.jobs import SpawnedJob, execute_parallel
 from pex.orderedset import OrderedSet
 from pex.pex_info import PexInfo
 from pex.pip import get_pip
@@ -360,7 +361,12 @@ class ResolveRequest(object):
             yield BuildRequest.create(target=target, source_path=local_project)
 
   def _run_parallel(self, inputs, spawn_func, raise_type):
-    for result in execute_parallel(self._max_parallel_jobs, inputs, spawn_func, raise_type):
+    for result in execute_parallel(
+        inputs=inputs,
+        spawn_func=spawn_func,
+        raise_type=raise_type,
+        max_jobs=self._max_parallel_jobs
+    ):
       yield result
 
   def _spawn_resolve(self, resolved_dists_dir, target):

--- a/tests/test_bdist_pex.py
+++ b/tests/test_bdist_pex.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 from textwrap import dedent
 
 from pex.common import open_zip, temporary_dir
-from pex.jobs import spawn_python_job
+from pex.interpreter import spawn_python_job
 from pex.testing import WheelBuilder, make_project, temporary_content
 
 


### PR DESCRIPTION
This speeds up both pex builds and pex executions on machines with
multiple interpreters and `--interpreter-constraint`s in-play.

Work towards #782.