### PR TITLE
Re-enable pyenv interpreter tests under pypy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,6 @@
-x-pyenv-shard: &x-pyenv-shard
-  language: generic
-  env: &env >
-    PYENV_ROOT="${HOME}/.pyenv_pex"
-    PATH="${PYENV_ROOT}/shims:${PATH}"
-  cache: &cache
-    # The default is 3 minutes (180).
-    timeout: 300
-    directories:
-      - .pyenv_test
-      - "${PYENV_ROOT}"
-  install: |
-    PYENV="${PYENV_ROOT}/bin/pyenv"
-    if [ ! -x "${PYENV}" ]; then
-      rm -rf ${PYENV_ROOT}
-      git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}";
-    fi
-    "${PYENV}" install --keep --skip-existing ${PYENV_VERSION}
-    "${PYENV}" global ${PYENV_VERSION}
-    pip install -U tox
-
-x-py27: &x-py27 PYENV_VERSION=2.7.17
-
-x-py38: &x-py38 PYENV_VERSION=3.8.0
-
-x-pypy: &x-pypy PYENV_VERSION=pypy2.7-7.2.0
-
 x-linux-shard: &x-linux-shard
   os: linux
-  dist: bionic 
+  dist: bionic
   language: python
   install: |
     pip install -U tox
@@ -45,9 +18,27 @@ x-linux-38-shard: &x-linux-38-shard
   python: 3.8
 
 x-osx-shard: &x-osx-shard
-  <<: *x-pyenv-shard
   os: osx
   osx_image: xcode9.4
+  language: generic
+  env: &env >
+    PYENV_ROOT="${HOME}/.pyenv_pex"
+    PATH="${PYENV_ROOT}/shims:${PATH}"
+  cache:
+    # The default is 3 minutes (180).
+    timeout: 300
+    directories:
+      - .pyenv_test
+      - "${PYENV_ROOT}"
+  install: |
+    PYENV="${PYENV_ROOT}/bin/pyenv"
+    if [ ! -x "${PYENV}" ]; then
+      rm -rf ${PYENV_ROOT}
+      git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}";
+    fi
+    "${PYENV}" install --keep --skip-existing ${PYENV_VERSION}
+    "${PYENV}" global ${PYENV_VERSION}
+    pip install -U tox
 
 x-osx-ssl: &x-osx-ssl >
   CPPFLAGS=-I/usr/local/opt/openssl/include
@@ -57,15 +48,15 @@ x-osx-27-shard: &x-osx-27-shard
   <<: *x-osx-shard
   env:
     - *env
-    - *x-py27
     - *x-osx-ssl
+    - PYENV_VERSION=2.7.17
 
 x-osx-38-shard: &x-osx-38-shard
   <<: *x-osx-shard
   env:
     - *env
-    - *x-py38
     - *x-osx-ssl
+    - PYENV_VERSION=3.8.0
 
 # NB: Travis partitions caches using a combination of os, language amd env vars. As such, we do not
 # use TOXENV and instead pass the toxenv via -e on the command line. This helps ensure we share

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -12,8 +12,6 @@ import sys
 from collections import namedtuple
 from textwrap import dedent
 
-import pytest
-
 from pex.common import open_zip, safe_mkdir, safe_mkdtemp, safe_rmtree, temporary_dir, touch
 from pex.compatibility import PY3, nested
 from pex.distribution_target import DistributionTarget
@@ -33,13 +31,6 @@ IS_LINUX = platform.system() == 'Linux'
 IS_NOT_LINUX = not IS_LINUX
 NOT_CPYTHON27_OR_OSX = NOT_CPYTHON27 or IS_NOT_LINUX
 NOT_CPYTHON36_OR_LINUX = NOT_CPYTHON36 or IS_LINUX
-
-
-skip_for_pyenv_use_under_pypy = pytest.mark.skipif(
-  IS_PYPY,
-  reason='Our pyenv interpreter setup fails under pypy: '
-         'https://github.com/pantsbuild/pex/issues/477'
-)
 
 
 @contextlib.contextmanager

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -19,6 +19,7 @@ from pex.compatibility import WINDOWS, nested, to_bytes
 from pex.pex_info import PexInfo
 from pex.pip import get_pip
 from pex.testing import (
+    IS_PYPY,
     NOT_CPYTHON27,
     NOT_CPYTHON27_OR_OSX,
     NOT_CPYTHON36_OR_LINUX,
@@ -34,7 +35,6 @@ from pex.testing import (
     run_pex_command,
     run_simple_pex,
     run_simple_pex_test,
-    skip_for_pyenv_use_under_pypy,
     temporary_content
 )
 from pex.third_party import pkg_resources
@@ -351,7 +351,6 @@ def test_interpreter_constraints_to_pex_info_py2():
     assert {'>=2.7,<3', '>=3.5'} == set(pex_info.interpreter_constraints)
 
 
-@skip_for_pyenv_use_under_pypy
 def test_interpreter_constraints_to_pex_info_py3():
   py3_interpreter = ensure_python_interpreter(PY36)
   with temporary_dir() as output_dir:
@@ -391,7 +390,6 @@ def test_interpreter_resolution_with_multiple_constraint_options():
     assert pex_info.build_properties['version'][0] < 3
 
 
-@skip_for_pyenv_use_under_pypy
 def test_interpreter_resolution_with_pex_python_path():
   with temporary_dir() as td:
     pexrc_path = os.path.join(td, '.pexrc')
@@ -425,7 +423,6 @@ def test_interpreter_resolution_with_pex_python_path():
       assert str(pex_python_path.split(':')[0]).encode() in stdout
 
 
-@skip_for_pyenv_use_under_pypy
 def test_interpreter_constraints_honored_without_ppp_or_pp():
   # Create a pex with interpreter constraints, but for not the default interpreter in the path.
   with temporary_dir() as td:
@@ -459,7 +456,6 @@ def test_interpreter_constraints_honored_without_ppp_or_pp():
     assert str(py36_path).encode() in stdout
 
 
-@skip_for_pyenv_use_under_pypy
 def test_interpreter_resolution_pex_python_path_precedence_over_pex_python():
   with temporary_dir() as td:
     pexrc_path = os.path.join(td, '.pexrc')
@@ -507,7 +503,6 @@ def test_plain_pex_exec_no_ppp_no_pp_no_constraints():
     assert os.path.realpath(sys.executable).encode() in stdout
 
 
-@skip_for_pyenv_use_under_pypy
 def test_pex_exec_with_pex_python_path_only():
   with temporary_dir() as td:
     pexrc_path = os.path.join(td, '.pexrc')
@@ -533,7 +528,6 @@ def test_pex_exec_with_pex_python_path_only():
     assert str(pex_python_path.split(':')[0]).encode() in stdout
 
 
-@skip_for_pyenv_use_under_pypy
 def test_pex_exec_with_pex_python_path_and_pex_python_but_no_constraints():
   with temporary_dir() as td:
     pexrc_path = os.path.join(td, '.pexrc')
@@ -561,7 +555,6 @@ def test_pex_exec_with_pex_python_path_and_pex_python_but_no_constraints():
     assert str(pex_python_path.split(':')[0]).encode() in stdout
 
 
-@skip_for_pyenv_use_under_pypy
 def test_pex_python():
   py2_path_interpreter = ensure_python_interpreter(PY27)
   py3_path_interpreter = ensure_python_interpreter(PY36)
@@ -622,7 +615,6 @@ def test_pex_python():
     assert correct_interpreter_path in stdout
 
 
-@skip_for_pyenv_use_under_pypy
 def test_entry_point_targeting():
   """Test bugfix for https://github.com/pantsbuild/pex/issues/434"""
   with temporary_dir() as td:
@@ -643,7 +635,6 @@ def test_entry_point_targeting():
     assert 'usage: autopep8'.encode() in stdout
 
 
-@skip_for_pyenv_use_under_pypy
 def test_interpreter_selection_using_os_environ_for_bootstrap_reexec():
   """
   This is a test for verifying the proper function of the
@@ -833,7 +824,6 @@ def pex_manylinux_and_tag_selection_context():
     yield test_resolve, ensure_failure
 
 
-@skip_for_pyenv_use_under_pypy
 def test_pex_manylinux_and_tag_selection_linux_msgpack():
   """Tests resolver manylinux support and tag targeting."""
   with pex_manylinux_and_tag_selection_context() as (test_resolve, ensure_failure):
@@ -983,7 +973,6 @@ def test_pex_resource_bundling():
       assert stdout == b'hello\n'
 
 
-@skip_for_pyenv_use_under_pypy
 def test_entry_point_verification_3rdparty():
   with temporary_dir() as td:
     pex_out_path = os.path.join(td, 'pex.pex')
@@ -994,7 +983,6 @@ def test_entry_point_verification_3rdparty():
     res.assert_success()
 
 
-@skip_for_pyenv_use_under_pypy
 def test_invalid_entry_point_verification_3rdparty():
   with temporary_dir() as td:
     pex_out_path = os.path.join(td, 'pex.pex')
@@ -1005,7 +993,6 @@ def test_invalid_entry_point_verification_3rdparty():
     res.assert_failure()
 
 
-@skip_for_pyenv_use_under_pypy
 def test_multiplatform_entrypoint():
   with temporary_dir() as td:
     pex_out_path = os.path.join(td, 'p537.pex')
@@ -1087,7 +1074,6 @@ def test_pex_interpreter_interact_custom_setuptools_useable():
     assert rc == 0, stdout
 
 
-@skip_for_pyenv_use_under_pypy
 def test_setup_python():
   interpreter = ensure_python_interpreter(PY27)
   with temporary_dir() as out:
@@ -1100,7 +1086,6 @@ def test_setup_python():
     subprocess.check_call([pex, '-c', 'import jsonschema'])
 
 
-@skip_for_pyenv_use_under_pypy
 def test_setup_interpreter_constraint():
   interpreter = ensure_python_interpreter(PY27)
   with temporary_dir() as out:
@@ -1120,7 +1105,6 @@ def test_setup_interpreter_constraint():
     assert rc == 0
 
 
-@skip_for_pyenv_use_under_pypy
 def test_setup_python_multiple_transitive_markers():
   py27_interpreter = ensure_python_interpreter(PY27)
   py36_interpreter = ensure_python_interpreter(PY36)
@@ -1154,7 +1138,6 @@ def test_setup_python_multiple_transitive_markers():
     assert to_bytes(os.path.realpath(py36_interpreter)) == stdout.strip()
 
 
-@skip_for_pyenv_use_under_pypy
 def test_setup_python_direct_markers():
   py36_interpreter = ensure_python_interpreter(PY36)
   with temporary_dir() as out:
@@ -1172,7 +1155,6 @@ def test_setup_python_direct_markers():
       subprocess.check_call(py2_only_program, env=make_env(PATH=os.path.dirname(py36_interpreter)))
 
 
-@skip_for_pyenv_use_under_pypy
 def test_setup_python_multiple_direct_markers():
   py36_interpreter = ensure_python_interpreter(PY36)
   py27_interpreter = ensure_python_interpreter(PY27)
@@ -1318,7 +1300,10 @@ def test_pkg_resource_early_import_on_pex_path():
     assert return_code == 0
 
 
-@skip_for_pyenv_use_under_pypy
+@pytest.mark.skipif(IS_PYPY,
+                    reason="The cryptography 2.6.1 project only has pre-built wheels for CPython "
+                           "available on PyPI and this test relies upon a pre-built wheel being "
+                           "available.")
 def test_issues_539_abi3_resolution():
   # The cryptography team releases the following relevant pre-built wheels for version 2.6.1:
   # cryptography-2.6.1-cp27-cp27m-macosx_10_6_intel.whl
@@ -1549,7 +1534,6 @@ def test_pex_reexec_constraints_dont_match_current_pex_python():
                      interpreter_constraints=['=={}'.format(version)])
 
 
-@skip_for_pyenv_use_under_pypy
 def test_issues_745_extras_isolation():
   # Here we ensure one of our extras, `subprocess32`, is properly isolated in the transition from
   # pex bootstrapping where it is imported by `pex.executor` to execution of user code.
@@ -1591,7 +1575,6 @@ def test_issues_745_extras_isolation():
     assert subprocess32_location.startswith(pex_root)
 
 
-@skip_for_pyenv_use_under_pypy
 def test_trusted_host_handling():
   python = ensure_python_interpreter(PY27)
   # Since we explicitly ask Pex to find links at http://www.antlr3.org/download/Python, it should

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -7,7 +7,7 @@ import pytest
 
 from pex import interpreter
 from pex.compatibility import PY3
-from pex.testing import PY27, PY35, ensure_python_interpreter, skip_for_pyenv_use_under_pypy
+from pex.testing import PY27, PY35, ensure_python_interpreter
 
 try:
   from mock import patch
@@ -44,12 +44,10 @@ class TestPythonInterpreter(object):
   def test_interpreter2(self):
     return ensure_python_interpreter(self.TEST_INTERPRETER2_VERSION)
 
-  @skip_for_pyenv_use_under_pypy
   def test_interpreter_versioning(self, test_interpreter1):
     py_interpreter = interpreter.PythonInterpreter.from_binary(test_interpreter1)
     assert py_interpreter.identity.version == self.TEST_INTERPRETER1_VERSION_TUPLE
 
-  @skip_for_pyenv_use_under_pypy
   def test_interpreter_caching(self, test_interpreter1, test_interpreter2):
     py_interpreter1 = interpreter.PythonInterpreter.from_binary(test_interpreter1)
     py_interpreter2 = interpreter.PythonInterpreter.from_binary(test_interpreter2)

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -30,7 +30,6 @@ from pex.testing import (
     run_simple_pex,
     run_simple_pex_test,
     safe_mkdir,
-    skip_for_pyenv_use_under_pypy,
     temporary_content,
     write_simple_pex
 )
@@ -479,7 +478,6 @@ def test_pex_verify_entry_point_module_should_fail():
           verify_entry_point=True)
 
 
-@skip_for_pyenv_use_under_pypy
 def test_activate_interpreter_different_from_current():
   with temporary_dir() as pex_root:
     interp_version = PY36 if PY2 else PY27

--- a/tests/test_pex_binary.py
+++ b/tests/test_pex_binary.py
@@ -17,8 +17,7 @@ from pex.testing import (
     built_wheel,
     ensure_python_interpreter,
     run_pex_command,
-    run_simple_pex,
-    skip_for_pyenv_use_under_pypy
+    run_simple_pex
 )
 
 
@@ -204,7 +203,6 @@ def assert_run_pex(python=None, pex_args=None):
   return results.error.splitlines()
 
 
-@skip_for_pyenv_use_under_pypy
 def test_run_pex():
   incompatible_platforms_warning_msg = 'WARNING: attempting to run PEX with incompatible platforms!'
 

--- a/tests/test_pex_bootstrapper.py
+++ b/tests/test_pex_bootstrapper.py
@@ -6,7 +6,7 @@ import sys
 
 from pex.interpreter import PythonInterpreter
 from pex.pex_bootstrapper import iter_compatible_interpreters
-from pex.testing import PY27, PY35, PY36, ensure_python_interpreter, skip_for_pyenv_use_under_pypy
+from pex.testing import PY27, PY35, PY36, ensure_python_interpreter
 
 
 def find_interpreters(path, *constraints):
@@ -15,7 +15,6 @@ def find_interpreters(path, *constraints):
                                        compatibility_constraints=constraints)]
 
 
-@skip_for_pyenv_use_under_pypy
 def test_find_compatible_interpreters():
   py27 = ensure_python_interpreter(PY27)
   py35 = ensure_python_interpreter(PY35)
@@ -41,7 +40,6 @@ def test_find_compatible_interpreters():
   assert set(interpreters).issubset(all_known_interpreters)
 
 
-@skip_for_pyenv_use_under_pypy
 def test_find_compatible_interpreters_bias_current():
   py36 = ensure_python_interpreter(PY36)
   assert [os.path.realpath(sys.executable), py36] == find_interpreters([py36, sys.executable])


### PR DESCRIPTION
It turned out the fundamental issue was a bad version of curl which was
actually hinted at by the dump originally included in #477. We've since
updated our linux image to bionic which happened to fix the issue moving
to a newer curl as a side-effect.

This change re-enables disabled tests as well as converting a test
skipped previously due to this blanket issue to a more specific,
legitimate skip. The `.travis.yml` is also cleaned up a bit.

The hint this might be worth pursing came from:
  https://github.com/unbit/uwsgi/issues/37#issuecomment-10295067

Fixes #477