### PR TITLE
Respect env markers when checking resolves.

### DIFF
--- a/pex/distribution_target.py
+++ b/pex/distribution_target.py
@@ -38,6 +38,21 @@ class DistributionTarget(object):
   def get_platform(self):
     return self._platform or Platform.current()
 
+  def requirement_applies(self, requirement):
+    """Determines if the given requirement applies to this distribution target.
+
+    :param requirement: The requirement to evaluate.
+    :type requirement: :class:`pex.third_party.pkg_resources.Requirement`
+    :rtype: bool
+    """
+    if not requirement.marker:
+      return True
+
+    if self._interpreter is None:
+      return True
+
+    return requirement.marker.evaluate(self._interpreter.identity.env_markers)
+
   @property
   def id(self):
     """A unique id for a resolve target suitable as a path name component.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=2.7,<3.9,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
 [tool.flit.metadata.requires-extra]
 # For improved subprocess robustness under python2.7.
-subprocess = ["subprocess32>=3.2.7"]
+subprocess = ["subprocess32>=3.2.7; python_version<'3'"]
 
 [tool.flit.scripts]
 pex = "pex.bin.pex:main"


### PR DESCRIPTION
Previously we failed to do this and would erroneously fail resolves as
a result.

Fixes #851