### PR TITLE
Ensure Pex PEX contraints match pex wheel / sdist.

### DIFF
--- a/scripts/package.py
+++ b/scripts/package.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytoml as toml
+
+PROJECT_METADATA = Path('pyproject.toml')
+
+
+def python_requires() -> str:
+  project_metadata = toml.loads(PROJECT_METADATA.read_text())
+  return project_metadata['tool']['flit']['metadata']['requires-python'].strip()
+
+
+def build_pex_pex() -> None:
+  # NB: We do not include the subprocess extra (which would be spelled: `.[subprocess]`) since we
+  # would then produce a pex that would not be consumable by all python interpreters otherwise
+  # meeting `python_requires`; ie: we'd need to then come up with a deploy environment / deploy
+  # tooling, that built subprocess32 for linux cp27m, cp27mu, pypy, ... etc. Even with all the work
+  # expended to do this, we'd still miss some platform someone wanted to run the Pex PEX on. As
+  # such, we just ship unadorned Pex which is pure-python and universal. Any user wanting the extra
+  # is encouraged to build a Pex PEX for their particular platform themselves.
+  pex_requirement = '.'
+
+  args = [
+    sys.executable,
+    '-m', 'pex',
+    '-v',
+    '--disable-cache',
+    '--no-build',
+    '--no-compile',
+    '--no-use-system-time',
+    '--interpreter-constraint', python_requires(),
+    '--python-shebang', '/usr/bin/env python',
+    '-o', 'dist/pex',
+    '-c', 'pex',
+    pex_requirement
+  ]
+  subprocess.run(args, check=True)
+
+
+if __name__ == '__main__':
+  if not PROJECT_METADATA.is_file():
+    print('This script must be run from the root of the Pex repo.', file=sys.stderr)
+    sys.exit(1)
+
+  build_pex_pex()

--- a/tox.ini
+++ b/tox.ini
@@ -160,18 +160,11 @@ commands =
 
 [testenv:package]
 skip_install = true
-# TODO(John Sirois): Include subprocess32 when #415, #658 and #694 are resolved.
+basepython = python3
+deps =
+  pytoml
 commands =
-  python -m pex -v \
-    --cache-dir {envtmpdir}/buildcache \
-    --interpreter-constraint=">=3.5,<3.9" \
-    --interpreter-constraint="==2.7.*" \
-    --no-compile \
-    --no-use-system-time \
-    --python-shebang="/usr/bin/env python" \
-    -o dist/pex \
-    -c pex \
-    .
+  python scripts/package.py
 
 [testenv:publish]
 skip_install = true


### PR DESCRIPTION
Previously we had to keep these values in sync and failed to do so often
enough leading to released Pex PEXes that would fail to run under
interpreters they should run under.