### PR TITLE
Improve hermeticity of vendoring.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -136,20 +136,24 @@ deps =
   ansicolors==1.1.8
   pip==19.3.1
   redbaron==0.9.2
+  setuptools==42.0.2
+  wheel==0.33.6
   {[testenv:isort-run]deps}
 commands =
   python -m pex.vendor
   {[testenv:isort-run]commands}
 
 [testenv:vendor-check]
+# The vendored dist may contain references to the python version it was build on
+# (e.g., pex/vendor/_vendored/pip/pip-20.0.dev0.dist-info/entry_points.txt).
+# So this test restricts the python version, to prevent spurious diffs that will cause it to fail.
+basepython = python3.8
 skip_install = true
 deps =
   tox
 commands =
   tox -e vendor
-  # Temporarily disable this check, as it currently fails due to lack of hermeticity.
-  # Will be reenabled in https://github.com/pantsbuild/pex/pull/873.
-  #git diff --exit-code
+  git diff --exit-code
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
- Force specific versions of setuptools and wheel to be used
  when running pip during vendoring.

- Force the vendor-check test to run on python 3.8.

These address issues in our tests, where re-vendoring pip caused
slight differences in its metadata, causing the `git diff` check to
fail.