### PR TITLE
Add a clear_cache() method to PythonInterpreter.

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -319,6 +319,11 @@ class PythonInterpreter(object):
   INTERP_INFO_FILE = 'INTERP-INFO'
 
   @classmethod
+  def clear_cache(cls):
+    interpreter_cache_dir = os.path.join(ENV.PEX_ROOT, 'interpreters')
+    safe_rmtree(interpreter_cache_dir)
+
+  @classmethod
   def _spawn_from_binary_external(cls, binary):
     def create_interpreter(stdout):
       identity = stdout.decode('utf-8').strip()
@@ -405,7 +410,7 @@ class PythonInterpreter(object):
   def _spawn_from_binary(cls, binary):
     normalized_binary = cls._normalize_path(binary)
 
-    # N.B.: The CACHE is written as the last step in PythonInterpreter instance initialization.
+    # N.B.: The cache is written as the last step in PythonInterpreter instance initialization.
     cached_interpreter = cls._PYTHON_INTERPRETER_BY_NORMALIZED_PATH.get(normalized_binary)
     if cached_interpreter is not None:
       return SpawnedJob.completed(cached_interpreter)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -57,6 +57,11 @@ class TestPythonInterpreter(object):
     py_interpreter3 = interpreter.PythonInterpreter.from_binary(test_interpreter1)
     assert py_interpreter1 is py_interpreter3
 
+    interpreter.PythonInterpreter.clear_cache()
+    py_interpreter4 = interpreter.PythonInterpreter.from_binary(test_interpreter1)
+    assert py_interpreter1 is not py_interpreter4
+
+
   def test_binary_name_matching(self):
     valid_binary_names = (
       'jython',

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -57,11 +57,6 @@ class TestPythonInterpreter(object):
     py_interpreter3 = interpreter.PythonInterpreter.from_binary(test_interpreter1)
     assert py_interpreter1 is py_interpreter3
 
-    interpreter.PythonInterpreter.clear_cache()
-    py_interpreter4 = interpreter.PythonInterpreter.from_binary(test_interpreter1)
-    assert py_interpreter1 is not py_interpreter4
-
-
   def test_binary_name_matching(self):
     valid_binary_names = (
       'jython',


### PR DESCRIPTION
Useful in the Pants interpreter selection tests.