### PR TITLE
Error eagerly if an interpreter binary doesn't exist.

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -404,6 +404,8 @@ class PythonInterpreter(object):
   @classmethod
   def _spawn_from_binary(cls, binary):
     normalized_binary = cls._normalize_path(binary)
+    if not os.path.exists(normalized_binary):
+      raise cls.InterpreterNotFound(normalized_binary)
 
     # N.B.: The CACHE is written as the last step in PythonInterpreter instance initialization.
     cached_interpreter = cls._PYTHON_INTERPRETER_BY_NORMALIZED_PATH.get(normalized_binary)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -57,6 +57,10 @@ class TestPythonInterpreter(object):
     py_interpreter3 = interpreter.PythonInterpreter.from_binary(test_interpreter1)
     assert py_interpreter1 is py_interpreter3
 
+  def test_nonexistent_interpreter(self):
+    with pytest.raises(interpreter.PythonInterpreter.InterpreterNotFound):
+      interpreter.PythonInterpreter.from_binary('/nonexistent/path')
+
   def test_binary_name_matching(self):
     valid_binary_names = (
       'jython',


### PR DESCRIPTION
The exception class already existed, it just wasn't used.

Due to caching, the interpreter may or may not fail
in find_binary(), so the calling code might fail at some
later stage.

This change causes us to fail eagerly and consistently if
the binary doesn't exist on disk.