### PR TITLE
[probably not for merging] cache parse_links() in vendored pip

### DIFF
--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = '2.1.2'
+__version__ = '2.1.2+cacheparsedpiplinks'


### PR DESCRIPTION
Fixes #887. I made this into a PR to demonstrate the idea, but I'm going to create a proper diff with test cases against https://github.com/pypa/pip/. The gist from https://github.com/pantsbuild/pex/issues/887#issuecomment-585513069 demonstrates how to generate a pathological `--find-links` page.