### PR TITLE
Convert `bdist_pex` tests to explicit cmdclass.

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -572,7 +572,7 @@ def spawn_python_job(
   :type expose: list of str
   :param pythonpath: The PYTHONPATH to expose to the spawned python process. These will be
                      pre-pended to the `expose` path if passed.
-  :type expose: list of str
+  :type pythonpath: list of str
   :param subprocess_kwargs: Any additional :class:`subprocess.Popen` kwargs to pass through.
   :returns: A job handle to the spawned python process.
   :rtype: :class:`Job`

--- a/tests/test_bdist_pex.py
+++ b/tests/test_bdist_pex.py
@@ -11,14 +11,22 @@ from pex.interpreter import spawn_python_job
 from pex.testing import WheelBuilder, make_project, temporary_content
 
 
+def pex_project_dir():
+  return subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).decode('utf-8').strip()
+
+
 @contextmanager
 def bdist_pex(project_dir, bdist_args=None):
   with temporary_dir() as dist_dir:
-    cmd = ['setup.py', 'bdist_pex', '--bdist-dir={}'.format(dist_dir)]
+    cmd = [
+      'setup.py',
+      '--command-packages', 'pex.commands',
+      'bdist_pex', '--bdist-dir={}'.format(dist_dir)
+    ]
     if bdist_args:
       cmd.extend(bdist_args)
 
-    spawn_python_job(args=cmd, cwd=project_dir).wait()
+    spawn_python_job(args=cmd, cwd=project_dir, pythonpath=[pex_project_dir()]).wait()
     dists = os.listdir(dist_dir)
     assert len(dists) == 1
     yield os.path.join(dist_dir, dists[0])


### PR DESCRIPTION
Previously the test relied upon the tox venv interpreter (which
implicitly builds and installs the pex wheel) being the interpreter that
executed the `python setup.py bdist_pex ...` command. This assumption
could be violated when running under `pyenv` which OSX CI shards do.
Instead, explicitly add pex to the `PYTHONPATH` of the interpreter and
let distutils know about `bdist_pex` via `--command-packages`.

Fixes #896