### PR TITLE
Show pex-root from env as default in help output

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -483,7 +483,8 @@ def configure_clp():
       '--pex-root',
       dest='pex_root',
       default=ENV.PEX_ROOT,
-      help='Specify the pex root used in this invocation of pex. [Default: ~/.pex]'
+      help='Specify the pex root used in this invocation of pex. [Default: {}]'.format(
+          (ENV.PEX_ROOT or '~/.pex').replace(os.path.expanduser('~'), '~')),
   )
 
   parser.add_option(

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -483,9 +483,7 @@ def configure_clp():
       '--pex-root',
       dest='pex_root',
       default=ENV.PEX_ROOT,
-      help='Specify the pex root used in this invocation of pex. [Default: {}]'.format(
-          (ENV.PEX_ROOT or '~/.pex').replace(os.path.expanduser('~'), '~')),
-  )
+      help='Specify the pex root used in this invocation of pex. [Default: %default]')
 
   parser.add_option(
       '--help-variables',


### PR DESCRIPTION
If PEX_ROOT is set, its value is shown in the --pex-root help string

```console
$ export PEX_ROOT="$HOME/.cache/pex"
$ pex --help 2>&1 | grep .-root
  --pex-root=PEX_ROOT   Specify the pex root used in this invocation of pex. [Default: ~/.cache/pex]
```