### PR TITLE
Kill `Pip.spawn_install_wheel` `overwrite` arg.

### DIFF
--- a/pex/pip.py
+++ b/pex/pip.py
@@ -209,7 +209,6 @@ class Pip(object):
                           wheel,
                           install_dir,
                           compile=False,
-                          overwrite=False,
                           cache=None,
                           target=None):
 
@@ -234,8 +233,6 @@ class Pip(object):
       install_cmd.append('--ignore-requires-python')
 
     install_cmd.append('--compile' if compile else '--no-compile')
-    if overwrite:
-      install_cmd.extend(['--upgrade', '--force-reinstall'])
     install_cmd.append(wheel)
     return self._spawn_pip_isolated(install_cmd, cache=cache, interpreter=interpreter)
 

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -54,7 +54,7 @@ class Pip(object):
     self._pip_pex_path = pip_pex_path
 
   def _spawn_pip_isolated(self, args, cache=None, interpreter=None):
-    pip_args = ['--disable-pip-version-check', '--isolated', '--exists-action', 'i']
+    pip_args = ['--disable-pip-version-check', '--isolated']
 
     # The max pip verbosity is -vvv and for pex it's -vvvvvvvvv; so we scale down by a factor of 3.
     pex_verbosity = ENV.PEX_VERBOSE

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -437,7 +437,6 @@ class ResolveRequest(object):
       wheel=install_request.wheel_path,
       install_dir=install_result.build_chroot,
       compile=self._compile,
-      overwrite=True,
       cache=self._cache,
       target=install_request.target
     )


### PR DESCRIPTION
Now that `AtomicDirectory` is used to do the install there will always
be a fresh empty dir to install to and so there will never be a need to
overwrite an existing installation or upgrade it.