### PR TITLE
Don't delete the root __init__.py when devendoring.

### DIFF
--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -439,10 +439,7 @@ def expose(dists):
   :raise: :class:`ValueError` if any distributions to expose cannot be found.
   :returns: An iterator of exposed vendored distribution chroot paths.
   """
-  from pex.common import safe_delete
-
   for path in VendorImporter.expose(dists, root=isolated()):
-    safe_delete(os.path.join(path, '__init__.py'))
     yield path
 
 


### PR DESCRIPTION
We implement devendoring of a dist by pointing to its
directory under pex/vendor/_vendored, either in an
isolated copy, or in the executing source tree.

Previously we deleted the `__init__.py` in the top-level dir
before yielding it as a de-vendored root. Presumably this
was done because root-level `__init__.py` files are neither
required nor useful, and only exist because we add them
when vendoring.

However we do sometimes treat those vendored roots as nested,
non-root packages. Specifically, in pex.third_party._Loader.load_module, 
we attempt to load modules using the full path from our root. E.g.,
pex.vendor._vendored.setuptools.pkg_resources.

If we delete the `__init__.py` from pex.vendor._vendored.setuptools
(say in a cached isolated pex exposure dir), then a subsequent
attempt to load modules as described above will fail.

This change restores those root-level `__init__.py`. The assumption
is that they cause no harm in practice.