### PR TITLE
Respect `Requires-Python` in `PEXEnvironment`.

### DIFF
--- a/pex/dist_metadata.py
+++ b/pex/dist_metadata.py
@@ -1,0 +1,31 @@
+# coding=utf-8
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import email
+
+from pex.third_party.packaging.specifiers import SpecifierSet
+from pex.third_party.pkg_resources import DistInfoDistribution
+
+
+def requires_python(dist):
+  """Examines dist for `Python-Requires` metadata and returns version constraints if any.
+
+  See: https://www.python.org/dev/peps/pep-0345/#requires-python
+
+  :param dist: A distribution to check for `Python-Requires` metadata.
+  :type dist: :class:`pkg_resources.Distribution`
+  :return: The required python version specifiers.
+  :rtype: :class:`packaging.specifiers.SpecifierSet` or None
+  """
+  if not dist.has_metadata(DistInfoDistribution.PKG_INFO):
+    return None
+
+  metadata = dist.get_metadata(DistInfoDistribution.PKG_INFO)
+  pkg_info = email.parser.Parser().parsestr(metadata)
+  python_requirement = pkg_info.get('Requires-Python')
+  if not python_requirement:
+    return None
+  return SpecifierSet(python_requirement)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1605,3 +1605,38 @@ def test_trusted_host_handling():
     python=python
   )
   results.assert_success()
+
+
+def test_issues_898():
+  python27 = ensure_python_interpreter(PY27)
+  python36 = ensure_python_interpreter(PY36)
+  with temporary_dir() as td:
+    src_dir = os.path.join(td, 'src')
+    with safe_open(os.path.join(src_dir, 'test_issues_898.py'), 'w') as fp:
+      fp.write(dedent("""
+        import zipp
+
+        print(zipp.__file__)
+      """))
+
+    pex_file = os.path.join(td, 'zipp.pex')
+
+    results = run_pex_command(
+      args=[
+        '--python={}'.format(python27),
+        '--python={}'.format(python36),
+        'zipp>=1,<=3.1.0',
+        '--sources-directory={}'.format(src_dir),
+        '--entry-point=test_issues_898',
+        '-o', pex_file
+      ],
+    )
+    results.assert_success()
+
+    pex_root = os.path.realpath(os.path.join(td, 'pex_root'))
+    for python in python27, python36:
+      output = subprocess.check_output([python, pex_file], env=make_env(PEX_ROOT=pex_root))
+      zipp_location = os.path.realpath(output.decode('utf-8').strip())
+      assert zipp_location.startswith(pex_root), (
+        'Failed to import zipp from {} under {}'.format(pex_file, python)
+      )


### PR DESCRIPTION
Previously Pex did not properly handle activation of wheels with
`Requires-Python` metadata restricting the wheel use to certain Python
interpreter versions.

Fixes #898