### PR TITLE
Improve interpreter not found error messages.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -15,7 +15,7 @@ from textwrap import TextWrapper
 
 from pex.common import die, safe_delete, safe_mkdtemp
 from pex.interpreter import PythonInterpreter
-from pex.interpreter_constraints import UnsatisfiableInterpreterConstraints, validate_constraints
+from pex.interpreter_constraints import UnsatisfiableInterpreterConstraintsError, validate_constraints
 from pex.jobs import DEFAULT_MAX_JOBS
 from pex.pex import PEX
 from pex.pex_bootstrapper import iter_compatible_interpreters
@@ -530,7 +530,7 @@ def build_pex(reqs, options):
         pex_python_path = None
       try:
         interpreters = list(iter_compatible_interpreters(pex_python_path, constraints))
-      except UnsatisfiableInterpreterConstraints as e:
+      except UnsatisfiableInterpreterConstraintsError as e:
         die(e.create_message('Could not find a compatible interpreter.'), CANNOT_SETUP_INTERPRETER)
 
   try:

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -15,7 +15,7 @@ from textwrap import TextWrapper
 
 from pex.common import die, safe_delete, safe_mkdtemp
 from pex.interpreter import PythonInterpreter
-from pex.interpreter_constraints import validate_constraints
+from pex.interpreter_constraints import UnsatisfiableInterpreterConstraints, validate_constraints
 from pex.jobs import DEFAULT_MAX_JOBS
 from pex.pex import PEX
 from pex.pex_bootstrapper import iter_compatible_interpreters
@@ -528,10 +528,10 @@ def build_pex(reqs, options):
         pex_python_path = rc_variables.get('PEX_PYTHON_PATH', None)
       else:
         pex_python_path = None
-      interpreters = list(iter_compatible_interpreters(pex_python_path, constraints))
-      if not interpreters:
-        die('Could not find compatible interpreter for constraints {}'.format(
-            ' or '.join(constraints)), CANNOT_SETUP_INTERPRETER)
+      try:
+        interpreters = list(iter_compatible_interpreters(pex_python_path, constraints))
+      except UnsatisfiableInterpreterConstraints as e:
+        die(e.create_message('Could not find a compatible interpreter.'), CANNOT_SETUP_INTERPRETER)
 
   try:
     with open(options.preamble_file) as preamble_fd:

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -15,7 +15,10 @@ from textwrap import TextWrapper
 
 from pex.common import die, safe_delete, safe_mkdtemp
 from pex.interpreter import PythonInterpreter
-from pex.interpreter_constraints import UnsatisfiableInterpreterConstraintsError, validate_constraints
+from pex.interpreter_constraints import (
+    UnsatisfiableInterpreterConstraintsError,
+    validate_constraints
+)
 from pex.jobs import DEFAULT_MAX_JOBS
 from pex.pex import PEX
 from pex.pex_bootstrapper import iter_compatible_interpreters

--- a/pex/interpreter_constraints.py
+++ b/pex/interpreter_constraints.py
@@ -21,19 +21,19 @@ def validate_constraints(constraints):
       die("Compatibility requirements are not formatted properly: %s" % str(e))
 
 
-class UnsatisfiableInterpreterConstraints(Exception):
+class UnsatisfiableInterpreterConstraintsError(Exception):
   """Indicates interpreter constraints could not be satisfied."""
 
   def __init__(self, constraints, candidates):
     """
     :param constraints: The constraints that could not be satisfied.
-    :type constraints: list of str
+    :type constraints: iterable of str
     :param candidates: The python interpreters that were compared against the constraints.
-    :type candidates: :class:`pex.interpreter.PythonInterpreter`
+    :type candidates: iterable of :class:`pex.interpreter.PythonInterpreter`
     """
-    self.constraints = constraints
-    self.candidates = candidates
-    super(UnsatisfiableInterpreterConstraints, self).__init__(self.create_message())
+    self.constraints = tuple(constraints)
+    self.candidates = tuple(candidates)
+    super(UnsatisfiableInterpreterConstraintsError, self).__init__(self.create_message())
 
   def create_message(self, preamble=None):
     """Create a message describing  failure to find matching interpreters with an optional preamble.
@@ -68,8 +68,9 @@ def matched_interpreters_iter(interpreters_iter, constraints):
     requirements agnostic to interpreter class. Multiple requirement strings may be combined
     into a list to OR the constraints, such as ['CPython>=2.7,<3', 'CPython>=3.4'].
   :return: returns a generator that yields compatible interpreters
-  :raises: :class:`UnsatisfiableInterpreterConstraints` if constraints were given and could not be
-           satisfied.
+  :raises: :class:`UnsatisfiableInterpreterConstraintsError` if constraints were given and could
+           not be satisfied. The exception will only be raised when the returned generator is fully
+           consumed.
   """
   candidates = []
   found = False
@@ -85,4 +86,4 @@ def matched_interpreters_iter(interpreters_iter, constraints):
       candidates.append(interpreter)
 
   if not found:
-    raise UnsatisfiableInterpreterConstraints(constraints, candidates)
+    raise UnsatisfiableInterpreterConstraintsError(constraints, candidates)

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -11,8 +11,8 @@ from pex.common import die
 from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
 from pex.interpreter_constraints import (
-    UnsatisfiableInterpreterConstraints,
-    matched_interpreters_iter
+  UnsatisfiableInterpreterConstraintsError,
+  matched_interpreters_iter
 )
 from pex.orderedset import OrderedSet
 from pex.tracer import TRACER
@@ -101,7 +101,7 @@ def _select_pex_python_interpreter(pex_python, compatibility_constraints=None):
   )
   try:
     return _select_interpreter(compatible_interpreters_iter)
-  except UnsatisfiableInterpreterConstraints as e:
+  except UnsatisfiableInterpreterConstraintsError as e:
     die(e.create_message('Failed to find a compatible PEX_PYTHON={pex_python}.'
                          .format(pex_python=pex_python)))
 
@@ -113,7 +113,7 @@ def _select_path_interpreter(path=None, compatibility_constraints=None):
   )
   try:
     return _select_interpreter(compatible_interpreters_iter)
-  except UnsatisfiableInterpreterConstraints as e:
+  except UnsatisfiableInterpreterConstraintsError as e:
     die(e.create_message('Failed to find compatible interpreter on path {path}.'
                          .format(path=path or os.getenv('PATH'))))
 

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -135,7 +135,7 @@ def _select_interpreter(candidate_interpreters_iter):
   return min(candidate_interpreters)
 
 
-def maybe_reexec_pex(pex, compatibility_constraints=None):
+def maybe_reexec_pex(compatibility_constraints=None):
   """Handle environment overrides for the Python interpreter to use when executing this pex.
 
   This function supports interpreter filtering based on interpreter constraints stored in PEX-INFO
@@ -239,7 +239,7 @@ def _bootstrap(entry_point):
 
 def bootstrap_pex(entry_point):
   pex_info = _bootstrap(entry_point)
-  maybe_reexec_pex(entry_point, pex_info.interpreter_constraints)
+  maybe_reexec_pex(pex_info.interpreter_constraints)
 
   from . import pex
   pex.PEX(entry_point).execute()

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -11,8 +11,8 @@ from pex.common import die
 from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
 from pex.interpreter_constraints import (
-  UnsatisfiableInterpreterConstraintsError,
-  matched_interpreters_iter
+    UnsatisfiableInterpreterConstraintsError,
+    matched_interpreters_iter
 )
 from pex.orderedset import OrderedSet
 from pex.tracer import TRACER

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -599,8 +599,7 @@ def test_pex_python():
     stdin_payload = b'import sys; print(sys.executable); sys.exit(0)'
     stdout, rc = run_simple_pex(pex_out_path, stdin=stdin_payload, env=env)
     assert rc == 1
-    fail_str = ('Failed to find a compatible PEX_PYTHON={} for constraints'
-                .format(pex_python)).encode()
+    fail_str = ('Failed to find a compatible PEX_PYTHON={}.'.format(pex_python)).encode()
     assert fail_str in stdout
 
     # test PEX_PYTHON with no constraints

--- a/tests/test_pex_bootstrapper.py
+++ b/tests/test_pex_bootstrapper.py
@@ -5,7 +5,10 @@ import os
 import sys
 from textwrap import dedent
 
+import pytest
+
 from pex.interpreter import PythonInterpreter
+from pex.interpreter_constraints import UnsatisfiableInterpreterConstraints
 from pex.pex_bootstrapper import iter_compatible_interpreters
 from pex.testing import PY27, PY35, PY36, ensure_python_interpreter
 
@@ -29,9 +32,14 @@ def test_find_compatible_interpreters():
   assert [py35] == find_interpreters(path, '>{}, <{}'.format(PY27, PY36))
   assert [py36] == find_interpreters(path, '>=3.6')
 
-  assert [] == find_interpreters(path, '<2')
-  assert [] == find_interpreters(path, '>4')
-  assert [] == find_interpreters(path, '>{}, <{}'.format(PY27, PY35))
+  with pytest.raises(UnsatisfiableInterpreterConstraints):
+    find_interpreters(path, '<2')
+
+  with pytest.raises(UnsatisfiableInterpreterConstraints):
+    find_interpreters(path, '>4')
+
+  with pytest.raises(UnsatisfiableInterpreterConstraints):
+    find_interpreters(path, '>{}, <{}'.format(PY27, PY35))
 
   # All interpreters on PATH including whatever interpreter is currently running.
   all_known_interpreters = set(PythonInterpreter.all())

--- a/tests/test_pex_bootstrapper.py
+++ b/tests/test_pex_bootstrapper.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 import pytest
 
 from pex.interpreter import PythonInterpreter
-from pex.interpreter_constraints import UnsatisfiableInterpreterConstraints
+from pex.interpreter_constraints import UnsatisfiableInterpreterConstraintsError
 from pex.pex_bootstrapper import iter_compatible_interpreters
 from pex.testing import PY27, PY35, PY36, ensure_python_interpreter
 
@@ -32,13 +32,13 @@ def test_find_compatible_interpreters():
   assert [py35] == find_interpreters(path, '>{}, <{}'.format(PY27, PY36))
   assert [py36] == find_interpreters(path, '>=3.6')
 
-  with pytest.raises(UnsatisfiableInterpreterConstraints):
+  with pytest.raises(UnsatisfiableInterpreterConstraintsError):
     find_interpreters(path, '<2')
 
-  with pytest.raises(UnsatisfiableInterpreterConstraints):
+  with pytest.raises(UnsatisfiableInterpreterConstraintsError):
     find_interpreters(path, '>4')
 
-  with pytest.raises(UnsatisfiableInterpreterConstraints):
+  with pytest.raises(UnsatisfiableInterpreterConstraintsError):
     find_interpreters(path, '>{}, <{}'.format(PY27, PY35))
 
   # All interpreters on PATH including whatever interpreter is currently running.


### PR DESCRIPTION
Centralize messaging in a new exception type and incorporate this in the
CLI and at PEX runtime. API users can use the new structured exception
type as they wish.

Fixes #922