### PR TITLE
Sanitize PEX_ROOT handling.

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -329,6 +329,27 @@ def chmod_plus_w(path):
   os.chmod(path, path_mode)
 
 
+def can_write_dir(path):
+  """Determines if the directory at path can be written to by the current process.
+
+  If the directory doesn't exist, determines if it can be created and thus written to.
+
+  N.B.: This is a best-effort check only that uses permission heuristics and does not actually test
+  that the directory can be written to with and writes.
+
+  :param str path: The directory path to test.
+  :return: `True` if the given path is a directory that can be written to by the current process.
+  :rtype boo:
+  """
+  while not os.access(path, os.F_OK):
+    parent_path = os.path.dirname(path)
+    if not parent_path or (parent_path == path):
+      # We've recursed up to the root without success, which shouldn't happen,
+      return False
+    path = parent_path
+  return os.path.isdir(path) and os.access(path, os.R_OK | os.W_OK | os.X_OK)
+
+
 def touch(file, times=None):
   """Equivalent of unix `touch path`.
 

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -233,7 +233,7 @@ def maybe_reexec_pex(compatibility_constraints=None):
 def _bootstrap(entry_point):
   from .pex_info import PexInfo
   pex_info = PexInfo.from_pex(entry_point)
-  pex_warnings.configure_warnings(pex_info)
+  pex_warnings.configure_warnings(pex_info, ENV)
   return pex_info
 
 

--- a/pex/pex_warnings.py
+++ b/pex/pex_warnings.py
@@ -6,15 +6,12 @@ from __future__ import absolute_import
 
 import warnings
 
-from pex.variables import ENV
-
 
 class PEXWarning(Warning):
   """Indicates a warning from PEX about suspect buildtime or runtime configuration."""
 
 
-def configure_warnings(pex_info, env=None):
-  env = env or ENV
+def configure_warnings(pex_info, env):
   if env.PEX_VERBOSE > 0:
     emit_warnings = True
   elif env.PEX_EMIT_WARNINGS is not None:

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -79,7 +79,7 @@ class Pip(object):
       pip_args.append('--no-cache-dir')
 
     command = pip_args + args
-    with ENV.strip().patch(PEX_ROOT=ENV.PEX_ROOT, PEX_VERBOSE=str(pex_verbosity)) as env:
+    with ENV.strip().patch(PEX_ROOT=cache or ENV.PEX_ROOT, PEX_VERBOSE=str(pex_verbosity)) as env:
       # Guard against API calls from environment with ambient PYTHONPATH preventing pip PEX
       # bootstrapping. See: https://github.com/pantsbuild/pex/issues/892
       pythonpath = env.pop('PYTHONPATH', None)

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -277,7 +277,7 @@ class Variables(object):
       return None
 
     if not can_write_dir(pex_root):
-      tmp_root = safe_mkdtemp()
+      tmp_root = os.path.realpath(safe_mkdtemp())
       pex_warnings.warn('PEX_ROOT is configured as {pex_root} but that path is un-writeable, '
                         'falling back to a temporary PEX_ROOT of {tmp_root} which will hurt '
                         'performance.'.format(pex_root=pex_root, tmp_root=tmp_root))

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -273,7 +273,7 @@ class Variables(object):
     pex_root = self._get_path('PEX_ROOT', default=os.path.expanduser('~/.pex'))
 
     if pex_root is None:
-      # PEX_ROOT is no set and we're running in stripped_defaults mode.
+      # PEX_ROOT is not set and we're running in stripped_defaults mode.
       return None
 
     if not can_write_dir(pex_root):

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -10,7 +10,8 @@ import os
 import sys
 from contextlib import contextmanager
 
-from pex.common import die
+from pex import pex_warnings
+from pex.common import can_write_dir, die, safe_mkdtemp
 
 __all__ = ('ENV', 'Variables')
 
@@ -269,7 +270,20 @@ class Variables(object):
     The directory location for PEX to cache any dependencies and code.  PEX must write
     not-zip-safe eggs and all wheels to disk in order to activate them.  Default: ~/.pex
     """
-    return self._get_path('PEX_ROOT', default=os.path.expanduser('~/.pex'))
+    pex_root = self._get_path('PEX_ROOT', default=os.path.expanduser('~/.pex'))
+
+    if pex_root is None:
+      # PEX_ROOT is no set and we're running in stripped_defaults mode.
+      return None
+
+    if not can_write_dir(pex_root):
+      tmp_root = safe_mkdtemp()
+      pex_warnings.warn('PEX_ROOT is configured as {pex_root} but that path is un-writeable, '
+                        'falling back to a temporary PEX_ROOT of {tmp_root} which will hurt '
+                        'performance.'.format(pex_root=pex_root, tmp_root=tmp_root))
+      pex_root = self._environ['PEX_ROOT'] = tmp_root
+
+    return pex_root
 
   @property
   def PEX_PATH(self):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -13,6 +13,7 @@ from pex.common import (
     Chroot,
     PermPreservingZipFile,
     atomic_directory,
+    can_write_dir,
     chmod_plus_x,
     temporary_dir,
     touch
@@ -178,3 +179,27 @@ def test_chroot_perms_link_cross_device():
     mock_link.side_effect = OSError(expected_errno, os.strerror(expected_errno))
 
     assert_chroot_perms(Chroot.link)
+
+
+def test_can_write_dir_writeable_perms():
+  with temporary_dir() as writeable:
+    assert can_write_dir(writeable)
+
+    path = os.path.join(writeable, 'does/not/exist/yet')
+    assert can_write_dir(path)
+    touch(path)
+    assert not can_write_dir(path), 'Should not be able to write to a file.'
+
+
+def test_can_write_dir_unwriteable_perms():
+  with temporary_dir() as writeable:
+    no_perms_path = os.path.join(writeable, 'no_perms')
+    os.mkdir(no_perms_path, 0o444)
+    assert not can_write_dir(no_perms_path)
+
+    path_that_does_not_exist_yet = os.path.join(no_perms_path, 'does/not/exist/yet')
+    assert not can_write_dir(path_that_does_not_exist_yet)
+
+    os.chmod(no_perms_path, 0o744)
+    assert can_write_dir(no_perms_path)
+    assert can_write_dir(path_that_does_not_exist_yet)

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -157,4 +157,4 @@ def test_pex_root_unwriteable():
     message = log[0].message
     assert isinstance(message, PEXWarning)
     assert pex_root in str(message)
-    assert env.PEX_ROOT in str(message)
+    assert os.path.realpath(env.PEX_ROOT) in str(message)

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -2,9 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+import warnings
 
 import pytest
 
+from pex.common import temporary_dir
+from pex.pex_warnings import PEXWarning
 from pex.testing import environment_as
 from pex.util import named_temporary_file
 from pex.variables import Variables
@@ -138,3 +141,20 @@ def test_pex_vars_defaults_stripped():
   # int
   assert v.PEX_VERBOSE is not None
   assert stripped.PEX_VERBOSE is None
+
+
+def test_pex_root_unwriteable():
+  with temporary_dir() as td:
+    pex_root = os.path.realpath(os.path.join(td, "pex_root"))
+    os.mkdir(pex_root, 0o444)
+
+    env = Variables(environ=dict(PEX_ROOT=pex_root))
+
+    with warnings.catch_warnings(record=True) as log:
+      assert pex_root != env.PEX_ROOT
+
+    assert 1 == len(log)
+    message = log[0].message
+    assert isinstance(message, PEXWarning)
+    assert pex_root in str(message)
+    assert env.PEX_ROOT in str(message)

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -157,4 +157,8 @@ def test_pex_root_unwriteable():
     message = log[0].message
     assert isinstance(message, PEXWarning)
     assert pex_root in str(message)
-    assert os.path.realpath(env.PEX_ROOT) in str(message)
+    assert env.PEX_ROOT in str(message)
+
+    assert env.PEX_ROOT == env.PEX_ROOT, (
+      "When an ephemeral PEX_ROOT is materialized it should be stable."
+    )


### PR DESCRIPTION
In the past, portions of the pex cache could be controlled individually
but this was no longer the case in practice nor was it desirable. Unify
all cache handling under the PEX_ROOT and deprecate `--cache-dir` to
codify the new single pex cache as the PEX_ROOT.

Also add best-effort support for always finding a a viable PEX_ROOT even
when the configured value is not writeable. In conjunction with
`--runtime-pex-root` this provides for both a Pex CLI and created PEXes
that should always work wrt having a viable PEX_ROOT but still display a
warning if a suboptimal alternate had to be used.

Fixes #746
Fixes #816
Fixes #926
