### PR TITLE
Remove second urllib import from compatibility

### DIFF
--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -96,10 +96,8 @@ else:
 
 if PY3:
   import urllib.parse as urlparse
-  from urllib.request import pathname2url, url2pathname
 else:
   import urlparse
-  from urllib import pathname2url, url2pathname
 
 
 if PY3:


### PR DESCRIPTION
This appears unused, but takes about 20ms to import:

Before this change:
```
pex$ mkdir -p trivial && echo 'print("Hello")' > trivial/trivial.py && python3.6 -m pex -D trivial -m trivial -o trivial.pex && multitime -n 50 python3.6 ./trivial.pex >/dev/null
===> multitime results
1: python3.6 ./trivial.pex
            Mean        Std.Dev.    Min         Median      Max
real        0.494       0.032       0.448       0.486       0.600
user        0.433       0.027       0.395       0.428       0.518
sys         0.056       0.005       0.049       0.055       0.072
```

After this change:
```
pex$ mkdir -p trivial && echo 'print("Hello")' > trivial/trivial.py && python3.6 -m pex -D trivial -m trivial -o trivial.pex && multitime -n 50 python3.6 ./trivial.pex >/dev/null
===> multitime results
1: python3.6 ./trivial.pex
            Mean        Std.Dev.    Min         Median      Max
real        0.466       0.015       0.437       0.466       0.504
user        0.410       0.013       0.387       0.410       0.441
sys         0.052       0.002       0.047       0.052       0.060
```

The easiest (but hopefully smallest) part of #930