### PR TITLE
Fix `PEX_*` env stripping and allow turning off.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -302,8 +302,16 @@ def configure_clp_pex_options(parser):
       '--runtime-pex-root',
       dest='runtime_pex_root',
       default=None,
-      help='Specify the pex root to be used in the generated .pex file. [Default: ~/.pex]'
-  )
+      help='Specify the pex root to be used in the generated .pex file. [Default: ~/.pex]')
+
+  group.add_option(
+      '--strip-pex-env', '--no-strip-pex-env',
+      dest='strip_pex_env',
+      default=True,
+      action='callback',
+      callback=parse_bool,
+      help='Strip all `PEX_*` environment variables used to control the PEX runtime before handing '
+           'off control to the PEX entrypoint. [Default: %default]')
 
   parser.add_option_group(group)
 
@@ -576,6 +584,7 @@ def build_pex(reqs, options):
   pex_info.emit_warnings = options.emit_warnings
   pex_info.inherit_path = options.inherit_path
   pex_info.pex_root = options.runtime_pex_root
+  pex_info.strip_pex_env = options.strip_pex_env
   if options.interpreter_constraint:
     for ic in options.interpreter_constraint:
       pex_builder.add_interpreter_constraint(ic)

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -310,8 +310,10 @@ def configure_clp_pex_options(parser):
       default=True,
       action='callback',
       callback=parse_bool,
-      help='Strip all `PEX_*` environment variables used to control the PEX runtime before handing '
-           'off control to the PEX entrypoint. [Default: %default]')
+      help='Strip all `PEX_*` environment variables used to control the pex runtime before handing '
+           'off control to the pex entrypoint. You might want to set this to `False` if the new '
+           'pex executes other pexes (or the Pex CLI itself and you want the executed pex to be '
+           'controllable via `PEX_*` environment variables. [Default: %default]')
 
   parser.add_option_group(group)
 

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -172,6 +172,19 @@ class PexInfo(object):
     self._pex_info['zip_safe'] = bool(value)
 
   @property
+  def strip_pex_env(self):
+    """Whether or not this PEX should strip `PEX_*` env vars before executing its entrypoint.
+
+    You might want to set this to `False` if this PEX executes other PEXes or the Pex CLI itself and
+    you want the executed PEX to be controlled via PEX environment variables.
+    """
+    return self._pex_info.get('strip_pex_env', True)
+
+  @strip_pex_env.setter
+  def strip_pex_env(self, value):
+    self._pex_info['strip_pex_env'] = bool(value)
+
+  @property
   def pex_path(self):
     """A colon separated list of other pex files to merge into the runtime environment.
 

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -34,6 +34,7 @@ def build_pex_pex() -> None:
     '--no-use-system-time',
     '--interpreter-constraint', python_requires(),
     '--python-shebang', '/usr/bin/env python',
+    '--no-strip-pex-env',
     '-o', 'dist/pex',
     '-c', 'pex',
     pex_requirement

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1687,42 +1687,43 @@ def test_issues_898():
       )
 
 
-def test_pex_run_strip_env(tmpdir):
-  src_dir = os.path.join(tmpdir, 'src')
-  with safe_open(os.path.join(src_dir, 'print_pex_env.py'), 'w') as fp:
-    fp.write(dedent("""
-      import json
-      import os
+def test_pex_run_strip_env():
+  with temporary_dir() as td:
+    src_dir = os.path.join(td, 'src')
+    with safe_open(os.path.join(src_dir, 'print_pex_env.py'), 'w') as fp:
+      fp.write(dedent("""
+        import json
+        import os
 
-      print(json.dumps({k: v for k, v in os.environ.items() if k.startswith('PEX_')}))
-    """))
+        print(json.dumps({k: v for k, v in os.environ.items() if k.startswith('PEX_')}))
+      """))
 
-  pex_env = dict(PEX_ROOT=os.path.join(tmpdir, 'pex_root'))
-  env = make_env(**pex_env)
+    pex_env = dict(PEX_ROOT=os.path.join(td, 'pex_root'))
+    env = make_env(**pex_env)
 
-  stripped_pex_file = os.path.join(tmpdir, 'stripped.pex')
-  results = run_pex_command(
-    args=[
-      '--sources-directory={}'.format(src_dir),
-      '--entry-point=print_pex_env',
-      '-o', stripped_pex_file
-    ],
-  )
-  results.assert_success()
-  assert {} == json.loads(subprocess.check_output([stripped_pex_file], env=env)), (
-    'Expected the entrypoint environment to be stripped of PEX_ environment variables.'
-  )
+    stripped_pex_file = os.path.join(td, 'stripped.pex')
+    results = run_pex_command(
+      args=[
+        '--sources-directory={}'.format(src_dir),
+        '--entry-point=print_pex_env',
+        '-o', stripped_pex_file
+      ],
+    )
+    results.assert_success()
+    assert {} == json.loads(subprocess.check_output([stripped_pex_file], env=env)), (
+      'Expected the entrypoint environment to be stripped of PEX_ environment variables.'
+    )
 
-  unstripped_pex_file = os.path.join(tmpdir, 'unstripped.pex')
-  results = run_pex_command(
-    args=[
-      '--sources-directory={}'.format(src_dir),
-      '--entry-point=print_pex_env',
-      '--no-strip-pex-env',
-      '-o', unstripped_pex_file
-    ],
-  )
-  results.assert_success()
-  assert pex_env == json.loads(subprocess.check_output([unstripped_pex_file], env=env)), (
-    'Expected the entrypoint environment to be left un-stripped.'
-  )
+    unstripped_pex_file = os.path.join(td, 'unstripped.pex')
+    results = run_pex_command(
+      args=[
+        '--sources-directory={}'.format(src_dir),
+        '--entry-point=print_pex_env',
+        '--no-strip-pex-env',
+        '-o', unstripped_pex_file
+      ],
+    )
+    results.assert_success()
+    assert pex_env == json.loads(subprocess.check_output([unstripped_pex_file], env=env)), (
+      'Expected the entrypoint environment to be left un-stripped.'
+    )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1685,3 +1685,44 @@ def test_issues_898():
       assert zipp_location.startswith(pex_root), (
         'Failed to import zipp from {} under {}'.format(pex_file, python)
       )
+
+
+def test_pex_run_strip_env(tmpdir):
+  src_dir = os.path.join(tmpdir, 'src')
+  with safe_open(os.path.join(src_dir, 'print_pex_env.py'), 'w') as fp:
+    fp.write(dedent("""
+      import json
+      import os
+
+      print(json.dumps({k: v for k, v in os.environ.items() if k.startswith('PEX_')}))
+    """))
+
+  pex_env = dict(PEX_ROOT=os.path.join(tmpdir, 'pex_root'))
+  env = make_env(**pex_env)
+
+  stripped_pex_file = os.path.join(tmpdir, 'stripped.pex')
+  results = run_pex_command(
+    args=[
+      '--sources-directory={}'.format(src_dir),
+      '--entry-point=print_pex_env',
+      '-o', stripped_pex_file
+    ],
+  )
+  results.assert_success()
+  assert {} == json.loads(subprocess.check_output([stripped_pex_file], env=env)), (
+    'Expected the entrypoint environment to be stripped of PEX_ environment variables.'
+  )
+
+  unstripped_pex_file = os.path.join(tmpdir, 'unstripped.pex')
+  results = run_pex_command(
+    args=[
+      '--sources-directory={}'.format(src_dir),
+      '--entry-point=print_pex_env',
+      '--no-strip-pex-env',
+      '-o', unstripped_pex_file
+    ],
+  )
+  results.assert_success()
+  assert pex_env == json.loads(subprocess.check_output([unstripped_pex_file], env=env)), (
+    'Expected the entrypoint environment to be left un-stripped.'
+  )

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -578,8 +578,8 @@ def test_pex_run_strip_env():
     pex_env = dict(PEX_MODULE='does_not_exist_in_sub_pex', PEX_ROOT=pex_root)
     with environment_as(**pex_env), temporary_dir() as pex_chroot:
       pex_builder = PEXBuilder(path=pex_chroot)
-      with tempfile.NamedTemporaryFile() as fp:
-        fp.write(dedent(b"""
+      with tempfile.NamedTemporaryFile(mode="w") as fp:
+        fp.write(dedent("""
           import json
           import os
 
@@ -591,7 +591,7 @@ def test_pex_run_strip_env():
 
       stdout, returncode = run_simple_pex(pex_chroot)
       assert 0 == returncode
-      assert {} == json.loads(stdout), (
+      assert {} == json.loads(stdout.decode('utf-8')), (
         'Expected the entrypoint environment to be stripped of PEX_ environment variables.'
       )
       assert pex_env == {k: v for k, v in os.environ.items() if k.startswith("PEX_")}, (

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -1,10 +1,11 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 import os
-from contextlib import contextmanager
 
 import pytest
 
+from pex.testing import environment_as
 from pex.util import named_temporary_file
 from pex.variables import Variables
 
@@ -67,24 +68,6 @@ def test_pex_get_int():
 
   with pytest.raises(SystemExit):
     assert Variables(environ={'HELLO': 'welp'})._get_int('HELLO')
-
-
-@contextmanager
-def environment_as(**kwargs):
-  existing = {key: os.environ.get(key) for key in kwargs}
-
-  def adjust_environment(mapping):
-    for key, value in mapping.items():
-      if value is not None:
-        os.environ[key] = value
-      else:
-        del os.environ[key]
-
-  adjust_environment(kwargs)
-  try:
-    yield
-  finally:
-    adjust_environment(existing)
 
 
 def assert_pex_vars_hermetic():


### PR DESCRIPTION
Previously, `PEX_*` environment variable stripping incorrectly stripped
`PEX_*` environment variables in host process when the `PEX.run` API was
used. This is fixed and an option to not strip pex environment variables
at all is added to `PexInfo` / the Pex CLI. This new option is used to
publish a Pex PEX that supports control via environment variables.

Fixes #180
Fixes #925
Work towards #926