### PR TITLE
Cache pip.pex.

### DIFF
--- a/tests/test_third_party.py
+++ b/tests/test_third_party.py
@@ -24,20 +24,27 @@ def temporary_pex_root():
 
 def test_isolated_pex_root():
   with temporary_pex_root() as (pex_root, _):
-    devendored_chroot = os.path.realpath(third_party.isolated())
+    devendored_chroot = os.path.realpath(third_party.isolated().chroot_path)
     assert pex_root == os.path.commonprefix([pex_root, devendored_chroot])
 
 
 def test_isolated_idempotent_inprocess():
   with temporary_pex_root():
-    assert os.path.realpath(third_party.isolated()) == os.path.realpath(third_party.isolated())
+    result1 = third_party.isolated()
+    result2 = third_party.isolated()
+    assert result1.pex_hash == result2.pex_hash
+    assert os.path.realpath(result1.chroot_path) == os.path.realpath(result2.chroot_path)
 
 
 def test_isolated_idempotent_subprocess():
   with temporary_pex_root() as (_, env):
-    devendored_chroot = os.path.realpath(third_party.isolated())
+    devendored_chroot = os.path.realpath(third_party.isolated().chroot_path)
     stdout = subprocess.check_output(
-      args=[sys.executable, '-c', 'from pex.third_party import isolated; print(isolated())'],
+      args=[
+        sys.executable,
+        '-c',
+        'from pex import third_party; print(third_party.isolated().chroot_path)'
+      ],
       env=env
     )
     assert devendored_chroot == os.path.realpath(stdout.decode('utf-8').strip())


### PR DESCRIPTION
Previously, the pip.pex was re-created once per Pex CLI run. Now it is
created once per unique Pex distribution.

Perf result difference for a single distribution PEX indicates this
shaves off ~600ms of overhead for a warm cache (after the 1st run of the
Pex CLI at a given version):

Before (Pex 2.1.7):
```
$ multitime -s 2 -n 10 python -m pex psutil -o psutil.pex
===> multitime results
1: /home/jsirois/.venv/pex1.6/bin/pex psutil -o psutil.pex
            Mean        Std.Dev.    Min         Median      Max
real        2.044       0.008       2.030       2.046       2.060
user        1.690       0.038       1.636       1.700       1.751
sys         0.220       0.039       0.164       0.210       0.273
```

After:
```
$ multitime -s 2 -n 10 python -m pex psutil -o psutil.pex
===> multitime results
1: python -m pex psutil -o psutil.pex
            Mean        Std.Dev.    Min         Median      Max
real        1.365       0.070       1.328       1.339       1.571
user        1.070       0.019       1.030       1.074       1.105
sys         0.139       0.015       0.116       0.137       0.170
```