### PR TITLE
Ensure the interpreter path is a file

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -533,7 +533,7 @@ def build_pex(reqs, options, cache=None):
   if options.python:
     with TRACER.timed('Resolving interpreters', V=2):
       def to_python_interpreter(full_path_or_basename):
-        if os.path.exists(full_path_or_basename):
+        if os.path.isfile(full_path_or_basename):
           return PythonInterpreter.from_binary(full_path_or_basename)
         else:
           interpreter = PythonInterpreter.from_env(full_path_or_basename)


### PR DESCRIPTION
Hi 👋 

We ran into the following exception during a pex build recently:

```
07:31:25  IsADirectoryError: [Errno 21] Is a directory: '/home/jenkins/workspace/project-PR-123/python'
```

This happened because we specify `--python=python` on the pex command line (some of our projects build for different interpreters) and the project had a directory named "python" at the root of their project.

This is fairly easy to reproduce:

```
$ mkdir /tmp/pex
$ cd /tmp/pex
$ mkdir python
$ pex -o pex.pex --python=python pex
Traceback (most recent call last):
  File "/Users/eborgstrom/bin/pex/.bootstrap/pex/pex.py", line 393, in execute
  File "/Users/eborgstrom/bin/pex/.bootstrap/pex/pex.py", line 325, in _wrap_coverage
  File "/Users/eborgstrom/bin/pex/.bootstrap/pex/pex.py", line 356, in _wrap_profiling
  File "/Users/eborgstrom/bin/pex/.bootstrap/pex/pex.py", line 432, in _execute
  File "/Users/eborgstrom/bin/pex/.bootstrap/pex/pex.py", line 507, in execute_script
  File "/Users/eborgstrom/bin/pex/.bootstrap/pex/pex.py", line 535, in execute_entry
  File "/Users/eborgstrom/bin/pex/.bootstrap/pex/pex.py", line 550, in execute_pkg_resources
  File "/Users/eborgstrom/.pex/installed_wheels/71f811f0e7d752e6edf87ce497c77a99a8b4b423/pex-2.1.7-py2.py3-none-any.whl/pex/bin/pex.py", line 699, in main
    pex_builder = build_pex(reqs, options, cache=ENV.PEX_ROOT)
  File "/Users/eborgstrom/.pex/installed_wheels/71f811f0e7d752e6edf87ce497c77a99a8b4b423/pex-2.1.7-py2.py3-none-any.whl/pex/bin/pex.py", line 544, in build_pex
    interpreters = [to_python_interpreter(interp) for interp in options.python]
  File "/Users/eborgstrom/.pex/installed_wheels/71f811f0e7d752e6edf87ce497c77a99a8b4b423/pex-2.1.7-py2.py3-none-any.whl/pex/bin/pex.py", line 544, in <listcomp>
    interpreters = [to_python_interpreter(interp) for interp in options.python]
  File "/Users/eborgstrom/.pex/installed_wheels/71f811f0e7d752e6edf87ce497c77a99a8b4b423/pex-2.1.7-py2.py3-none-any.whl/pex/bin/pex.py", line 537, in to_python_interpreter
    return PythonInterpreter.from_binary(full_path_or_basename)
  File "/Users/eborgstrom/.pex/installed_wheels/71f811f0e7d752e6edf87ce497c77a99a8b4b423/pex-2.1.7-py2.py3-none-any.whl/pex/interpreter.py", line 427, in from_binary
    return cls._spawn_from_binary(binary).await_result()
  File "/Users/eborgstrom/.pex/installed_wheels/71f811f0e7d752e6edf87ce497c77a99a8b4b423/pex-2.1.7-py2.py3-none-any.whl/pex/interpreter.py", line 417, in _spawn_from_binary
    return cls._spawn_from_binary_external(normalized_binary)
  File "/Users/eborgstrom/.pex/installed_wheels/71f811f0e7d752e6edf87ce497c77a99a8b4b423/pex-2.1.7-py2.py3-none-any.whl/pex/interpreter.py", line 343, in _spawn_from_binary_external
    interpreter_hash = CacheHelper.hash(binary)
  File "/Users/eborgstrom/.pex/installed_wheels/71f811f0e7d752e6edf87ce497c77a99a8b4b423/pex-2.1.7-py2.py3-none-any.whl/pex/util.py", line 104, in hash
    with open(path, 'rb') as fh:
IsADirectoryError: [Errno 21] Is a directory: '/private/tmp/pex/python'
```

This PR simply changes the `exists` check to an `isfile` check before using `PythonInterpreter.from_binary`