### PR TITLE
Support an unzip toggle for PEXes.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -245,9 +245,21 @@ def configure_clp_pex_options(parser):
       default=True,
       action='callback',
       callback=parse_bool,
-      help='Whether or not the sources in the pex file are zip safe.  If they are '
-           'not zip safe, they will be written to disk prior to execution; '
-           'Default: zip safe.')
+      help='Whether or not the sources in the pex file are zip safe.  If they are not zip safe, '
+           'they will be written to disk prior to execution. Also see --unzip which will cause the '
+           'complete pex file, including dependencies, to be unzipped.'
+           '[Default: zip safe.]')
+
+  group.add_option(
+    '--unzip', '--no-unzip',
+    dest='unzip',
+    default=False,
+    action='callback',
+    callback=parse_bool,
+    help='Whether or not the pex file should be unzipped before executing it. If the pex file will '
+         'be run multiple times under a stable runtime PEX_ROOT the unzipping will only be '
+         'performed once and subsequent runs will enjoy lower startup latency. '
+         '[Default: do not unzip.]')
 
   group.add_option(
       '--always-write-cache',
@@ -583,6 +595,7 @@ def build_pex(reqs, options, cache=None):
 
   pex_info = pex_builder.info
   pex_info.zip_safe = options.zip_safe
+  pex_info.unzip = options.unzip
   pex_info.pex_path = options.pex_path
   pex_info.always_write_cache = options.always_write_cache
   pex_info.ignore_errors = options.ignore_errors

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -172,6 +172,19 @@ class PexInfo(object):
     self._pex_info['zip_safe'] = bool(value)
 
   @property
+  def unzip(self):
+    """Whether or not PEX should be unzipped before it's executed.
+
+    Unzipping a PEX is a operation that can be cached on the 1st run of a given PEX file which can
+    result in lower startup latency in subsequent runs.
+    """
+    return self._pex_info.get('unzip', False)
+
+  @unzip.setter
+  def unzip(self, value):
+    self._pex_info['unzip'] = bool(value)
+
+  @property
   def strip_pex_env(self):
     """Whether or not this PEX should strip `PEX_*` env vars before executing its entrypoint.
 


### PR DESCRIPTION
This adds a `PexInfo.unzip` toggle and `--unzip` `--no-unzip` in the
CLI to mark a PEX file that should be unzipped before execution.
Combined with a stable PEX_ROOT cache, this can offer improved startup
latency in both cold and hot cases.

Work towards #930.