### PR TITLE
Better support unzip mode PEXes.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -435,7 +435,7 @@ def configure_clp():
       '%prog builds a PEX (Python Executable) file based on the given specifications: '
       'sources, requirements, their dependencies and other options.')
 
-  parser = OptionParser(usage=usage, version='%prog {0}'.format(__version__))
+  parser = OptionParser(usage=usage, version='%prog {}'.format(__version__))
   configure_clp_pex_resolution(parser)
   configure_clp_pex_options(parser)
   configure_clp_pex_environment(parser)

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -419,6 +419,12 @@ class PEX(object):  # noqa: T000
   def _execute(self):
     force_interpreter = self._vars.PEX_INTERPRETER
 
+    # N.B.: This is set in `__main__.py` of the executed PEX by `PEXBuilder` when we've been
+    # executed from within a PEX zip file in `--unzip` mode.  We replace `sys.argv[0]` to avoid
+    # confusion and allow the user code we hand off to to provide useful messages and fully valid
+    # re-execs that always re-directed through the PEX file.
+    sys.argv[0] = os.environ.pop('__PEX_EXE__', sys.argv[0])
+
     self._clean_environment(strip_pex_env=self._pex_info.strip_pex_env)
 
     if force_interpreter:

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -233,6 +233,7 @@ def maybe_reexec_pex(compatibility_constraints=None):
 def _bootstrap(entry_point):
   from .pex_info import PexInfo
   pex_info = PexInfo.from_pex(entry_point)
+  pex_info.update(PexInfo.from_env())
   pex_warnings.configure_warnings(pex_info, ENV)
   return pex_info
 

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -32,7 +32,8 @@ class PexInfo(object):
   entry_point: string                 # entry point into this pex
   script: string                      # script to execute in this pex environment
                                       # at most one of script/entry_point can be specified
-  zip_safe: True, default False       # is this pex zip safe?
+  zip_safe: bool, default True        # is this pex zip safe?
+  unzip: bool, default False          # should this pex be unzipped and re-executed from there?
   inherit_path: false/fallback/prefer # should this pex inherit site-packages + user site-packages
                                       # + PYTHONPATH?
   ignore_errors: True, default False  # should we ignore inability to resolve dependencies?
@@ -92,11 +93,13 @@ class PexInfo(object):
   def from_env(cls, env=ENV):
     supplied_env = env.strip_defaults()
     zip_safe = None if supplied_env.PEX_FORCE_LOCAL is None else not supplied_env.PEX_FORCE_LOCAL
+    unzip = None if supplied_env.PEX_UNZIP is None else supplied_env.PEX_UNZIP
     pex_info = {
       'pex_root': supplied_env.PEX_ROOT,
       'entry_point': supplied_env.PEX_MODULE,
       'script': supplied_env.PEX_SCRIPT,
       'zip_safe': zip_safe,
+      'unzip': unzip,
       'inherit_path': supplied_env.PEX_INHERIT_PATH,
       'ignore_errors': supplied_env.PEX_IGNORE_ERRORS,
       'always_write_cache': supplied_env.PEX_ALWAYS_CACHE,

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -163,9 +163,21 @@ class Variables(object):
 
     Force this PEX to be not-zip-safe. This forces all code and dependencies to be written into
     $PEX_ROOT prior to invocation.  This is an option for applications with static assets that
-    refer to paths relative to __file__ instead of using pkgutil/pkg_resources.  Default: false.
+    refer to paths relative to __file__ instead of using pkgutil/pkg_resources.  Also see PEX_UNZIP
+    which will cause the complete PEX file to be unzipped and re-executed which can often improve
+    startup latency in addition to providing support for __file__ access.  Default: false.
     """
     return self._get_bool('PEX_FORCE_LOCAL', default=False)
+
+  @property
+  def PEX_UNZIP(self):
+    """Boolean
+
+    Force this PEX to unzip itself to $PEX_ROOT and re-execute from there.  If the pex file will be
+    run multiple times under a stable $PEX_ROOT the unzipping will only be performed once and
+    subsequent runs will enjoy lower startup latency.  Default: false.
+    """
+    return self._get_bool('PEX_UNZIP', default=False)
 
   @property
   def PEX_IGNORE_ERRORS(self):

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -35,6 +35,7 @@ def build_pex_pex() -> None:
     '--interpreter-constraint', python_requires(),
     '--python-shebang', '/usr/bin/env python',
     '--no-strip-pex-env',
+    '--unzip',
     '-o', 'dist/pex',
     '-c', 'pex',
     pex_requirement

--- a/tests/test_pex_info.py
+++ b/tests/test_pex_info.py
@@ -58,6 +58,7 @@ def test_from_env():
                    PEX_MODULE='entry:point',
                    PEX_SCRIPT='script.sh',
                    PEX_FORCE_LOCAL='true',
+                   PEX_UNZIP='true',
                    PEX_INHERIT_PATH='prefer',
                    PEX_IGNORE_ERRORS='true',
                    PEX_ALWAYS_CACHE='true')
@@ -66,6 +67,7 @@ def test_from_env():
                 entry_point='entry:point',
                 script='script.sh',
                 zip_safe=False,
+                unzip=True,
                 inherit_path=True,
                 ignore_errors=True,
                 always_write_cache=True)


### PR DESCRIPTION
Preserve `sys.argv[0]` as the original PEX zip file path and allow
runtime control of the unzip mode with `PEX_UNZIP`.

With these affordances in place, change the Pex PEX to ship in unzip
mode assuming the standard use will be multi-use with a stable
`PEX_ROOT`.