### PR TITLE
Fix runtime resolve error message generation.

### DIFF
--- a/pex/environment.py
+++ b/pex/environment.py
@@ -270,7 +270,8 @@ class PEXEnvironment(Environment):
           TRACER.log('Failed to resolve a requirement: %s' % e)
           requirers = unresolved_reqs.setdefault(e.req, OrderedSet())
           if e.requirers:
-            requirers.update(reqs_by_key[requirer] for requirer in e.requirers)
+            for requirer in e.requirers:
+              requirers.update(reqs_by_key[requirer])
 
     if unresolved_reqs:
       TRACER.log('Unresolved requirements:')


### PR DESCRIPTION
PR #828 introduced a bug in the code that gathers the
requirers of requirements that failed to be resolved
(so that we can display those requirers in an error message.)

Specifically, reqs_by_key's values are lists of requirements,
so we need to call update() on each such value separately.