### PR TITLE
Make the interpreter cache deterministic.

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -240,7 +240,7 @@ class PythonInterpreter(object):
     re.compile(r'python[23]$'),
     re.compile(r'python[23].[0-9]$'),
 
-    # Some distributions include a suffix on the in the interpreter name, similar to PEP-3149.
+    # Some distributions include a suffix on the interpreter name, similar to PEP-3149.
     # For example, Gentoo has /usr/bin/python3.6m to indicate it was built with pymalloc.
     re.compile(r'python[23].[0-9][a-z]$'),
 


### PR DESCRIPTION
Sort the keys in the INTERP-INFO json files and ensure interpreter hard
links get their own INTERP-INFO file.