### PR TITLE
Fix wheel filename parsing in PEXEnvironment.can_add

### DIFF
--- a/pex/environment.py
+++ b/pex/environment.py
@@ -11,8 +11,6 @@ import sys
 import zipfile
 from collections import OrderedDict, defaultdict
 
-from setuptools import wheel
-
 from pex import dist_metadata, pex_builder, pex_warnings
 from pex.bootstrap import Bootstrap
 from pex.common import atomic_directory, die, open_zip
@@ -23,6 +21,11 @@ from pex.third_party.packaging import tags
 from pex.third_party.pkg_resources import DistributionNotFound, Environment, Requirement, WorkingSet
 from pex.tracer import TRACER
 from pex.util import CacheHelper, DistributionHelper
+
+if "__PEX_UNVENDORED__" in __import__("os").environ:
+  from setuptools import wheel  # vendor:skip
+else:
+  from pex.third_party.setuptools import wheel
 
 
 def _import_pkg_resources():

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -19,7 +19,7 @@ from pex.orderedset import OrderedSet
 from pex.platforms import Platform
 from pex.third_party.packaging import tags
 from pex.third_party.pkg_resources import DistributionNotFound, Environment, Requirement, WorkingSet
-from pex.third_party.setuptools.wheel import Wheel
+from pex.third_party.setuptools import wheel
 from pex.tracer import TRACER
 from pex.util import CacheHelper, DistributionHelper
 
@@ -221,7 +221,7 @@ class PEXEnvironment(Environment):
       return True
 
     try:
-      wheel = Wheel(filename)
+      wheel = wheel.Wheel(filename)
       wheel_tags = '-'.join([wheel.py_version, wheel.abi, wheel.platform])
     except ValueError:
       return False

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -22,11 +22,6 @@ from pex.third_party.pkg_resources import DistributionNotFound, Environment, Req
 from pex.tracer import TRACER
 from pex.util import CacheHelper, DistributionHelper
 
-if "__PEX_UNVENDORED__" in __import__("os").environ:
-  from setuptools import wheel  # vendor:skip
-else:
-  from pex.third_party.setuptools import wheel
-
 
 def _import_pkg_resources():
   try:
@@ -225,8 +220,10 @@ class PEXEnvironment(Environment):
       return True
 
     try:
-      whl = wheel.Wheel(filename)
-      wheel_tags = '-'.join([whl.py_version, whl.abi, whl.platform])
+      # Wheel filename format from PEP 427: https://www.python.org/dev/peps/pep-0427/#file-name-convention
+      # `{distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}.whl`
+      wheel_parts = filename[:-4].split('-')
+      wheel_tags = '-'.join(wheel_parts[-3:])  # `{python tag}-{abi tag}-{platform tag}`
     except ValueError:
       return False
 

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -10,6 +10,7 @@ import site
 import sys
 import zipfile
 from collections import OrderedDict, defaultdict
+from setuptools import wheel
 
 from pex import dist_metadata, pex_builder, pex_warnings
 from pex.bootstrap import Bootstrap
@@ -21,7 +22,6 @@ from pex.third_party.packaging import tags
 from pex.third_party.pkg_resources import DistributionNotFound, Environment, Requirement, WorkingSet
 from pex.tracer import TRACER
 from pex.util import CacheHelper, DistributionHelper
-from pex.vendor._vendored.setuptools.setuptools import wheel
 
 
 def _import_pkg_resources():

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -221,8 +221,8 @@ class PEXEnvironment(Environment):
       return True
 
     try:
-      wheel = wheel.Wheel(filename)
-      wheel_tags = '-'.join([wheel.py_version, wheel.abi, wheel.platform])
+      whl = wheel.Wheel(filename)
+      wheel_tags = '-'.join([whl.py_version, whl.abi, whl.platform])
     except ValueError:
       return False
 

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -19,9 +19,9 @@ from pex.orderedset import OrderedSet
 from pex.platforms import Platform
 from pex.third_party.packaging import tags
 from pex.third_party.pkg_resources import DistributionNotFound, Environment, Requirement, WorkingSet
-from pex.third_party.wheel import wheelfile
 from pex.tracer import TRACER
 from pex.util import CacheHelper, DistributionHelper
+from pex.vendor._vendored.setuptools.setuptools import wheel
 
 
 def _import_pkg_resources():
@@ -220,11 +220,12 @@ class PEXEnvironment(Environment):
       # platforms it supports at buildtime and runtime so this is always safe.
       return True
 
-    wheel_match = wheelfile.WHEEL_INFO_RE(filename)
-    if not wheel_match:
+    try:
+      whl = wheel.Wheel(filename)
+      wheel_tags = '-'.join([whl.py_version, whl.abi, whl.platform])
+    except ValueError:
       return False
 
-    wheel_tags = '-'.join([wheel_match['pyver'], wheel_match['abi'], wheel_match['plat']])
     if self._supported_tags.isdisjoint(tags.parse_tag(wheel_tags)):
       return False
 

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -10,6 +10,7 @@ import site
 import sys
 import zipfile
 from collections import OrderedDict, defaultdict
+
 from setuptools import wheel
 
 from pex import dist_metadata, pex_builder, pex_warnings

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -19,6 +19,7 @@ from pex.orderedset import OrderedSet
 from pex.platforms import Platform
 from pex.third_party.packaging import tags
 from pex.third_party.pkg_resources import DistributionNotFound, Environment, Requirement, WorkingSet
+from pex.third_party.setuptools.wheel import Wheel
 from pex.tracer import TRACER
 from pex.util import CacheHelper, DistributionHelper
 
@@ -220,7 +221,8 @@ class PEXEnvironment(Environment):
       return True
 
     try:
-      wheel_name_, wheel_raw_version_, wheel_tags = filename.split('-', 2)
+      wheel = Wheel(filename)
+      wheel_tags = '-'.join([wheel.py_version, wheel.abi, wheel.platform])
     except ValueError:
       return False
 

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -19,6 +19,7 @@ from pex.orderedset import OrderedSet
 from pex.platforms import Platform
 from pex.third_party.packaging import tags
 from pex.third_party.pkg_resources import DistributionNotFound, Environment, Requirement, WorkingSet
+from pex.third_party.wheel import wheelfile
 from pex.tracer import TRACER
 from pex.util import CacheHelper, DistributionHelper
 
@@ -219,14 +220,11 @@ class PEXEnvironment(Environment):
       # platforms it supports at buildtime and runtime so this is always safe.
       return True
 
-    try:
-      from pex.third_party.setuptools import wheel
-
-      whl = wheel.Wheel(filename)
-      wheel_tags = '-'.join([whl.py_version, whl.abi, whl.platform])
-    except ValueError:
+    wheel_match = wheelfile.WHEEL_INFO_RE(filename)
+    if not wheel_match:
       return False
 
+    wheel_tags = '-'.join([wheel_match['pyver'], wheel_match['abi'], wheel_match['plat']])
     if self._supported_tags.isdisjoint(tags.parse_tag(wheel_tags)):
       return False
 

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -219,14 +219,10 @@ class PEXEnvironment(Environment):
       # platforms it supports at buildtime and runtime so this is always safe.
       return True
 
-    try:
-      # Wheel filename format from PEP 427: https://www.python.org/dev/peps/pep-0427/#file-name-convention
-      # `{distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}.whl`
-      wheel_parts = filename[:-4].split('-')
-      wheel_tags = '-'.join(wheel_parts[-3:])  # `{python tag}-{abi tag}-{platform tag}`
-    except ValueError:
-      return False
-
+    # Wheel filename format from PEP 427: https://www.python.org/dev/peps/pep-0427/#file-name-convention
+    # `{distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}.whl`
+    wheel_parts = filename[:-4].split('-')
+    wheel_tags = '-'.join(wheel_parts[-3:])  # `{python tag}-{abi tag}-{platform tag}`
     if self._supported_tags.isdisjoint(tags.parse_tag(wheel_tags)):
       return False
 

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -219,7 +219,7 @@ class PEXEnvironment(Environment):
       # platforms it supports at buildtime and runtime so this is always safe.
       return True
 
-    # Wheel filename format from PEP 427: https://www.python.org/dev/peps/pep-0427/#file-name-convention
+    # Wheel filename format: https://www.python.org/dev/peps/pep-0427/#file-name-convention
     # `{distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}.whl`
     wheel_parts = filename[:-4].split('-')
     wheel_tags = '-'.join(wheel_parts[-3:])  # `{python tag}-{abi tag}-{platform tag}`

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -19,7 +19,6 @@ from pex.orderedset import OrderedSet
 from pex.platforms import Platform
 from pex.third_party.packaging import tags
 from pex.third_party.pkg_resources import DistributionNotFound, Environment, Requirement, WorkingSet
-from pex.third_party.setuptools import wheel
 from pex.tracer import TRACER
 from pex.util import CacheHelper, DistributionHelper
 
@@ -221,6 +220,8 @@ class PEXEnvironment(Environment):
       return True
 
     try:
+      from pex.third_party.setuptools import wheel
+
       whl = wheel.Wheel(filename)
       wheel_tags = '-'.join([whl.py_version, whl.abi, whl.platform])
     except ValueError:

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -221,8 +221,7 @@ class PEXEnvironment(Environment):
 
     # Wheel filename format: https://www.python.org/dev/peps/pep-0427/#file-name-convention
     # `{distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}.whl`
-    wheel_parts = filename[:-4].split('-')
-    wheel_tags = '-'.join(wheel_parts[-3:])  # `{python tag}-{abi tag}-{platform tag}`
+    wheel_tags = '-'.join(filename.split('-')[-3:])  # `{python tag}-{abi tag}-{platform tag}`
     if self._supported_tags.isdisjoint(tags.parse_tag(wheel_tags)):
       return False
 

--- a/pex/vendor/__init__.py
+++ b/pex/vendor/__init__.py
@@ -105,8 +105,8 @@ def iter_vendor_specs():
   # pex.third_party at runtime in various ways.
   yield VendorSpec.pinned('setuptools', '42.0.2')
 
-  # We expose this to pip at buildtime for legacy builds, and at runtime to parse wheel filenames
-  yield VendorSpec.pinned('wheel', '0.33.6')
+  # We expose this to pip at buildtime for legacy builds.
+  yield VendorSpec.pinned('wheel', '0.33.6', rewrite=False)
 
 
 def vendor_runtime(chroot, dest_basedir, label, root_module_names):

--- a/pex/vendor/__init__.py
+++ b/pex/vendor/__init__.py
@@ -105,8 +105,8 @@ def iter_vendor_specs():
   # pex.third_party at runtime in various ways.
   yield VendorSpec.pinned('setuptools', '42.0.2')
 
-  # We expose this to pip at buildtime for legacy builds.
-  yield VendorSpec.pinned('wheel', '0.33.6', rewrite=False)
+  # We expose this to pip at buildtime for legacy builds, and at runtime to parse wheel filenames
+  yield VendorSpec.pinned('wheel', '0.33.6')
 
 
 def vendor_runtime(chroot, dest_basedir, label, root_module_names):

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -348,3 +348,12 @@ def test_present_non_empty_namespace_packages_metadata_does_warn():
 
 def test_present_but_empty_namespace_packages_metadata_does_not_warn():
   assert_namespace_packages_warning('pycodestyle', '2.5.0', expected_warning=False)
+
+
+def test_can_add_handles_wheel_with_build_tag():
+  # The actual PEXEnviroment is irrelevant; all we need is an instance
+  interpreter = PythonInterpreter.get()
+  pex_info = PexInfo.default(interpreter)
+  pex_enviroment = PEXEnvironment("", pex_info)
+  wheel_with_build_tag = 'llvmlite-0.29.0-1-cp37-cp37m-manylinux1_x86_64.whl'
+  assert pex_enviroment.can_add(wheel_with_build_tag) in (True, False)

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -26,6 +26,7 @@ from pex.testing import (
     temporary_content,
     temporary_filename
 )
+from pex.third_party.pkg_resources import Distribution
 
 
 @contextmanager
@@ -356,4 +357,4 @@ def test_can_add_handles_wheel_with_build_tag():
   pex_info = PexInfo.default(interpreter)
   pex_enviroment = PEXEnvironment("", pex_info)
   wheel_with_build_tag = 'llvmlite-0.29.0-1-cp37-cp37m-manylinux1_x86_64.whl'
-  assert pex_enviroment.can_add(wheel_with_build_tag) in (True, False)
+  assert pex_enviroment.can_add(Distribution(wheel_with_build_tag)) in (True, False)

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -19,6 +19,7 @@ from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
 from pex.resolver import resolve
 from pex.testing import (
+    IS_LINUX,
     PY35,
     WheelBuilder,
     ensure_python_interpreter,
@@ -351,14 +352,25 @@ def test_present_but_empty_namespace_packages_metadata_does_not_warn():
   assert_namespace_packages_warning('pycodestyle', '2.5.0', expected_warning=False)
 
 
-@pytest.mark.parametrize('wheel_filename', [
-  pytest.param('llvmlite-0.29.0-cp35-cp35m-any.whl', id="without_build_tag"),
-  pytest.param('llvmlite-0.29.0-1-cp35-cp35m-any.whl', id="with_build_tag"),
+@pytest.mark.parametrize(('wheel_filename', 'wheel_is_linux'), [
+  pytest.param('llvmlite-0.29.0-cp35-cp35m-linux_x86_64.whl', True,
+               id="without_build_tag_linux"),
+  pytest.param('llvmlite-0.29.0-1-cp35-cp35m-linux_x86_64.whl', True,
+               id="with_build_tag_linux"),
+  pytest.param('llvmlite-0.29.0-cp35-cp35m-macosx_10.9_x86_64.whl', False,
+               id="without_build_tag_osx"),
+  pytest.param('llvmlite-0.29.0-1-cp35-cp35m-macosx_10.9_x86_64.whl', False,
+               id="with_build_tag_osx"),
 ])
-def test_can_add_handles_optional_build_tag_in_wheel(python_35_interpreter, wheel_filename):
+def test_can_add_handles_optional_build_tag_in_wheel(
+  python_35_interpreter,
+  wheel_filename,
+  wheel_is_linux
+):
   pex_environment = PEXEnvironment(
     pex="",
     pex_info=PexInfo.default(python_35_interpreter),
     interpreter=python_35_interpreter
   )
-  assert pex_environment.can_add(Distribution(wheel_filename)) is True
+  native_wheel = IS_LINUX and wheel_is_linux
+  assert pex_environment.can_add(Distribution(wheel_filename)) is native_wheel

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -351,10 +351,14 @@ def test_present_but_empty_namespace_packages_metadata_does_not_warn():
   assert_namespace_packages_warning('pycodestyle', '2.5.0', expected_warning=False)
 
 
-def test_can_add_handles_wheel_with_build_tag():
-  # The actual PEXEnviroment is irrelevant; all we need is an instance
-  interpreter = PythonInterpreter.get()
-  pex_info = PexInfo.default(interpreter)
-  pex_enviroment = PEXEnvironment("", pex_info)
-  wheel_with_build_tag = 'llvmlite-0.29.0-1-cp37-cp37m-manylinux1_x86_64.whl'
-  assert pex_enviroment.can_add(Distribution(wheel_with_build_tag)) in (True, False)
+@pytest.mark.parametrize('wheel_filename', [
+  pytest.param('llvmlite-0.29.0-cp35-cp35m-any.whl', id="without_build_tag"),
+  pytest.param('llvmlite-0.29.0-1-cp35-cp35m-any.whl', id="with_build_tag"),
+])
+def test_can_add_handles_optional_build_tag_in_wheel(python_35_interpreter, wheel_filename):
+  pex_environment = PEXEnvironment(
+    pex="",
+    pex_info=PexInfo.default(python_35_interpreter),
+    interpreter=python_35_interpreter
+  )
+  assert pex_environment.can_add(Distribution(wheel_filename)) is True


### PR DESCRIPTION
PEX issue: https://github.com/pantsbuild/pex/issues/964

This PR updates `PEXEnvironment.can_add` to split the whole wheel filename in order to gather up the trailing three tags. The previous implementation was overly naive and failed when a wheel filename included a (valid) build tag. 