### PR TITLE
Add a `--local` mode for packaging the Pex PEX.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -192,7 +192,7 @@ deps =
   pygments
   pytoml
 commands =
-  python scripts/package.py --additional-format wheel --serve
+  python scripts/package.py --additional-format wheel --local --serve
 
 [testenv:publish]
 skip_install = true


### PR DESCRIPTION
This significantly speeds up `--server` launch for local integration
testing when there are many local interpreters that match Pex
requires-python.