### PR TITLE
Restore handling for bad wheel filenames to `.can_add()`

### DIFF
--- a/pex/environment.py
+++ b/pex/environment.py
@@ -221,7 +221,11 @@ class PEXEnvironment(Environment):
 
     # Wheel filename format: https://www.python.org/dev/peps/pep-0427/#file-name-convention
     # `{distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}.whl`
-    wheel_tags = '-'.join(filename.split('-')[-3:])  # `{python tag}-{abi tag}-{platform tag}`
+    wheel_components = filename.split('-')
+    if len(wheel_components) < 3:
+      return False
+
+    wheel_tags = '-'.join(wheel_components[-3:])  # `{python tag}-{abi tag}-{platform tag}`
     if self._supported_tags.isdisjoint(tags.parse_tag(wheel_tags)):
       return False
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -374,3 +374,12 @@ def test_can_add_handles_optional_build_tag_in_wheel(
   )
   native_wheel = IS_LINUX and wheel_is_linux
   assert pex_environment.can_add(Distribution(wheel_filename)) is native_wheel
+
+
+def test_can_add_handles_invalid_wheel_filename(python_35_interpreter):
+  pex_environment = PEXEnvironment(
+    pex="",
+    pex_info=PexInfo.default(python_35_interpreter),
+    interpreter=python_35_interpreter
+  )
+  assert pex_environment.can_add(Distribution('pep427-invalid.whl')) is False


### PR DESCRIPTION
My previous PR (#965) unintentionally removed handling for invalid wheel names (e.g. `"foo.whl"` or `"foo-bar.whl"`). This PR restores the previous functionality, namely returning `False` for (a subset of) bad wheel filenames.

I made the conservative choice to only reject filenames with < 3 wheel components (matching the previous behavior), but there's a valid argument to made for rejecting wheels with < 5 components, per [PEP 427](https://www.python.org/dev/peps/pep-0427/#file-name-convention).

---

Previous implementation: https://github.com/pantsbuild/pex/blob/2f048d8df0dbcebdc24d2355bf58130baa35de0f/pex/environment.py#L221-L225