### PR TITLE
Expose Pip network configuration.

### DIFF
--- a/pex/network_configuration.py
+++ b/pex/network_configuration.py
@@ -16,7 +16,7 @@ class NetworkConfiguration(namedtuple('NetworkConfiguration', [
   'cert',
   'client_cert'
 ])):
-  """Configurtion for network requests made by the resolver."""
+  """Configuration for network requests made by the resolver."""
 
   @classmethod
   def create(

--- a/pex/network_configuration.py
+++ b/pex/network_configuration.py
@@ -1,0 +1,58 @@
+# coding=utf-8
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from collections import namedtuple
+
+
+class NetworkConfiguration(namedtuple('NetworkConfiguration', [
+  'cache_ttl',
+  'retries',
+  'timeout',
+  'headers',
+  'proxy',
+  'cert',
+  'client_cert'
+])):
+  """Configurtion for network requests made by the resolver."""
+
+  @classmethod
+  def create(
+      cls,
+      cache_ttl=3600,
+      retries=5,
+      timeout=15,
+      headers=None,
+      proxy=None,
+      cert=None,
+      client_cert=None
+  ):
+    """
+    Creates a new network configuration accepting defaults for any values not explicitly provided.
+
+    :param int cache_ttl: The maximum time an item is retained in the HTTP cache in seconds.
+    :param int retries: The maximum number of retries each connection should attempt.
+    :param timeout: The socket timeout in seconds.
+    :param headers: A list of additional HTTP headers to send in the form NAME:VALUE.
+    :type headers: list of str
+    :param str proxy: A proxy to use in the form [user:passwd@]proxy.server:port.
+    :param str cert: The path to an alternate CA bundle.
+    :param str client_cert: The path to an SSL client certificate which should be a single file
+                            containing the private key and the certificate in PEM format.
+    :return: The resulting network configuration.
+    :rtype: :class:`NetworkConfiguration`
+    """
+    assert cache_ttl >= 0, 'The cache_ttl parameter should be >= 0; given: {}'.format(cache_ttl)
+    assert retries >= 0, 'The retries parameter should be >= 0; given: {}'.format(retries)
+    assert timeout >= 0, 'The timeout parameter should be > 0; given: {}'.format(timeout)
+    return cls(
+      cache_ttl=cache_ttl,
+      retries=retries,
+      timeout=timeout,
+      headers=tuple(headers or ()),
+      proxy=proxy,
+      cert=cert,
+      client_cert=client_cert
+    )

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -165,6 +165,7 @@ class DownloadRequest(namedtuple('DownloadRequest', [
   'transitive',
   'indexes',
   'find_links',
+  'network_configuration',
   'cache',
   'build',
   'use_wheel',
@@ -214,6 +215,7 @@ class DownloadRequest(namedtuple('DownloadRequest', [
       target=target,
       indexes=self.indexes,
       find_links=self.find_links,
+      network_configuration=self.network_configuration,
       cache=self.cache,
       build=self.build,
       manylinux=self.manylinux,
@@ -449,6 +451,7 @@ class BuildAndInstallRequest(object):
                install_requests,
                indexes=None,
                find_links=None,
+               network_configuration=None,
                cache=None,
                compile=False):
 
@@ -456,6 +459,7 @@ class BuildAndInstallRequest(object):
     self._install_requests = install_requests
     self._indexes = indexes
     self._find_links = find_links
+    self._network_configuration = network_configuration
     self._cache = cache
     self._compile = compile
 
@@ -481,6 +485,7 @@ class BuildAndInstallRequest(object):
       cache=self._cache,
       indexes=self._indexes,
       find_links=self._find_links,
+      network_configuration=self._network_configuration,
       interpreter=build_request.target.get_interpreter()
     )
     return SpawnedJob.wait(job=build_job, result=build_result)
@@ -655,6 +660,7 @@ def resolve(requirements=None,
             platform=None,
             indexes=None,
             find_links=None,
+            network_configuration=None,
             cache=None,
             build=True,
             use_wheel=True,
@@ -688,6 +694,9 @@ def resolve(requirements=None,
     local html file paths, these are parsed for links to distributions. If a local directory path,
     its listing is used to discover distributons.
   :type find_links: list of str
+  :keyword network_configuration: Configuration for network requests made downloading and building
+    distributions.
+  :type network_configuration: :class:`pex.network_configuration.NetworkConfiguration`
   :keyword str cache: A directory path to use to cache distributions locally.
   :keyword bool build: Whether to allow building source distributions when no wheel is found.
     Defaults to ``True``.
@@ -716,6 +725,7 @@ def resolve(requirements=None,
                        platforms=None if platform is None else [platform],
                        indexes=indexes,
                        find_links=find_links,
+                       network_configuration=network_configuration,
                        cache=cache,
                        build=build,
                        use_wheel=use_wheel,
@@ -734,6 +744,7 @@ def resolve_multi(requirements=None,
                   platforms=None,
                   indexes=None,
                   find_links=None,
+                  network_configuration=None,
                   cache=None,
                   build=True,
                   use_wheel=True,
@@ -772,6 +783,9 @@ def resolve_multi(requirements=None,
     local html file paths, these are parsed for links to distributions. If a local directory path,
     its listing is used to discover distributons.
   :type find_links: list of str
+  :keyword network_configuration: Configuration for network requests made downloading and building
+    distributions.
+  :type network_configuration: :class:`pex.network_configuration.NetworkConfiguration`
   :keyword str cache: A directory path to use to cache distributions locally.
   :keyword bool build: Whether to allow building source distributions when no wheel is found.
     Defaults to ``True``.
@@ -831,6 +845,7 @@ def resolve_multi(requirements=None,
     transitive=transitive,
     indexes=indexes,
     find_links=find_links,
+    network_configuration=network_configuration,
     cache=cache,
     build=build,
     use_wheel=use_wheel,
@@ -850,6 +865,7 @@ def resolve_multi(requirements=None,
     install_requests=install_requests,
     indexes=indexes,
     find_links=find_links,
+    network_configuration=network_configuration,
     cache=cache,
     compile=compile
   )
@@ -873,6 +889,7 @@ def _download_internal(requirements=None,
                        platforms=None,
                        indexes=None,
                        find_links=None,
+                       network_configuration=None,
                        cache=None,
                        build=True,
                        use_wheel=True,
@@ -910,6 +927,7 @@ def _download_internal(requirements=None,
     transitive=transitive,
     indexes=indexes,
     find_links=find_links,
+    network_configuration=network_configuration,
     cache=cache,
     build=build,
     use_wheel=use_wheel,
@@ -947,6 +965,7 @@ def download(requirements=None,
              platforms=None,
              indexes=None,
              find_links=None,
+             network_configuration=None,
              cache=None,
              build=True,
              use_wheel=True,
@@ -981,6 +1000,9 @@ def download(requirements=None,
     local html file paths, these are parsed for links to distributions. If a local directory path,
     its listing is used to discover distributons.
   :type find_links: list of str
+  :keyword network_configuration: Configuration for network requests made downloading and building
+    distributions.
+  :type network_configuration: :class:`pex.network_configuration.NetworkConfiguration`
   :keyword str cache: A directory path to use to cache distributions locally.
   :keyword bool build: Whether to allow building source distributions when no wheel is found.
     Defaults to ``True``.
@@ -1005,6 +1027,7 @@ def download(requirements=None,
     transitive=transitive,
     indexes=indexes,
     find_links=find_links,
+    network_configuration=network_configuration,
     cache=cache,
     build=build,
     use_wheel=use_wheel,
@@ -1037,6 +1060,7 @@ def download(requirements=None,
 def install(local_distributions,
             indexes=None,
             find_links=None,
+            network_configuration=None,
             cache=None,
             compile=False,
             max_parallel_jobs=None,
@@ -1053,6 +1077,9 @@ def install(local_distributions,
     local html file paths, these are parsed for links to distributions. If a local directory path,
     its listing is used to discover distributons.
   :type find_links: list of str
+  :keyword network_configuration: Configuration for network requests made downloading and building
+    distributions.
+  :type network_configuration: :class:`pex.network_configuration.NetworkConfiguration`
   :keyword str cache: A directory path to use to cache distributions locally.
   :keyword bool compile: Whether to pre-compile resolved distribution python sources.
     Defaults to ``False``.
@@ -1079,6 +1106,7 @@ def install(local_distributions,
     install_requests=install_requests,
     indexes=indexes,
     find_links=find_links,
+    network_configuration=network_configuration,
     cache=cache,
     compile=compile
   )

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -339,28 +339,6 @@ class Variables(object):
     """
     return self._get_int('PEX_VERBOSE', default=0)
 
-  # TODO(#94) Remove and push into --flags.
-  @property
-  def PEX_HTTP_RETRIES(self):
-    """Integer
-
-    The number of HTTP retries when performing dependency resolution when building a PEX file.
-    Default: 5.
-    """
-    return self._get_int('PEX_HTTP_RETRIES', default=5)
-
-  # TODO(#94) Remove and push into --flags.
-  @property
-  def PEX_HTTP_TIMEOUT(self):
-    """Integer
-
-    When built with the `requests` HTTP library, a timeout to apply for HTTP connect attempts and
-    read attempts. See the `requests` docs (https://2.python-requests.org/en/master/user/quickstart/#timeouts)
-    for more information.
-    Default: 15.
-    """
-    return self._get_int('PEX_HTTP_TIMEOUT', default=15)
-
   @property
   def PEX_IGNORE_RCFILES(self):
     """Boolean

--- a/pex/vendor/__init__.py
+++ b/pex/vendor/__init__.py
@@ -99,7 +99,7 @@ def iter_vendor_specs():
 
   # We shell out to pip at buildtime to resolve and install dependencies.
   # N.B.: This is pip 20.0.dev0 with a patch to support foreign download targets more fully.
-  yield VendorSpec.vcs('git+https://github.com/pantsbuild/pip@5eb9470c0c59#egg=pip', rewrite=False)
+  yield VendorSpec.vcs('git+https://github.com/pantsbuild/pip@f9dde7cb6bab#egg=pip', rewrite=False)
 
   # We expose this to pip at buildtime for legacy builds, but we also use pkg_resources via
   # pex.third_party at runtime in various ways.

--- a/pex/vendor/_vendored/pip/pip/_internal/cli/cmdoptions.py
+++ b/pex/vendor/_vendored/pip/pip/_internal/cli/cmdoptions.py
@@ -323,6 +323,19 @@ index_url = partial(
 )  # type: Callable[..., Option]
 
 
+def headers():
+    # type: () -> Option
+    return Option(
+        '-H', '--header',
+        dest='headers',
+        action='append',
+        metavar='KEY:VAL',
+        default=[],
+        help='HTTP header to include in all requests. This option can be used '
+             'multiple times. Conflicts with --extra-index-url.',
+    )
+
+
 def extra_index_url():
     # type: () -> Option
     return Option(
@@ -912,6 +925,7 @@ general_group = {
     'options': [
         help_,
         isolated_mode,
+        headers,
         require_virtualenv,
         verbose,
         version,

--- a/pex/vendor/_vendored/pip/pip/_internal/cli/req_command.py
+++ b/pex/vendor/_vendored/pip/pip/_internal/cli/req_command.py
@@ -7,6 +7,7 @@ PackageFinder machinery and all its vendored dependencies, etc.
 
 import logging
 import os
+import re
 from functools import partial
 
 from pip._internal.cli.base_command import Command
@@ -33,7 +34,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
     from optparse import Values
-    from typing import List, Optional, Tuple
+    from typing import Dict, List, Optional, Tuple
     from pip._internal.cache import WheelCache
     from pip._internal.models.target_python import TargetPython
     from pip._internal.req.req_set import RequirementSet
@@ -68,6 +69,37 @@ class SessionCommandMixin(CommandContextMixIn):
         # Return None rather than an empty list
         return index_urls or None
 
+    @classmethod
+    def _get_headers(cls, options):
+        # type: (Values) -> Optional[Dict[str, str]]
+        """
+        Return a dict of extra HTTP request headers from user-provided options.
+        """
+        # Pull header inputs
+        header_inputs = getattr(options, 'headers', [])
+        if not header_inputs:
+            return None
+
+        # Refuse to set headers when multiple index URLs are set
+        index_urls = cls._get_index_urls(options)
+        if index_urls and len(index_urls) > 1:
+            logger.warning(
+                'Refusing to set -H / --header option(s) because multiple '
+                'index URLs are configured.',
+            )
+            return None
+
+        # Parse header inputs into dict
+        headers = {}
+        for header in header_inputs:
+            match = re.match(r'^(.+?):\s*(.+)$', header.lstrip())
+            if match:
+                key, val = match.groups()
+                headers[key] = val
+            else:
+                logger.critical('Could not parse header {!r}'.format(header))
+        return headers or None
+
     def get_default_session(self, options):
         # type: (Values) -> PipSession
         """Get a default-managed session."""
@@ -89,6 +121,7 @@ class SessionCommandMixin(CommandContextMixIn):
             retries=retries if retries is not None else options.retries,
             trusted_hosts=options.trusted_hosts,
             index_urls=self._get_index_urls(options),
+            headers=self._get_headers(options),
         )
 
         # Handle custom ca-bundles from the user

--- a/pex/vendor/_vendored/pip/pip/_internal/index/collector.py
+++ b/pex/vendor/_vendored/pip/pip/_internal/index/collector.py
@@ -166,7 +166,9 @@ def _get_html_response(url, session):
             # trip for the conditional GET now instead of only
             # once per 10 minutes.
             # For more information, please see pypa/pip#5670.
-            "Cache-Control": "max-age=0",
+            # However if we want to override Cache-Control, e.g. via CLI,
+            # we can still do so.
+            "Cache-Control": session.headers.get('Cache-Control', 'max-age=0'),
         },
     )
     resp.raise_for_status()

--- a/pex/vendor/_vendored/pip/pip/_internal/network/session.py
+++ b/pex/vendor/_vendored/pip/pip/_internal/network/session.py
@@ -39,7 +39,7 @@ from pip._internal.utils.urls import url_to_path
 
 if MYPY_CHECK_RUNNING:
     from typing import (
-        Iterator, List, Optional, Tuple, Union,
+        Dict, Iterator, List, Optional, Tuple, Union,
     )
 
     from pip._internal.models.link import Link
@@ -231,6 +231,7 @@ class PipSession(requests.Session):
         cache = kwargs.pop("cache", None)
         trusted_hosts = kwargs.pop("trusted_hosts", [])  # type: List[str]
         index_urls = kwargs.pop("index_urls", None)
+        headers = kwargs.pop("headers", {})  # type: Dict(str, str)
 
         super(PipSession, self).__init__(*args, **kwargs)
 
@@ -240,6 +241,10 @@ class PipSession(requests.Session):
 
         # Attach our User Agent to the request
         self.headers["User-Agent"] = user_agent()
+
+        # Attach provided HTTP headers to the request
+        if headers:
+            self.headers.update(**headers)
 
         # Attach our Authentication handler to the session
         self.auth = MultiDomainBasicAuth(index_urls=index_urls)


### PR DESCRIPTION
Also add back the `--cache-ttl` option from Pex 1.x and plumb the header
needed to make it so.

Also remove long-ignored `PEX_HTTP_RETRIES` and `PEX_HTTP_TIMEOUT` env
var support.

Fixes #94
Fixes #803