### PR TITLE
Fix Tox not finding Python 3.8 on OSX.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,15 @@
 x-tox-env: &x-tox-env >
-  TOX_BIN=~/.tox-pex/bin
-  PATH="${TOX_BIN}:${PATH}"
+  TOX_CMD="tox --skip-missing-interpreters=false -v"
 
-x-tox: &x-tox |
-  # Run tox from a self-contained virtual environment.
-  python3 -mvenv ~/.tox-pex
-  source ${TOX_BIN}/activate
+x-tox-install: &x-tox-install |
   pip install -U pip
-  pip install tox==3.14.1
-
-  # Prove we have the tox we just installed on the PATH.
-  which python
-  deactivate
-  tox --version
+  pip install 'tox<=3.14.5' 'virtualenv<20.0.5'
 
 x-linux-shard: &x-linux-shard
   os: linux
   dist: bionic
   language: python
-  install: *x-tox
+  install: *x-tox-install
   env: *x-tox-env
   addons:
     apt:
@@ -41,8 +32,8 @@ x-linux-38-shard: &x-linux-38-shard
   python: 3.8.2
 
 x-osx-env: &x-osx-env >
-  PYENV_ROOT="${HOME}/.pyenv_pex"
-  PATH="${PYENV_ROOT}/versions/${PYENV_VERSION}/bin:${PATH}"
+  PYENV_ROOT=~/.pyenv-pex
+  PATH="${PYENV_ROOT}/shims:${PATH}"
 
 x-osx-shard: &x-osx-shard
   os: osx
@@ -55,7 +46,7 @@ x-osx-shard: &x-osx-shard
       - .pyenv_test
       - "${PYENV_ROOT}"
   install:
-    - *x-tox
+    - *x-tox-install
     - |
       # Ensure we have the targeted Python for tox to find on $PATH
       PYENV="${PYENV_ROOT}/bin/pyenv"
@@ -64,6 +55,7 @@ x-osx-shard: &x-osx-shard
         git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}";
       fi
       "${PYENV}" install --keep --skip-existing ${PYENV_VERSION}
+      "${PYENV}" global ${PYENV_VERSION}
 
 x-osx-27-shard: &x-osx-27-shard
   <<: *x-osx-shard
@@ -86,71 +78,71 @@ matrix:
   include:
     - <<: *x-linux-27-shard
       name: TOXENV=style
-      script: tox -v -e style
+      script: ${TOX_CMD} -e style
 
     - <<: *x-linux-38-shard
       name: TOXENV=isort-check
-      script: tox -v -e isort-check
+      script: ${TOX_CMD} -e isort-check
 
     - <<: *x-linux-38-shard
       name: TOXENV=vendor-check
-      script: tox -v -e vendor-check
+      script: ${TOX_CMD} -e vendor-check
 
     - <<: *x-linux-27-shard
       name: TOXENV=py27
-      script: tox -v -e py27
+      script: ${TOX_CMD} -e py27
 
     - <<: *x-linux-27-shard
       name: TOXENV=py27-subprocess
-      script: tox -v -e py27-subprocess
+      script: ${TOX_CMD} -e py27-subprocess
 
     - <<: *x-linux-shard
       name: TOXENV=py35
       python: 3.5.9
-      script: tox -v -e py35
+      script: ${TOX_CMD} -e py35
 
     - <<: *x-linux-shard
       name: TOXENV=py36
       python: 3.6.10
-      script: tox -v -e py36
+      script: ${TOX_CMD} -e py36
 
     - <<: *x-linux-shard
       name: TOXENV=py37
       python: 3.7.7
-      script: tox -v -e py37
+      script: ${TOX_CMD} -e py37
 
     - <<: *x-linux-38-shard
       name: TOXENV=py38
-      script: tox -v -e py38
+      script: ${TOX_CMD} -e py38
 
     - <<: *x-linux-pypy-shard
       name: TOXENV=pypy
-      script: tox -v -e pypy
+      script: ${TOX_CMD} -e pypy
 
     - <<: *x-linux-27-shard
       name: TOXENV=py27-integration
-      script: tox -v -e py27-integration
+      script: ${TOX_CMD} -e py27-integration
 
     - <<: *x-linux-38-shard
       name: TOXENV=py38-integration
-      script: tox -v -e py38-integration
+      script: ${TOX_CMD} -e py38-integration
 
     - <<: *x-linux-pypy-shard
       name: TOXENV=pypy-integration
-      script: tox -v -e pypy-integration
+      script: ${TOX_CMD} -e pypy-integration
 
     - <<: *x-osx-27-shard
       name: TOXENV=py27
-      script: tox -v -e py27
+      script: ${TOX_CMD} -e py27
 
     - <<: *x-osx-38-shard
       name: TOXENV=py38
-      script: tox -v -e py38
+      script: ${TOX_CMD} -e py38
 
     - <<: *x-osx-27-shard
       name: TOXENV=py27-integration
-      script: tox -v -e py27-integration
+      script: ${TOX_CMD} -e py27-integration
 
     - <<: *x-osx-38-shard
       name: TOXENV=py38-integration
-      script: tox -v -e py38-integration
+      script: ${TOX_CMD} -e py38-integration

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ minversion = 3.14.1
 # virtualenv just below that and, correspondingly, tox at the highest version that supports
 # virtualenv 20.0.4.
 # See: https://github.com/pantsbuild/pex/issues/967
+# N.B.: When altering these requires, make the corresponding alteration to .travis.yml.
 requires =
   tox<=3.14.5
   virtualenv<20.0.5


### PR DESCRIPTION
This works, but I can't explain why the prior did not. Moving on with
the fix though since real green is better than the current early exit
green due to not being able to find Python 3.8 and having our tox.ini
configured for `skip_missing_interpreters = True`. Patch that by adding
`--skip-missing-interpreters=false` to our tox invocations in CI.