### PR TITLE
use relative paths within wheel cache

### DIFF
--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -418,6 +418,9 @@ class InstallResult(namedtuple('InstallResult', ['request', 'installation_root',
     runtime_key_dir = os.path.join(self.installation_root, wheel_dir_hash)
     with atomic_directory(runtime_key_dir) as work_dir:
       if work_dir:
+        # Note: Create a relative path symlink between the two directories so that the PEX_ROOT can be
+        # used within a chroot environment where the prefix of the path may change between programs
+        # running inside and outside of the chroot.
         source_path = os.path.join(work_dir, self.request.wheel_file)
         start_dir = os.path.dirname(source_path)
         relative_target_path = os.path.relpath(self.install_chroot, start_dir)

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -418,7 +418,10 @@ class InstallResult(namedtuple('InstallResult', ['request', 'installation_root',
     runtime_key_dir = os.path.join(self.installation_root, wheel_dir_hash)
     with atomic_directory(runtime_key_dir) as work_dir:
       if work_dir:
-        os.symlink(self.install_chroot, os.path.join(work_dir, self.request.wheel_file))
+        source_path = os.path.join(work_dir, self.request.wheel_file)
+        start_dir = os.path.dirname(source_path)
+        relative_target_path = os.path.relpath(self.install_chroot, start_dir)
+        os.symlink(relative_target_path, source_path)
 
     return self._iter_requirements_requests(install_requests)
 

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -418,9 +418,9 @@ class InstallResult(namedtuple('InstallResult', ['request', 'installation_root',
     runtime_key_dir = os.path.join(self.installation_root, wheel_dir_hash)
     with atomic_directory(runtime_key_dir) as work_dir:
       if work_dir:
-        # Note: Create a relative path symlink between the two directories so that the PEX_ROOT can be
-        # used within a chroot environment where the prefix of the path may change between programs
-        # running inside and outside of the chroot.
+        # Note: Create a relative path symlink between the two directories so that the PEX_ROOT
+        # can be used within a chroot environment where the prefix of the path may change
+        # between programs running inside and outside of the chroot.
         source_path = os.path.join(work_dir, self.request.wheel_file)
         start_dir = os.path.dirname(source_path)
         relative_target_path = os.path.relpath(self.install_chroot, start_dir)


### PR DESCRIPTION
When running pex within a chroot environment, the symlinks generated by `pex/pex/resolver.py` use the absolute path within the chroot in the path for the symlinks' targets. These symlinks are invalid paths to any program that accesses the wheel cache outside of the chroot. (This was seen within a remote execution environment with Buildfarm.)

Switch to using relative paths for the symlinks.

Fixes https://github.com/pantsbuild/pex/issues/978.
