### PR TITLE
A PEX_EXTRA_SYS_PATH runtime variable.

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -321,6 +321,11 @@ class PEX(object):  # noqa: T000
 
     new_sys_path, new_sys_path_importer_cache, new_sys_modules = self.minimum_sys(inherit_path)
 
+    if self._vars.PEX_EXTRA_SYS_PATH:
+      TRACER.log('Adding %s to sys.path' % self._vars.PEX_EXTRA_SYS_PATH)
+      new_sys_path.extend(self._vars.PEX_EXTRA_SYS_PATH.split(':'))
+    TRACER.log('New sys.path: %s' % new_sys_path)
+
     patch_all(new_sys_path, new_sys_path_importer_cache, new_sys_modules)
 
   def _wrap_coverage(self, runner, *args):

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -201,6 +201,8 @@ class Variables(object):
     Using this option is generally not advised, but can help in situations when certain dependencies
     do not conform to standard packaging practices and thus cannot be bundled into PEX files.
 
+    See also PEX_EXTRA_SYS_PATH for how to *add* to the sys.path.
+
     Default: false.
     """
     return self._get_string('PEX_INHERIT_PATH', default='false')
@@ -285,6 +287,11 @@ class Variables(object):
     interact with code outside it.
 
     Ex: "/path/to/lib1:/path/to/lib2"
+
+    This is distinct from PEX_INHERIT_PATH, which controls how the interpreter's
+    existing sys.path (which you may not have control over) is scrubbed.
+
+    See also PEX_PATH for how to merge packages from other pexes into the current environment.
     """
     return self._get_string('PEX_EXTRA_SYS_PATH', default=None)
 
@@ -319,6 +326,8 @@ class Variables(object):
     containing plugin entry points to be consumed by a main application.  Paths should be
     specified in the same manner as $PATH, e.g. PEX_PATH=/path/to/pex1.pex:/path/to/pex2.pex
     and so forth.
+
+    See also PEX_EXTRA_SYS_PATH for how to add arbitrary entries to the sys.path.
     """
     return self._get_string('PEX_PATH', default='')
 

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -276,6 +276,19 @@ class Variables(object):
     return self._get_string('PEX_PYTHON_PATH', default=None)
 
   @property
+  def PEX_EXTRA_SYS_PATH(self):
+    """String
+
+    A colon-separated string containing paths to add to the runtime sys.path.
+
+    Should be used sparingly, e.g., if you know that code inside this PEX needs to
+    interact with code outside it.
+
+    Ex: "/path/to/lib1:/path/to/lib2"
+    """
+    return self._get_string('PEX_EXTRA_SYS_PATH', default=None)
+
+  @property
   def PEX_ROOT(self):
     """Directory
 

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -253,6 +253,23 @@ def test_pex_run():
       assert fake_stdout.read() == b'hellohello'
 
 
+def test_pex_run_extra_sys_path():
+  with named_temporary_file() as fake_stdout:
+    with temporary_dir() as temp_dir:
+      pex = write_simple_pex(
+        temp_dir,
+        'import sys; sys.stdout.write(":".join(sys.path)); sys.exit(0)'
+      )
+      rc = PEX(pex.path()).run(stdin=None, stdout=fake_stdout, stderr=None, env={
+        'PEX_EXTRA_SYS_PATH': 'extra/syspath/entry1:extra/syspath/entry2'})
+      assert rc == 0
+
+      fake_stdout.seek(0)
+      syspath = fake_stdout.read().split(b':')
+      assert b'extra/syspath/entry1' in syspath
+      assert b'extra/syspath/entry2' in syspath
+
+
 class PythonpathIsolationTest(namedtuple('PythonpathIsolationTest',
                                          ['pythonpath', 'dists', 'exe'])):
 


### PR DESCRIPTION
If set, we add these path elements to PEX's runtime sys.path.
This allows code in the pex to interact with code outside the
pex (for example, running pytest in a pex on code outside it).