### PR TITLE
Ensure pip download dir is uncontended.

### DIFF
--- a/pex/distribution_target.py
+++ b/pex/distribution_target.py
@@ -3,6 +3,8 @@
 
 from __future__ import absolute_import
 
+import os
+
 from pex.interpreter import PythonInterpreter
 from pex.platforms import Platform
 
@@ -55,14 +57,13 @@ class DistributionTarget(object):
 
   @property
   def id(self):
-    """A unique id for a resolve target suitable as a path name component.
+    """A unique id for this distribution target suitable as a path name component.
 
     :rtype: str
     """
     if self._platform is None:
       interpreter = self.get_interpreter()
-      return '{python}-{abi}'.format(python=interpreter.identity.python_tag,
-                                     abi=interpreter.identity.abi_tag)
+      return interpreter.binary.replace(os.sep, '.').lstrip('.')
     else:
       return str(self._platform)
 

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -529,16 +529,13 @@ class PythonInterpreter(object):
     process = Executor.open_process(cmd, env=env, **kwargs)
     return cmd, process
 
-  def _tup(self):
-    return self._binary, self._identity
-
   def __hash__(self):
-    return hash(self._tup())
+    return hash(self._binary)
 
   def __eq__(self, other):
     if type(other) is not type(self):
       return NotImplemented
-    return self._tup() == other._tup()
+    return self._binary == other._binary
 
   def __lt__(self, other):
     if type(other) is not type(self):

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -68,7 +68,14 @@ class Pip(object):
       '--isolated',
 
       # If we want to warn about a version of python we support, we should do it, not pip.
-      '--no-python-version-warning'
+      '--no-python-version-warning',
+
+      # If pip encounters a duplicate file path during its operations we don't want it to prompt
+      # and we'd also like to know about this since it should never occur. We leverage the pip
+      # global option:
+      # --exists-action <action>
+      #   Default action when a path already exists: (s)witch, (i)gnore, (w)ipe, (b)ackup, (a)bort.
+      '--exists-action', 'a'
     ]
 
     # The max pip verbosity is -vvv and for pex it's -vvvvvvvvv; so we scale down by a factor of 3.

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -934,8 +934,13 @@ def _download_internal(requirements=None,
           #    were specified).
           yield DistributionTarget.for_platform(platform)
 
+  # Only download for each target once. The download code assumes this unique targets optimization
+  # when spawning parallel downloads.
+  # TODO(John Sirois): centralize the de-deuping in the DownloadRequest constructor when we drop
+  # python 2.7 and move from namedtuples to dataclasses.
+  unique_targets = OrderedSet(iter_targets())
   download_request = DownloadRequest(
-    targets=OrderedSet(iter_targets()),
+    targets=unique_targets,
     requirements=requirements,
     requirement_files=requirement_files,
     constraint_files=constraint_files,


### PR DESCRIPTION
When pip encounters an existing file during any of its file operations
it prompts for an action if `--exists-action` has not been set. Pex was
supplying a download directory to pip that was degenerate for
interpreters with the same abi and same major and minor versions (e.g.:
2.7.6 and 2.7.18). We ensure the download directory is unique per
interpreter and further configure the `--exists-action` to abort to get
fail fast behavior and smoke out regressions or any remaining issues in
this vein.

Fixes #983