### PR TITLE
Add support for resolving --platform locally.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -22,6 +22,7 @@ from pex.interpreter_constraints import (
 )
 from pex.jobs import DEFAULT_MAX_JOBS
 from pex.network_configuration import NetworkConfiguration
+from pex.orderedset import OrderedSet
 from pex.pex import PEX
 from pex.pex_bootstrapper import iter_compatible_interpreters
 from pex.pex_builder import PEXBuilder
@@ -448,6 +449,17 @@ def configure_clp_pex_environment(parser):
                    Platform.of_interpreter(current_interpreter),
                    sys.argv[0]))
 
+  group.add_option(
+      '--resolve-local-platforms',
+      dest='resolve_local_platforms',
+      default=False,
+      action='callback',
+      callback=parse_bool,
+      help='When --platforms are specified, attempt to resolve a local interpreter that matches '
+           'each platform specified. If found, use the interpreter to resolve distributions; if '
+           'not, resolve for the platform only allowing matching binary distributions and failing '
+           'if only sdists or non-matching binary distributions can be found.')
+
   parser.add_option_group(group)
 
 
@@ -607,6 +619,11 @@ def _safe_link(src, dst):
 def build_pex(reqs, options, cache=None):
   interpreters = None  # Default to the current interpreter.
 
+  pex_python_path = None  # Defaults to $PATH
+  if options.rc_file or not ENV.PEX_IGNORE_RCFILES:
+    rc_variables = Variables.from_rc(rc=options.rc_file)
+    pex_python_path = rc_variables.get('PEX_PYTHON_PATH', None)
+
   # NB: options.python and interpreter constraints cannot be used together.
   if options.python:
     with TRACER.timed('Resolving interpreters', V=2):
@@ -624,15 +641,34 @@ def build_pex(reqs, options, cache=None):
     with TRACER.timed('Resolving interpreters', V=2):
       constraints = options.interpreter_constraint
       validate_constraints(constraints)
-      if options.rc_file or not ENV.PEX_IGNORE_RCFILES:
-        rc_variables = Variables.from_rc(rc=options.rc_file)
-        pex_python_path = rc_variables.get('PEX_PYTHON_PATH', None)
-      else:
-        pex_python_path = None
       try:
         interpreters = list(iter_compatible_interpreters(pex_python_path, constraints))
       except UnsatisfiableInterpreterConstraintsError as e:
         die(e.create_message('Could not find a compatible interpreter.'), CANNOT_SETUP_INTERPRETER)
+
+  platforms = OrderedSet(options.platforms)
+  interpreters = interpreters or []
+  if options.platforms and options.resolve_local_platforms:
+    with TRACER.timed('Searching for local interpreters matching {}'
+                      .format(', '.join(map(str, platforms)))):
+      for candidate_interpreter in iter_compatible_interpreters(pex_python_path):
+        resolved_platforms = candidate_interpreter.supported_platforms.intersection(platforms)
+        if resolved_platforms:
+          for resolved_platform in resolved_platforms:
+            TRACER.log('Resolved {} for platform {}'
+                       .format(candidate_interpreter, resolved_platform))
+            platforms.remove(resolved_platform)
+          interpreters.append(candidate_interpreter)
+    if platforms:
+      TRACER.log(
+        'Could not resolve a local interpreter for {}, will resolve only binary distributions '
+        'for {}.'.format(
+          ', '.join(map(str, platforms)),
+          'this platform' if len(platforms) == 1 else 'these platforms'
+        )
+      )
+
+  interpreter = min(interpreters) if interpreters else None
 
   try:
     with open(options.preamble_file) as preamble_fd:
@@ -640,8 +676,6 @@ def build_pex(reqs, options, cache=None):
   except TypeError:
     # options.preamble_file is None
     preamble = None
-
-  interpreter = min(interpreters) if interpreters else None
 
   pex_builder = PEXBuilder(path=safe_mkdtemp(), interpreter=interpreter, preamble=preamble)
 
@@ -697,7 +731,7 @@ def build_pex(reqs, options, cache=None):
                                 allow_prereleases=options.allow_prereleases,
                                 transitive=options.transitive,
                                 interpreters=interpreters,
-                                platforms=options.platforms,
+                                platforms=list(platforms),
                                 indexes=indexes,
                                 find_links=options.find_links,
                                 network_configuration=network_configuration,
@@ -740,10 +774,11 @@ def transform_legacy_arg(arg):
   return arg
 
 
-def _compatible_with_current_platform(platforms):
+def _compatible_with_current_platform(interpreter, platforms):
   if not platforms:
     return True
-  current_platforms = {None, Platform.current()}
+  current_platforms = set(interpreter.supported_platforms)
+  current_platforms.add(None)
   return current_platforms.intersection(platforms)
 
 
@@ -790,8 +825,9 @@ def main(args=None):
       pex_builder = build_pex(reqs, options, cache=ENV.PEX_ROOT)
 
     pex_builder.freeze(bytecode_compile=options.compile)
+    interpreter = pex_builder.interpreter
     pex = PEX(pex_builder.path(),
-              interpreter=pex_builder.interpreter,
+              interpreter=interpreter,
               verify_entry_point=options.validate_ep)
 
     if options.pex_name is not None:
@@ -805,10 +841,10 @@ def main(args=None):
       )
       os.rename(tmp_name, options.pex_name)
     else:
-      if not _compatible_with_current_platform(options.platforms):
+      if not _compatible_with_current_platform(interpreter, options.platforms):
         log('WARNING: attempting to run PEX with incompatible platforms!', V=1)
         log('Running on platform {} but built for {}'
-            .format(Platform.current(), ', '.join(map(str, options.platforms))), V=1)
+            .format(interpreter.platform, ', '.join(map(str, options.platforms))), V=1)
 
       log('Running PEX file at %s with args %s' % (pex_builder.path(), cmdline),
           V=options.verbosity)

--- a/pex/distribution_target.py
+++ b/pex/distribution_target.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 import os
 
 from pex.interpreter import PythonInterpreter
-from pex.platforms import Platform
 
 
 class DistributionTarget(object):
@@ -32,13 +31,13 @@ class DistributionTarget(object):
   def is_foreign(self):
     if self._platform is None:
       return False
-    return self._platform != Platform.of_interpreter(self._interpreter)
+    return self._platform not in self.get_interpreter().supported_platforms
 
   def get_interpreter(self):
     return self._interpreter or PythonInterpreter.get()
 
   def get_platform(self):
-    return self._platform or Platform.current()
+    return self._platform or self.get_interpreter().platform
 
   def requirement_applies(self, requirement):
     """Determines if the given requirement applies to this distribution target.

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -16,7 +16,6 @@ from pex.bootstrap import Bootstrap
 from pex.common import atomic_directory, die, open_zip
 from pex.interpreter import PythonInterpreter
 from pex.orderedset import OrderedSet
-from pex.platforms import Platform
 from pex.third_party.packaging import tags
 from pex.third_party.pkg_resources import DistributionNotFound, Environment, Requirement, WorkingSet
 from pex.tracer import TRACER
@@ -318,7 +317,7 @@ class PEXEnvironment(Environment):
         die(
           'Failed to execute PEX file. Needed {platform} compatible dependencies for:\n{items}'
           .format(
-            platform=Platform.of_interpreter(self._interpreter),
+            platform=self._interpreter.platform,
             items='\n'.join(items)
           )
         )

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -52,10 +52,9 @@ class PexInfo(object):
   @classmethod
   def make_build_properties(cls, interpreter=None):
     from .interpreter import PythonInterpreter
-    from .platforms import Platform
 
     pi = interpreter or PythonInterpreter.get()
-    plat = Platform.current()
+    plat = pi.platform
     platform_name = plat.platform
     return {
       'pex_version': pex_version,

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import
 from collections import namedtuple
 from textwrap import dedent
 
-from pex.interpreter import PythonInterpreter
-
 
 class Platform(namedtuple('Platform', ['platform', 'impl', 'version', 'abi'])):
   """Represents a target platform and it's extended interpreter compatibility
@@ -78,18 +76,13 @@ class Platform(namedtuple('Platform', ['platform', 'impl', 'version', 'abi'])):
     return super(Platform, cls).__new__(cls, platform, impl, version, abi)
 
   @classmethod
-  def of_interpreter(cls, intepreter=None):
-    intepreter = intepreter or PythonInterpreter.get()
-    identity = intepreter.identity
-    impl, version = identity.python_tag[:2], identity.python_tag[2:]
-    return cls(platform=identity.platform_tag,
-               impl=impl,
-               version=version,
-               abi=identity.abi_tag)
+  def from_tags(cls, platform, python, abi):
+    """Creates a platform corresponding to wheel compatibility tags.
 
-  @classmethod
-  def current(cls):
-    return cls.of_interpreter()
+    See: https://www.python.org/dev/peps/pep-0425/#details
+    """
+    impl, version = python[:2], python[2:]
+    return cls(platform=platform, impl=impl, version=version, abi=abi)
 
   def __str__(self):
     return self.SEP.join(self)

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -270,10 +270,11 @@ class Variables(object):
     """String
 
     A colon-separated string containing paths of blessed Python interpreters
-    for overriding the Python interpreter used to invoke this PEX. Must be absolute paths to the
-    interpreter.
+    for overriding the Python interpreter used to invoke this PEX. Can be absolute paths to
+    interpreters or standard $PATH style directory entries that are searched for child files that
+    are python binaries.
 
-    Ex: "/path/to/python27:/path/to/python36"
+    Ex: "/path/to/python27:/path/to/python36-distribution/bin"
     """
     return self._get_string('PEX_PYTHON_PATH', default=None)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,6 +5,7 @@ import filecmp
 import functools
 import glob
 import json
+import multiprocessing
 import os
 import re
 import shutil
@@ -19,6 +20,7 @@ import pytest
 from pex import pex_builder
 from pex.common import safe_copy, safe_mkdir, safe_open, safe_rmtree, safe_sleep, temporary_dir
 from pex.compatibility import WINDOWS, nested, to_bytes
+from pex.interpreter import PythonInterpreter
 from pex.pex_info import PexInfo
 from pex.pip import get_pip
 from pex.testing import (
@@ -1856,3 +1858,40 @@ def test_unzip_mode():
     )
     assert output1 == output2
     assert not os.path.exists(unzipped_cache)
+
+
+def test_issues_996():
+  python27 = ensure_python_interpreter(PY27)
+  python36 = ensure_python_interpreter(PY36)
+  pex_python_path = os.pathsep.join((python27, python36))
+
+  def create_platform_pex(args):
+    return run_pex_command(
+      args=['--platform', str(PythonInterpreter.from_binary(python36).platform)] + args,
+      python=python27,
+      env=make_env(PEX_PYTHON_PATH=pex_python_path)
+    )
+
+  with temporary_dir() as td:
+    pex_file = os.path.join(td, 'pex_file')
+
+    # N.B.: We use psutil since only an sdist is available for linux and osx and the distribution
+    # has no dependencies.
+    args = ['psutil==5.7.0', '-o', pex_file]
+
+    # By default, no --platforms are resolved and so distributions must be available in binary form.
+    results = create_platform_pex(args)
+    results.assert_failure()
+
+    # If --platform resolution is enabled however, we should be able to find a corresponsing local
+    # interpreter to perform a full-featured resolve with.
+    results = create_platform_pex(['--resolve-local-platforms'] + args)
+    results.assert_success()
+
+    output, returncode = run_simple_pex(
+      pex=pex_file,
+      args=('-c', 'import psutil; print(psutil.cpu_count())'),
+      interpreter=PythonInterpreter.from_binary(python36)
+    )
+    assert 0 == returncode
+    assert int(output.strip()) >= multiprocessing.cpu_count()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1883,7 +1883,7 @@ def test_issues_996():
     results = create_platform_pex(args)
     results.assert_failure()
 
-    # If --platform resolution is enabled however, we should be able to find a corresponsing local
+    # If --platform resolution is enabled however, we should be able to find a corresponding local
     # interpreter to perform a full-featured resolve with.
     results = create_platform_pex(['--resolve-local-platforms'] + args)
     results.assert_success()

--- a/tests/test_pex_binary.py
+++ b/tests/test_pex_binary.py
@@ -11,7 +11,7 @@ import pytest
 from pex.bin.pex import build_pex, configure_clp, configure_clp_pex_resolution
 from pex.common import safe_copy, temporary_dir
 from pex.compatibility import nested, to_bytes
-from pex.platforms import Platform
+from pex.interpreter import PythonInterpreter
 from pex.testing import (
     PY27,
     built_wheel,
@@ -209,7 +209,7 @@ def test_run_pex():
   assert incompatible_platforms_warning_msg not in assert_run_pex()
   assert incompatible_platforms_warning_msg not in assert_run_pex(pex_args=['--platform=current'])
   assert incompatible_platforms_warning_msg not in assert_run_pex(
-    pex_args=['--platform={}'.format(Platform.current())]
+    pex_args=['--platform={}'.format(PythonInterpreter.get().platform)]
   )
 
   py27 = ensure_python_interpreter(PY27)


### PR DESCRIPTION
Introduce new APIs to get a PythonInterpreter's associated platforms
directly and use this to implement resolution of specified platforms to
local interpreters when possible if --resolve-local-platforms is
specified.

Fixes #996.