### PR TITLE
Improve --platform help.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -428,6 +428,7 @@ def configure_clp_pex_environment(parser):
            '#!.  This overrides the default behavior, which picks an environment python '
            'interpreter compatible with the one used to build the PEX file.')
 
+  current_interpreter = PythonInterpreter.get()
   group.add_option(
       '--platform',
       dest='platforms',
@@ -442,7 +443,10 @@ def configure_clp_pex_environment(parser):
            'stem from wheel name conventions as outlined in '
            'https://www.python.org/dev/peps/pep-0427#file-name-convention and influenced by '
            'https://www.python.org/dev/peps/pep-0425. For the current interpreter at {} the full '
-           'platform string is {}'.format(PythonInterpreter.get().binary, Platform.current()))
+           'platform string is {}. To find out more, try `{} --platform explain`.'
+           .format(current_interpreter.binary,
+                   Platform.of_interpreter(current_interpreter),
+                   sys.argv[0]))
 
   parser.add_option_group(group)
 

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -47,6 +47,10 @@ class Platform(namedtuple('Platform', ['platform', 'impl', 'version', 'abi'])):
         The abbreviated platform string is:
           linux-x86_64-cp-37-m
 
+        Some other canonical platform string examples:
+        + OSX CPython: macosx-10.13-x86_64-cp-36-cp36m
+        + Linux PyPy: linux-x86_64-pp-273-pypy_73.
+
         These fields stem from wheel name conventions as outlined in
         https://www.python.org/dev/peps/pep-0427#file-name-convention and influenced by
         https://www.python.org/dev/peps/pep-0425.


### PR DESCRIPTION
This adds a prompt to use --platform explain as a hack to get more
information from a platform parse error. Also add examples to the parse
error message to cover OSX and PyPy covering the other major variants
we support.