### PR TITLE
Add `--use-first-matching-interpreter`

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -526,10 +526,11 @@ def configure_clp_pex_environment(parser):
         action="callback",
         callback=parse_bool,
         help=(
-            "If multiple interpreters are valid, use the first one. Normally, when multiple "
-            "interpreters match, Pex will resolve requirements for each interpreter; this allows "
-            "the resulting Pex to work with more interpreters, such as different Python versions. "
-            "However, resolving for multiple interpreters results in worse performance."
+            "If multiple interpreters are valid, use the first one, which is the minimum "
+            "compatible Python version. Normally, when multiple interpreters match, Pex will "
+            "resolve requirements for each interpreter; this allows the resulting Pex to be "
+            "compatible with more interpreters, such as different Python versions. However, "
+            "resolving for multiple interpreters results in worse performance."
         ),
     )
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -592,11 +592,12 @@ def test_use_first_matching_interpreter():
                 "-v",
                 "-o",
                 pex_out_path,
-            ], env=env
+            ],
+            env=env,
         )
         res.assert_success()
-        assert "using {}".format(py35_path) in res.error.decode()
-        assert "will not be used: {}".format(py36_path) in res.error.decode()
+        assert "using {}".format(py35_path) in res.error
+        assert "will not be used: {}".format(py36_path) in res.error
         # We do not attempt to update the PexInfo to solely refer to the chosen interpreter.
         pex_info = PexInfo.from_pex(pex_out_path)
         assert {">=3.5"} == set(pex_info.interpreter_constraints)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -575,6 +575,33 @@ def test_interpreter_resolution_pex_python_path_precedence_over_pex_python():
         assert correct_interpreter_path in stdout
 
 
+def test_use_first_matching_interpreter():
+    with temporary_dir() as output_dir:
+        py35_path = ensure_python_interpreter(PY35)
+        py36_path = ensure_python_interpreter(PY36)
+        env = make_env(
+            PEX_IGNORE_RCFILES="1",
+            PATH=os.pathsep.join([os.path.dirname(py35_path), os.path.dirname(py36_path)]),
+        )
+        pex_out_path = os.path.join(output_dir, "pex_py2.pex")
+        res = run_pex_command(
+            [
+                "--disable-cache",
+                "--interpreter-constraint=>=3.5",
+                "--use-first-matching-interpreter",
+                "-v",
+                "-o",
+                pex_out_path,
+            ], env=env
+        )
+        res.assert_success()
+        assert "using {}".format(py35_path) in res.error.decode()
+        assert "will not be used: {}".format(py36_path) in res.error.decode()
+        # We do not attempt to update the PexInfo to solely refer to the chosen interpreter.
+        pex_info = PexInfo.from_pex(pex_out_path)
+        assert {">=3.5"} == set(pex_info.interpreter_constraints)
+
+
 def test_plain_pex_exec_no_ppp_no_pp_no_constraints():
     with temporary_dir() as td:
         pex_out_path = os.path.join(td, "pex.pex")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -605,7 +605,7 @@ def test_use_first_matching_interpreter():
             stdin_payload = b"import sys, psutil; print(sys.executable); sys.exit(0)"
             stdout, rc = run_simple_pex(pex_out_path, stdin=stdin_payload, env=env)
             assert rc == 0
-            assert py35_path in stdout
+            assert py35_path in stdout.decode()
 
             stdout, rc = run_simple_pex(
                 pex_out_path, stdin=stdin_payload, env=make_env(PEX_PYTHON_PATH=py36_path)
@@ -614,11 +614,11 @@ def test_use_first_matching_interpreter():
 
     without_flag_stdout, without_flag_rc = run_pex_with_py36(use_first_matching_flag=False)
     assert without_flag_rc == 0
-    assert py36_path in without_flag_stdout
+    assert py36_path in without_flag_stdout.decode()
 
     with_flag_stdout, with_flag_rc = run_pex_with_py36(use_first_matching_flag=True)
     assert with_flag_rc == 1
-    assert bool(re.search(r"Needed.*cp-36-cp36m", with_flag_stdout))
+    assert bool(re.search(r"Needed.*cp-36-cp36m", with_flag_stdout.decode()))
 
 
 def test_plain_pex_exec_no_ppp_no_pp_no_constraints():


### PR DESCRIPTION
Before:
```
1: python -m pex --disable-cache --interpreter-constraint=CPython>=3.6 cryptography -o t.pex
            Mean        Std.Dev.    Min         Median      Max
real        7.541       0.258       7.283       7.378       7.967
user        21.989      0.609       20.890      21.887      23.020
sys         5.979       0.169       5.690       5.918       6.237
```

After:
```
1: python -m pex --disable-cache --use-first-matching-interpreter --interpreter-constraint=CPython>=3.6 cryptography -o t.pex
            Mean        Std.Dev.    Min         Median      Max
real        6.217       0.478       5.820       6.118       7.592
user        11.233      0.349       10.593      11.292      11.751
sys         3.538       0.106       3.305       3.542       3.675
```

This is expected to be particularly useful for Pants, where often have loose interpreter constraints like the default of `>=3.6`. The only time we actually need to build for `>=3.6` is when running `binary`. All other times, we only need the first matching interpreter.