### PR TITLE
Fix --use-first-matching-interpreter at runtime.

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -598,7 +598,9 @@ def test_use_first_matching_interpreter():
             # We do not attempt to update the PexInfo, even if `--use-first-matching-interpreter`
             # is used.
             pex_info = PexInfo.from_pex(pex_out_path)
-            assert {">=3.5"} == set(pex_info.interpreter_constraints)
+            assert (
+                [] if use_first_matching_flag else [">=3.5"]
+            ) == pex_info.interpreter_constraints
 
             # Running with Python 3.5 should always work because that is the first matching
             # interpreter.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -595,8 +595,6 @@ def test_use_first_matching_interpreter():
             res = run_pex_command(args, env=env)
             res.assert_success()
 
-            # We do not attempt to update the PexInfo, even if `--use-first-matching-interpreter`
-            # is used.
             pex_info = PexInfo.from_pex(pex_out_path)
             assert (
                 [] if use_first_matching_flag else [">=3.5"]


### PR DESCRIPTION
Restrict the runtime interpreter to match the buildtime interpreter
by the crude means of relying on the pythonX.Y shebang.