### PR TITLE
PEX zips now contain directory entries.

### DIFF
--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -367,10 +367,10 @@ def isolated():
             os.mkdir(dstdir)
             for entry_name in resource_listdir(module, srcdir):
                 if not entry_name:
-                    # The `resource_listdir` function returns a '' asset for the directory entry
-                    # itself if it is either present on the filesystem or present as an explicit
-                    # zip entry. Since we only care about files and subdirectories at this point,
-                    # skip these assets.
+                    # The `resource_listdir` function returns a '' entry name for the directory
+                    # entry itself if it is either present on the filesystem or present as an
+                    # explicit zip entry. Since we only care about files and subdirectories at this
+                    # point, skip these entries.
                     continue
                 # NB: Resource path components are always separated by /, on all systems.
                 src_entry = "{}/{}".format(srcdir, entry_name) if srcdir else entry_name

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -362,9 +362,16 @@ def isolated():
 
         module = "pex"
 
+        # TODO(John Sirois): Unify with `pex.util.DistributionHelper.access_zipped_assets`.
         def recursive_copy(srcdir, dstdir):
             os.mkdir(dstdir)
             for entry_name in resource_listdir(module, srcdir):
+                if not entry_name:
+                    # The `resource_listdir` function returns a '' asset for the directory entry
+                    # itself if it is either present on the filesystem or present as an explicit
+                    # zip entry. Since we only care about files and subdirectories at this point,
+                    # skip these assets.
+                    continue
                 # NB: Resource path components are always separated by /, on all systems.
                 src_entry = "{}/{}".format(srcdir, entry_name) if srcdir else entry_name
                 dst_entry = os.path.join(dstdir, entry_name)

--- a/pex/util.py
+++ b/pex/util.py
@@ -32,11 +32,17 @@ class DistributionHelper(object):
         :returns temp_dir: Temporary directory with the zipped assets inside
         :rtype: str
         """
-
         # asset_path is initially a module name that's the same as the static_path, but will be
         # changed to walk the directory tree
+        # TODO(John Sirois): Unify with `pex.third_party.isolated(recursive_copy)`.
         def walk_zipped_assets(static_module_name, static_path, asset_path, temp_dir):
             for asset in resource_listdir(static_module_name, asset_path):
+                if not asset:
+                    # The `resource_listdir` function returns a '' asset for the directory entry
+                    # itself if it is either present on the filesystem or present as an explicit
+                    # zip entry. Since we only care about files and subdirectories at this point,
+                    # skip these assets.
+                    continue
                 asset_target = os.path.normpath(
                     os.path.join(os.path.relpath(asset_path, static_path), asset)
                 )


### PR DESCRIPTION
Previously they did not which led to PEP-420 namespace packages not
working in `--zip-safe` context.

Fixes #1021