### PR TITLE
Add type hints to most tests

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -9,7 +9,7 @@ no_implicit_optional = True
 
 warn_redundant_casts = True
 warn_unused_configs = True
-# TODO: enable the below to be True once we drop Python 2. Otherwise, we need it because some
+# TODO: enable `warn_unused_ignores = True` once we drop Python 2. Otherwise, we need it because some
 # ignores depend on which interpreter we use.
 warn_unused_ignores = False
 warn_no_return = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,11 +7,11 @@ check_untyped_defs = False
 
 no_implicit_optional = True
 
-# TODO: enable the below three to be True once we drop Python 2. Otherwise, we need them because some
+warn_redundant_casts = True
+warn_unused_configs = True
+# TODO: enable the below to be True once we drop Python 2. Otherwise, we need it because some
 # ignores depend on which interpreter we use.
-warn_redundant_casts = False
 warn_unused_ignores = False
-warn_unused_configs = False
 warn_no_return = True
 warn_return_any = True
 warn_unreachable = True

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -125,6 +125,7 @@ def process_platform(option, option_str, option_value, parser):
 
 
 def configure_clp_pex_resolution(parser):
+    # type: (OptionParser) -> None
     group = OptionGroup(
         parser,
         "Resolver options",
@@ -326,6 +327,7 @@ def configure_clp_pex_resolution(parser):
 
 
 def configure_clp_pex_options(parser):
+    # type: (OptionParser) -> None
     group = OptionGroup(
         parser,
         "PEX output options",
@@ -440,6 +442,7 @@ def configure_clp_pex_options(parser):
 
 
 def configure_clp_pex_environment(parser):
+    # type: (OptionParser) -> None
     group = OptionGroup(
         parser,
         "PEX environment options",
@@ -538,6 +541,7 @@ def configure_clp_pex_environment(parser):
 
 
 def configure_clp_pex_entry_points(parser):
+    # type: (OptionParser) -> None
     group = OptionGroup(
         parser,
         "PEX entry point options",
@@ -581,6 +585,7 @@ def configure_clp_pex_entry_points(parser):
 
 
 def configure_clp():
+    # type: () -> OptionParser
     usage = (
         "%prog [-o OUTPUT.PEX] [options] [-- arg1 arg2 ...]\n\n"
         "%prog builds a PEX (Python Executable) file based on the given specifications: "

--- a/pex/common.py
+++ b/pex/common.py
@@ -19,6 +19,12 @@ from contextlib import contextmanager
 from datetime import datetime
 from uuid import uuid4
 
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
 # We use the start of MS-DOS time, which is what zipfiles use (see section 4.4.6 of
 # https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT).
 DETERMINISTIC_DATETIME = datetime(
@@ -172,12 +178,13 @@ def temporary_dir(cleanup=True):
 
 
 def safe_mkdtemp(**kw):
+    # type: (**Any) -> str
     """Create a temporary directory that is cleaned up on process exit.
 
     Takes the same parameters as tempfile.mkdtemp.
     """
     # proper lock sanitation on fork [issue 6721] would be desirable here.
-    return _MKDTEMP_SINGLETON.register(tempfile.mkdtemp(**kw))
+    return _MKDTEMP_SINGLETON.register(tempfile.mkdtemp(**kw))  # type: ignore[no-any-return]
 
 
 def register_rmtree(directory):

--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -13,7 +13,7 @@ from sys import version_info as sys_version_info
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Optional
+    from typing import Optional, AnyStr, Text
 
 
 try:
@@ -29,8 +29,6 @@ PY2 = sys_version_info[0] == 2
 PY3 = sys_version_info[0] == 3
 
 string = (str,) if PY3 else (str, unicode)  # type: ignore[name-defined]
-unicode_string = (str,) if PY3 else (unicode,)  # type: ignore[name-defined]
-bytes = (bytes,)  # type: ignore[has-type]
 
 if PY2:
     from collections import Iterable as Iterable
@@ -42,6 +40,7 @@ else:
 if PY2:
 
     def to_bytes(st, encoding="utf-8"):
+        # type: (AnyStr, Text) -> bytes
         if isinstance(st, unicode):
             return st.encode(encoding)
         elif isinstance(st, bytes):
@@ -50,6 +49,7 @@ if PY2:
             raise ValueError("Cannot convert %s to bytes" % type(st))
 
     def to_unicode(st, encoding="utf-8"):
+        # type: (AnyStr, Text) -> Text
         if isinstance(st, unicode):
             return st
         elif isinstance(st, (str, bytes)):
@@ -61,6 +61,7 @@ if PY2:
 else:
 
     def to_bytes(st, encoding="utf-8"):
+        # type: (AnyStr, Text) -> bytes
         if isinstance(st, str):
             return st.encode(encoding)
         elif isinstance(st, bytes):
@@ -69,6 +70,7 @@ else:
             raise ValueError("Cannot convert %s to bytes." % type(st))
 
     def to_unicode(st, encoding="utf-8"):
+        # type: (AnyStr, Text) -> Text
         if isinstance(st, str):
             return st
         elif isinstance(st, bytes):

--- a/pex/compiler.py
+++ b/pex/compiler.py
@@ -1,11 +1,17 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from pex.compatibility import to_bytes
 from pex.executor import Executor
+from pex.interpreter import PythonInterpreter
+from pex.typing import TYPE_CHECKING
 from pex.util import named_temporary_file
+
+if TYPE_CHECKING:
+    from typing import Iterable, Text, List
+
 
 _COMPILER_MAIN = """
 from __future__ import print_function
@@ -60,24 +66,24 @@ class Compiler(object):
     class Error(Exception):
         pass
 
-    class CompilationFailure(
-        Error
-    ):  # N.B. This subclasses `Error` only for backwards compatibility.
+    # N.B. This subclasses `Error` only for backwards compatibility.
+    class CompilationFailure(Error):
         """Indicates an error compiling one or more python source files."""
 
     def __init__(self, interpreter):
+        # type: (PythonInterpreter) -> None
         """Creates a bytecode compiler for the given `interpreter`.
 
         :param interpreter: The interpreter to use to compile sources with.
-        :type interpreter: :class:`pex.interpreter.PythonInterpreter`
         """
         self._interpreter = interpreter
 
     def compile(self, root, relpaths):
+        # type: (str, Iterable[Text]) -> List[Text]
         """Compiles the given python source files using this compiler's interpreter.
 
-        :param string root: The root path all the source files are found under.
-        :param list relpaths: The relative paths from the `root` of the source files to compile.
+        :param root: The root path all the source files are found under.
+        :param relpaths: The relative paths from the `root` of the source files to compile.
         :returns: A list of relative paths of the compiled bytecode files.
         :raises: A :class:`Compiler.Error` if there was a problem bytecode compiling any of the files.
         """
@@ -94,4 +100,5 @@ class Compiler(object):
                     "encountered %r during bytecode compilation.\nstderr was:\n%s\n" % (e, e.stderr)
                 )
 
-            return out.splitlines()
+            # TODO(#1034): remove the ignore once python_interpreter.py is updated.
+            return out.splitlines()  # type: ignore[no-any-return]

--- a/pex/compiler.py
+++ b/pex/compiler.py
@@ -100,5 +100,5 @@ class Compiler(object):
                     "encountered %r during bytecode compilation.\nstderr was:\n%s\n" % (e, e.stderr)
                 )
 
-            # TODO(#1034): remove the ignore once python_interpreter.py is updated.
+            # TODO(#1034): remove the ignore once interpreter.py is updated.
             return out.splitlines()  # type: ignore[no-any-return]

--- a/pex/compiler.py
+++ b/pex/compiler.py
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 
 from pex.compatibility import to_bytes
 from pex.executor import Executor
@@ -79,7 +79,7 @@ class Compiler(object):
         self._interpreter = interpreter
 
     def compile(self, root, relpaths):
-        # type: (str, Iterable[Text]) -> List[Text]
+        # type: (str, Iterable[str]) -> List[Text]
         """Compiles the given python source files using this compiler's interpreter.
 
         :param root: The root path all the source files are found under.

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -494,13 +494,13 @@ class PythonInterpreter(object):
 
     @classmethod
     def from_binary(cls, binary):
+        # type: (str) -> PythonInterpreter
         """Create an interpreter from the given `binary`.
 
-        :param str binary: The path to the python interpreter binary.
+        :param binary: The path to the python interpreter binary.
         :return: an interpreter created from the given `binary`.
-        :rtype: :class:`PythonInterpreter`
         """
-        return cls._spawn_from_binary(binary).await_result()
+        return cls._spawn_from_binary(binary).await_result()  # type: ignore[no-any-return]
 
     @classmethod
     def _matches_binary_name(cls, path):

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -10,9 +10,14 @@ from pex import pex_warnings
 from pex.common import can_write_dir, open_zip, safe_mkdtemp
 from pex.compatibility import PY2
 from pex.compatibility import string as compatibility_string
+from pex.interpreter import PythonInterpreter
 from pex.orderedset import OrderedSet
+from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
 from pex.version import __version__ as pex_version
+
+if TYPE_CHECKING:
+    from typing import Optional
 
 
 # TODO(wickman) Split this into a PexInfoBuilder/PexInfo to ensure immutability.
@@ -51,8 +56,6 @@ class PexInfo(object):
 
     @classmethod
     def make_build_properties(cls, interpreter=None):
-        from .interpreter import PythonInterpreter
-
         pi = interpreter or PythonInterpreter.get()
         plat = pi.platform
         platform_name = plat.platform
@@ -65,6 +68,7 @@ class PexInfo(object):
 
     @classmethod
     def default(cls, interpreter=None):
+        # type: (Optional[PythonInterpreter]) -> PexInfo
         pex_info = {
             "requirements": [],
             "distributions": {},

--- a/tests/test_bdist_pex.py
+++ b/tests/test_bdist_pex.py
@@ -10,9 +10,14 @@ from pex import resolver
 from pex.common import open_zip, temporary_dir
 from pex.interpreter import spawn_python_job
 from pex.testing import WheelBuilder, make_project, temporary_content
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Dict, List, Iterator, Iterable, Optional, Text, Union
 
 
 def pex_project_dir():
+    # type: () -> Text
     return subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode("utf-8").strip()
 
 
@@ -20,6 +25,7 @@ BDIST_PEX_PYTHONPATH = None
 
 
 def bdist_pex_pythonpath():
+    # type: () -> List[Text]
     # In order to run the bdist_pex distutils command we need:
     # 1. setuptools on the PYTHONPATH since the test projects use and test setuptools.setup and its
     #    additional features above and beyond distutils.core.setup like entry points declaration.
@@ -43,6 +49,7 @@ def bdist_pex_pythonpath():
 
 @contextmanager
 def bdist_pex(project_dir, bdist_args=None):
+    # type: (str, Optional[Iterable[str]]) -> Iterator[str]
     with temporary_dir() as dist_dir:
         cmd = [
             "setup.py",
@@ -61,6 +68,7 @@ def bdist_pex(project_dir, bdist_args=None):
 
 
 def assert_entry_points(entry_points):
+    # type: (Union[str, Dict[str, List[str]]]) -> None
     with make_project(name="my_app", entry_points=entry_points) as project_dir:
         with bdist_pex(project_dir) as my_app_pex:
             process = subprocess.Popen([my_app_pex], stdout=subprocess.PIPE)
@@ -71,6 +79,7 @@ def assert_entry_points(entry_points):
 
 
 def assert_pex_args_shebang(shebang):
+    # type: (str) -> None
     with make_project() as project_dir:
         pex_args = '--pex-args=--python-shebang="{}"'.format(shebang)
         with bdist_pex(project_dir, bdist_args=[pex_args]) as my_app_pex:
@@ -79,10 +88,12 @@ def assert_pex_args_shebang(shebang):
 
 
 def test_entry_points_dict():
+    # type: () -> None
     assert_entry_points({"console_scripts": ["my_app = my_app.my_module:do_something"]})
 
 
 def test_entry_points_ini_string():
+    # type: () -> None
     assert_entry_points(
         dedent(
             """
@@ -94,14 +105,17 @@ def test_entry_points_ini_string():
 
 
 def test_pex_args_shebang_with_spaces():
+    # type: () -> None
     assert_pex_args_shebang("#!/usr/bin/env python")
 
 
 def test_pex_args_shebang_without_spaces():
+    # type: () -> None
     assert_pex_args_shebang("#!/usr/bin/python")
 
 
 def test_unwriteable_contents():
+    # type: () -> None
     my_app_setup_py = dedent(
         """
         from setuptools import setup

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -3,28 +3,32 @@
 
 import pytest
 
-from pex.compatibility import to_bytes, to_unicode, unicode_string
+from pex.compatibility import PY3, to_bytes, to_unicode
+
+unicode_string = (str,) if PY3 else (unicode,)  # type: ignore[name-defined]
 
 
 def test_to_bytes():
+    # type: () -> None
     assert isinstance(to_bytes(""), bytes)
     assert isinstance(to_bytes("abc"), bytes)
     assert isinstance(to_bytes(b"abc"), bytes)
     assert isinstance(to_bytes(u"abc"), bytes)
-    assert isinstance(to_bytes(b"abc".decode("latin-1"), encoding="utf-8"), bytes)
+    assert isinstance(to_bytes(b"abc".decode("latin-1"), encoding=u"utf-8"), bytes)
 
     for bad_value in (123, None):
         with pytest.raises(ValueError):
-            to_bytes(bad_value)
+            to_bytes(bad_value)  # type: ignore[type-var]
 
 
 def test_to_unicode():
+    # type: () -> None
     assert isinstance(to_unicode(""), unicode_string)
     assert isinstance(to_unicode("abc"), unicode_string)
     assert isinstance(to_unicode(b"abc"), unicode_string)
     assert isinstance(to_unicode(u"abc"), unicode_string)
-    assert isinstance(to_unicode(u"abc".encode("latin-1"), encoding="latin-1"), unicode_string)
+    assert isinstance(to_unicode(u"abc".encode("latin-1"), encoding=u"latin-1"), unicode_string)
 
     for bad_value in (123, None):
         with pytest.raises(ValueError):
-            to_unicode(bad_value)
+            to_unicode(bad_value)  # type: ignore[type-var]

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -13,9 +13,14 @@ from pex.common import safe_open, temporary_dir
 from pex.compatibility import to_bytes
 from pex.compiler import Compiler
 from pex.interpreter import PythonInterpreter
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Dict, Iterable, Iterator, List, Text, Tuple
 
 
 def write_source(path, valid=True):
+    # type: (str, bool) -> None
     with safe_open(path, "wb") as fp:
         fp.write(to_bytes("basename = %r\n" % os.path.basename(path)))
         if not valid:
@@ -23,7 +28,8 @@ def write_source(path, valid=True):
 
 
 @contextlib.contextmanager
-def compilation(valid_paths=None, invalid_paths=None, compile_paths=None):
+def compilation(valid_paths, invalid_paths, compile_paths):
+    # type: (Iterable[str], Iterable[str], Iterable[str]) -> Iterator[Tuple[str, List[Text]]]
     with temporary_dir() as root:
         for path in valid_paths:
             write_source(os.path.join(root, path))
@@ -34,6 +40,7 @@ def compilation(valid_paths=None, invalid_paths=None, compile_paths=None):
 
 
 def test_compile_success():
+    # type: () -> None
     with compilation(
         valid_paths=["a.py", "c/c.py"],
         invalid_paths=["b.py", "d/d.py"],
@@ -54,7 +61,7 @@ def test_compile_success():
                 if compatibility.PY3:
                     fp.read(4)  # Skip the size.
                 code = marshal.load(fp)
-            local_symbols = {}
+            local_symbols = {}  # type: Dict[str, str]
             exec (code, {}, local_symbols)
             results[compiled] = local_symbols
 
@@ -64,6 +71,7 @@ def test_compile_success():
 
 
 def test_compile_failure():
+    # type: () -> None
     with pytest.raises(Compiler.Error) as e:
         with compilation(
             valid_paths=["a.py", "c/c.py"],

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -8,6 +8,10 @@ import pytest
 
 from pex.common import safe_mkdir, temporary_dir
 from pex.executor import Executor
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Callable, List
 
 TEST_EXECUTABLE = "/a/nonexistent/path/to/nowhere"
 TEST_CMD_LIST = [TEST_EXECUTABLE, "--version"]
@@ -19,12 +23,14 @@ TEST_CODE = 3
 
 
 def test_executor_open_process_wait_return():
+    # type: () -> None
     process = Executor.open_process("exit 8", shell=True)
     exit_code = process.wait()
     assert exit_code == 8
 
 
 def test_executor_open_process_communicate():
+    # type: () -> None
     process = Executor.open_process(
         ["/bin/echo", "-n", "hello"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
@@ -34,6 +40,7 @@ def test_executor_open_process_communicate():
 
 
 def test_executor_execute():
+    # type: () -> None
     assert Executor.execute("/bin/echo -n stdout >&1", shell=True) == ("stdout", "")
     assert Executor.execute("/bin/echo -n stderr >&2", shell=True) == ("", "stderr")
     assert Executor.execute("/bin/echo -n TEST | tee /dev/stderr", shell=True) == ("TEST", "TEST")
@@ -43,11 +50,13 @@ def test_executor_execute():
 
 
 def test_executor_execute_zero():
+    # type: () -> None
     Executor.execute("exit 0", shell=True)
 
 
 @pytest.mark.parametrize("testable", [Executor.open_process, Executor.execute])
 def test_executor_execute_not_found(testable):
+    # type: (Callable) -> None
     with pytest.raises(Executor.ExecutableNotFound) as exc:
         testable(TEST_CMD_LIST)
     assert exc.value.executable == TEST_EXECUTABLE
@@ -56,6 +65,7 @@ def test_executor_execute_not_found(testable):
 
 @pytest.mark.parametrize("exit_code", [1, 127, -1])
 def test_executor_execute_nonzero(exit_code):
+    # type: (int) -> None
     with pytest.raises(Executor.NonZeroExit) as exc:
         Executor.execute("exit %s" % exit_code, shell=True)
 
@@ -65,6 +75,7 @@ def test_executor_execute_nonzero(exit_code):
 
 @pytest.mark.parametrize("cmd", TEST_CMD_PARAMETERS)
 def test_executor_exceptions_executablenotfound(cmd):
+    # type: (List[str]) -> None
     exc_cause = OSError("test")
     exc = Executor.ExecutableNotFound(cmd=cmd, exc=exc_cause)
     assert exc.executable == TEST_EXECUTABLE
@@ -74,6 +85,7 @@ def test_executor_exceptions_executablenotfound(cmd):
 
 @pytest.mark.parametrize("cmd", TEST_CMD_PARAMETERS)
 def test_executor_exceptions_nonzeroexit(cmd):
+    # type: (List[str]) -> None
     exc = Executor.NonZeroExit(cmd=cmd, exit_code=TEST_CODE, stdout=TEST_STDOUT, stderr=TEST_STDERR)
     assert exc.executable == TEST_EXECUTABLE
     assert exc.cmd == cmd
@@ -83,6 +95,7 @@ def test_executor_exceptions_nonzeroexit(cmd):
 
 
 def test_executor_execute_dir():
+    # type: () -> None
     with temporary_dir() as temp_dir:
         test_dir = os.path.realpath(os.path.join(temp_dir, "tmp"))
         safe_mkdir(test_dir)

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -7,13 +7,18 @@ import pytest
 
 from pex.finders import get_entry_point_from_console_script, get_script_from_distributions
 from pex.pip import get_pip
+from pex.typing import TYPE_CHECKING
 from pex.util import DistributionHelper
+
+if TYPE_CHECKING:
+    from typing import Any, Dict
 
 
 # In-part, tests a bug where the wheel distribution name has dashes as reported in:
 #   https://github.com/pantsbuild/pex/issues/443
 #   https://github.com/pantsbuild/pex/issues/551
 def test_get_script_from_distributions(tmpdir):
+    # type: (Any) -> None
     whl_path = "./tests/example_packages/aws_cfn_bootstrap-1.4-py2-none-any.whl"
     install_dir = os.path.join(str(tmpdir), os.path.basename(whl_path))
     get_pip().spawn_install_wheel(wheel=whl_path, install_dir=install_dir).wait()
@@ -33,15 +38,18 @@ def test_get_script_from_distributions(tmpdir):
 
 class FakeDist(object):
     def __init__(self, key, console_script_entry):
+        # type: (str, str) -> None
         self.key = key
         script = console_script_entry.split("=")[0].strip()
         self._entry_map = {"console_scripts": {script: console_script_entry}}
 
     def get_entry_map(self):
+        # type: () -> Dict[str, Dict[str, str]]
         return self._entry_map
 
 
 def test_get_entry_point_from_console_script():
+    # type: () -> None
     dists = [
         FakeDist(key="fake", console_script_entry="bob= bob.main:run"),
         FakeDist(key="fake", console_script_entry="bob =bob.main:run"),
@@ -53,6 +61,7 @@ def test_get_entry_point_from_console_script():
 
 
 def test_get_entry_point_from_console_script_conflict():
+    # type: () -> None
     dists = [
         FakeDist(key="bob", console_script_entry="bob= bob.main:run"),
         FakeDist(key="fake", console_script_entry="bob =bob.main:run"),
@@ -62,6 +71,7 @@ def test_get_entry_point_from_console_script_conflict():
 
 
 def test_get_entry_point_from_console_script_dne():
+    # type: () -> None
     dists = [
         FakeDist(key="bob", console_script_entry="bob= bob.main:run"),
         FakeDist(key="fake", console_script_entry="bob =bob.main:run"),

--- a/tests/test_inherits_path_option.py
+++ b/tests/test_inherits_path_option.py
@@ -3,18 +3,23 @@
 
 import os
 from contextlib import contextmanager
+from io import open
 
 from pex.common import temporary_dir
 from pex.pex_builder import PEXBuilder
 from pex.testing import run_simple_pex
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Iterator, Text
 
 
 @contextmanager
-def write_and_run_simple_pex(inheriting=False):
+def write_and_run_simple_pex(inheriting):
+    # type: (str) -> Iterator[Text]
     """Write a pex file that contains an executable entry point.
 
-    :param inheriting: whether this pex should inherit site-packages paths
-    :type inheriting: bool
+    :param inheriting: whether this pex should inherit site-packages paths.
     """
     with temporary_dir() as td:
         pex_path = os.path.join(td, "show_path.pex")
@@ -26,26 +31,23 @@ def write_and_run_simple_pex(inheriting=False):
         pb.set_executable(os.path.join(td, "exe.py"))
         pb.freeze()
         pb.build(pex_path)
-        yield run_simple_pex(pex_path, env={"PEX_VERBOSE": "1"})[0]
+        stdout, _ = run_simple_pex(pex_path, env={"PEX_VERBOSE": "1"})
+        yield stdout.decode("utf-8")
 
 
 def test_inherits_path_fallback_option():
     with write_and_run_simple_pex(inheriting="fallback") as so:
-        assert "Scrubbing from user site" not in str(so), "User packages should not be scrubbed."
-        assert "Scrubbing from site-packages" not in str(
-            so
-        ), "Site packages should not be scrubbed."
+        assert "Scrubbing from user site" not in so, "User packages should not be scrubbed."
+        assert "Scrubbing from site-packages" not in so, "Site packages should not be scrubbed."
 
 
 def test_inherits_path_prefer_option():
     with write_and_run_simple_pex(inheriting="prefer") as so:
-        assert "Scrubbing from user site" not in str(so), "User packages should not be scrubbed."
-        assert "Scrubbing from site-packages" not in str(
-            so
-        ), "Site packages should not be scrubbed."
+        assert "Scrubbing from user site" not in so, "User packages should not be scrubbed."
+        assert "Scrubbing from site-packages" not in so, "Site packages should not be scrubbed."
 
 
 def test_does_not_inherit_path_option():
     with write_and_run_simple_pex(inheriting="false") as so:
-        assert "Scrubbing from user site" in str(so), "User packages should be scrubbed."
-        assert "Scrubbing from site-packages" in str(so), "Site packages should be scrubbed."
+        assert "Scrubbing from user site" in so, "User packages should be scrubbed."
+        assert "Scrubbing from site-packages" in so, "Site packages should be scrubbed."

--- a/tests/test_inherits_path_option.py
+++ b/tests/test_inherits_path_option.py
@@ -24,7 +24,7 @@ def write_and_run_simple_pex(inheriting):
     with temporary_dir() as td:
         pex_path = os.path.join(td, "show_path.pex")
         with open(os.path.join(td, "exe.py"), "w") as fp:
-            fp.write("")  # No contents, we just want the startup messages
+            fp.write(u"")  # No contents, we just want the startup messages
 
         pb = PEXBuilder(path=td, preamble=None)
         pb.info.inherit_path = inheriting

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -8,19 +8,25 @@ import pytest
 from pex import interpreter
 from pex.compatibility import PY3
 from pex.testing import PY27, PY35, ensure_python_interpreter
+from pex.typing import TYPE_CHECKING
 
 try:
     from mock import patch
 except ImportError:
     from unittest.mock import patch  # type: ignore[misc,no-redef,import]
 
+if TYPE_CHECKING:
+    from typing import Tuple
+
 
 def tuple_from_version(version_string):
+    # type: (str) -> Tuple[int, ...]
     return tuple(int(component) for component in version_string.split("."))
 
 
 class TestPythonInterpreter(object):
     def test_all_does_not_raise_with_empty_path_envvar(self):
+        # type: () -> None
         """additionally, tests that the module does not raise at import."""
         with patch.dict(os.environ, clear=True):
             if PY3:
@@ -39,17 +45,21 @@ class TestPythonInterpreter(object):
 
     @pytest.fixture
     def test_interpreter1(self):
+        # type: () -> str
         return ensure_python_interpreter(self.TEST_INTERPRETER1_VERSION)
 
     @pytest.fixture
     def test_interpreter2(self):
+        # type: () -> str
         return ensure_python_interpreter(self.TEST_INTERPRETER2_VERSION)
 
     def test_interpreter_versioning(self, test_interpreter1):
+        # type: (str) -> None
         py_interpreter = interpreter.PythonInterpreter.from_binary(test_interpreter1)
         assert py_interpreter.identity.version == self.TEST_INTERPRETER1_VERSION_TUPLE
 
     def test_interpreter_caching(self, test_interpreter1, test_interpreter2):
+        # type: (str, str) -> None
         py_interpreter1 = interpreter.PythonInterpreter.from_binary(test_interpreter1)
         py_interpreter2 = interpreter.PythonInterpreter.from_binary(test_interpreter2)
         assert py_interpreter1 is not py_interpreter2
@@ -59,10 +69,12 @@ class TestPythonInterpreter(object):
         assert py_interpreter1 is py_interpreter3
 
     def test_nonexistent_interpreter(self):
+        # type: () -> None
         with pytest.raises(interpreter.PythonInterpreter.InterpreterNotFound):
             interpreter.PythonInterpreter.from_binary("/nonexistent/path")
 
     def test_binary_name_matching(self):
+        # type: () -> None
         valid_binary_names = (
             "jython",
             "pypy",

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -5,20 +5,24 @@ from pex.jobs import _ABSOLUTE_MAX_JOBS, DEFAULT_MAX_JOBS, _sanitize_max_jobs
 
 
 def test_sanitize_max_jobs_none():
+    # type: () -> None
     assert DEFAULT_MAX_JOBS == _sanitize_max_jobs(None)
 
 
 def test_sanitize_max_jobs_less_then_one():
+    # type: () -> None
     assert DEFAULT_MAX_JOBS == _sanitize_max_jobs(0)
     assert DEFAULT_MAX_JOBS == _sanitize_max_jobs(-1)
     assert DEFAULT_MAX_JOBS == _sanitize_max_jobs(-5)
 
 
 def test_sanitize_max_jobs_nominal():
+    # type: () -> None
     assert 1 == _sanitize_max_jobs(1)
 
 
 def test_sanitize_max_jobs_too_large():
+    # type: () -> None
     assert _ABSOLUTE_MAX_JOBS == _sanitize_max_jobs(_ABSOLUTE_MAX_JOBS)
     assert _ABSOLUTE_MAX_JOBS == _sanitize_max_jobs(_ABSOLUTE_MAX_JOBS + 1)
     assert _ABSOLUTE_MAX_JOBS == _sanitize_max_jobs(_ABSOLUTE_MAX_JOBS + 5)

--- a/tests/test_pex_binary.py
+++ b/tests/test_pex_binary.py
@@ -19,14 +19,20 @@ from pex.testing import (
     run_pex_command,
     run_simple_pex,
 )
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Iterator, List, Optional, Text
 
 
 @contextmanager
 def option_parser():
+    # type: () -> Iterator[OptionParser]
     yield OptionParser()
 
 
 def test_clp_no_pypi_option():
+    # type: () -> None
     with option_parser() as parser:
         configure_clp_pex_resolution(parser)
         options, _ = parser.parse_args(args=[])
@@ -36,6 +42,7 @@ def test_clp_no_pypi_option():
 
 
 def test_clp_pypi_option_duplicate():
+    # type: () -> None
     with option_parser() as parser:
         configure_clp_pex_resolution(parser)
         options, _ = parser.parse_args(args=[])
@@ -46,6 +53,7 @@ def test_clp_pypi_option_duplicate():
 
 
 def test_clp_find_links_option():
+    # type: () -> None
     with option_parser() as parser:
         configure_clp_pex_resolution(parser)
         options, _ = parser.parse_args(args=["-f", "http://www.example.com"])
@@ -54,6 +62,7 @@ def test_clp_find_links_option():
 
 
 def test_clp_index_option():
+    # type: () -> None
     with option_parser() as parser:
         configure_clp_pex_resolution(parser)
         options, _ = parser.parse_args(args=[])
@@ -65,6 +74,7 @@ def test_clp_index_option():
 
 
 def test_clp_index_option_render():
+    # type: () -> None
     with option_parser() as parser:
         configure_clp_pex_resolution(parser)
         options, _ = parser.parse_args(args=["--index", "http://www.example.com"])
@@ -74,6 +84,7 @@ def test_clp_index_option_render():
 
 
 def test_clp_build_precedence():
+    # type: () -> None
     with option_parser() as parser:
         configure_clp_pex_resolution(parser)
 
@@ -91,18 +102,21 @@ def test_clp_build_precedence():
 
 # Make sure that we're doing append and not replace
 def test_clp_requirements_txt():
+    # type: () -> None
     parser = configure_clp()
     options, _ = parser.parse_args(args="-r requirements1.txt -r requirements2.txt".split())
     assert options.requirement_files == ["requirements1.txt", "requirements2.txt"]
 
 
 def test_clp_constraints_txt():
+    # type: () -> None
     parser = configure_clp()
     options, _ = parser.parse_args(args="--constraint requirements1.txt".split())
     assert options.constraint_files == ["requirements1.txt"]
 
 
 def test_clp_preamble_file():
+    # type: () -> None
     with NamedTemporaryFile() as tmpfile:
         tmpfile.write(to_bytes('print "foo!"'))
         tmpfile.flush()
@@ -116,6 +130,7 @@ def test_clp_preamble_file():
 
 
 def test_clp_prereleases():
+    # type: () -> None
     with option_parser() as parser:
         configure_clp_pex_resolution(parser)
 
@@ -130,6 +145,7 @@ def test_clp_prereleases():
 
 
 def test_clp_prereleases_resolver():
+    # type: () -> None
     with nested(
         built_wheel(name="prerelease-dep", version="1.2.3b1"),
         built_wheel(name="transitive-dep", install_reqs=["prerelease-dep"]),
@@ -187,6 +203,7 @@ def test_clp_prereleases_resolver():
 
 
 def test_build_pex():
+    # type: () -> None
     with temporary_dir() as sandbox:
         pex_path = os.path.join(sandbox, "pex")
         results = run_pex_command(["ansicolors==1.1.8", "--output-file", pex_path])
@@ -198,20 +215,22 @@ def test_build_pex():
         assert b"black red green yellow blue magenta cyan white" == stdout.strip()
 
 
-def assert_run_pex(python=None, pex_args=None):
-    pex_args = list(pex_args) if pex_args else []
-    results = run_pex_command(
-        python=python,
-        args=pex_args
-        + ["ansicolors==1.1.8", "--", "-c", 'import colors; print(" ".join(colors.COLORS))'],
-        quiet=True,
-    )
-    results.assert_success()
-    assert "black red green yellow blue magenta cyan white" == results.output.strip()
-    return results.error.splitlines()
-
-
 def test_run_pex():
+    # type: () -> None
+
+    def assert_run_pex(python=None, pex_args=None):
+        # type: (Optional[str], Optional[List[str]]) -> List[Text]
+        pex_args = list(pex_args) if pex_args else []
+        results = run_pex_command(
+            python=python,
+            args=pex_args
+            + ["ansicolors==1.1.8", "--", "-c", 'import colors; print(" ".join(colors.COLORS))'],
+            quiet=True,
+        )
+        results.assert_success()
+        assert "black red green yellow blue magenta cyan white" == results.output.strip()
+        return results.error.splitlines()
+
     incompatible_platforms_warning_msg = (
         "WARNING: attempting to run PEX with incompatible platforms!"
     )

--- a/tests/test_pex_bootstrapper.py
+++ b/tests/test_pex_bootstrapper.py
@@ -11,9 +11,14 @@ from pex.interpreter import PythonInterpreter
 from pex.interpreter_constraints import UnsatisfiableInterpreterConstraintsError
 from pex.pex_bootstrapper import iter_compatible_interpreters
 from pex.testing import PY27, PY35, PY36, ensure_python_interpreter
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import AnyStr, List
 
 
 def find_interpreters(path, *constraints):
+    # type: (List[str], *str) -> List[AnyStr]
     return [
         interp.binary
         for interp in iter_compatible_interpreters(
@@ -23,6 +28,7 @@ def find_interpreters(path, *constraints):
 
 
 def test_find_compatible_interpreters():
+    # type: () -> None
     py27 = ensure_python_interpreter(PY27)
     py35 = ensure_python_interpreter(PY35)
     py36 = ensure_python_interpreter(PY36)
@@ -65,11 +71,13 @@ def test_find_compatible_interpreters():
 
 
 def test_find_compatible_interpreters_none():
+    # type: () -> None
     with pytest.raises(UnsatisfiableInterpreterConstraintsError):
         find_interpreters([os.path.devnull], ">2")
 
 
 def test_find_compatible_interpreters_bias_current():
+    # type: () -> None
     py36 = ensure_python_interpreter(PY36)
     assert [os.path.realpath(sys.executable), py36] == find_interpreters([py36, sys.executable])
     assert [os.path.realpath(sys.executable), py36] == find_interpreters([sys.executable, py36])

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -13,6 +13,10 @@ from pex.pex import PEX
 from pex.pex_builder import BOOTSTRAP_DIR, PEXBuilder
 from pex.testing import make_bdist
 from pex.testing import write_simple_pex as write_pex
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import List
 
 exe_main = """
 import sys
@@ -35,6 +39,7 @@ with open(sys.argv[1], 'w') as fp:
 
 
 def test_pex_builder():
+    # type: () -> None
     # test w/ and w/o zipfile dists
     with nested(temporary_dir(), make_bdist("p1")) as (td, p1):
         pb = write_pex(td, exe_main, dists=[p1])
@@ -57,6 +62,7 @@ def test_pex_builder():
 
 
 def test_pex_builder_wheeldep():
+    # type: () -> None
     """Repeat the pex_builder test, but this time include an import of something from a wheel that
     doesn't come in importable form."""
     with nested(temporary_dir(), make_bdist("p1")) as (td, p1):
@@ -70,7 +76,9 @@ def test_pex_builder_wheeldep():
 
 
 def test_pex_builder_shebang():
+    # type: () -> None
     def builder(shebang):
+        # type: (str) -> PEXBuilder
         pb = PEXBuilder()
         pb.set_shebang(shebang)
         return pb
@@ -86,6 +94,7 @@ def test_pex_builder_shebang():
 
 
 def test_pex_builder_preamble():
+    # type: () -> None
     with temporary_dir() as td:
         target = os.path.join(td, "foo.pex")
         should_create = os.path.join(td, "foo.1")
@@ -108,6 +117,7 @@ def test_pex_builder_preamble():
 
 
 def test_pex_builder_compilation():
+    # type: () -> None
     with nested(temporary_dir(), temporary_dir(), temporary_dir()) as (td1, td2, td3):
         src = os.path.join(td1, "src.py")
         with open(src, "w") as fp:
@@ -118,6 +128,7 @@ def test_pex_builder_compilation():
             fp.write(exe_main)
 
         def build_and_check(path, precompile):
+            # type: (str, bool) -> None
             pb = PEXBuilder(path=path)
             pb.add_source(src, "lib/src.py")
             pb.set_executable(exe, "exe.py")
@@ -129,7 +140,7 @@ def test_pex_builder_compilation():
                 else:
                     assert not pyc_exists
             bootstrap_dir = os.path.join(path, BOOTSTRAP_DIR)
-            bootstrap_pycs = []
+            bootstrap_pycs = []  # type: List[str]
             for _, _, files in os.walk(bootstrap_dir):
                 bootstrap_pycs.extend(f for f in files if f.endswith(".pyc"))
             if precompile:
@@ -143,12 +154,14 @@ def test_pex_builder_compilation():
 
 @pytest.mark.skipif(WINDOWS, reason="No hardlinks on windows")
 def test_pex_builder_copy_or_link():
+    # type: () -> None
     with nested(temporary_dir(), temporary_dir(), temporary_dir()) as (td1, td2, td3):
         src = os.path.join(td1, "exe.py")
         with open(src, "w") as fp:
             fp.write(exe_main)
 
         def build_and_check(path, copy):
+            # type: (str, bool) -> None
             pb = PEXBuilder(path=path, copy=copy)
             pb.add_source(src, "exe.py")
 
@@ -169,6 +182,7 @@ def test_pex_builder_copy_or_link():
 
 
 def test_pex_builder_deterministic_timestamp():
+    # type: () -> None
     pb = PEXBuilder()
     with temporary_dir() as td:
         target = os.path.join(td, "foo.pex")
@@ -178,7 +192,9 @@ def test_pex_builder_deterministic_timestamp():
 
 
 def test_pex_builder_from_requirements_pex():
+    # type: () -> None
     def build_from_req_pex(path, req_pex):
+        # type: (str, PEXBuilder) -> PEXBuilder
         pb = PEXBuilder(path=path)
         pb.add_from_requirements_pex(req_pex)
         with open(os.path.join(path, "exe.py"), "w") as fp:
@@ -188,6 +204,7 @@ def test_pex_builder_from_requirements_pex():
         return pb
 
     def verify(pb):
+        # type: (PEXBuilder) -> None
         success_txt = os.path.join(pb.path(), "success.txt")
         PEX(pb.path(), interpreter=pb.interpreter).run(args=[success_txt])
         assert os.path.exists(success_txt)

--- a/tests/test_pex_info.py
+++ b/tests/test_pex_info.py
@@ -10,15 +10,21 @@ from pex.common import temporary_dir
 from pex.orderedset import OrderedSet
 from pex.pex_info import PexInfo
 from pex.pex_warnings import PEXWarning
+from pex.typing import TYPE_CHECKING
 from pex.variables import Variables
 from pex.version import __version__ as pex_version
 
-
-def make_pex_info(requirements):
-    return PexInfo(info={"requirements": requirements})
+if TYPE_CHECKING:
+    from typing import Dict, List, Text
 
 
 def test_backwards_incompatible_pex_info():
+    # type: () -> None
+
+    def make_pex_info(requirements):
+        # type: (List[Text]) -> PexInfo
+        return PexInfo(info={"requirements": requirements})
+
     # forwards compatibility
     pi = make_pex_info(["hello"])
     assert pi.requirements == OrderedSet(["hello"])
@@ -28,32 +34,35 @@ def test_backwards_incompatible_pex_info():
 
     # malformed
     with pytest.raises(ValueError):
-        make_pex_info("hello")
+        make_pex_info("hello")  # type: ignore[arg-type]
 
     with pytest.raises(ValueError):
-        make_pex_info([("hello", False)])
+        make_pex_info([("hello", False)])  # type: ignore[list-item]
 
     # backwards compatibility
     pi = make_pex_info(
         [
-            ["hello==0.1", False, None],
-            ["world==0.2", False, None],
+            ["hello==0.1", False, None],  # type: ignore[list-item]
+            ["world==0.2", False, None],  # type: ignore[list-item]
         ]
     )
     assert pi.requirements == OrderedSet(["hello==0.1", "world==0.2"])
 
 
 def assert_same_info(expected, actual):
+    # type: (PexInfo, PexInfo) -> None
     assert expected.dump(sort_keys=True) == actual.dump(sort_keys=True)
 
 
 def test_from_empty_env():
+    # type: () -> None
     environ = Variables(environ={})
-    info = {}
+    info = {}  # type: Dict
     assert_same_info(PexInfo(info=info), PexInfo.from_env(env=environ))
 
 
 def test_from_env():
+    # type: () -> None
     with temporary_dir() as td:
         pex_root = os.path.realpath(os.path.join(td, "pex_root"))
         environ = dict(
@@ -82,10 +91,12 @@ def test_from_env():
 
 
 def test_build_properties():
+    # type: () -> None
     assert pex_version == PexInfo.default().build_properties["pex_version"]
 
 
 def test_merge_split():
+    # type: () -> None
     path_1, path_2 = "/pex/path/1:/pex/path/2", "/pex/path/3:/pex/path/4"
     result = PexInfo._merge_split(path_1, path_2)
     assert result == ["/pex/path/1", "/pex/path/2", "/pex/path/3", "/pex/path/4"]
@@ -106,6 +117,7 @@ def test_merge_split():
 
 
 def test_pex_root_set_none():
+    # type: () -> None
     pex_info = PexInfo.default()
     pex_info.pex_root = None
 
@@ -114,6 +126,7 @@ def test_pex_root_set_none():
 
 
 def test_pex_root_set_unwriteable():
+    # type: () -> None
     with temporary_dir() as td:
         pex_root = os.path.realpath(os.path.join(td, "pex_root"))
         os.mkdir(pex_root, 0o444)

--- a/tests/test_pex_warnings.py
+++ b/tests/test_pex_warnings.py
@@ -10,17 +10,24 @@ from pex import pex_warnings
 from pex.compatibility import PY2
 from pex.pex_info import PexInfo
 from pex.pex_warnings import PEXWarning
+from pex.typing import TYPE_CHECKING
 from pex.variables import Variables
+
+if TYPE_CHECKING:
+    from typing import List
 
 
 def exercise_warnings(pex_info, **env):
+    # type: (PexInfo, **str) -> List[warnings.WarningMessage]
     with warnings.catch_warnings(record=True) as events:
         pex_warnings.configure_warnings(pex_info, env=Variables(environ=env))
         pex_warnings.warn("test")
-        return events
+    assert events is not None
+    return events
 
 
 def assert_warnings(pex_info, **env):
+    # type: (PexInfo, **str) -> None
     events = exercise_warnings(pex_info, **env)
     assert 1 == len(events)
     warning = events[0]
@@ -29,11 +36,13 @@ def assert_warnings(pex_info, **env):
 
 
 def assert_no_warnings(pex_info, **env):
+    # type: (PexInfo, **str) -> None
     events = exercise_warnings(pex_info, **env)
     assert 0 == len(events)
 
 
 def pex_info_no_emit_warnings():
+    # type: () -> PexInfo
     pex_info = PexInfo.default()
     pex_info.emit_warnings = False
     return pex_info
@@ -50,29 +59,35 @@ skip_py2_warnings = pytest.mark.skipif(
 
 @skip_py2_warnings
 def test_emit_warnings_default_on():
+    # type: () -> None
     assert_warnings(PexInfo.default())
 
 
 @skip_py2_warnings
 def test_emit_warnings_pex_info_off():
+    # type: () -> None
     assert_no_warnings(pex_info_no_emit_warnings())
 
 
 @skip_py2_warnings
 def test_emit_warnings_emit_env_off():
+    # type: () -> None
     assert_no_warnings(PexInfo.default(), PEX_EMIT_WARNINGS="0")
 
 
 @skip_py2_warnings
 def test_emit_warnings_pex_info_off_emit_env_override():
+    # type: () -> None
     assert_warnings(pex_info_no_emit_warnings(), PEX_EMIT_WARNINGS="1")
 
 
 @skip_py2_warnings
 def test_emit_warnings_pex_info_off_verbose_override():
+    # type: () -> None
     assert_warnings(pex_info_no_emit_warnings(), PEX_VERBOSE="1")
 
 
 @skip_py2_warnings
 def test_emit_warnings_pex_info_off_verbose_trumps_emit_env():
+    # type: () -> None
     assert_warnings(pex_info_no_emit_warnings(), PEX_VERBOSE="1", PEX_EMIT_WARNINGS="0")

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -9,11 +9,13 @@ EXPECTED_BASE = [("py27", "none", "any"), ("py2", "none", "any")]
 
 
 def test_platform():
+    # type: () -> None
     assert Platform("linux-x86_64", "cp", "27", "mu") == ("linux_x86_64", "cp", "27", "cp27mu")
     assert str(Platform("linux-x86_64", "cp", "27", "m")) == "linux_x86_64-cp-27-cp27m"
 
 
 def test_platform_create():
+    # type: () -> None
     assert Platform.create("linux-x86_64-cp-27-cp27mu") == ("linux_x86_64", "cp", "27", "cp27mu")
     assert Platform.create("linux-x86_64-cp-27-mu") == ("linux_x86_64", "cp", "27", "cp27mu")
     assert Platform.create("macosx-10.4-x86_64-cp-27-m") == (
@@ -25,15 +27,18 @@ def test_platform_create():
 
 
 def test_platform_create_bad_platform_missing_fields():
+    # type: () -> None
     with pytest.raises(Platform.InvalidPlatformError):
         Platform.create("linux-x86_64")
 
 
 def test_platform_create_bad_platform_empty_fields():
+    # type: () -> None
     with pytest.raises(Platform.InvalidPlatformError):
         Platform.create("linux-x86_64-cp--cp27mu")
 
 
 def test_platform_create_noop():
+    # type: () -> None
     existing = Platform.create("linux-x86_64-cp-27-mu")
     assert Platform.create(existing) == existing

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -15,6 +15,7 @@ from pex.compatibility import nested
 from pex.distribution_target import DistributionTarget
 from pex.interpreter import PythonInterpreter, spawn_python_job
 from pex.resolver import (
+    InstalledDistribution,
     IntegrityError,
     LocalDistribution,
     Unsatisfiable,
@@ -35,12 +36,17 @@ from pex.testing import (
     make_source_dir,
 )
 from pex.third_party.pkg_resources import Requirement
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, List, Union
 
 
-def create_sdist(*args, **kwargs):
+def create_sdist(**kwargs):
+    # type: (**Any) -> str
     dist_dir = safe_mkdtemp()
 
-    with make_project(*args, **kwargs) as project_dir:
+    with make_project(**kwargs) as project_dir:
         cmd = ["setup.py", "sdist", "--dist-dir={}".format(dist_dir)]
         spawn_python_job(
             args=cmd,
@@ -55,18 +61,21 @@ def create_sdist(*args, **kwargs):
     return os.path.join(dist_dir, dists[0])
 
 
-def build_wheel(*args, **kwargs):
-    with built_wheel(*args, **kwargs) as whl:
+def build_wheel(**kwargs):
+    # type: (**Any) -> str
+    with built_wheel(**kwargs) as whl:
         return whl
 
 
 def local_resolve_multi(*args, **kwargs):
+    # type: (*Any, **Any) -> List[InstalledDistribution]
     # Skip remote lookups.
     kwargs["indexes"] = []
     return list(resolve_multi(*args, **kwargs))
 
 
 def test_empty_resolve():
+    # type: () -> None
     empty_resolve_multi = local_resolve_multi([])
     assert empty_resolve_multi == []
 
@@ -76,15 +85,18 @@ def test_empty_resolve():
 
 
 def test_simple_local_resolve():
+    # type: () -> None
     project_wheel = build_wheel(name="project")
 
     with temporary_dir() as td:
         safe_copy(project_wheel, os.path.join(td, os.path.basename(project_wheel)))
         resolved_dists = local_resolve_multi(["project"], find_links=[td])
         assert len(resolved_dists) == 1
+        raise ValueError(resolved_dists[0])
 
 
 def test_resolve_cache():
+    # type: () -> None
     project_wheel = build_wheel(name="project")
 
     with nested(temporary_dir(), temporary_dir()) as (td, cache):
@@ -108,6 +120,7 @@ def test_resolve_cache():
 
 
 def test_diamond_local_resolve_cached():
+    # type: () -> None
     # This exercises the issue described here: https://github.com/pantsbuild/pex/issues/120
     project1_wheel = build_wheel(name="project1", install_reqs=["project2<1.0.0"])
     project2_wheel = build_wheel(name="project2")
@@ -123,6 +136,7 @@ def test_diamond_local_resolve_cached():
 
 
 def test_cached_dependency_pinned_unpinned_resolution_multi_run():
+    # type: () -> None
     # This exercises the issue described here: https://github.com/pantsbuild/pex/issues/178
     project1_0_0 = build_wheel(name="project", version="1.0.0")
     project1_1_0 = build_wheel(name="project", version="1.1.0")
@@ -144,6 +158,7 @@ def test_cached_dependency_pinned_unpinned_resolution_multi_run():
 
 
 def test_intransitive():
+    # type: () -> None
     foo1_0 = build_wheel(name="foo", version="1.0.0")
     # The nonexistent req ensures that we are actually not acting transitively (as that would fail).
     bar1_0 = build_wheel(name="bar", version="1.0.0", install_reqs=["nonexistent==1.0.0"])
@@ -158,6 +173,7 @@ def test_intransitive():
 
 
 def test_resolve_prereleases():
+    # type: () -> None
     stable_dep = build_wheel(name="dep", version="2.0.0")
     prerelease_dep = build_wheel(name="dep", version="3.0.0rc3")
 
@@ -177,10 +193,14 @@ def test_resolve_prereleases():
 
 
 def _parse_requirement(req):
-    return Requirement.parse(str(req))
+    # type: (Union[str, Requirement]) -> Requirement
+    if isinstance(req, Requirement):
+        req = str(req)
+    return Requirement.parse(req)
 
 
 def test_resolve_extra_setup_py():
+    # type: () -> None
     with make_source_dir(
         name="project1", version="1.0.0", extras_require={"foo": ["project2"]}
     ) as project1_dir:
@@ -195,6 +215,7 @@ def test_resolve_extra_setup_py():
 
 
 def test_resolve_extra_wheel():
+    # type: () -> None
     project1_wheel = build_wheel(
         name="project1", version="1.0.0", extras_require={"foo": ["project2"]}
     )
@@ -210,6 +231,7 @@ def test_resolve_extra_wheel():
 
 
 def resolve_wheel_names(**kwargs):
+    # type: (**Any) -> List[str]
     return [
         os.path.basename(resolved_distribution.distribution.location)
         for resolved_distribution in resolve_multi(**kwargs)
@@ -217,11 +239,13 @@ def resolve_wheel_names(**kwargs):
 
 
 def resolve_p537_wheel_names(**kwargs):
+    # type: (**Any) -> List[str]
     return resolve_wheel_names(requirements=["p537==1.0.4"], transitive=False, **kwargs)
 
 
 @pytest.fixture(scope="module")
 def p537_resolve_cache():
+    # type: () -> str
     return safe_mkdtemp()
 
 
@@ -229,6 +253,7 @@ def p537_resolve_cache():
     PY_VER < (3, 5) or IS_PYPY, reason="The p537 distribution only builds for CPython 3.5+"
 )
 def test_resolve_current_platform(p537_resolve_cache):
+    # type: (str) -> None
     resolve_current = functools.partial(
         resolve_p537_wheel_names, cache=p537_resolve_cache, platforms=["current"]
     )
@@ -255,6 +280,7 @@ def test_resolve_current_platform(p537_resolve_cache):
     PY_VER < (3, 5) or IS_PYPY, reason="The p537 distribution only builds for CPython 3.5+"
 )
 def test_resolve_current_and_foreign_platforms(p537_resolve_cache):
+    # type: (str) -> None
     foreign_platform = "macosx-10.13-x86_64-cp-37-m" if IS_LINUX else "manylinux1_x86_64-cp-37-m"
     resolve_current_and_foreign = functools.partial(
         resolve_p537_wheel_names, cache=p537_resolve_cache, platforms=["current", foreign_platform]
@@ -276,6 +302,7 @@ def test_resolve_current_and_foreign_platforms(p537_resolve_cache):
 
 
 def test_resolve_foreign_abi3():
+    # type: () -> None
     # For version 2.8, cryptography publishes the following abi3 wheels for linux and macosx:
     # cryptography-2.8-cp34-abi3-macosx_10_6_intel.whl
     # cryptography-2.8-cp34-abi3-manylinux1_x86_64.whl
@@ -315,6 +342,7 @@ def test_resolve_foreign_abi3():
 
 
 def test_issues_851():
+    # type: () -> None
     # Previously, the PY36 resolve would fail post-resolution checks for configparser, pathlib2 and
     # contextlib2 which are only required for python_version<3.
 
@@ -341,6 +369,7 @@ def test_issues_851():
 
 
 def test_issues_892():
+    # type: () -> None
     python27 = ensure_python_interpreter(PY27)
     program = dedent(
         """\
@@ -385,6 +414,7 @@ def test_issues_892():
 
 
 def test_download():
+    # type: () -> None
     project1_sdist = create_sdist(
         name="project1", version="1.0.0", extras_require={"foo": ["project2"]}
     )
@@ -422,6 +452,7 @@ def test_download():
 
 
 def test_install():
+    # type: () -> None
     project1_sdist = create_sdist(name="project1", version="1.0.0")
     project2_wheel = build_wheel(name="project2", version="2.0.0")
 
@@ -449,6 +480,7 @@ def test_install():
 
 
 def test_install_unsatisfiable():
+    # type: () -> None
     project1_sdist = create_sdist(name="project1", version="1.0.0")
     project2_wheel = build_wheel(name="project2", version="2.0.0", install_reqs=["project1==1.0.1"])
     local_distributions = [
@@ -462,6 +494,7 @@ def test_install_unsatisfiable():
 
 
 def test_install_invalid_local_distribution():
+    # type: () -> None
     project1_sdist = create_sdist(name="project1", version="1.0.0")
 
     valid_local_sdist = LocalDistribution.create(project1_sdist)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -92,7 +92,6 @@ def test_simple_local_resolve():
         safe_copy(project_wheel, os.path.join(td, os.path.basename(project_wheel)))
         resolved_dists = local_resolve_multi(["project"], find_links=[td])
         assert len(resolved_dists) == 1
-        raise ValueError(resolved_dists[0])
 
 
 def test_resolve_cache():

--- a/tests/test_third_party.py
+++ b/tests/test_third_party.py
@@ -8,11 +8,16 @@ from contextlib import contextmanager
 
 from pex import third_party
 from pex.common import temporary_dir
+from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
+
+if TYPE_CHECKING:
+    from typing import Dict, Iterator, Tuple
 
 
 @contextmanager
 def temporary_pex_root():
+    # type: () -> Iterator[Tuple[str, Dict[str, str]]]
     with temporary_dir() as pex_root, ENV.patch(PEX_ROOT=os.path.realpath(pex_root)) as env:
         original_isolated = third_party._ISOLATED
         try:
@@ -23,12 +28,14 @@ def temporary_pex_root():
 
 
 def test_isolated_pex_root():
+    # type: () -> None
     with temporary_pex_root() as (pex_root, _):
         devendored_chroot = os.path.realpath(third_party.isolated().chroot_path)
         assert pex_root == os.path.commonprefix([pex_root, devendored_chroot])
 
 
 def test_isolated_idempotent_inprocess():
+    # type: () -> None
     with temporary_pex_root():
         result1 = third_party.isolated()
         result2 = third_party.isolated()
@@ -37,6 +44,7 @@ def test_isolated_idempotent_inprocess():
 
 
 def test_isolated_idempotent_subprocess():
+    # type: () -> None
     with temporary_pex_root() as (_, env):
         devendored_chroot = os.path.realpath(third_party.isolated().chroot_path)
         stdout = subprocess.check_output(

--- a/tests/test_unified_install_cache.py
+++ b/tests/test_unified_install_cache.py
@@ -13,15 +13,18 @@ from pex.common import safe_mkdir, safe_mkdtemp, safe_open, safe_rmtree
 from pex.pex_info import PexInfo
 from pex.pip import get_pip
 from pex.testing import run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Dict
 
 
-@pytest.fixture(scope="module")
-def pex_project_dir():
-    return subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode("utf-8").strip()
-
-
-def test_issues_789_demo(pex_project_dir):
+def test_issues_789_demo():
+    # type: () -> None
     tmpdir = safe_mkdtemp()
+    pex_project_dir = (
+        subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode("utf-8").strip()
+    )
 
     # 1. Imagine we've pre-resolved the requirements needed in our wheel house.
     requirements = [
@@ -42,7 +45,7 @@ def test_issues_789_demo(pex_project_dir):
         indexes=[],  # Turn off pypi.
         find_links=[wheelhouse],  # Use our wheel house.
         build=False,  # Use only pre-built wheels.
-    )
+    )  # type: Dict[str, Any]
 
     # 3. That same configuration was used to build a standard pex:
     resolver_args = []
@@ -200,7 +203,7 @@ def test_issues_789_demo(pex_project_dir):
             "--always-write-cache",
             "--pex-root",
             ptex_cache,
-            pex_project_dir,
+            pex_project_dir,  # type: ignore[list-item]  # This is unicode in Py2, whereas everthing else is bytes. That's fine.
             "--sources-directory",
             ptex_code_dir,
             "--sources-directory",

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -10,6 +10,7 @@ from pex.common import safe_mkdir, temporary_dir
 from pex.compatibility import nested, to_bytes
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
+from pex.typing import TYPE_CHECKING
 from pex.util import CacheHelper, DistributionHelper, iter_pth_paths, named_temporary_file
 
 try:
@@ -17,13 +18,17 @@ try:
 except ImportError:
     import mock  # type: ignore[no-redef]
 
+if TYPE_CHECKING:
+    from typing import Any
+
 
 def test_hash():
-    empty_hash = sha1().hexdigest()
+    # type: () -> None
+    empty_hash_digest = sha1().hexdigest()
 
     with named_temporary_file() as fp:
         fp.flush()
-        assert empty_hash == CacheHelper.hash(fp.name)
+        assert empty_hash_digest == CacheHelper.hash(fp.name)
 
     with named_temporary_file() as fp:
         string = b"asdf" * 1024 * sha1().block_size + b"extra padding"
@@ -61,13 +66,13 @@ except ImportError:
 @mock.patch("pex.util.resource_isdir", autospec=True, spec_set=True)
 @mock.patch("pex.util.resource_string", autospec=True, spec_set=True)
 def test_access_zipped_assets(
-    mock_resource_string,
-    mock_resource_isdir,
-    mock_resource_listdir,
-    mock_safe_mkdir,
-    mock_safe_mkdtemp,
+    mock_resource_string,  # type: Any
+    mock_resource_isdir,  # type: Any
+    mock_resource_listdir,  # type: Any
+    mock_safe_mkdir,  # type: Any
+    mock_safe_mkdtemp,  # type: Any
 ):
-
+    # type: (...) -> None
     mock_open = mock.mock_open()
     mock_safe_mkdtemp.side_effect = iter(["tmpJIMMEH", "faketmpDir"])
     mock_resource_listdir.side_effect = iter([["./__init__.py", "./directory/"], ["file.py"]])
@@ -86,6 +91,7 @@ def test_access_zipped_assets(
 
 
 def assert_access_zipped_assets(distribution_helper_import):
+    # type: (str) -> bytes
     test_executable = dedent(
         """
         import os
@@ -121,21 +127,24 @@ def assert_access_zipped_assets(distribution_helper_import):
         stdout, stderr = process.communicate()
         assert process.returncode == 0
         assert b"accessed\n" == stdout
-        return stderr
+        # TODO(#1034): remove once MyPy understands Executor.open_process()
+        return stderr  # type: ignore[no-any-return]
 
 
 def test_access_zipped_assets_integration():
+    # type: () -> None
     stderr = assert_access_zipped_assets("from pex.util import DistributionHelper")
     assert b"" == stderr.strip()
 
 
 def test_access_zipped_assets_integration_deprecated():
+    # type: () -> None
     stderr = assert_access_zipped_assets("from _pex.util import DistributionHelper")
     assert b"`import _pex.util`" in stderr
 
 
 def test_named_temporary_file():
-    name = ""
+    # type: () -> None
     with named_temporary_file() as fp:
         name = fp.name
         fp.write(b"hi")
@@ -149,6 +158,7 @@ def test_named_temporary_file():
 
 @mock.patch("os.path.exists", autospec=True, spec_set=True)
 def test_iter_pth_paths(mock_exists):
+    # type: (Any) -> None
     # Ensure path checking always returns True for dummy paths.
     mock_exists.return_value = True
 

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -14,6 +14,7 @@ from pex.variables import Variables
 
 
 def test_process_pydoc():
+    # type: () -> None
     def thing():
         # no pydoc
         pass
@@ -32,6 +33,7 @@ def test_process_pydoc():
 
 
 def test_iter_help():
+    # type: () -> None
     for variable_name, variable_type, variable_text in Variables.iter_help():
         assert variable_name.startswith("PEX_")
         assert "\n" not in variable_type
@@ -39,6 +41,7 @@ def test_iter_help():
 
 
 def test_pex_bool_variables():
+    # type: () -> None
     Variables(environ={})._get_bool("NOT_HERE", default=False) is False
     Variables(environ={})._get_bool("NOT_HERE", default=True) is True
 
@@ -57,6 +60,7 @@ def test_pex_bool_variables():
 
 
 def test_pex_string_variables():
+    # type: () -> None
     Variables(environ={})._get_string("NOT_HERE") is None
     Variables(environ={})._get_string("NOT_HERE", default="lolol") == "lolol"
     Variables(environ={"HERE": "stuff"})._get_string("HERE") == "stuff"
@@ -64,6 +68,7 @@ def test_pex_string_variables():
 
 
 def test_pex_get_int():
+    # type: () -> None
     assert Variables()._get_int("HELLO") is None
     assert Variables()._get_int("HELLO", default=42) == 42
     assert Variables(environ={"HELLO": 23})._get_int("HELLO") == 23
@@ -74,6 +79,7 @@ def test_pex_get_int():
 
 
 def assert_pex_vars_hermetic():
+    # type: () -> None
     v = Variables()
     assert os.environ == v.copy()
 
@@ -86,15 +92,18 @@ def assert_pex_vars_hermetic():
 
 
 def test_pex_vars_hermetic_no_pexrc():
+    # type: () -> None
     assert_pex_vars_hermetic()
 
 
 def test_pex_vars_hermetic():
+    # type: () -> None
     with environment_as(PEX_IGNORE_RCFILES="True"):
         assert_pex_vars_hermetic()
 
 
 def test_pex_get_kv():
+    # type: () -> None
     v = Variables(environ={})
     assert v._get_kv("HELLO") is None
     assert v._get_kv("=42") is None
@@ -103,6 +112,7 @@ def test_pex_get_kv():
 
 
 def test_pex_from_rc():
+    # type: () -> None
     with named_temporary_file(mode="w") as pexrc:
         pexrc.write("HELLO=42")
         pexrc.flush()
@@ -111,6 +121,7 @@ def test_pex_from_rc():
 
 
 def test_pexrc_precedence():
+    # type: () -> None
     with named_temporary_file(mode="w") as pexrc:
         pexrc.write("HELLO=FORTYTWO")
         pexrc.flush()
@@ -119,6 +130,7 @@ def test_pexrc_precedence():
 
 
 def test_rc_ignore():
+    # type: () -> None
     with named_temporary_file(mode="w") as pexrc:
         pexrc.write("HELLO=FORTYTWO")
         pexrc.flush()
@@ -127,6 +139,7 @@ def test_rc_ignore():
 
 
 def test_pex_vars_defaults_stripped():
+    # type: () -> None
     v = Variables(environ={})
     stripped = v.strip_defaults()
 
@@ -144,6 +157,7 @@ def test_pex_vars_defaults_stripped():
 
 
 def test_pex_root_unwriteable():
+    # type: () -> None
     with temporary_dir() as td:
         pex_root = os.path.realpath(os.path.join(td, "pex_root"))
         os.mkdir(pex_root, 0o444)

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -7,22 +7,26 @@ from pex.vendor import VendorSpec
 
 
 def test_pinned():
+    # type: () -> None
     vendor_spec = VendorSpec.pinned("foo", "1.2.3")
     assert "foo" == vendor_spec.key
     assert "foo==1.2.3" == vendor_spec.requirement
 
 
 def test_vcs_valid():
+    # type: () -> None
     vendor_spec = VendorSpec.vcs("git+https://github.com/foo.git@da39a3ee#egg=bar")
     assert "bar" == vendor_spec.key
     assert "git+https://github.com/foo.git@da39a3ee#egg=bar" == vendor_spec.requirement
 
 
 def test_vcs_invalid_no_egg():
+    # type: () -> None
     with pytest.raises(ValueError):
         VendorSpec.vcs("git+https://github.com/foo.git@da39a3ee")
 
 
 def test_vcs_invalid_multiple_egg():
+    # type: () -> None
     with pytest.raises(ValueError):
         VendorSpec.vcs("git+https://github.com/foo.git@da39a3ee#egg=bar&egg=foo")


### PR DESCRIPTION
Now all tests have full coverage except for `test_environment.py`, `test_pex.py`, and `test_integration.py`, which are saved for a dedicated followup.

Why start with tests? These are the call-sites of much of our production code, and this will help to ensure that when we add types to our production code, the hints reflect reality. The tests also are "roots", which makes it easier to add hints to than adding hints to code with lots of dependees.

### `str` vs. `bytes` vs. `Text` vs. `AnyStr`

Python 2 lets you freely mix unicode and bytes :/ Pex uses this abundantly, in contrast to Pants's (awkward) use of `future` to ensure that Py2 always used the exact same type as Py3.

Originally, this PR added `from __future__ import unicode_literals`, but that was reverted to instead optimize for fewer code changes. PEX's Py2 support works well as is, and it's well tested. It's not worth the energy to do a Pants-style migration that ensures Py2 behaves like Py3.

Instead, these hints try to capture the truth, as follows:
* `bytes` -> when both Py2 and Py3 use `bytes`
* `str` -> when Py2 uses `bytes`, but Py3 uses unicode
* `Text` -> when both use unicode. This only really happens when we explicitly call `.decode('utf-8')`
* `AnyStr` -> when it can be either unicode or bytes; shorthand for `Union`

Once we require Py3 to run, `Text` and `AnyStr` will both be converted into simply `str` (i.e. unicode).