### PR TITLE
add a -V VERBOSITY option accepting an explicit nonnegative int

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -50,8 +50,12 @@ def increment_verbosity(option, opt_str, _, parser):
     setattr(parser.values, option.dest, verbosity + 1)
 
 
-def process_disable_cache(option, option_str, option_value, parser):
-    setattr(parser.values, option.dest, None)
+def process_explicit_verbosity(option, _, option_value, parser):
+    if option_value < 0:
+        raise OptionValueError(
+            "Please specify a nonnegative integer; ie: >=0. Given {}".format(option_value)
+        )
+    setattr(parser.values, option.dest, option_value)
 
 
 class PyPiSentinel(object):
@@ -681,6 +685,16 @@ def configure_clp():
         action="callback",
         callback=increment_verbosity,
         help="Turn on logging verbosity, may be specified multiple times.",
+    )
+    parser.add_option(
+        "-V",
+        dest="verbosity",
+        default=0,
+        type=int,
+        action="callback",
+        callback=process_explicit_verbosity,
+        help="Set or reset logging verbosity to a specific nonnegative number (>= 0). "
+        "A -v argument after a -V will increment the verbosity further.",
     )
 
     parser.add_option(


### PR DESCRIPTION
Closes #988. The option `-V` now more-or-less corresponds to the `PEX_VERBOSE` environment variable when executing a PEX file. Further `-v` arguments will continue to increment the verbosity, while further `-V` arguments will reset it to the specific value indicated.

Feel free to close this if it introduces unnecessary choice to the CLI.

```bash
> pex --help
...
  -v                    Turn on logging verbosity, may be specified multiple
                        times.
  -V VERBOSITY          Set or reset logging verbosity to a specific
                        nonnegative number (>= 0). A -v argument after a -V
                        will increment the verbosity further.
...
> pex -V1
pex: Building pex: 2.8ms
pex:   Resolving distributions ([]): 0.3ms
...
> pex -V0 -v
pex: Building pex: 1.4ms
pex:   Resolving distributions ([]): 0.2ms
...
> pex -v -V0
Python 3.6.11 (default, Sep 19 2020, 01:11:19)
[GCC Apple LLVM 12.0.0 (clang-1200.0.32.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>>
```