### PR TITLE
Add type hints to the remaining tests

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -34,6 +34,7 @@ from pex.testing import (
     PY27,
     PY35,
     PY36,
+    IntegResults,
     WheelBuilder,
     built_wheel,
     ensure_python_distribution,
@@ -46,10 +47,15 @@ from pex.testing import (
     temporary_content,
 )
 from pex.third_party import pkg_resources
+from pex.typing import TYPE_CHECKING
 from pex.util import DistributionHelper, named_temporary_file
+
+if TYPE_CHECKING:
+    from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple
 
 
 def make_env(**kwargs):
+    # type: (**Any) -> Dict[str, str]
     env = os.environ.copy()
     env.update((k, str(v)) for k, v in kwargs.items() if v is not None)
     for k, v in kwargs.items():
@@ -59,23 +65,27 @@ def make_env(**kwargs):
 
 
 def test_pex_execute():
+    # type: () -> None
     body = "print('Hello')"
     _, rc = run_simple_pex_test(body, coverage=True)
     assert rc == 0
 
 
 def test_pex_raise():
+    # type: () -> None
     body = "raise Exception('This will improve coverage.')"
     run_simple_pex_test(body, coverage=True)
 
 
 def assert_installed_wheels(label, pex_root):
+    # type: (str, str) -> None
     assert "installed_wheels" in os.listdir(
         pex_root
     ), "Expected {label} pex root to be populated with buildtime artifacts.".format(label=label)
 
 
 def test_pex_root_build():
+    # type: () -> None
     with nested(temporary_dir(), temporary_dir(), temporary_dir()) as (
         buildtime_pex_root,
         output_dir,
@@ -97,6 +107,7 @@ def test_pex_root_build():
 
 
 def test_pex_root_run():
+    # type: () -> None
     with nested(temporary_dir(), temporary_dir(), temporary_dir(), temporary_dir()) as (
         buildtime_pex_root,
         runtime_pex_root,
@@ -133,6 +144,7 @@ def test_pex_root_run():
 
 
 def test_cache_disable():
+    # type: () -> None
     with nested(temporary_dir(), temporary_dir(), temporary_dir()) as (td, output_dir, tmp_home):
         output_path = os.path.join(output_dir, "pex.pex")
         args = [
@@ -150,6 +162,7 @@ def test_cache_disable():
 
 
 def test_pex_interpreter():
+    # type: () -> None
     with named_temporary_file() as fp:
         fp.write(b"print('Hello world')")
         fp.flush()
@@ -162,6 +175,7 @@ def test_pex_interpreter():
 
 
 def test_pex_repl_cli():
+    # type: () -> None
     """Tests the REPL in the context of the pex cli itself."""
     stdin_payload = b"import sys; sys.exit(3)"
 
@@ -180,6 +194,7 @@ def test_pex_repl_cli():
 
 
 def test_pex_repl_built():
+    # type: () -> None
     """Tests the REPL in the context of a built pex."""
     stdin_payload = b"import requests; import sys; sys.exit(3)"
 
@@ -197,6 +212,7 @@ def test_pex_repl_built():
 
 @pytest.mark.skipif(WINDOWS, reason="No symlinks on windows")
 def test_pex_python_symlink():
+    # type: () -> None
     with temporary_dir() as td:
         symlink_path = os.path.join(td, "python-symlink")
         os.symlink(sys.executable, symlink_path)
@@ -210,6 +226,7 @@ def test_pex_python_symlink():
 
 
 def test_entry_point_exit_code():
+    # type: () -> None
     setup_py = dedent(
         """
         from setuptools import setup
@@ -247,6 +264,7 @@ def test_entry_point_exit_code():
     NOT_CPYTHON36_OR_LINUX, reason="inherits linux abi on linux w/ no backing packages"
 )
 def test_pex_multi_resolve():
+    # type: () -> None
     """Tests multi-interpreter + multi-platform resolution."""
     with temporary_dir() as output_dir:
         pex_path = os.path.join(output_dir, "pex.pex")
@@ -273,6 +291,7 @@ def test_pex_multi_resolve():
 
 @pytest.mark.xfail(reason="See https://github.com/pantsbuild/pants/issues/4682")
 def test_pex_re_exec_failure():
+    # type: () -> None
     with temporary_dir() as output_dir:
 
         # create 2 pex files for PEX_PATH
@@ -321,6 +340,7 @@ def test_pex_re_exec_failure():
 
 
 def test_pex_path_arg():
+    # type: () -> None
     with temporary_dir() as output_dir:
 
         # create 2 pex files for PEX_PATH
@@ -369,6 +389,7 @@ def test_pex_path_arg():
 
 
 def test_pex_path_in_pex_info_and_env():
+    # type: () -> None
     with temporary_dir() as output_dir:
 
         # create 2 pex files for PEX-INFO pex_path
@@ -418,6 +439,7 @@ def test_pex_path_in_pex_info_and_env():
 
 
 def test_interpreter_constraints_to_pex_info_py2():
+    # type: () -> None
     with temporary_dir() as output_dir:
         # target python 2
         pex_out_path = os.path.join(output_dir, "pex_py2.pex")
@@ -436,6 +458,7 @@ def test_interpreter_constraints_to_pex_info_py2():
 
 
 def test_interpreter_constraints_to_pex_info_py3():
+    # type: () -> None
     py3_interpreter = ensure_python_interpreter(PY36)
     with temporary_dir() as output_dir:
         # target python 3
@@ -450,6 +473,7 @@ def test_interpreter_constraints_to_pex_info_py3():
 
 
 def test_interpreter_resolution_with_constraint_option():
+    # type: () -> None
     with temporary_dir() as output_dir:
         pex_out_path = os.path.join(output_dir, "pex1.pex")
         res = run_pex_command(
@@ -462,6 +486,7 @@ def test_interpreter_resolution_with_constraint_option():
 
 
 def test_interpreter_resolution_with_multiple_constraint_options():
+    # type: () -> None
     with temporary_dir() as output_dir:
         pex_out_path = os.path.join(output_dir, "pex1.pex")
         res = run_pex_command(
@@ -482,6 +507,7 @@ def test_interpreter_resolution_with_multiple_constraint_options():
 
 
 def test_interpreter_resolution_with_pex_python_path():
+    # type: () -> None
     with temporary_dir() as td:
         pexrc_path = os.path.join(td, ".pexrc")
         with open(pexrc_path, "w") as pexrc:
@@ -520,6 +546,7 @@ def test_interpreter_resolution_with_pex_python_path():
 
 
 def test_interpreter_constraints_honored_without_ppp_or_pp():
+    # type: () -> None
     # Create a pex with interpreter constraints, but for not the default interpreter in the path.
     with temporary_dir() as td:
         py36_path = ensure_python_interpreter(PY36)
@@ -553,6 +580,7 @@ def test_interpreter_constraints_honored_without_ppp_or_pp():
 
 
 def test_interpreter_resolution_pex_python_path_precedence_over_pex_python():
+    # type: () -> None
     with temporary_dir() as td:
         pexrc_path = os.path.join(td, ".pexrc")
         with open(pexrc_path, "w") as pexrc:
@@ -584,6 +612,7 @@ def test_interpreter_resolution_pex_python_path_precedence_over_pex_python():
 
 
 def test_use_first_matching_interpreter():
+    # type: () -> None
     py35_path = ensure_python_interpreter(PY35)
     py36_path = ensure_python_interpreter(PY36)
     env = make_env(PEX_PYTHON_PATH=os.pathsep.join((py35_path, py36_path)))
@@ -630,6 +659,7 @@ def test_use_first_matching_interpreter():
 
 
 def test_plain_pex_exec_no_ppp_no_pp_no_constraints():
+    # type: () -> None
     with temporary_dir() as td:
         pex_out_path = os.path.join(td, "pex.pex")
         env = make_env(
@@ -645,6 +675,7 @@ def test_plain_pex_exec_no_ppp_no_pp_no_constraints():
 
 
 def test_pex_exec_with_pex_python_path_only():
+    # type: () -> None
     with temporary_dir() as td:
         pexrc_path = os.path.join(td, ".pexrc")
         with open(pexrc_path, "w") as pexrc:
@@ -667,6 +698,7 @@ def test_pex_exec_with_pex_python_path_only():
 
 
 def test_pex_exec_with_pex_python_path_and_pex_python_but_no_constraints():
+    # type: () -> None
     with temporary_dir() as td:
         pexrc_path = os.path.join(td, ".pexrc")
         with open(pexrc_path, "w") as pexrc:
@@ -691,6 +723,7 @@ def test_pex_exec_with_pex_python_path_and_pex_python_but_no_constraints():
 
 
 def test_pex_python():
+    # type: () -> None
     py2_path_interpreter = ensure_python_interpreter(PY27)
     py3_path_interpreter = ensure_python_interpreter(PY36)
     path = ":".join([os.path.dirname(py2_path_interpreter), os.path.dirname(py3_path_interpreter)])
@@ -761,6 +794,7 @@ def test_pex_python():
 
 
 def test_entry_point_targeting():
+    # type: () -> None
     """Test bugfix for https://github.com/pantsbuild/pex/issues/434."""
     with temporary_dir() as td:
         pexrc_path = os.path.join(td, ".pexrc")
@@ -778,6 +812,7 @@ def test_entry_point_targeting():
 
 
 def test_interpreter_selection_using_os_environ_for_bootstrap_reexec():
+    # type: () -> None
     """This is a test for verifying the proper function of the pex bootstrapper's interpreter
     selection logic and validate a corresponding bugfix.
 
@@ -872,23 +907,26 @@ def test_interpreter_selection_using_os_environ_for_bootstrap_reexec():
         assert rc == 0
         # Ensure that child pex used the proper interpreter as specified by its pexrc.
         correct_interpreter_path = ensure_python_interpreter(child_pex_interpreter_version)
-        correct_interpreter_path = correct_interpreter_path.encode()  # Py 2/3 compatibility
-        assert correct_interpreter_path in stdout
+        assert correct_interpreter_path in stdout.decode("utf-8")
 
 
 def test_inherit_path_fallback():
+    # type: () -> None
     inherit_path("=fallback")
 
 
 def test_inherit_path_backwards_compatibility():
+    # type: () -> None
     inherit_path("")
 
 
 def test_inherit_path_prefer():
+    # type: () -> None
     inherit_path("=prefer")
 
 
 def inherit_path(inherit_path):
+    # type: (str) -> None
     with temporary_dir() as output_dir:
         exe = os.path.join(output_dir, "exe.py")
         body = "import sys ; print('\\n'.join(sys.path))"
@@ -929,6 +967,7 @@ def inherit_path(inherit_path):
 
 
 def test_pex_multi_resolve_2():
+    # type: () -> None
     """Tests multi-interpreter + multi-platform resolution using extended platform notation."""
     with temporary_dir() as output_dir:
         pex_path = os.path.join(output_dir, "pex.pex")
@@ -957,6 +996,7 @@ def test_pex_multi_resolve_2():
 
 @contextmanager
 def pex_manylinux_and_tag_selection_context():
+    # type: () -> Iterator[Tuple[Callable[[str, str, str, str, Optional[str]], None], Callable[[str, str, str, str], None]]]
     with temporary_dir() as output_dir:
 
         def do_resolve(req_name, req_version, platform, extra_flags=None):
@@ -976,6 +1016,7 @@ def pex_manylinux_and_tag_selection_context():
             return pex_path, results
 
         def test_resolve(req_name, req_version, platform, substr, extra_flags=None):
+            # type: (str, str, str, str, Optional[str]) -> None
             pex_path, results = do_resolve(req_name, req_version, platform, extra_flags)
             results.assert_success()
             included_dists = get_dep_dist_names_from_pex(pex_path, req_name.replace("-", "_"))
@@ -984,6 +1025,7 @@ def pex_manylinux_and_tag_selection_context():
             )
 
         def ensure_failure(req_name, req_version, platform, extra_flags):
+            # type: (str, str, str, str) -> None
             pex_path, results = do_resolve(req_name, req_version, platform, extra_flags)
             results.assert_failure()
 
@@ -991,6 +1033,7 @@ def pex_manylinux_and_tag_selection_context():
 
 
 def test_pex_manylinux_and_tag_selection_linux_msgpack():
+    # type: () -> None
     """Tests resolver manylinux support and tag targeting."""
     with pex_manylinux_and_tag_selection_context() as (test_resolve, ensure_failure):
         msgpack, msgpack_ver = "msgpack-python", "0.4.7"
@@ -1027,13 +1070,19 @@ def test_pex_manylinux_and_tag_selection_linux_msgpack():
 
 
 def test_pex_manylinux_and_tag_selection_lxml_osx():
+    # type: () -> None
     with pex_manylinux_and_tag_selection_context() as (test_resolve, ensure_failure):
-        test_resolve("lxml", "3.8.0", "macosx-10.6-x86_64-cp-27-m", "lxml-3.8.0-cp27-cp27m-macosx")
-        test_resolve("lxml", "3.8.0", "macosx-10.6-x86_64-cp-36-m", "lxml-3.8.0-cp36-cp36m-macosx")
+        test_resolve(
+            "lxml", "3.8.0", "macosx-10.6-x86_64-cp-27-m", "lxml-3.8.0-cp27-cp27m-macosx", None
+        )
+        test_resolve(
+            "lxml", "3.8.0", "macosx-10.6-x86_64-cp-36-m", "lxml-3.8.0-cp36-cp36m-macosx", None
+        )
 
 
 @pytest.mark.skipif(NOT_CPYTHON27_OR_OSX, reason="Relies on a pre-built wheel for linux 2.7")
 def test_pex_manylinux_runtime():
+    # type: () -> None
     """Tests resolver manylinux support and runtime resolution (and --platform=current)."""
     test_stub = dedent(
         """
@@ -1058,10 +1107,11 @@ def test_pex_manylinux_runtime():
         results.assert_success()
 
         out = subprocess.check_output([pex_path, tester_path])
-        assert out.strip() == "[1, 2, 3]"
+        assert out.strip() == b"[1, 2, 3]"
 
 
 def test_pex_exit_code_propagation():
+    # type: () -> None
     """Tests exit code propagation."""
     test_stub = dedent(
         """
@@ -1081,11 +1131,13 @@ def test_pex_exit_code_propagation():
 
 @pytest.mark.skipif(NOT_CPYTHON27, reason="Tests environment markers that select for python 2.7.")
 def test_ipython_appnope_env_markers():
+    # type: () -> None
     res = run_pex_command(["--disable-cache", "ipython==5.8.0", "-c", "ipython", "--", "--version"])
     res.assert_success()
 
 
 def test_cross_platform_abi_targeting_behavior_exact():
+    # type: () -> None
     with temporary_dir() as td:
         pex_out_path = os.path.join(td, "pex.pex")
         res = run_pex_command(
@@ -1103,6 +1155,7 @@ def test_cross_platform_abi_targeting_behavior_exact():
 
 
 def test_pex_source_bundling():
+    # type: () -> None
     with temporary_dir() as output_dir:
         with temporary_dir() as input_dir:
             with open(os.path.join(input_dir, "exe.py"), "w") as fh:
@@ -1134,6 +1187,7 @@ def test_pex_source_bundling():
 
 
 def test_pex_source_bundling_pep420():
+    # type: () -> None
     with temporary_dir() as output_dir:
         with temporary_dir() as input_dir:
             with safe_open(os.path.join(input_dir, "a/b/c.py"), "w") as fh:
@@ -1162,6 +1216,7 @@ def test_pex_source_bundling_pep420():
 
 
 def test_pex_resource_bundling():
+    # type: () -> None
     with temporary_dir() as output_dir:
         with temporary_dir() as input_dir, temporary_dir() as resources_input_dir:
             with open(os.path.join(resources_input_dir, "greeting"), "w") as fh:
@@ -1200,6 +1255,7 @@ def test_pex_resource_bundling():
 
 
 def test_entry_point_verification_3rdparty():
+    # type: () -> None
     with temporary_dir() as td:
         pex_out_path = os.path.join(td, "pex.pex")
         res = run_pex_command(
@@ -1209,6 +1265,7 @@ def test_entry_point_verification_3rdparty():
 
 
 def test_invalid_entry_point_verification_3rdparty():
+    # type: () -> None
     with temporary_dir() as td:
         pex_out_path = os.path.join(td, "pex.pex")
         res = run_pex_command(
@@ -1218,6 +1275,7 @@ def test_invalid_entry_point_verification_3rdparty():
 
 
 def test_multiplatform_entrypoint():
+    # type: () -> None
     with temporary_dir() as td:
         pex_out_path = os.path.join(td, "p537.pex")
         interpreter = ensure_python_interpreter(PY36)
@@ -1243,6 +1301,7 @@ def test_multiplatform_entrypoint():
 
 
 def test_pex_console_script_custom_setuptools_useable():
+    # type: () -> None
     setup_py = dedent(
         """
         from setuptools import setup
@@ -1291,6 +1350,7 @@ def test_pex_console_script_custom_setuptools_useable():
 
 @contextmanager
 def pex_with_no_entrypoints():
+    # type: () -> Iterator[Tuple[str, bytes, str]]
     with temporary_dir() as out:
         pex = os.path.join(out, "pex.pex")
         run_pex_command(["setuptools==36.2.7", "-o", pex])
@@ -1299,6 +1359,7 @@ def pex_with_no_entrypoints():
 
 
 def test_pex_interpreter_execute_custom_setuptools_useable():
+    # type: () -> None
     with pex_with_no_entrypoints() as (pex, test_script, out):
         script = os.path.join(out, "script.py")
         with open(script, "wb") as fp:
@@ -1308,12 +1369,14 @@ def test_pex_interpreter_execute_custom_setuptools_useable():
 
 
 def test_pex_interpreter_interact_custom_setuptools_useable():
+    # type: () -> None
     with pex_with_no_entrypoints() as (pex, test_script, _):
         stdout, rc = run_simple_pex(pex, env=make_env(PEX_VERBOSE=1), stdin=test_script)
         assert rc == 0, stdout
 
 
 def test_setup_python():
+    # type: () -> None
     interpreter = ensure_python_interpreter(PY27)
     with temporary_dir() as out:
         pex = os.path.join(out, "pex.pex")
@@ -1325,6 +1388,7 @@ def test_setup_python():
 
 
 def test_setup_interpreter_constraint():
+    # type: () -> None
     interpreter = ensure_python_interpreter(PY27)
     with temporary_dir() as out:
         pex = os.path.join(out, "pex.pex")
@@ -1349,6 +1413,7 @@ def test_setup_interpreter_constraint():
 
 
 def test_setup_python_multiple_transitive_markers():
+    # type: () -> None
     py27_interpreter = ensure_python_interpreter(PY27)
     py36_interpreter = ensure_python_interpreter(PY36)
     with temporary_dir() as out:
@@ -1388,6 +1453,7 @@ def test_setup_python_multiple_transitive_markers():
 
 
 def test_setup_python_direct_markers():
+    # type: () -> None
     py36_interpreter = ensure_python_interpreter(PY36)
     with temporary_dir() as out:
         pex = os.path.join(out, "pex.pex")
@@ -1415,6 +1481,7 @@ def test_setup_python_direct_markers():
 
 
 def test_setup_python_multiple_direct_markers():
+    # type: () -> None
     py36_interpreter = ensure_python_interpreter(PY36)
     py27_interpreter = ensure_python_interpreter(PY27)
     with temporary_dir() as out:
@@ -1451,6 +1518,7 @@ def test_setup_python_multiple_direct_markers():
 
 
 def test_force_local_implicit_ns_packages_issues_598():
+    # type: () -> None
     # This was a minimal repro for the issue documented in #598.
     with temporary_dir() as out:
         tcl_pex = os.path.join(out, "tcl.pex")
@@ -1472,6 +1540,7 @@ def test_force_local_implicit_ns_packages_issues_598():
     "again, until we can address this.",
 )
 def test_issues_661_devendoring_required():
+    # type: () -> None
     # The cryptography distribution does not have a whl released for python3 on linux at version 2.5.
     # As a result, we're forced to build it under python3 and, prior to the fix for
     # https://github.com/pantsbuild/pex/issues/661, this would fail using the vendored setuptools
@@ -1485,6 +1554,7 @@ def test_issues_661_devendoring_required():
 
 
 def build_and_execute_pex_with_warnings(*extra_build_args, **extra_runtime_env):
+    # type: (*str, **str) -> bytes
     with temporary_dir() as out:
         tcl_pex = os.path.join(out, "tcl.pex")
         run_pex_command(["twitter.common.lang==0.3.10", "-o", tcl_pex] + list(extra_build_args))
@@ -1498,26 +1568,31 @@ def build_and_execute_pex_with_warnings(*extra_build_args, **extra_runtime_env):
 
 
 def test_emit_warnings_default():
+    # type: () -> None
     stderr = build_and_execute_pex_with_warnings()
     assert stderr
 
 
 def test_no_emit_warnings():
+    # type: () -> None
     stderr = build_and_execute_pex_with_warnings("--no-emit-warnings")
     assert not stderr
 
 
 def test_no_emit_warnings_emit_env_override():
+    # type: () -> None
     stderr = build_and_execute_pex_with_warnings("--no-emit-warnings", PEX_EMIT_WARNINGS="true")
     assert stderr
 
 
 def test_no_emit_warnings_verbose_override():
+    # type: () -> None
     stderr = build_and_execute_pex_with_warnings("--no-emit-warnings", PEX_VERBOSE="1")
     assert stderr
 
 
 def test_undeclared_setuptools_import_on_pex_path():
+    # type: () -> None
     """Test that packages which access pkg_resources at import time can be found with pkg_resources.
 
     See https://github.com/pantsbuild/pex/issues/729 for context. We warn when a package accesses
@@ -1562,6 +1637,7 @@ def test_undeclared_setuptools_import_on_pex_path():
 
 
 def test_pkg_resource_early_import_on_pex_path():
+    # type: () -> None
     """Test that packages which access pkg_resources at import time can be found with pkg_resources.
 
     See https://github.com/pantsbuild/pex/issues/749 for context. We only declare namespace packages
@@ -1614,6 +1690,7 @@ def test_pkg_resource_early_import_on_pex_path():
     "available.",
 )
 def test_issues_539_abi3_resolution():
+    # type: () -> None
     # The cryptography team releases the following relevant pre-built wheels for version 2.6.1:
     # cryptography-2.6.1-cp27-cp27m-macosx_10_6_intel.whl
     # cryptography-2.6.1-cp27-cp27m-manylinux1_x86_64.whl
@@ -1646,6 +1723,7 @@ def test_issues_539_abi3_resolution():
 
 
 def assert_reproducible_build(args):
+    # type: (List[str]) -> None
     with temporary_dir() as td:
         pex1 = os.path.join(td, "1.pex")
         pex2 = os.path.join(td, "2.pex")
@@ -1681,23 +1759,28 @@ def assert_reproducible_build(args):
 
 
 def test_reproducible_build_no_args():
+    # type: () -> None
     assert_reproducible_build([])
 
 
 def test_reproducible_build_bdist_requirements():
+    # type: () -> None
     # We test both a pure Python wheel (six) and a platform-specific wheel (cryptography).
     assert_reproducible_build(["six==1.12.0", "cryptography==2.6.1"])
 
 
 def test_reproducible_build_sdist_requirements():
+    # type: () -> None
     assert_reproducible_build(["pycparser==2.19", "--no-wheel"])
 
 
 def test_reproducible_build_m_flag():
+    # type: () -> None
     assert_reproducible_build(["-m", "pydoc"])
 
 
 def test_reproducible_build_c_flag_from_source():
+    # type: () -> None
     setup_py = dedent(
         """\
         from setuptools import setup
@@ -1719,18 +1802,22 @@ def test_reproducible_build_c_flag_from_source():
 
 
 def test_reproducible_build_c_flag_from_dependency():
+    # type: () -> None
     assert_reproducible_build(["future==0.17.1", "-c", "futurize"])
 
 
 def test_reproducible_build_python_flag():
+    # type: () -> None
     assert_reproducible_build(["--python=python2.7"])
 
 
 def test_reproducible_build_python_shebang_flag():
+    # type: () -> None
     assert_reproducible_build(["--python-shebang=/usr/bin/python"])
 
 
 def test_issues_736_requirement_setup_py_with_extras():
+    # type: () -> None
     with make_source_dir(
         name="project1", version="1.0.0", extras_require={"foo": ["project2"]}
     ) as project1_dir:
@@ -1756,13 +1843,13 @@ def test_issues_736_requirement_setup_py_with_extras():
 
 
 def _assert_exec_chain(
-    exec_chain=None,
-    pex_python=None,
-    pex_python_path=None,
-    interpreter_constraints=None,
-    pythonpath=None,
+    exec_chain=None,  # type: Optional[List[str]]
+    pex_python=None,  # type: Optional[str]
+    pex_python_path=None,  # type: Optional[Iterable[str]]
+    interpreter_constraints=None,  # type: Optional[Iterable[str]]
+    pythonpath=None,  # type: Optional[Iterable[str]]
 ):
-
+    # type: (...) -> None
     with temporary_dir() as td:
         test_pex = os.path.join(td, "test.pex")
 
@@ -1771,9 +1858,10 @@ def _assert_exec_chain(
             args.extend("--interpreter-constraint={}".format(ic) for ic in interpreter_constraints)
 
         env = os.environ.copy()
-        PATH = env.get("PATH").split(os.pathsep)
+        PATH = env["PATH"].split(os.pathsep)
 
         def add_to_path(entry):
+            # type: (str) -> None
             if os.path.isfile(entry):
                 entry = os.path.dirname(entry)
             PATH.append(entry)
@@ -1816,19 +1904,23 @@ def _assert_exec_chain(
 
 
 def test_pex_no_reexec_no_constraints():
+    # type: () -> None
     _assert_exec_chain()
 
 
 def test_pex_reexec_no_constraints_pythonpath_present():
+    # type: () -> None
     _assert_exec_chain(exec_chain=[os.path.realpath(sys.executable)], pythonpath=["."])
 
 
 def test_pex_no_reexec_constraints_match_current():
+    # type: () -> None
     current_version = ".".join(str(component) for component in sys.version_info[0:3])
     _assert_exec_chain(interpreter_constraints=["=={}".format(current_version)])
 
 
 def test_pex_reexec_constraints_match_current_pythonpath_present():
+    # type: () -> None
     current_version = ".".join(str(component) for component in sys.version_info[0:3])
     _assert_exec_chain(
         exec_chain=[os.path.realpath(sys.executable)],
@@ -1838,6 +1930,7 @@ def test_pex_reexec_constraints_match_current_pythonpath_present():
 
 
 def test_pex_reexec_constraints_dont_match_current_pex_python_path():
+    # type: () -> None
     py36_interpreter = ensure_python_interpreter(PY36)
     py27_interpreter = ensure_python_interpreter(PY27)
     _assert_exec_chain(
@@ -1848,6 +1941,7 @@ def test_pex_reexec_constraints_dont_match_current_pex_python_path():
 
 
 def test_pex_reexec_constraints_dont_match_current_pex_python_path_min_py_version_selected():
+    # type: () -> None
     py36_interpreter = ensure_python_interpreter(PY36)
     py27_interpreter = ensure_python_interpreter(PY27)
     _assert_exec_chain(
@@ -1856,6 +1950,7 @@ def test_pex_reexec_constraints_dont_match_current_pex_python_path_min_py_versio
 
 
 def test_pex_reexec_constraints_dont_match_current_pex_python():
+    # type: () -> None
     version = PY27 if sys.version_info[0:2] == (3, 6) else PY36
     interpreter = ensure_python_interpreter(version)
     _assert_exec_chain(
@@ -1866,6 +1961,7 @@ def test_pex_reexec_constraints_dont_match_current_pex_python():
 
 
 def test_issues_745_extras_isolation():
+    # type: () -> None
     # Here we ensure one of our extras, `subprocess32`, is properly isolated in the transition from
     # pex bootstrapping where it is imported by `pex.executor` to execution of user code.
     python, pip = ensure_python_distribution(PY27)
@@ -1976,6 +2072,7 @@ def test_issues_1025_extras_isolation(issues_1025_pth):
 
 
 def test_trusted_host_handling():
+    # type: () -> None
     python = ensure_python_interpreter(PY27)
     # Since we explicitly ask Pex to find links at http://www.antlr3.org/download/Python, it should
     # implicitly trust the www.antlr3.org host.
@@ -1993,6 +2090,7 @@ def test_trusted_host_handling():
 
 
 def test_issues_898():
+    # type: () -> None
     python27 = ensure_python_interpreter(PY27)
     python36 = ensure_python_interpreter(PY36)
     with temporary_dir() as td:
@@ -2033,6 +2131,7 @@ def test_issues_898():
 
 
 def test_pex_run_strip_env():
+    # type: () -> None
     with temporary_dir() as td:
         src_dir = os.path.join(td, "src")
         with safe_open(os.path.join(src_dir, "print_pex_env.py"), "w") as fp:
@@ -2061,7 +2160,7 @@ def test_pex_run_strip_env():
         )
         results.assert_success()
         assert {} == json.loads(
-            subprocess.check_output([stripped_pex_file], env=env)
+            subprocess.check_output([stripped_pex_file], env=env).decode("utf-8")
         ), "Expected the entrypoint environment to be stripped of PEX_ environment variables."
 
         unstripped_pex_file = os.path.join(td, "unstripped.pex")
@@ -2076,15 +2175,16 @@ def test_pex_run_strip_env():
         )
         results.assert_success()
         assert pex_env == json.loads(
-            subprocess.check_output([unstripped_pex_file], env=env)
+            subprocess.check_output([unstripped_pex_file], env=env).decode("utf-8")
         ), "Expected the entrypoint environment to be left un-stripped."
 
 
-def iter_distributions(pex_root, project_name=None):
+def iter_distributions(pex_root, project_name):
+    # type: (str, str) -> Iterator[pkg_resources.Distribution]
     found = set()
     for root, dirs, _ in os.walk(pex_root):
         for d in dirs:
-            if project_name and not d.startswith(project_name):
+            if not d.startswith(project_name):
                 continue
             if not d.endswith(".whl"):
                 continue
@@ -2098,6 +2198,7 @@ def iter_distributions(pex_root, project_name=None):
 
 
 def test_pex_cache_dir_and_pex_root():
+    # type: () -> None
     python = ensure_python_interpreter(PY36)
     with temporary_dir() as td:
         cache_dir = os.path.join(td, "cache_dir")
@@ -2127,6 +2228,7 @@ def test_pex_cache_dir_and_pex_root():
 
 
 def test_disable_cache():
+    # type: () -> None
     python = ensure_python_interpreter(PY36)
     with temporary_dir() as td:
         pex_root = os.path.join(td, "pex_root")
@@ -2141,6 +2243,7 @@ def test_disable_cache():
 
 
 def test_unzip_mode():
+    # type: () -> None
     with temporary_dir() as td:
         pex_root = os.path.join(td, "pex_root")
         pex_file = os.path.join(td, "pex_file")
@@ -2196,11 +2299,13 @@ def test_unzip_mode():
 
 
 def test_issues_996():
+    # type: () -> None
     python27 = ensure_python_interpreter(PY27)
     python36 = ensure_python_interpreter(PY36)
     pex_python_path = os.pathsep.join((python27, python36))
 
     def create_platform_pex(args):
+        # type: (List[str]) -> IntegResults
         return run_pex_command(
             args=["--platform", str(PythonInterpreter.from_binary(python36).platform)] + args,
             python=python27,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -19,7 +19,7 @@ except ImportError:
     import mock  # type: ignore[no-redef]
 
 if TYPE_CHECKING:
-    from typing import Any
+    from typing import Any, Dict, List
 
 
 def test_hash():
@@ -181,7 +181,7 @@ def test_iter_pth_paths(mock_exists):
             "import nosuchmodule\nfoo": [],
             "import nosuchmodule\n": [],
             "import bad)syntax\n": [],
-        }
+        }  # type: Dict[str, List[str]]
 
         for i, pth_content in enumerate(PTH_TEST_MAPPING):
             pth_tmp_path = os.path.abspath(os.path.join(tmpdir, "test%s.pth" % i))


### PR DESCRIPTION
Now that we have full type coverage for the tests, we'll get useful validation when adding hints to our source code that the hints line up.