### PR TITLE
Add type hints to variables.py and platforms.py

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -7,10 +7,10 @@ check_untyped_defs = False
 
 no_implicit_optional = True
 
-warn_redundant_casts = True
 warn_unused_configs = True
-# TODO: enable `warn_unused_ignores = True` once we drop Python 2. Otherwise, we need it because some
-# ignores depend on which interpreter we use.
+# TODO: enable `warn_unused_ignores` and `warn_reudandant_casts` once we drop Python 2. Otherwise,
+# we need it because some ignores depend on which interpreter we use.
+warn_redundant_casts = False
 warn_unused_ignores = False
 warn_no_return = True
 warn_return_any = True

--- a/pex/dist_metadata.py
+++ b/pex/dist_metadata.py
@@ -7,18 +7,21 @@ from __future__ import absolute_import
 import email
 
 from pex.third_party.packaging.specifiers import SpecifierSet
-from pex.third_party.pkg_resources import DistInfoDistribution
+from pex.third_party.pkg_resources import DistInfoDistribution, Distribution
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Optional
 
 
 def requires_python(dist):
+    # type: (Distribution) -> Optional[SpecifierSet]
     """Examines dist for `Python-Requires` metadata and returns version constraints if any.
 
     See: https://www.python.org/dev/peps/pep-0345/#requires-python
 
     :param dist: A distribution to check for `Python-Requires` metadata.
-    :type dist: :class:`pkg_resources.Distribution`
     :return: The required python version specifiers.
-    :rtype: :class:`packaging.specifiers.SpecifierSet` or None
     """
     if not dist.has_metadata(DistInfoDistribution.PKG_INFO):
         return None

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -29,7 +29,7 @@ from pex.util import CacheHelper
 from pex.variables import ENV
 
 if TYPE_CHECKING:
-    from typing import Dict
+    from typing import Dict, Iterator
 
 
 class PythonIdentity(object):
@@ -144,6 +144,7 @@ class PythonIdentity(object):
 
     @property
     def version_str(self):
+        # type: () -> str
         return ".".join(map(str, self.version))
 
     @property
@@ -164,14 +165,13 @@ class PythonIdentity(object):
 
     @property
     def distribution(self):
+        # type: () -> Distribution
         return Distribution(project_name=self.interpreter, version=self.version_str)
 
     def iter_supported_platforms(self):
+        # type: () -> Iterator[Platform]
         """All platforms supported by the associated interpreter ordered from most specific to
-        least.
-
-        :rtype: iterator of :class:`Platform`
-        """
+        least."""
         for tags in self._supported_tags:
             yield Platform.from_tags(platform=tags.platform, python=tags.interpreter, abi=tags.abi)
 
@@ -200,6 +200,7 @@ class PythonIdentity(object):
         return self.distribution in requirement
 
     def hashbang(self):
+        # type: () -> str
         hashbang_string = self.INTERPRETER_NAME_TO_HASHBANG.get(
             self._interpreter_name, "CPython"
         ) % {
@@ -211,11 +212,13 @@ class PythonIdentity(object):
 
     @property
     def python(self):
+        # type: () -> str
         # return the python version in the format of the 'python' key for distributions
         # specifically, '2.7', '3.2', etc.
         return "%d.%d" % (self.version[0:2])
 
     def __str__(self):
+        # type: () -> str
         # N.B.: Kept as distinct from __repr__ to support legacy str(identity) used by Pants v1 when
         # forming cache locations.
         return "{interpreter_name}-{major}.{minor}.{patch}".format(
@@ -226,6 +229,7 @@ class PythonIdentity(object):
         )
 
     def __repr__(self):
+        # type: () -> str
         return (
             "{type}({binary!r}, {python_tag!r}, {abi_tag!r}, {platform_tag!r}, {version!r})".format(
                 type=self.__class__.__name__,
@@ -246,6 +250,7 @@ class PythonIdentity(object):
         return self._tup() == other._tup()
 
     def __hash__(self):
+        # type: () -> int
         return hash(self._tup())
 
 

--- a/pex/interpreter_constraints.py
+++ b/pex/interpreter_constraints.py
@@ -8,10 +8,15 @@ from __future__ import absolute_import, print_function
 import os
 
 from pex.common import die
-from pex.interpreter import PythonIdentity
+from pex.interpreter import PythonIdentity, PythonInterpreter
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Iterable, Optional, Tuple
 
 
 def validate_constraints(constraints):
+    # type: (Iterable[str]) -> None
     # TODO: add check to see if constraints are mutually exclusive (bad) so no time is wasted:
     # https://github.com/pantsbuild/pex/issues/432
     for req in constraints:
@@ -26,11 +31,10 @@ class UnsatisfiableInterpreterConstraintsError(Exception):
     """Indicates interpreter constraints could not be satisfied."""
 
     def __init__(self, constraints, candidates, failures):
+        # type: (Iterable[str], Iterable[PythonInterpreter], Iterable[Tuple[str, str]]) -> None
         """
         :param constraints: The constraints that could not be satisfied.
-        :type constraints: iterable of str
         :param candidates: The python interpreters that were compared against the constraints.
-        :type candidates: iterable of :class:`pex.interpreter.PythonInterpreter`
         """
         self.constraints = tuple(constraints)
         self.candidates = tuple(candidates)
@@ -38,13 +42,13 @@ class UnsatisfiableInterpreterConstraintsError(Exception):
         super(UnsatisfiableInterpreterConstraintsError, self).__init__(self.create_message())
 
     def create_message(self, preamble=None):
+        # type: (Optional[str]) -> str
         """Create a message describing  failure to find matching interpreters with an optional
         preamble.
 
-        :param str preamble: An optional preamble to the message that will be displayed above it
+        :param preamble: An optional preamble to the message that will be displayed above it
                              separated by an empty blank line.
         :return: A descriptive message useable for display to an end user.
-        :rtype: str
         """
         preamble = "{}\n\n".format(preamble) if preamble else ""
 

--- a/pex/pex_warnings.py
+++ b/pex/pex_warnings.py
@@ -6,13 +6,20 @@ from __future__ import absolute_import
 
 import warnings
 
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pex.pex_info import PexInfo
+    from pex.variables import Variables
+
 
 class PEXWarning(Warning):
     """Indicates a warning from PEX about suspect buildtime or runtime configuration."""
 
 
 def configure_warnings(pex_info, env):
-    if env.PEX_VERBOSE > 0:
+    # type: (PexInfo, Variables) -> None
+    if env.PEX_VERBOSE is not None and env.PEX_VERBOSE > 0:
         emit_warnings = True
     elif env.PEX_EMIT_WARNINGS is not None:
         emit_warnings = env.PEX_EMIT_WARNINGS
@@ -24,4 +31,5 @@ def configure_warnings(pex_info, env):
 
 
 def warn(message):
+    # type: (str) -> None
     warnings.warn(message, category=PEXWarning, stacklevel=2)

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -102,22 +102,22 @@ class Platform(namedtuple("Platform", ["platform", "impl", "version", "abi"])):
     @property
     def platform(self):
         # type: () -> str
-        return super(Platform, self).platform  # type: ignore[no-any-return]
+        return cast(str, super(Platform, self).platform)
 
     @property
     def impl(self):
         # type: () -> str
-        return super(Platform, self).impl  # type: ignore[no-any-return]
+        return cast(str, super(Platform, self).impl)
 
     @property
     def version(self):
         # type: () -> str
-        return super(Platform, self).version  # type: ignore[no-any-return]
+        return cast(str, super(Platform, self).version)
 
     @property
     def abi(self):
         # type: () -> str
-        return super(Platform, self).abi  # type: ignore[no-any-return]
+        return cast(str, super(Platform, self).abi)
 
     def __str__(self):
         # type: () -> str

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 from textwrap import dedent
 
-from pex.typing import TYPE_CHECKING
+from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from typing import Any, Iterator, Union, Tuple
@@ -115,7 +115,7 @@ class Platform(object):
 
     def __eq__(self, other):
         # type: (Any) -> bool
-        return self._tup() == other  # type: ignore[no-any-return]
+        return cast(bool, self._tup() == other)
 
     def __hash__(self):
         # type: () -> int

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -300,8 +300,7 @@ def write_simple_pex(
     return pb
 
 
-# We would normally use a dataclass or NamedTuple, but can't do that with Python 2 in a way
-# understood by MyPy.
+# TODO(#1041): use `typing.NamedTuple` once we require Python 3.
 class IntegResults(object):
     """Convenience object to return integration run results."""
 

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -42,15 +42,15 @@ def test_iter_help():
 
 def test_pex_bool_variables():
     # type: () -> None
-    Variables(environ={})._get_bool("NOT_HERE", default=False) is False
-    Variables(environ={})._get_bool("NOT_HERE", default=True) is True
+    assert Variables(environ={})._get_bool("NOT_HERE", default=False) is False
+    assert Variables(environ={})._get_bool("NOT_HERE", default=True) is True
 
     for value in ("0", "faLsE", "false"):
         for default in (True, False):
-            Variables(environ={"HERE": value})._get_bool("HERE", default=default) is False
+            assert Variables(environ={"HERE": value})._get_bool("HERE", default=default) is False
     for value in ("1", "TrUe", "true"):
         for default in (True, False):
-            Variables(environ={"HERE": value})._get_bool("HERE", default=default) is True
+            assert Variables(environ={"HERE": value})._get_bool("HERE", default=default) is True
     with pytest.raises(SystemExit):
         Variables(environ={"HERE": "garbage"})._get_bool("HERE")
 
@@ -61,18 +61,18 @@ def test_pex_bool_variables():
 
 def test_pex_string_variables():
     # type: () -> None
-    Variables(environ={})._get_string("NOT_HERE") is None
-    Variables(environ={})._get_string("NOT_HERE", default="lolol") == "lolol"
-    Variables(environ={"HERE": "stuff"})._get_string("HERE") == "stuff"
-    Variables(environ={"HERE": "stuff"})._get_string("HERE", default="lolol") == "stuff"
+    assert Variables(environ={})._get_string("NOT_HERE") is None
+    assert Variables(environ={})._get_string("NOT_HERE", default="lolol") == "lolol"
+    assert Variables(environ={"HERE": "stuff"})._get_string("HERE") == "stuff"
+    assert Variables(environ={"HERE": "stuff"})._get_string("HERE", default="lolol") == "stuff"
 
 
 def test_pex_get_int():
     # type: () -> None
     assert Variables()._get_int("HELLO") is None
     assert Variables()._get_int("HELLO", default=42) == 42
-    assert Variables(environ={"HELLO": 23})._get_int("HELLO") == 23
-    assert Variables(environ={"HELLO": 23})._get_int("HELLO", default=42) == 23
+    assert Variables(environ={"HELLO": "23"})._get_int("HELLO") == 23
+    assert Variables(environ={"HELLO": "23"})._get_int("HELLO", default=42) == 23
 
     with pytest.raises(SystemExit):
         assert Variables(environ={"HELLO": "welp"})._get_int("HELLO")
@@ -81,7 +81,7 @@ def test_pex_get_int():
 def assert_pex_vars_hermetic():
     # type: () -> None
     v = Variables()
-    assert os.environ == v.copy()
+    assert os.environ.copy() == v.copy()
 
     existing = os.environ.get("TEST")
     expected = (existing or "") + "different"
@@ -125,7 +125,7 @@ def test_pexrc_precedence():
     with named_temporary_file(mode="w") as pexrc:
         pexrc.write("HELLO=FORTYTWO")
         pexrc.flush()
-        v = Variables(rc=pexrc.name, environ={"HELLO": 42})
+        v = Variables(rc=pexrc.name, environ={"HELLO": "42"})
         assert v._get_int("HELLO") == 42
 
 
@@ -171,6 +171,7 @@ def test_pex_root_unwriteable():
         message = log[0].message
         assert isinstance(message, PEXWarning)
         assert pex_root in str(message)
+        assert env.PEX_ROOT is not None
         assert env.PEX_ROOT in str(message)
 
         assert (


### PR DESCRIPTION
Unfortunately, so long as we require Python 2, we cannot use `namedtuple` robustly with MyPy because it does not support annotating the fields of a named tuple. So, we recreate namedtuple through our own conventional class. This can be fixed once we require Python 3 to run. See https://github.com/pantsbuild/pex/issues/1041.