### PR TITLE
Path filter for PythonInterpreter.iter_candidates.

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -19,17 +19,27 @@ from pex import third_party
 from pex.common import safe_rmtree
 from pex.compatibility import string
 from pex.executor import Executor
-from pex.jobs import Job, Retain, SpawnedJob, execute_parallel
+from pex.jobs import ErrorHandler, Job, Retain, SpawnedJob, execute_parallel
 from pex.platforms import Platform
 from pex.third_party.packaging import markers, tags
 from pex.third_party.pkg_resources import Distribution, Requirement
 from pex.tracer import TRACER
-from pex.typing import TYPE_CHECKING, cast
+from pex.typing import TYPE_CHECKING, cast, overload
 from pex.util import CacheHelper
 from pex.variables import ENV
 
 if TYPE_CHECKING:
-    from typing import Dict, Iterator
+    from typing import Callable, Dict, Iterable, Iterator, MutableMapping, Optional, Tuple, Union
+
+    PathFilter = Callable[[str], bool]
+
+    InterpreterIdentificationJobError = Tuple[str, Union[Job.Error, Exception]]
+    InterpreterOrJobError = Union["PythonInterpreter", InterpreterIdentificationJobError]
+
+    # N.B.: We convert InterpreterIdentificationJobErrors that result from spawning interpreter
+    # identification jobs to these end-user InterpreterIdentificationErrors for display.
+    InterpreterIdentificationError = Tuple[str, str]
+    InterpreterOrError = Union["PythonInterpreter", InterpreterIdentificationError]
 
 
 class PythonIdentity(object):
@@ -289,42 +299,46 @@ class PythonInterpreter(object):
 
     @staticmethod
     def _paths(paths=None):
+        # type: (Optional[Iterable[str]]) -> Iterable[str]
         return paths or os.getenv("PATH", "").split(os.pathsep)
 
     @classmethod
     def iter(cls, paths=None):
+        # type: (Optional[Iterable[str]]) -> Iterator[PythonInterpreter]
         """Iterate all valid interpreters found in `paths`.
 
         NB: The paths can either be directories to search for python binaries or the paths of python
         binaries themselves.
 
         :param paths: The paths to look for python interpreters; by default the `PATH`.
-        :type paths: list str
-        :return: An iterator of PythonInterpreter.
         """
         return cls._filter(cls._find(cls._paths(paths=paths)))
 
     @classmethod
-    def iter_candidates(cls, paths=None):
+    def iter_candidates(cls, paths=None, path_filter=None):
+        # type: (Optional[Iterable[str]], Optional[PathFilter]) -> Iterator[InterpreterOrError]
         """Iterate all likely interpreters found in `paths`.
 
         NB: The paths can either be directories to search for python binaries or the paths of python
         binaries themselves.
 
         :param paths: The paths to look for python interpreters; by default the `PATH`.
-        :type paths: list str
+        :param path_filter: An optional predicate to test whether a candidate interpreter's binary
+                            path is acceptable.
         :return: A heterogeneous iterator over valid interpreters and (python, error) invalid
                  python binary tuples.
-        :rtype: A heterogeneous iterator over :class:`PythonInterpreter` and (str, str).
         """
-        failed_interpreters = OrderedDict()
+        failed_interpreters = OrderedDict()  # type: MutableMapping[str, str]
 
         def iter_interpreters():
-            for candidate in cls._find(cls._paths(paths=paths), error_handler=Retain()):
+            # type: () -> Iterator[PythonInterpreter]
+            for candidate in cls._find(
+                cls._paths(paths=paths), path_filter=path_filter, error_handler=Retain()
+            ):
                 if isinstance(candidate, cls):
                     yield candidate
                 else:
-                    python, exception = candidate
+                    python, exception = cast("InterpreterIdentificationJobError", candidate)
                     if isinstance(exception, Job.Error):
                         # We spawned a subprocess to identify the interpreter but the interpreter
                         # could not run our identification code meaning the interpreter is either
@@ -345,6 +359,7 @@ class PythonInterpreter(object):
 
     @classmethod
     def all(cls, paths=None):
+        # type: (Optional[Iterable[str]]) -> Iterable[PythonInterpreter]
         return list(cls.iter(paths=paths))
 
     @classmethod
@@ -509,35 +524,90 @@ class PythonInterpreter(object):
 
     @classmethod
     def _matches_binary_name(cls, path):
+        # type: (str) -> bool
         basefile = os.path.basename(path)
         return any(matcher.match(basefile) is not None for matcher in cls._REGEXEN)
 
+    @overload
     @classmethod
-    def _find(cls, paths, error_handler=None):
+    def _find(cls, paths):
+        # type: (Iterable[str]) -> Iterator[PythonInterpreter]
+        pass
+
+    @overload
+    @classmethod
+    def _find(
+        cls,
+        paths,  # type: Iterable[str]
+        error_handler,  # type: Retain
+        path_filter=None,  # type: Optional[PathFilter]
+    ):
+        # type: (...) -> Iterator[InterpreterOrJobError]
+        pass
+
+    @classmethod
+    def _find(
+        cls,
+        paths,  # type: Iterable[str]
+        error_handler=None,  # type: Optional[ErrorHandler]
+        path_filter=None,  # type: Optional[PathFilter]
+    ):
+        # type: (...) -> Union[Iterator[PythonInterpreter], Iterator[InterpreterOrJobError]]
         """Given a list of files or directories, try to detect python interpreters amongst them.
 
         Returns an iterator over PythonInterpreter objects.
         """
         return cls._identify_interpreters(
-            filter=cls._matches_binary_name, paths=paths, error_handler=error_handler
+            filter=path_filter or cls._matches_binary_name, paths=paths, error_handler=error_handler
         )
 
+    @overload
     @classmethod
-    def _identify_interpreters(cls, filter, paths=None, error_handler=None):
+    def _identify_interpreters(
+        cls,
+        filter,  # type: PathFilter
+        error_handler,  # type: None
+        paths=None,  # type: Optional[Iterable[str]]
+    ):
+        # type: (...) -> Iterator[PythonInterpreter]
+        pass
+
+    @overload
+    @classmethod
+    def _identify_interpreters(
+        cls,
+        filter,  # type: PathFilter
+        error_handler,  # type: Retain
+        paths=None,  # type: Optional[Iterable[str]]
+    ):
+        # type: (...) -> Iterator[InterpreterOrJobError]
+        pass
+
+    @classmethod
+    def _identify_interpreters(
+        cls,
+        filter,  # type: PathFilter
+        error_handler=None,  # type: Optional[ErrorHandler]
+        paths=None,  # type: Optional[Iterable[str]]
+    ):
+        # type: (...) -> Union[Iterator[PythonInterpreter], Iterator[InterpreterOrJobError]]
         def iter_candidates():
+            # type: () -> Iterator[str]
             for path in cls._paths(paths=paths):
                 for fn in cls._expand_path(path):
                     if filter(fn):
                         yield fn
 
-        return execute_parallel(
+        results = execute_parallel(
             inputs=list(iter_candidates()),
             spawn_func=cls._spawn_from_binary,
             error_handler=error_handler,
         )
+        return cast("Union[Iterator[PythonInterpreter], Iterator[InterpreterOrJobError]]", results)
 
     @classmethod
     def _filter(cls, pythons):
+        # type: (Iterable[PythonInterpreter]) -> Iterator[PythonInterpreter]
         """Filters duplicate python interpreters and versions we don't support.
 
         Returns an iterator over PythonInterpreters.
@@ -545,6 +615,7 @@ class PythonInterpreter(object):
         MAJOR, MINOR, SUBMINOR = range(3)
 
         def version_filter(version):
+            # type: (Tuple[int, int, int]) -> bool
             return (
                 version[MAJOR] == 2
                 and version[MINOR] >= 7

--- a/pex/typing.py
+++ b/pex/typing.py
@@ -15,7 +15,8 @@ evaluates to True. This allows us to safely import `typing` without it ever bein
 production.
 
 Note that we only use type comments, rather than normal annotations, which is what allows us to
-never need `typing` at runtime. (Exception for `cast`, see the below binding.)
+never need `typing` at runtime except for `cast` and `overload` which have no-op runtime bindings
+below.
 
 To add type comments, use a conditional import like this:
 
@@ -31,11 +32,22 @@ from __future__ import absolute_import
 
 TYPE_CHECKING = False
 
-# Unlike most type-hints, `cast` gets used at runtime. We define a no-op version for when
-# TYPE_CHECKING is false.
+# Unlike most type-hints, `cast` and `overload` get used at runtime. We define no-op versions for
+# runtime use.
 if TYPE_CHECKING:
     from typing import cast as cast
+    from typing import overload as overload
 else:
 
-    def cast(type_, value):  # type: ignore[no-redef]
+    def cast(_type, value):
         return value
+
+    def overload(_func):
+        def _never_called_since_structurally_shadowed(*_args, **_kwargs):
+            raise NotImplementedError(
+                "You should not call an overloaded function. A series of @overload-decorated "
+                "functions outside a stub module should always be followed by an implementation "
+                "that is not @overload-ed."
+            )
+
+        return _never_called_since_structurally_shadowed

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from typing import Iterator
 
 import pytest
 
@@ -111,6 +112,7 @@ class TestPythonInterpreter(object):
 
     @pytest.fixture
     def invalid_interpreter(self):
+        # type: () -> Iterator[str]
         with temporary_dir() as bin_dir:
             invalid_interpreter = os.path.join(bin_dir, "python")
             touch(invalid_interpreter)
@@ -150,6 +152,7 @@ class TestPythonInterpreter(object):
         self.assert_error(errors[0], invalid_interpreter)
 
     def test_iter_interpreter_path_filter(self, test_interpreter1, test_interpreter2):
+        # type: (str, str) -> None
         assert [PythonInterpreter.from_binary(test_interpreter2)] == list(
             PythonInterpreter.iter_candidates(
                 paths=[test_interpreter1, test_interpreter2],
@@ -158,6 +161,7 @@ class TestPythonInterpreter(object):
         )
 
     def test_iter_interpreter_path_filter_symlink(self, test_interpreter1, test_interpreter2):
+        # type: (str, str) -> None
         with temporary_dir() as bin_dir:
             os.symlink(test_interpreter2, os.path.join(bin_dir, "jake"))
 

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -6,7 +6,9 @@ import os
 import pytest
 
 from pex import interpreter
+from pex.common import temporary_dir, touch
 from pex.compatibility import PY3
+from pex.interpreter import PythonInterpreter
 from pex.testing import PY27, PY35, ensure_python_interpreter
 from pex.typing import TYPE_CHECKING
 
@@ -16,7 +18,10 @@ except ImportError:
     from unittest.mock import patch  # type: ignore[misc,no-redef,import]
 
 if TYPE_CHECKING:
-    from typing import Tuple
+    from typing import Tuple, Union
+
+    InterpreterIdentificationError = Tuple[str, str]
+    InterpreterOrError = Union[PythonInterpreter, InterpreterIdentificationError]
 
 
 def tuple_from_version(version_string):
@@ -35,7 +40,7 @@ class TestPythonInterpreter(object):
                 importlib.reload(interpreter)
             else:
                 reload(interpreter)
-            interpreter.PythonInterpreter.all()
+            PythonInterpreter.all()
 
     TEST_INTERPRETER1_VERSION = PY27
     TEST_INTERPRETER1_VERSION_TUPLE = tuple_from_version(TEST_INTERPRETER1_VERSION)
@@ -55,23 +60,23 @@ class TestPythonInterpreter(object):
 
     def test_interpreter_versioning(self, test_interpreter1):
         # type: (str) -> None
-        py_interpreter = interpreter.PythonInterpreter.from_binary(test_interpreter1)
+        py_interpreter = PythonInterpreter.from_binary(test_interpreter1)
         assert py_interpreter.identity.version == self.TEST_INTERPRETER1_VERSION_TUPLE
 
     def test_interpreter_caching(self, test_interpreter1, test_interpreter2):
         # type: (str, str) -> None
-        py_interpreter1 = interpreter.PythonInterpreter.from_binary(test_interpreter1)
-        py_interpreter2 = interpreter.PythonInterpreter.from_binary(test_interpreter2)
+        py_interpreter1 = PythonInterpreter.from_binary(test_interpreter1)
+        py_interpreter2 = PythonInterpreter.from_binary(test_interpreter2)
         assert py_interpreter1 is not py_interpreter2
         assert py_interpreter2.identity.version == self.TEST_INTERPRETER2_VERSION_TUPLE
 
-        py_interpreter3 = interpreter.PythonInterpreter.from_binary(test_interpreter1)
+        py_interpreter3 = PythonInterpreter.from_binary(test_interpreter1)
         assert py_interpreter1 is py_interpreter3
 
     def test_nonexistent_interpreter(self):
         # type: () -> None
-        with pytest.raises(interpreter.PythonInterpreter.InterpreterNotFound):
-            interpreter.PythonInterpreter.from_binary("/nonexistent/path")
+        with pytest.raises(PythonInterpreter.InterpreterNotFound):
+            PythonInterpreter.from_binary("/nonexistent/path")
 
     def test_binary_name_matching(self):
         # type: () -> None
@@ -89,6 +94,82 @@ class TestPythonInterpreter(object):
             "python3.6m",
         )
 
-        matches = interpreter.PythonInterpreter._matches_binary_name
+        matches = PythonInterpreter._matches_binary_name
         for name in valid_binary_names:
             assert matches(name), "Expected {} to be valid binary name".format(name)
+
+    def test_iter_interpreter_some(self, test_interpreter1, test_interpreter2):
+        # type: (str, str) -> None
+        assert [
+            PythonInterpreter.from_binary(test_interpreter1),
+            PythonInterpreter.from_binary(test_interpreter2),
+        ] == list(PythonInterpreter.iter_candidates(paths=[test_interpreter1, test_interpreter2]))
+
+    def test_iter_interpreter_none(self):
+        # type: () -> None
+        assert [] == list(PythonInterpreter.iter_candidates(paths=[os.devnull]))
+
+    @pytest.fixture
+    def invalid_interpreter(self):
+        with temporary_dir() as bin_dir:
+            invalid_interpreter = os.path.join(bin_dir, "python")
+            touch(invalid_interpreter)
+            yield invalid_interpreter
+
+    def assert_error(self, result, expected_python):
+        # type: (InterpreterOrError, str) -> None
+        assert isinstance(result, tuple)
+        python, error_message = result
+        assert expected_python == python
+        assert isinstance(error_message, str)
+        assert len(error_message) > 0
+
+    def test_iter_interpreter_errors(self, invalid_interpreter):
+        # type: (str) -> None
+        results = list(PythonInterpreter.iter_candidates(paths=[invalid_interpreter]))
+
+        assert len(results) == 1
+        self.assert_error(results[0], invalid_interpreter)
+
+    def test_iter_interpreter_mixed(
+        self, test_interpreter1, test_interpreter2, invalid_interpreter
+    ):
+        # type: (str, str, str) -> None
+        results = list(
+            PythonInterpreter.iter_candidates(
+                paths=[test_interpreter1, invalid_interpreter, test_interpreter2]
+            )
+        )
+
+        assert len(results) == 3
+        assert [
+            PythonInterpreter.from_binary(path) for path in (test_interpreter1, test_interpreter2)
+        ] == [result for result in results if isinstance(result, PythonInterpreter)]
+        errors = [result for result in results if not isinstance(result, PythonInterpreter)]
+        assert len(errors) == 1
+        self.assert_error(errors[0], invalid_interpreter)
+
+    def test_iter_interpreter_path_filter(self, test_interpreter1, test_interpreter2):
+        assert [PythonInterpreter.from_binary(test_interpreter2)] == list(
+            PythonInterpreter.iter_candidates(
+                paths=[test_interpreter1, test_interpreter2],
+                path_filter=lambda path: path == test_interpreter2,
+            )
+        )
+
+    def test_iter_interpreter_path_filter_symlink(self, test_interpreter1, test_interpreter2):
+        with temporary_dir() as bin_dir:
+            os.symlink(test_interpreter2, os.path.join(bin_dir, "jake"))
+
+            # Verify path filtering happens before interpreter resolution, which os.path.realpaths
+            # the interpreter binary. This supports specifying a path filter like
+            # "basename is python2" where discovered interpreter binaries are symlinks to more
+            # specific interpreter versions, e.g.: /usr/bin/python2 -> /usr/bin/python2.7.
+            expected_interpreter = PythonInterpreter.from_binary(test_interpreter2)
+            assert [expected_interpreter] == list(
+                PythonInterpreter.iter_candidates(
+                    paths=[test_interpreter1, bin_dir],
+                    path_filter=lambda path: os.path.basename(path) == "jake",
+                )
+            )
+            assert os.path.basename(expected_interpreter.binary) != "jake"

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-from typing import Iterator
 
 import pytest
 
@@ -19,7 +18,7 @@ except ImportError:
     from unittest.mock import patch  # type: ignore[misc,no-redef,import]
 
 if TYPE_CHECKING:
-    from typing import Tuple, Union
+    from typing import Iterator, Tuple, Union
 
     InterpreterIdentificationError = Tuple[str, str]
     InterpreterOrError = Union[PythonInterpreter, InterpreterIdentificationError]


### PR DESCRIPTION
This adds support for a path filter to allow unification of Pex
buildtime and runtime interpreter discovery. The PythonInterpreter
public API family of `iter`, `iter_candidates` and `all` is
type-annotated and tests are added for `iter_candidates`. To support
proper annotation of iter_candidates helpers, `@overload` support is
added for Python 2.7.

Work towards #1043