### PR TITLE
slightly demystify the relationship between platforms and interpreters in the library API and CLI

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -500,11 +500,9 @@ def configure_clp_pex_environment(parser):
         callback=process_platform,
         help="The platform for which to build the PEX. This option can be passed multiple times "
         "to create a multi-platform pex. To use the platform corresponding to the current "
-        "interpreter you can pass `current` "
-        "(which is the default value if this option is not provided). "
-        "To target any other platform you pass a string composed of fields: "
-        "<platform>-<python impl abbr>-<python version>-<abi>. "
-        "These fields stem from wheel name conventions as outlined in "
+        "interpreter you can pass `current`. To target any other platform you pass a string "
+        "composed of fields: <platform>-<python impl abbr>-<python version>-<abi>. These fields "
+        "stem from wheel name conventions as outlined in "
         "https://www.python.org/dev/peps/pep-0427#file-name-convention and influenced by "
         "https://www.python.org/dev/peps/pep-0425. For the current interpreter at {} the full "
         "platform string is {}. To find out more, try `{} --platform explain`.".format(

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -500,9 +500,7 @@ def configure_clp_pex_environment(parser):
         callback=process_platform,
         help="The platform for which to build the PEX. This option can be passed multiple times "
         "to create a multi-platform pex. To use the platform corresponding to the current "
-        "interpreter you can pass `current`. If any distributions need to be built, use the "
-        "--python or --interpreter-constraint argument instead, providing the corresponding "
-        "interpreter. To target any other platform you pass a string "
+        "interpreter you can pass `current`. To target any other platform you pass a string "
         "composed of fields: <platform>-<python impl abbr>-<python version>-<abi>. "
         "These fields stem from wheel name conventions as outlined in "
         "https://www.python.org/dev/peps/pep-0427#file-name-convention and influenced by "
@@ -537,7 +535,7 @@ def configure_clp_pex_environment(parser):
             "resolve requirements for each interpreter; this allows the resulting Pex to be "
             "compatible with more interpreters, such as different Python versions. However, "
             "resolving for multiple interpreters will take longer to build, and the resulting PEX "
-            "will be larger."
+            "may be larger."
         ),
     )
 

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -500,9 +500,11 @@ def configure_clp_pex_environment(parser):
         callback=process_platform,
         help="The platform for which to build the PEX. This option can be passed multiple times "
         "to create a multi-platform pex. To use the platform corresponding to the current "
-        "interpreter you can pass `current`. To target any other platform you pass a string "
-        "composed of fields: <platform>-<python impl abbr>-<python version>-<abi>. These fields "
-        "stem from wheel name conventions as outlined in "
+        "interpreter you can pass `current`. If any distributions need to be built, use the "
+        "--python or --interpreter-constraint argument instead, providing the corresponding "
+        "interpreter. To target any other platform you pass a string "
+        "composed of fields: <platform>-<python impl abbr>-<python version>-<abi>. "
+        "These fields stem from wheel name conventions as outlined in "
         "https://www.python.org/dev/peps/pep-0427#file-name-convention and influenced by "
         "https://www.python.org/dev/peps/pep-0425. For the current interpreter at {} the full "
         "platform string is {}. To find out more, try `{} --platform explain`.".format(

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -520,9 +520,9 @@ def configure_clp_pex_environment(parser):
         callback=parse_bool,
         help="When --platforms are specified, attempt to resolve a local interpreter that matches "
         "each platform specified. If found, use the interpreter to resolve distributions; if "
-        "not (or if this option is not specified), resolve for the platform only allowing matching "
-        "binary distributions and failing if only sdists or non-matching binary distributions "
-        "can be found.",
+        "not (or if this option is not specified), resolve for each platform only allowing "
+        "matching binary distributions and failing if only sdists or non-matching binary "
+        "distributions can be found.",
     )
 
     group.add_option(
@@ -536,7 +536,8 @@ def configure_clp_pex_environment(parser):
             "compatible Python version. Normally, when multiple interpreters match, Pex will "
             "resolve requirements for each interpreter; this allows the resulting Pex to be "
             "compatible with more interpreters, such as different Python versions. However, "
-            "resolving for multiple interpreters results in worse performance."
+            "resolving for multiple interpreters will take longer to build, and the resulting PEX "
+            "will be larger."
         ),
     )
 

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -500,9 +500,11 @@ def configure_clp_pex_environment(parser):
         callback=process_platform,
         help="The platform for which to build the PEX. This option can be passed multiple times "
         "to create a multi-platform pex. To use the platform corresponding to the current "
-        "interpreter you can pass `current`. To target any other platform you pass a string "
-        "composed of fields: <platform>-<python impl abbr>-<python version>-<abi>. These fields "
-        "stem from wheel name conventions as outlined in "
+        "interpreter you can pass `current` "
+        "(which is the default value if this option is not provided). "
+        "To target any other platform you pass a string composed of fields: "
+        "<platform>-<python impl abbr>-<python version>-<abi>. "
+        "These fields stem from wheel name conventions as outlined in "
         "https://www.python.org/dev/peps/pep-0427#file-name-convention and influenced by "
         "https://www.python.org/dev/peps/pep-0425. For the current interpreter at {} the full "
         "platform string is {}. To find out more, try `{} --platform explain`.".format(
@@ -518,8 +520,9 @@ def configure_clp_pex_environment(parser):
         callback=parse_bool,
         help="When --platforms are specified, attempt to resolve a local interpreter that matches "
         "each platform specified. If found, use the interpreter to resolve distributions; if "
-        "not, resolve for the platform only allowing matching binary distributions and failing "
-        "if only sdists or non-matching binary distributions can be found.",
+        "not (or if this option is not specified), resolve for the platform only allowing matching "
+        "binary distributions and failing if only sdists or non-matching binary distributions "
+        "can be found.",
     )
 
     group.add_option(

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -733,11 +733,13 @@ def resolve(
       prerelease or development versions will override this setting.
     :keyword bool transitive: Whether to resolve transitive dependencies of requirements.
       Defaults to ``True``.
-    :keyword interpreter: The interpreter to use for building distributions and for testing
-      distribution compatibility. Defaults to the current interpreter.
+    :keyword interpreter: If specified, distributions will be resolved for this interpreter, and
+      non-wheel distributions will be built against this interpreter. If both `interpreter` and
+      `platform` are ``None`` (the default), this defaults to the current interpreter.
     :type interpreter: :class:`pex.interpreter.PythonInterpreter`
-    :keyword str platform: The exact target platform to resolve distributions for. If ``None`` or
-      ``'current'``, resolve for distributions appropriate for `interpreter`.
+    :keyword str platform: The exact PEP425-compatible platform string to resolve distributions for,
+      in addition to the platform of the given interpreter, if provided. The current interpreter
+      will be used to build any non-wheel distributions.
     :keyword indexes: A list of urls or paths pointing to PEP 503 compliant repositories to search for
       distributions. Defaults to ``None`` which indicates to use the default pypi index. To turn off
       use of all indexes, pass an empty list.
@@ -826,12 +828,14 @@ def resolve_multi(
       prerelease or development versions will override this setting.
     :keyword bool transitive: Whether to resolve transitive dependencies of requirements.
       Defaults to ``True``.
-    :keyword interpreters: The interpreters to use for building distributions and for testing
-      distribution compatibility. Defaults to the current interpreter.
+    :keyword interpreters: If specified, distributions will be resolved for these interpreters, and
+      non-wheel distributions will be built against each interpreter. If both `interpreters` and
+      `platforms` are ``None`` (the default) or an empty iterable, this defaults to a list
+      containing only the current interpreter.
     :type interpreters: list of :class:`pex.interpreter.PythonInterpreter`
     :keyword platforms: An iterable of PEP425-compatible platform strings to resolve distributions
-      for. If ``None`` (the default) or an empty iterable, use the platforms of the given
-      interpreters.
+      for, in addition to the platforms of any given interpreters. The current interpreter will be
+      used to build any non-wheel distributions.
     :type platforms: list of str
     :keyword indexes: A list of urls or paths pointing to PEP 503 compliant repositories to search for
       distributions. Defaults to ``None`` which indicates to use the default pypi index. To turn off
@@ -1051,12 +1055,12 @@ def download(
       prerelease or development versions will override this setting.
     :keyword bool transitive: Whether to resolve transitive dependencies of requirements.
       Defaults to ``True``.
-    :keyword interpreters: The interpreters to use for building distributions and for testing
-      distribution compatibility. Defaults to the current interpreter.
+    :keyword interpreters: If specified, distributions will be resolved for these interpreters.
+      If both `interpreters` and `platforms` are ``None`` (the default) or an empty iterable, this
+      defaults to a list containing only the current interpreter.
     :type interpreters: list of :class:`pex.interpreter.PythonInterpreter`
     :keyword platforms: An iterable of PEP425-compatible platform strings to resolve distributions
-      for. If ``None`` (the default) or an empty iterable, use the platforms of the given
-      interpreters.
+      for, in addition to the platforms of any given interpreters.
     :type platforms: list of str
     :keyword indexes: A list of urls or paths pointing to PEP 503 compliant repositories to search for
       distributions. Defaults to ``None`` which indicates to use the default pypi index. To turn off

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -737,9 +737,7 @@ def resolve(
       distribution compatibility. Defaults to the current interpreter.
     :type interpreter: :class:`pex.interpreter.PythonInterpreter`
     :keyword str platform: The exact target platform to resolve distributions for. If ``None`` or
-      ``'current'``, resolve for distributions appropriate for `interpreter` instead. If any
-      distributions need to be built, the corresponding interpreter must be provided in the
-      `interpreter` argument, or an exception will be raised.
+      ``'current'``, resolve for distributions appropriate for `interpreter`.
     :keyword indexes: A list of urls or paths pointing to PEP 503 compliant repositories to search for
       distributions. Defaults to ``None`` which indicates to use the default pypi index. To turn off
       use of all indexes, pass an empty list.
@@ -767,6 +765,8 @@ def resolve(
     :raises Unsatisfiable: If ``requirements`` is not transitively satisfiable.
     :raises Untranslatable: If no compatible distributions could be acquired for
       a particular requirement.
+    :raises ValueError: If a foreign `platform` was provided, and `use_wheel=False`.
+    :raises ValueError: If `build=False` and `use_wheel=False`.
     """
     # TODO(https://github.com/pantsbuild/pex/issues/969): Deprecate resolve with a single interpreter
     #  or platform and rename resolve_multi to resolve for a single API entrypoint to a full resolve.
@@ -829,11 +829,9 @@ def resolve_multi(
     :keyword interpreters: The interpreters to use for building distributions and for testing
       distribution compatibility. Defaults to the current interpreter.
     :type interpreters: list of :class:`pex.interpreter.PythonInterpreter`
-    :keyword platforms: An iterable of PEP425-compatible platform strings. If provided,
-      distributions will be resolved for exactly these platforms. If ``None`` (the default) or an
-      empty iterable, resolve for distributions appropriate for `interpreters` instead. If any
-      distributions need to be built, a corresponding interpreter must be provided in
-      `interpreters`, or an exception will be raised.
+    :keyword platforms: An iterable of PEP425-compatible platform strings to resolve distributions
+      for. If ``None`` (the default) or an empty iterable, use the platforms of the given
+      interpreters.
     :type platforms: list of str
     :keyword indexes: A list of urls or paths pointing to PEP 503 compliant repositories to search for
       distributions. Defaults to ``None`` which indicates to use the default pypi index. To turn off
@@ -862,6 +860,8 @@ def resolve_multi(
     :raises Unsatisfiable: If ``requirements`` is not transitively satisfiable.
     :raises Untranslatable: If no compatible distributions could be acquired for
       a particular requirement.
+    :raises ValueError: If a foreign platform was provided in `platforms`, and `use_wheel=False`.
+    :raises ValueError: If `build=False` and `use_wheel=False`.
     """
 
     # A resolve happens in four stages broken into two phases:
@@ -1054,11 +1054,9 @@ def download(
     :keyword interpreters: The interpreters to use for building distributions and for testing
       distribution compatibility. Defaults to the current interpreter.
     :type interpreters: list of :class:`pex.interpreter.PythonInterpreter`
-    :keyword platforms: An iterable of PEP425-compatible platform strings. If provided,
-      distributions will be resolved for exactly these platforms. If ``None`` (the default) or an
-      empty iterable, resolve for distributions appropriate for `interpreters` instead. If any
-      distributions need to be built, a corresponding interpreter must be provided in
-      `interpreters`, or an exception will be raised.
+    :keyword platforms: An iterable of PEP425-compatible platform strings to resolve distributions
+      for. If ``None`` (the default) or an empty iterable, use the platforms of the given
+      interpreters.
     :type platforms: list of str
     :keyword indexes: A list of urls or paths pointing to PEP 503 compliant repositories to search for
       distributions. Defaults to ``None`` which indicates to use the default pypi index. To turn off
@@ -1081,8 +1079,10 @@ def download(
     :keyword str dest: A directory path to download distributions to.
     :keyword int max_parallel_jobs: The maximum number of parallel jobs to use when resolving,
       building and installing distributions in a resolve. Defaults to the number of CPUs available.
-    :raises Unsatisfiable: If the resolution of download of distributions fails for any reason.
     :returns: List of :class:`LocalDistribution` instances meeting ``requirements``.
+    :raises Unsatisfiable: If the resolution of download of distributions fails for any reason.
+    :raises ValueError: If a foreign platform was provided in `platforms`, and `use_wheel=False`.
+    :raises ValueError: If `build=False` and `use_wheel=False`.
     """
 
     local_distributions, download_results = _download_internal(

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -740,6 +740,8 @@ def resolve(
     :keyword str platform: The exact PEP425-compatible platform string to resolve distributions for,
       in addition to the platform of the given interpreter, if provided. If any distributions need
       to be built, use the interpreter argument instead, providing the corresponding interpreter.
+      However, if the platform matches the current interpreter, the current interpreter will be used
+      to build any non-wheels.
     :keyword indexes: A list of urls or paths pointing to PEP 503 compliant repositories to search for
       distributions. Defaults to ``None`` which indicates to use the default pypi index. To turn off
       use of all indexes, pass an empty list.
@@ -836,6 +838,8 @@ def resolve_multi(
     :keyword platforms: An iterable of PEP425-compatible platform strings to resolve distributions
       for, in addition to the platforms of any given interpreters. If any distributions need to be
       built, use the interpreters argument instead, providing the corresponding interpreter.
+      However, if any platform matches the current interpreter, the current interpreter will be used
+      to build any non-wheels for that platform.
     :type platforms: list of str
     :keyword indexes: A list of urls or paths pointing to PEP 503 compliant repositories to search for
       distributions. Defaults to ``None`` which indicates to use the default pypi index. To turn off

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -737,7 +737,9 @@ def resolve(
       distribution compatibility. Defaults to the current interpreter.
     :type interpreter: :class:`pex.interpreter.PythonInterpreter`
     :keyword str platform: The exact target platform to resolve distributions for. If ``None`` or
-      ``'current'``, resolve for distributions appropriate for `interpreter`.
+      ``'current'``, resolve for distributions appropriate for `interpreter` instead. If any
+      distributions need to be built, the corresponding interpreter must be provided in the
+      `interpreter` argument, or an exception will be raised.
     :keyword indexes: A list of urls or paths pointing to PEP 503 compliant repositories to search for
       distributions. Defaults to ``None`` which indicates to use the default pypi index. To turn off
       use of all indexes, pass an empty list.
@@ -827,9 +829,11 @@ def resolve_multi(
     :keyword interpreters: The interpreters to use for building distributions and for testing
       distribution compatibility. Defaults to the current interpreter.
     :type interpreters: list of :class:`pex.interpreter.PythonInterpreter`
-    :keyword platforms: An iterable of PEP425-compatible platform strings to resolve distributions
-      for. If ``None`` (the default) or an empty iterable, use the platforms of the given
-      interpreters.
+    :keyword platforms: An iterable of PEP425-compatible platform strings. If provided,
+      distributions will be resolved for exactly these platforms. If ``None`` (the default) or an
+      empty iterable, resolve for distributions appropriate for `interpreters` instead. If any
+      distributions need to be built, a corresponding interpreter must be provided in
+      `interpreters`, or an exception will be raised.
     :type platforms: list of str
     :keyword indexes: A list of urls or paths pointing to PEP 503 compliant repositories to search for
       distributions. Defaults to ``None`` which indicates to use the default pypi index. To turn off
@@ -1050,9 +1054,11 @@ def download(
     :keyword interpreters: The interpreters to use for building distributions and for testing
       distribution compatibility. Defaults to the current interpreter.
     :type interpreters: list of :class:`pex.interpreter.PythonInterpreter`
-    :keyword platforms: An iterable of PEP425-compatible platform strings to resolve distributions
-      for. If ``None`` (the default) or an empty iterable, use the platforms of the given
-      interpreters.
+    :keyword platforms: An iterable of PEP425-compatible platform strings. If provided,
+      distributions will be resolved for exactly these platforms. If ``None`` (the default) or an
+      empty iterable, resolve for distributions appropriate for `interpreters` instead. If any
+      distributions need to be built, a corresponding interpreter must be provided in
+      `interpreters`, or an exception will be raised.
     :type platforms: list of str
     :keyword indexes: A list of urls or paths pointing to PEP 503 compliant repositories to search for
       distributions. Defaults to ``None`` which indicates to use the default pypi index. To turn off

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -738,8 +738,8 @@ def resolve(
       `platform` are ``None`` (the default), this defaults to the current interpreter.
     :type interpreter: :class:`pex.interpreter.PythonInterpreter`
     :keyword str platform: The exact PEP425-compatible platform string to resolve distributions for,
-      in addition to the platform of the given interpreter, if provided. The current interpreter
-      will be used to build any non-wheel distributions.
+      in addition to the platform of the given interpreter, if provided. If any distributions need
+      to be built, use the interpreter argument instead, providing the corresponding interpreter.
     :keyword indexes: A list of urls or paths pointing to PEP 503 compliant repositories to search for
       distributions. Defaults to ``None`` which indicates to use the default pypi index. To turn off
       use of all indexes, pass an empty list.
@@ -834,8 +834,8 @@ def resolve_multi(
       containing only the current interpreter.
     :type interpreters: list of :class:`pex.interpreter.PythonInterpreter`
     :keyword platforms: An iterable of PEP425-compatible platform strings to resolve distributions
-      for, in addition to the platforms of any given interpreters. The current interpreter will be
-      used to build any non-wheel distributions.
+      for, in addition to the platforms of any given interpreters. If any distributions need to be
+      built, use the interpreters argument instead, providing the corresponding interpreter.
     :type platforms: list of str
     :keyword indexes: A list of urls or paths pointing to PEP 503 compliant repositories to search for
       distributions. Defaults to ``None`` which indicates to use the default pypi index. To turn off


### PR DESCRIPTION
@jsirois read my mind in https://github.com/pantsbuild/pex/issues/1033#issuecomment-699590960 after I asked why Pex couldn't resolve for an interpreter it doesn't have locally. This was in fact already possible, and he suggested a documentation fix to make it more clear. These changes make it clear that:
- `platform{,s}` takes precedence over `interpreter{,s}` when resolving wheels
- `interpreter{,s}` are used to seed `platform{,s}` if not provided
- matching `interpreter{,s}` must be provided for all `platform{,s}` if any distributions need to be built from source

Closes #1033.