### PR TITLE
Fix use of `iter_compatible_interpreters`.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -750,7 +750,11 @@ def build_pex(reqs, options, cache=None):
             constraints = options.interpreter_constraint
             validate_constraints(constraints)
             try:
-                interpreters = list(iter_compatible_interpreters(pex_python_path, constraints))
+                interpreters = list(
+                    iter_compatible_interpreters(
+                        path=pex_python_path, interpreter_constraints=constraints
+                    )
+                )
             except UnsatisfiableInterpreterConstraintsError as e:
                 die(
                     e.create_message("Could not find a compatible interpreter."),
@@ -763,7 +767,7 @@ def build_pex(reqs, options, cache=None):
         with TRACER.timed(
             "Searching for local interpreters matching {}".format(", ".join(map(str, platforms)))
         ):
-            candidate_interpreters = OrderedSet(iter_compatible_interpreters(pex_python_path))
+            candidate_interpreters = OrderedSet(iter_compatible_interpreters(path=pex_python_path))
             candidate_interpreters.add(PythonInterpreter.get())
             for candidate_interpreter in candidate_interpreters:
                 resolved_platforms = candidate_interpreter.supported_platforms.intersection(


### PR DESCRIPTION
Previously, `iter_compatible_interpreters` let its use of
`PythonIntepreter.iter_candidates` leak outside its direct control.
This allowed the heterogeneous iterator returned by `iter_candidates` to
end up in places that did not know about its heterogeneous nature.

Expand `iter_compatible_interpreters` to accept an optional
`valid_basenames` filter so that interpreter selection at Pex buildtime
and at PEX runtime can share the same code path and use this unification
to localize consumption of the heteogeneous iterator.

Fixes #1043.