### PR TITLE
Fix Variables typing.

### DIFF
--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -12,7 +12,7 @@ from pex.compatibility import PY2
 from pex.compatibility import string as compatibility_string
 from pex.orderedset import OrderedSet
 from pex.typing import TYPE_CHECKING
-from pex.variables import ENV
+from pex.variables import ENV, Variables
 from pex.version import __version__ as pex_version
 
 if TYPE_CHECKING:
@@ -104,20 +104,17 @@ class PexInfo(object):
 
     @classmethod
     def from_env(cls, env=ENV):
-        supplied_env = env.strip_defaults()
-        zip_safe = (
-            None if supplied_env.PEX_FORCE_LOCAL is None else not supplied_env.PEX_FORCE_LOCAL
-        )
-        unzip = None if supplied_env.PEX_UNZIP is None else supplied_env.PEX_UNZIP
+        pex_force_local = Variables.PEX_FORCE_LOCAL.strip_default(env)
+        zip_safe = None if pex_force_local is None else not pex_force_local
         pex_info = {
-            "pex_root": supplied_env.PEX_ROOT,
-            "entry_point": supplied_env.PEX_MODULE,
-            "script": supplied_env.PEX_SCRIPT,
+            "pex_root": Variables.PEX_ROOT.strip_default(env),
+            "entry_point": env.PEX_MODULE,
+            "script": env.PEX_SCRIPT,
             "zip_safe": zip_safe,
-            "unzip": unzip,
-            "inherit_path": supplied_env.PEX_INHERIT_PATH,
-            "ignore_errors": supplied_env.PEX_IGNORE_ERRORS,
-            "always_write_cache": supplied_env.PEX_ALWAYS_CACHE,
+            "unzip": Variables.PEX_UNZIP.strip_default(env),
+            "inherit_path": Variables.PEX_INHERIT_PATH.strip_default(env),
+            "ignore_errors": Variables.PEX_IGNORE_ERRORS.strip_default(env),
+            "always_write_cache": Variables.PEX_ALWAYS_CACHE.strip_default(env),
         }
         # Filter out empty entries not explicitly set in the environment.
         return cls(info=dict((k, v) for (k, v) in pex_info.items() if v is not None))

--- a/pex/pex_warnings.py
+++ b/pex/pex_warnings.py
@@ -19,7 +19,7 @@ class PEXWarning(Warning):
 
 def configure_warnings(pex_info, env):
     # type: (PexInfo, Variables) -> None
-    if env.PEX_VERBOSE is not None and env.PEX_VERBOSE > 0:
+    if env.PEX_VERBOSE > 0:
         emit_warnings = True
     elif env.PEX_EMIT_WARNINGS is not None:
         emit_warnings = env.PEX_EMIT_WARNINGS

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -95,12 +95,7 @@ class Pip(object):
         ]
 
         # The max pip verbosity is -vvv and for pex it's -vvvvvvvvv; so we scale down by a factor of 3.
-
-        # We cast to work around the current awkward state of `Variables` which can only return
-        # `None` in a non-production states.
-        # TODO(John Sirois): https://github.com/pantsbuild/pex/issues/1059
-        pex_verbosity = cast(int, ENV.PEX_VERBOSE)
-        pip_verbosity = pex_verbosity // 3
+        pip_verbosity = ENV.PEX_VERBOSE // 3
         if pip_verbosity > 0:
             pip_args.append("-{}".format("v" * pip_verbosity))
         else:
@@ -113,12 +108,8 @@ class Pip(object):
 
         command = pip_args + args
 
-        # We cast to work around the current awkward state of `Variables` which can only return
-        # `None` in a non-production states.
-        # TODO(John Sirois): https://github.com/pantsbuild/pex/issues/1059
-        pex_root = cast(str, ENV.PEX_ROOT)
         with ENV.strip().patch(
-            PEX_ROOT=cache or pex_root, PEX_VERBOSE=str(pex_verbosity), **(env or {})
+            PEX_ROOT=cache or ENV.PEX_ROOT, PEX_VERBOSE=str(ENV.PEX_VERBOSE), **(env or {})
         ) as env:
             # Guard against API calls from environment with ambient PYTHONPATH preventing pip PEX
             # bootstrapping. See: https://github.com/pantsbuild/pex/issues/892

--- a/pex/tracer.py
+++ b/pex/tracer.py
@@ -129,6 +129,6 @@ class TraceLogger(object):
 
 
 TRACER = TraceLogger(
-    predicate=lambda verbosity: ENV.PEX_VERBOSE is not None and verbosity <= ENV.PEX_VERBOSE,
+    predicate=lambda verbosity: verbosity <= ENV.PEX_VERBOSE,
     prefix="pex: ",
 )

--- a/pex/typing.py
+++ b/pex/typing.py
@@ -37,6 +37,7 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import cast as cast
     from typing import overload as overload
+    from typing import Generic as Generic
 else:
 
     def cast(_type, value):
@@ -51,3 +52,11 @@ else:
             )
 
         return _never_called_since_structurally_shadowed
+
+    class _Generic(object):
+        def __getitem__(self, type_var):
+            return object
+
+    Generic = _Generic()
+
+    del _Generic

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -194,7 +194,7 @@ def test_pex_builder_deterministic_timestamp():
 def test_pex_builder_from_requirements_pex():
     # type: () -> None
     def build_from_req_pex(path, req_pex):
-        # type: (str, PEXBuilder) -> PEXBuilder
+        # type: (str, str) -> PEXBuilder
         pb = PEXBuilder(path=path)
         pb.add_from_requirements_pex(req_pex)
         with open(os.path.join(path, "exe.py"), "w") as fp:


### PR DESCRIPTION
Re-structure `strip_defaults` to allow typing to reflect real usage and
simplify call sites.

Fixes #1059