### PR TITLE
Add atomic_directory exclusive mode.

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -319,16 +319,16 @@ class AtomicDirectory(object):
 
 
 @contextmanager
-def atomic_directory(target_dir, source=None, exclusive=False):
-    # type: (str, Optional[str], bool) -> Iterator[Optional[str]]
+def atomic_directory(target_dir, exclusive, source=None):
+    # type: (str, bool, Optional[str]) -> Iterator[Optional[str]]
     """A context manager that yields a new empty work directory path it will move to `target_dir`.
 
     :param target_dir: The target directory to atomically update.
-    :param source: An optional source offset into the work directory to use for the atomic update
-                   of the target directory. By default the whole work directory is used.
     :param exclusive: If `True`, its guaranteed that only one process will be yielded a non `None`
                       workdir; otherwise two or more processes might be yielded unique non-`None`
                       workdirs with the last process to finish "winning".
+    :param source: An optional source offset into the work directory to use for the atomic update
+                   of the target directory. By default the whole work directory is used.
 
     If the `target_dir` already exists the enclosed block will be yielded `None` to signal there is
     no work to do.

--- a/pex/common.py
+++ b/pex/common.py
@@ -20,7 +20,6 @@ from contextlib import contextmanager
 from datetime import datetime
 from uuid import uuid4
 
-from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:

--- a/pex/common.py
+++ b/pex/common.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, print_function
 import atexit
 import contextlib
 import errno
+import fcntl
 import os
 import shutil
 import stat
@@ -19,10 +20,11 @@ from contextlib import contextmanager
 from datetime import datetime
 from uuid import uuid4
 
+from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from typing import Any, DefaultDict, Iterator, NoReturn, Optional, Tuple, Set, Union
+    from typing import Any, DefaultDict, Iterator, NoReturn, Optional, Set
 
 
 # We use the start of MS-DOS time, which is what zipfiles use (see section 4.4.6 of
@@ -318,12 +320,16 @@ class AtomicDirectory(object):
 
 
 @contextmanager
-def atomic_directory(target_dir, source=None):
+def atomic_directory(target_dir, source=None, exclusive=False):
+    # type: (str, Optional[str], bool) -> Iterator[Optional[str]]
     """A context manager that yields a new empty work directory path it will move to `target_dir`.
 
-    :param str target_dir: The target directory to atomically update.
-    :param str source: An optional source offset into the work directory to use for the atomic update
-                       of the target directory. By default the whole work directory is used.
+    :param target_dir: The target directory to atomically update.
+    :param source: An optional source offset into the work directory to use for the atomic update
+                   of the target directory. By default the whole work directory is used.
+    :param exclusive: If `True`, its guaranteed that only one process will be yielded a non `None`
+                      workdir; otherwise two or more processes might be yielded unique non-`None`
+                      workdirs with the last process to finish "winning".
 
     If the `target_dir` already exists the enclosed block will be yielded `None` to signal there is
     no work to do.
@@ -332,17 +338,45 @@ def atomic_directory(target_dir, source=None):
 
     The new work directory will be cleaned up regardless of whether or not the enclosed block
     succeeds.
+
+    If the contents of the resulting directory will be subsequently mutated it's probably correct to
+    pass `exclusive=True` to ensure mutations that race the creation process are not lost.
     """
     atomic_dir = AtomicDirectory(target_dir=target_dir)
     if atomic_dir.is_finalized:
+        # Our work is already done for us so exit early.
         yield None
         return
+
+    lock_fd = None  # type: Optional[int]
+    if exclusive:
+        head, tail = os.path.split(atomic_dir.target_dir)
+        if head:
+            safe_mkdir(head)
+        # N.B.: We don't actually write anything to the lock file but the fcntl file locking
+        # operations only work on files opened for at least write.
+        lock_fd = os.open(
+            os.path.join(head, ".{}.atomic_directory.lck".format(tail or "here")),
+            os.O_CREAT | os.O_WRONLY,
+        )
+        # N.B.: Since lockf operates on an open file descriptor and these are guaranteed to be
+        # closed by the operating system when the owning process exits, this lock is immune to
+        # staleness.
+        fcntl.lockf(lock_fd, fcntl.LOCK_EX)  # A blocking write lock.
+        if atomic_dir.is_finalized:
+            # We lost the double-checked locking race and our work was done for us by the race
+            # winner so exit early.
+            yield None
+            return
 
     safe_mkdir(atomic_dir.work_dir)
     try:
         yield atomic_dir.work_dir
         atomic_dir.finalize(source=source)
     finally:
+        if lock_fd is not None:
+            fcntl.lockf(lock_fd, fcntl.LOCK_UN)
+            os.close(lock_fd)
         atomic_dir.cleanup()
 
 

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -107,7 +107,7 @@ class PEXEnvironment(Environment):
             return pex_file
         explode_dir = os.path.join(pex_info.zip_unsafe_cache, pex_info.code_hash)
         TRACER.log("PEX is not zip safe, exploding to %s" % explode_dir)
-        with atomic_directory(explode_dir) as explode_tmp:
+        with atomic_directory(explode_dir, exclusive=True) as explode_tmp:
             if explode_tmp:
                 with TRACER.timed("Unzipping %s" % pex_file):
                     with open_zip(pex_file) as pex_zip:

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -476,7 +476,7 @@ class PythonInterpreter(object):
 
                         encoded_identity = PythonIdentity.get(binary={binary!r}).encode()
                         sys.stdout.write(encoded_identity)
-                        with atomic_directory({cache_dir!r}) as cache_dir:
+                        with atomic_directory({cache_dir!r}, exclusive=False) as cache_dir:
                             if cache_dir:
                                 with safe_open(os.path.join(cache_dir, {info_file!r}), 'w') as fp:
                                     fp.write(encoded_identity)

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -46,7 +46,7 @@ def __maybe_run_unzipped__(pex_zip):
     with open(pex_zip, 'rb') as fp:
       hasher.update(fp.read())
   unzip_to = os.path.join(pex_info.pex_root, {unzipped_dir!r}, hasher.hexdigest())
-  with atomic_directory(unzip_to) as chroot:
+  with atomic_directory(unzip_to, exclusive=True) as chroot:
     if chroot:
       with TRACER.timed('Extracting {{}} to {{}}'.format(pex_zip, unzip_to)):
         with open_zip(pex_zip) as zip:

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -32,7 +32,7 @@ class Pip(object):
         :param str path: The path to build the pip tool pex at.
         """
         pip_pex_path = os.path.join(path, isolated().pex_hash)
-        with atomic_directory(pip_pex_path) as chroot:
+        with atomic_directory(pip_pex_path, exclusive=True) as chroot:
             if chroot is not None:
                 from pex.pex_builder import PEXBuilder
 

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -437,7 +437,7 @@ class InstallResult(namedtuple("InstallResult", ["request", "installation_root",
         #
         wheel_dir_hash = CacheHelper.dir_hash(self.install_chroot)
         runtime_key_dir = os.path.join(self.installation_root, wheel_dir_hash)
-        with atomic_directory(runtime_key_dir) as work_dir:
+        with atomic_directory(runtime_key_dir, exclusive=False) as work_dir:
             if work_dir:
                 # Note: Create a relative path symlink between the two directories so that the PEX_ROOT
                 # can be used within a chroot environment where the prefix of the path may change

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -389,7 +389,7 @@ def isolated():
         isolated_dir = os.path.join(ENV.PEX_ROOT, "isolated", dir_hash)
 
         with _tracer().timed("Isolating pex"):
-            with atomic_directory(isolated_dir) as chroot:
+            with atomic_directory(isolated_dir, exclusive=True) as chroot:
                 if chroot:
                     with _tracer().timed("Extracting pex to {}".format(isolated_dir)):
                         recursive_copy("", os.path.join(chroot, "pex"))

--- a/pex/util.py
+++ b/pex/util.py
@@ -180,7 +180,7 @@ class CacheHelper(object):
         :param target_dir: The directory to cache the distribution in if not already cached.
         :returns: The cached distribution.
         """
-        with atomic_directory(target_dir, source=source) as target_dir_tmp:
+        with atomic_directory(target_dir, source=source, exclusive=True) as target_dir_tmp:
             if target_dir_tmp is None:
                 TRACER.log("Using cached {}".format(target_dir))
             else:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -93,6 +93,7 @@ def test_atomic_directory_empty_workdir_failure():
         target_dir = os.path.join(sandbox, "target_dir")
         with pytest.raises(SimulatedRuntimeError):
             with atomic_directory(target_dir) as work_dir:
+                assert work_dir is not None
                 touch(os.path.join(work_dir, "created"))
                 raise SimulatedRuntimeError()
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -70,7 +70,7 @@ def test_atomic_directory_empty_workdir_finalize():
         target_dir = os.path.join(sandbox, "target_dir")
         assert not os.path.exists(target_dir)
 
-        with atomic_directory(target_dir) as work_dir:
+        with atomic_directory(target_dir, exclusive=False) as work_dir:
             assert work_dir is not None
             assert os.path.exists(work_dir)
             assert os.path.isdir(work_dir)
@@ -92,7 +92,7 @@ def test_atomic_directory_empty_workdir_failure():
     with temporary_dir() as sandbox:
         target_dir = os.path.join(sandbox, "target_dir")
         with pytest.raises(SimulatedRuntimeError):
-            with atomic_directory(target_dir) as work_dir:
+            with atomic_directory(target_dir, exclusive=False) as work_dir:
                 assert work_dir is not None
                 touch(os.path.join(work_dir, "created"))
                 raise SimulatedRuntimeError()
@@ -106,7 +106,7 @@ def test_atomic_directory_empty_workdir_failure():
 def test_atomic_directory_empty_workdir_finalized():
     # type: () -> None
     with temporary_dir() as target_dir:
-        with atomic_directory(target_dir) as work_dir:
+        with atomic_directory(target_dir, exclusive=False) as work_dir:
             assert work_dir is None, "When the target_dir exists no work_dir should be created."
 
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -57,10 +57,17 @@ def test_force_local():
         pb.build(pex_file)
 
         code_cache = PEXEnvironment._force_local(pex_file, pb.info)
+
         assert os.path.exists(pb.info.zip_unsafe_cache)
-        assert len(os.listdir(pb.info.zip_unsafe_cache)) == 1
-        assert [os.path.basename(code_cache)] == os.listdir(pb.info.zip_unsafe_cache)
-        assert set(os.listdir(code_cache)) == set([PexInfo.PATH, "__main__.py", "__main__.pyc"])
+        listing = set(os.listdir(pb.info.zip_unsafe_cache))
+
+        # The code_cache should be a write-locked directory.
+        assert len(listing) == 2
+        listing.remove(os.path.basename(code_cache))
+        lockfile = listing.pop()
+        assert os.path.isfile(os.path.join(pb.info.zip_unsafe_cache, lockfile))
+
+        assert set(os.listdir(code_cache)) == {PexInfo.PATH, "__main__.py", "__main__.pyc"}
 
         # idempotence
         assert PEXEnvironment._force_local(pex_file, pb.info) == code_cache


### PR DESCRIPTION
Use this new mode to ensure directories Pex creates that contain Python
code are created exactly once so that the implicit Python bytecode
compilation process is not thwarted by racing directory creation.

Fixes #1051