### PR TITLE
Honor `sys.executable` unless macOS Framework.

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -69,16 +69,17 @@ class PythonIdentity(object):
 
     @classmethod
     def get(cls, binary=None):
+        # type: (Optional[str]) -> PythonIdentity
+
         # N.B.: We should not need to look past `sys.executable` to learn the current interpreter's
         # executable path, but on OSX there has been a bug where the `sys.executable` reported is
         # _not_ the path of the current interpreter executable:
-        # https://bugs.python.org/issue22490#msg283859
-        if binary and binary != sys.executable:
-            TRACER.log(
-                "Identifying interpreter found at {} which reports an incorrect sys.executable of "
-                "{}.".format(binary, sys.executable),
-                V=9,
-            )
+        #   https://bugs.python.org/issue22490#msg283859
+        # That case is distinguished by the presence of a `__PYVENV_LAUNCHER__` environment
+        # variable as detailed in the Python bug linked above.
+        if binary and binary != sys.executable and "__PYVENV_LAUNCHER__" not in os.environ:
+            # Here we assume sys.executable is accurate and binary is something like a pyenv shim.
+            binary = sys.executable
 
         supported_tags = tuple(tags.sys_tags())
         preferred_tag = supported_tags[0]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1970,7 +1970,7 @@ def test_issues_745_extras_isolation():
     # type: () -> None
     # Here we ensure one of our extras, `subprocess32`, is properly isolated in the transition from
     # pex bootstrapping where it is imported by `pex.executor` to execution of user code.
-    python, pip = ensure_python_distribution(PY27)
+    python, pip, _ = ensure_python_distribution(PY27)
     subprocess.check_call([pip, "install", "subprocess32"])
     with temporary_dir() as td:
         src_dir = os.path.join(td, "src")
@@ -2046,7 +2046,7 @@ def issues_1025_pth():
 
 
 def test_issues_1025_extras_isolation(issues_1025_pth):
-    python, pip = ensure_python_distribution(PY36)
+    python, pip, _ = ensure_python_distribution(PY36)
     interpreter = PythonInterpreter.from_binary(python)
     _, stdout, _ = interpreter.execute(args=["-c", "import site; print(site.getsitepackages()[0])"])
     with temporary_dir() as tmpdir:


### PR DESCRIPTION
The prior fix for #1009 undid the fix in #860. Re-enable that fix
for any case that's clearly not in the context of a macOS Framework
Python build. Also add tests for pyenv shims to prevent further
regressions.