### PR TITLE
Add a `--tmpdir` option to the Pex CLI.

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2357,7 +2357,7 @@ def tmp_workdir():
     # type: () -> Iterator[str]
     with temporary_dir() as tmpdir:
         os.chdir(tmpdir)
-        yield tmpdir
+        yield os.path.realpath(tmpdir)
 
 
 def test_tmpdir_absolute(tmp_workdir):


### PR DESCRIPTION
This allows for explicit control of the temporary directory both Pex
and its subprocesses use.

Fixes #1067