### PR TITLE
Encapsulate `--inherit-path` handling.

### DIFF
--- a/pex/inherit_path.py
+++ b/pex/inherit_path.py
@@ -1,0 +1,42 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Tuple, Union
+
+
+class InheritPath(object):
+    class Value(object):
+        def __init__(self, value):
+            # type: (str) -> None
+            self.value = value
+
+        def __repr__(self):
+            # type: () -> str
+            return repr(self.value)
+
+    FALSE = Value("false")
+    PREFER = Value("prefer")
+    FALLBACK = Value("fallback")
+
+    values = FALSE, PREFER, FALLBACK
+
+    @classmethod
+    def for_value(cls, value):
+        # type: (Union[str, bool]) -> InheritPath.Value
+        if value is False:
+            return InheritPath.FALSE
+        elif value is True:
+            return InheritPath.PREFER
+        for v in cls.values:
+            if v.value == value:
+                return v
+        raise ValueError(
+            "{!r} of type {} must be one of {}".format(
+                value, type(value), ", ".join(map(repr, cls.values))
+            )
+        )

--- a/tests/test_inherits_path_option.py
+++ b/tests/test_inherits_path_option.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from io import open
 
 from pex.common import temporary_dir
+from pex.inherit_path import InheritPath
 from pex.pex_builder import PEXBuilder
 from pex.testing import run_simple_pex
 from pex.typing import TYPE_CHECKING
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 
 @contextmanager
 def write_and_run_simple_pex(inheriting):
-    # type: (str) -> Iterator[Text]
+    # type: (InheritPath.Value) -> Iterator[Text]
     """Write a pex file that contains an executable entry point.
 
     :param inheriting: whether this pex should inherit site-packages paths.
@@ -36,18 +37,21 @@ def write_and_run_simple_pex(inheriting):
 
 
 def test_inherits_path_fallback_option():
-    with write_and_run_simple_pex(inheriting="fallback") as so:
+    # type: () -> None
+    with write_and_run_simple_pex(inheriting=InheritPath.FALLBACK) as so:
         assert "Scrubbing from user site" not in so, "User packages should not be scrubbed."
         assert "Scrubbing from site-packages" not in so, "Site packages should not be scrubbed."
 
 
 def test_inherits_path_prefer_option():
-    with write_and_run_simple_pex(inheriting="prefer") as so:
+    # type: () -> None
+    with write_and_run_simple_pex(inheriting=InheritPath.PREFER) as so:
         assert "Scrubbing from user site" not in so, "User packages should not be scrubbed."
         assert "Scrubbing from site-packages" not in so, "Site packages should not be scrubbed."
 
 
 def test_does_not_inherit_path_option():
-    with write_and_run_simple_pex(inheriting="false") as so:
+    # type: () -> None
+    with write_and_run_simple_pex(inheriting=InheritPath.FALSE) as so:
         assert "Scrubbing from user site" in so, "User packages should be scrubbed."
         assert "Scrubbing from site-packages" in so, "Site packages should be scrubbed."

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -313,9 +313,7 @@ class PythonpathIsolationTest(
     @staticmethod
     def pex_info(inherit_path):
         # type: (Union[str, bool]) -> PexInfo
-        pex_info = PexInfo.default()
-        pex_info.inherit_path = inherit_path
-        return pex_info
+        return PexInfo.from_json(json.dumps({"inherit_path": inherit_path}))
 
     def assert_isolation(self, inherit_path, expected_output):
         # type: (Union[str, bool], str) -> None


### PR DESCRIPTION
Factor out an enum-like class that encodes legacy bool behavior
centrally and use this to provide the same validation in
`--inherit-path` and PEX_INHERIT_PATH.

Fixes #921