### PR TITLE
Remove `--use-first-matching-interpreter` misfeature

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -619,53 +619,6 @@ def test_interpreter_resolution_pex_python_path_precedence_over_pex_python():
         assert correct_interpreter_path in stdout
 
 
-def test_use_first_matching_interpreter():
-    # type: () -> None
-    py35_path = ensure_python_interpreter(PY35)
-    py36_path = ensure_python_interpreter(PY36)
-    env = make_env(PEX_PYTHON_PATH=os.pathsep.join((py35_path, py36_path)))
-
-    def run_pex_with_py36(use_first_matching_flag):
-        with temporary_dir() as output_dir:
-            pex_out_path = os.path.join(output_dir, "first_matching.pex")
-            args = [
-                "--disable-cache",
-                "--interpreter-constraint=>=3.5",
-                "-o",
-                pex_out_path,
-                "psutil==5.7.0",
-            ]
-            if use_first_matching_flag:
-                args.append("--use-first-matching-interpreter")
-            res = run_pex_command(args, env=env)
-            res.assert_success()
-
-            pex_info = PexInfo.from_pex(pex_out_path)
-            assert (
-                [] if use_first_matching_flag else [">=3.5"]
-            ) == pex_info.interpreter_constraints
-
-            # Running with Python 3.5 should always work because that is the first matching
-            # interpreter.
-            stdin_payload = b"import sys, psutil; print(sys.executable); sys.exit(0)"
-            stdout, rc = run_simple_pex(pex_out_path, stdin=stdin_payload, env=env)
-            assert rc == 0
-            assert py35_path in stdout.decode()
-
-            stdout, rc = run_simple_pex(
-                pex_out_path, stdin=stdin_payload, env=make_env(PEX_PYTHON_PATH=py36_path)
-            )
-            return stdout, rc
-
-    without_flag_stdout, without_flag_rc = run_pex_with_py36(use_first_matching_flag=False)
-    assert without_flag_rc == 0
-    assert py36_path in without_flag_stdout.decode()
-
-    with_flag_stdout, with_flag_rc = run_pex_with_py36(use_first_matching_flag=True)
-    assert with_flag_rc == 1
-    assert bool(re.search(r"Needed.*cp-36-cp36m", with_flag_stdout.decode()))
-
-
 def test_plain_pex_exec_no_ppp_no_pp_no_constraints():
     # type: () -> None
     with temporary_dir() as td:


### PR DESCRIPTION
This was a misfeature added to support a Pants use case, which is implemented another way.

This never worked very robustly:

> To be clear though, there are many corners this will not work for including mismatching abi (python2.7m vs python2.7mu) when the PEX contains platform specific wheels, etc.

If a user only wants to resolve for one interpreter, they should use `--python` or a finer grained `--interpreter-constraints`.

We don't use a proper deprecation due to https://github.com/pantsbuild/pex/issues/584. We'll call attention to this in the release notes.