### PR TITLE
Pin sphinx requirements for doc generation.

### DIFF
--- a/docs/rtd/requirements.txt
+++ b/docs/rtd/requirements.txt
@@ -1,2 +1,2 @@
-sphinx
-sphinx_rtd_theme
+sphinx==3.2.1
+sphinx_rtd_theme==0.5.0


### PR DESCRIPTION
Otherwise rtd uses a really old version.