### PR TITLE
Fix `--pex-python` when it's the same as the current interpreter

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -312,7 +312,8 @@ class PythonInterpreter(object):
     @staticmethod
     def _paths(paths=None):
         # type: (Optional[Iterable[str]]) -> Iterable[str]
-        return paths or os.getenv("PATH", "").split(os.pathsep)
+        # NB: If `paths=[]`, we will not read $PATH.
+        return paths if paths is not None else os.getenv("PATH", "").split(os.pathsep)
 
     @classmethod
     def iter(cls, paths=None):

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -76,8 +76,7 @@ def iter_compatible_interpreters(
             OrderedSet(os.path.realpath(p) for p in path.split(os.pathsep)) if path else None
         )
 
-        # Check if the current interpreter is valid. If `path` was specified, the current
-        # interpreter must be included in the value; otherwise, we always yield the interpreter.
+        # Prefer the current interpreter, if valid.
         current_interpreter = PythonInterpreter.get()
         if not _valid_path or _valid_path(current_interpreter.binary):
             if normalized_paths:
@@ -94,18 +93,12 @@ def iter_compatible_interpreters(
                 seen.add(current_interpreter)
                 yield current_interpreter
 
-        # NB: We only check for other interpreters if there are remaining candidate interpreters
-        # _or_ if the user left off `path`, meaning to default to looking at $PATH.
-        #
-        # There is a tricky edge case where `path` was specified, but its only entry is the current
-        # interpreter so it was already removed.
-        if normalized_paths or path is None:
-            for interp in PythonInterpreter.iter_candidates(
-                paths=normalized_paths, path_filter=_valid_path
-            ):
-                if interp not in seen:
-                    seen.add(interp)
-                    yield interp
+        for interp in PythonInterpreter.iter_candidates(
+            paths=normalized_paths, path_filter=_valid_path
+        ):
+            if interp not in seen:
+                seen.add(interp)
+                yield interp
 
     def _valid_interpreter(interp_or_error):
         # type: (InterpreterOrError) -> bool

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -117,6 +117,15 @@ class TestPythonInterpreter(object):
         # type: () -> None
         assert [] == list(PythonInterpreter.iter_candidates(paths=[os.devnull]))
 
+    def test_iter_candidates_empty_paths(self, test_interpreter1):
+        # type: (str) -> None
+        # Whereas `paths=None` should inspect $PATH, `paths=[]` means to search nothing.
+        with environment_as(PATH=test_interpreter1):
+            assert [] == list(PythonInterpreter.iter_candidates(paths=[]))
+            assert [PythonInterpreter.from_binary(test_interpreter1)] == list(
+                PythonInterpreter.iter_candidates(paths=None)
+            )
+
     @pytest.fixture
     def invalid_interpreter(self):
         # type: () -> Iterator[str]


### PR DESCRIPTION
Before, this unexpectedly fails:

```
$ PATH=/Library/Developer/CommandLineTools/usr/bin/python3 PEX_IGNORE_RCFILES=true /Users/eric/.pyenv/versions/3.8.5/bin/python ./pex --interpreter-constraint='CPython>=3.7' --python-path='/Users/eric/.pyenv/versions/3.8.5/bin/python' -- -c 'import sys; print(sys.executable)'
/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/bin/python3.7
```

But this succeeds:

```
$ PATH=/Library/Developer/CommandLineTools/usr/bin/python3 PEX_IGNORE_RCFILES=true /Library/Developer/CommandLineTools/usr/bin/python3 ./pex --interpreter-constraint='CPython>=3.7' --python-path='/Users/eric/.pyenv/versions/3.8.5/bin/python' -- -c 'import sys; print(sys.executable)'
/Users/eric/.pyenv/versions/3.8.5/bin/python3.8
```

This issue is that we remove the current interpreter from our candidates if they are valid with the interpreter constraints. When `--pex-path` has only one entry, this results in the `paths` variable being empty, so that it looks like the user never specified `--pex-path`, and we fall back to `$PATH`.