### PR TITLE
Prefer more recent patch versions in interpreter discovery.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -807,7 +807,11 @@ def build_pex(reqs, options, cache=None):
                 )
             )
 
-    interpreter = PythonInterpreter.safe_min(interpreters) if interpreters else None
+    interpreter = (
+        PythonInterpreter.latest_release_of_min_compatible_version(interpreters)
+        if interpreters
+        else None
+    )
 
     try:
         with open(options.preamble_file) as preamble_fd:

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -807,7 +807,7 @@ def build_pex(reqs, options, cache=None):
                 )
             )
 
-    interpreter = min(interpreters) if interpreters else None
+    interpreter = PythonInterpreter.safe_min(interpreters) if interpreters else None
 
     try:
         with open(options.preamble_file) as preamble_fd:

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -323,10 +323,10 @@ class PythonInterpreter(object):
     @staticmethod
     def latest_release_of_min_compatible_version(interps):
         # type: (Sequence[PythonInterpreter]) -> PythonInterpreter
-        """Find the minimum major version, but use the most recent patch version within that minor
+        """Find the minimum major version, but use the most recent micro version within that minor
         version.
 
-        That is, 3.6.1 < 3.6.0 < 3.7.*.
+        That is, prefer 3.6.1 over 3.6.0, and prefer both over 3.7.*.
         """
         assert interps, "No interpreters passed to `PythonInterpreter.safe_min()`"
         return min(

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -175,8 +175,7 @@ class PythonIdentity(object):
         # type: () -> Tuple[int, int, int]
         """The interpreter version as a normalized tuple.
 
-        This assumes that the interpreter uses semantic versioning in the form
-        <major>.<minor>.<patch>, which is used by CPython, PyPy, and Jython.
+        Consistent with `sys.version_info`, the tuple corresponds to `<major>.<minor>.<micro>`.
         """
         return cast("Tuple[int, int, int]", self._version)
 
@@ -322,7 +321,7 @@ class PythonInterpreter(object):
         pass
 
     @staticmethod
-    def safe_min(interps):
+    def latest_release_of_min_compatible_version(interps):
         # type: (Sequence[PythonInterpreter]) -> PythonInterpreter
         """Find the minimum major version, but use the most recent patch version within that minor
         version.
@@ -330,16 +329,9 @@ class PythonInterpreter(object):
         That is, 3.6.1 < 3.6.0 < 3.7.*.
         """
         assert interps, "No interpreters passed to `PythonInterpreter.safe_min()`"
-        result = interps[0]
-        for interp in interps[1:]:
-            result_major, result_minor, result_patch = result.version
-            curr_major, curr_minor, curr_patch = interp.version
-            if (curr_major, curr_minor) < (result_major, result_minor) or (
-                (curr_major, curr_minor) == (result_major, result_minor)
-                and curr_patch > result_patch
-            ):
-                result = interp
-        return result
+        return min(
+            interps, key=lambda interp: (interp.version[0], interp.version[1], -interp.version[2])
+        )
 
     @classmethod
     def get(cls):

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -173,7 +173,7 @@ def _select_path_interpreter(
 
     # TODO: Allow the selection strategy to be parameterized:
     #   https://github.com/pantsbuild/pex/issues/430
-    return min(candidate_interpreters)
+    return PythonInterpreter.safe_min(candidate_interpreters)
 
 
 def maybe_reexec_pex(compatibility_constraints=None):

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -173,7 +173,7 @@ def _select_path_interpreter(
 
     # TODO: Allow the selection strategy to be parameterized:
     #   https://github.com/pantsbuild/pex/issues/430
-    return PythonInterpreter.safe_min(candidate_interpreters)
+    return PythonInterpreter.latest_release_of_min_compatible_version(candidate_interpreters)
 
 
 def maybe_reexec_pex(compatibility_constraints=None):

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -221,21 +221,22 @@ class TestPythonInterpreter(object):
                         os.rename(py35_deleted, py35)
 
 
-def test_safe_min():
+def test_latest_release_of_min_compatible_version():
     # type: () -> None
     def mock_interp(version):
         interp = Mock()
         interp.version = tuple(int(v) for v in version.split("."))
         return interp
 
-    def assert_min(expected_version, other_version):
+    def assert_chosen(expected_version, other_version):
         expected = mock_interp(expected_version)
         other = mock_interp(other_version)
         assert (
-            PythonInterpreter.safe_min([expected, other]) == expected
+            PythonInterpreter.latest_release_of_min_compatible_version([expected, other])
+            == expected
         ), "{} was selected instead of {}".format(other_version, expected_version)
 
     # Note that we don't consider the interpreter name in comparisons.
-    assert_min(expected_version="2.7.0", other_version="3.6.0")
-    assert_min(expected_version="3.5.0", other_version="3.6.0")
-    assert_min(expected_version="3.6.1", other_version="3.6.0")
+    assert_chosen(expected_version="2.7.0", other_version="3.6.0")
+    assert_chosen(expected_version="3.5.0", other_version="3.6.0")
+    assert_chosen(expected_version="3.6.1", other_version="3.6.0")


### PR DESCRIPTION
Currently, our naive `min()` means that Pex will choose 3.6.3 instead of 3.6.8, for example. This is not ideal because the newer patch will have important bug fixes, and should still be backward compatible.

For macOS users, there's an added benefit of this PR that the problematic system Pythons usually use older patch versions. A user is likely to have installed a more modern patch with both Homebrew and Pyenv; this PR means that Pex will correctly prefer those over the broken system Python.

This does not solve https://github.com/pantsbuild/pex/issues/430; we will still always prefer the minimum major/minor version, i.e. `3.6.1` is preferred over `3.6.0`, and both are preferred over `3.7.*`.