### PR TITLE
Fix ResourceWarning for unclosed /dev/null.

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -467,7 +467,7 @@ class PEX(object):  # noqa: T000
                 if PY3:
                     # Python 3 warns about unclosed resources. In this case we intentionally do not
                     # close `/dev/null` since we want all stderr to flow there until the latest
-                    # stages of Python interpreter shutdown when the Pythoin runtime will del the
+                    # stages of Python interpreter shutdown when the Python runtime will `del` the
                     # open file and thus finally close the underlying file descriptor. As such,
                     # suppress the warning.
                     warnings.filterwarnings(

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -782,3 +782,18 @@ def test_pex_run_custom_pex_useable():
         assert process.returncode == 0
         assert old_pex_version == stdout.strip().decode("utf-8")
         assert old_pex_version != __version__
+
+
+def test_interpreter_teardown_dev_null_unclosed_resource_warning_suppressed():
+    # type: () -> None
+
+    # See https://github.com/pantsbuild/pex/issues/1101 and
+    # https://github.com/pantsbuild/pants/issues/11058 for the motivating issue.
+    with temporary_dir() as pex_chroot:
+        pex_builder = PEXBuilder(path=pex_chroot)
+        pex_builder.freeze()
+
+        output = subprocess.check_output(
+            args=[sys.executable, "-W" "all", pex_chroot, "-c", ""], stderr=subprocess.STDOUT
+        )
+        assert b"" == output


### PR DESCRIPTION
Since the lack of an explicit close is intended, we suppress the
warning.

Fixes #1101