### PR TITLE
Fix `Requires-Python` environment marker mapping.

### DIFF
--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -23,6 +23,8 @@ from pex.pip import PackageIndexConfiguration, get_pip
 from pex.platforms import Platform
 from pex.requirements import local_project_from_requirement, local_projects_from_requirement_file
 from pex.third_party.packaging.markers import Marker
+from pex.third_party.packaging.version import Version
+from pex.third_party.packaging.version import parse as parse_version
 from pex.third_party.pkg_resources import Distribution, Environment, Requirement
 from pex.tracer import TRACER
 from pex.util import CacheHelper
@@ -130,11 +132,22 @@ class DistributionRequirements(object):
         # + https://www.python.org/dev/peps/pep-0508/#environment-markers
         python_requires = dist_metadata.requires_python(dist)
         if python_requires:
+
+            def choose_marker(version):
+                # type: (str) -> str
+                parsed_version = parse_version(version)
+                if type(parsed_version) != Version or len(parsed_version.release) > 2:
+                    return "python_full_version"
+                else:
+                    return "python_version"
+
             markers.update(
                 Marker(python_version)
                 for python_version in sorted(
-                    "python_version {operator} {version!r}".format(
-                        operator=specifier.operator, version=specifier.version
+                    "{marker} {operator} {version!r}".format(
+                        marker=choose_marker(specifier.version),
+                        operator=specifier.operator,
+                        version=specifier.version,
                     )
                     for specifier in python_requires
                 )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2413,3 +2413,20 @@ def test_resolve_arbitrary_equality_issues_940():
         stdout, returncode = run_simple_pex(pex_file, args=["-c", "import foo"])
         assert returncode == 0
         assert stdout == b""
+
+
+def test_resolve_python_requires_full_version_issues_1017():
+    # type: () -> None
+    python36 = ensure_python_interpreter(PY36)
+    result = run_pex_command(
+        python=python36,
+        args=[
+            "pandas==1.0.5",
+            "--",
+            "-c",
+            "import pandas; print(pandas._version.get_versions()['version'])",
+        ],
+        quiet=True,
+    )
+    result.assert_success()
+    assert "1.0.5" == result.output.strip()


### PR DESCRIPTION
Previously `Requires-Python` metadata was unconditionally mapped to
`python_version` environment marker clauses. This was incorrect for any
`Requires-Python` clauses that included version information beyond
`X.Y` and prevented activation of requirements in PEX files at runtime
in some cases. A previously failing test is added for the pandas case
that revealed this issue.

Fixes #1017