### PR TITLE
Prototype: Expose scripts to path #1097 

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -530,7 +530,7 @@ def configure_clp_pex_entry_points(parser):
         dest="exposed_entry_points",
         default=None,
         metavar="EXPOSED_ENTRY_POINTS",
-        help="TODO"
+        help="TODO",
     )
 
     group.add_argument(
@@ -538,7 +538,7 @@ def configure_clp_pex_entry_points(parser):
         dest="exposed_scripts",
         default=None,
         metavar="EXPOSED_SCRIPTS",
-        help="TODO"
+        help="TODO",
     )
 
     group.add_argument(

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -526,6 +526,22 @@ def configure_clp_pex_entry_points(parser):
     )
 
     group.add_argument(
+        "--exposed-entry-points",
+        dest="exposed_entry_points",
+        default=None,
+        metavar="EXPOSED_ENTRY_POINTS",
+        help="TODO"
+    )
+
+    group.add_argument(
+        "--exposed-scripts",
+        dest="exposed_scripts",
+        default=None,
+        metavar="EXPOSED_SCRIPTS",
+        help="TODO"
+    )
+
+    group.add_argument(
         "--validate-entry-point",
         dest="validate_ep",
         default=False,
@@ -860,6 +876,12 @@ def build_pex(reqs, options, cache=None):
         pex_builder.set_entry_point(options.entry_point)
     elif options.script:
         pex_builder.set_script(options.script)
+
+    if options.exposed_entry_points:
+        pex_builder.set_exposed_entry_points(options.exposed_entry_points)
+
+    if options.exposed_scripts:
+        pex_builder.set_exposed_scripts(options.exposed_scripts)
 
     if options.python_shebang:
         pex_builder.set_shebang(options.python_shebang)

--- a/pex/expose_scripts.py
+++ b/pex/expose_scripts.py
@@ -1,0 +1,70 @@
+import hashlib
+import itertools
+import os
+
+from pathlib import Path
+
+
+SCRIPT_TEMPLATE = """#!/bin/sh
+
+{pex_var}={entry} exec {executable} {pex_path} $@
+"""
+
+
+def get_hash(shebang, pex_path, entry_points, scripts):
+    entry_points = sorted(entry_points)
+    scripts = sorted(scripts)
+
+    hasher = hashlib.md5()
+    hasher.update(shebang.encode("utf-8"))
+    hasher.update(pex_path.encode("utf-8"))
+    for item in itertools.chain(entry_points, scripts):
+        hasher.update(item.encode("utf-8"))
+
+    return hasher.hexdigest()
+
+
+def render_wrapper_scripts(shebang, pex_path, bin_path, entry_points, scripts):
+    executable = shebang[2:]
+    bin_path.mkdir(mode=0o750, parents=True, exist_ok=True)
+    # TODO: what should be the script name for entry_points?
+    for item in entry_points:
+        item_path = bin_path / item
+        contents = SCRIPT_TEMPLATE.format(
+            pex_var="PEX_MODULE", entry=item, executable=executable, pex_path=pex_path
+        )
+        with item_path.open("w") as f:
+            f.write(contents)
+        item_path.chmod(0o770)
+
+    for item in scripts:
+        item_path = bin_path / item
+        contents = SCRIPT_TEMPLATE.format(
+            pex_var="PEX_SCRIPT", entry=item, executable=executable, pex_path=pex_path
+        )
+        with item_path.open("w") as f:
+            f.write(contents)
+        item_path.chmod(0o770)
+
+
+def expose_scripts(pex_path, pex_info):
+    shebang = pex_info.shebang
+    exposed_entry_points = pex_info.exposed_entry_points
+    exposed_scripts = pex_info.exposed_scripts
+
+    if len(exposed_entry_points) == 0 and len(exposed_scripts) == 0:
+        return
+
+    pex_path = Path(pex_path).resolve()
+    pex_path_str = str(pex_path)
+    bin_hash = get_hash(shebang, pex_path_str, exposed_entry_points, exposed_scripts)
+    bin_path = Path(pex_info.pex_root) / "bin" / bin_hash
+    render_wrapper_scripts(
+        shebang,
+        pex_path_str,
+        bin_path,
+        exposed_entry_points,
+        exposed_scripts,
+    )
+    env_path = os.environ.get("PATH", default="")
+    os.environ["PATH"] = f"{bin_path}:{env_path}"

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -8,6 +8,7 @@ import sys
 
 from pex import pex_warnings
 from pex.common import die
+from pex.expose_scripts import expose_scripts
 from pex.interpreter import PythonInterpreter
 from pex.interpreter_constraints import UnsatisfiableInterpreterConstraintsError
 from pex.orderedset import OrderedSet
@@ -353,6 +354,7 @@ def _bootstrap(entry_point):
 def bootstrap_pex(entry_point):
     # type: (str) -> None
     pex_info = _bootstrap(entry_point)
+    expose_scripts(entry_point, pex_info)
     maybe_reexec_pex(pex_info.interpreter_constraints)
 
     from . import pex

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -143,6 +143,7 @@ class PEXBuilder(object):
         self._copy = copy
 
         self._shebang = self._interpreter.identity.hashbang()
+        self._pex_info.shebang = self._shebang
         self._logger = logging.getLogger(__name__)
         self._frozen = False
         self._distributions = set()

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -349,13 +349,13 @@ class PEXBuilder(object):
         self._pex_info.entry_point = entry_point
 
     def set_exposed_entry_points(self, entry_points):
-        entry_points = entry_points.split(',')
+        entry_points = entry_points.split(",")
         if len(entry_points) > 0:
             self._pex_info.exposed_entry_points = entry_points
 
     # TODO: check if scripts should be handled as entry-points
     def set_exposed_scripts(self, scripts):
-        scripts = scripts.split(',')
+        scripts = scripts.split(",")
         if len(scripts) > 0:
             self._pex_info.exposed_scripts = scripts
 

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -347,6 +347,17 @@ class PEXBuilder(object):
         self._ensure_unfrozen("Setting an entry point")
         self._pex_info.entry_point = entry_point
 
+    def set_exposed_entry_points(self, entry_points):
+        entry_points = entry_points.split(',')
+        if len(entry_points) > 0:
+            self._pex_info.exposed_entry_points = entry_points
+
+    # TODO: check if scripts should be handled as entry-points
+    def set_exposed_scripts(self, scripts):
+        scripts = scripts.split(',')
+        if len(scripts) > 0:
+            self._pex_info.exposed_scripts = scripts
+
     def set_shebang(self, shebang):
         """Set the exact shebang line for the PEX file.
 

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -310,6 +310,22 @@ class PexInfo(object):
     def script(self, value):
         self._pex_info["script"] = value
 
+    @property
+    def exposed_entry_points(self):
+        return self._get_safe("exposed_entry_points")
+
+    @exposed_entry_points.setter
+    def exposed_entry_points(self, value):
+        self._pex_info["exposed_entry_points"] = value
+
+    @property
+    def exposed_scripts(self):
+        return self._get_safe("exposed_scripts")
+
+    @exposed_scripts.setter
+    def exposed_scripts(self, value):
+        self._pex_info["exposed_scripts"] = value
+
     def add_requirement(self, requirement):
         self._requirements.add(str(requirement))
 

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -304,15 +304,19 @@ class PexInfo(object):
 
     @property
     def script(self):
-        return self._get_safe("script")
+        value = self._get_safe("script")
 
     @script.setter
     def script(self, value):
         self._pex_info["script"] = value
 
+    # TODO: `_get_safe` should take a default kwarg
     @property
     def exposed_entry_points(self):
-        return self._get_safe("exposed_entry_points")
+        value = self._get_safe("exposed_entry_points")
+        if value is None:
+            value = []
+        return value
 
     @exposed_entry_points.setter
     def exposed_entry_points(self, value):
@@ -320,11 +324,22 @@ class PexInfo(object):
 
     @property
     def exposed_scripts(self):
-        return self._get_safe("exposed_scripts")
+        value = self._get_safe("exposed_scripts")
+        if value is None:
+            value = []
+        return value
 
     @exposed_scripts.setter
     def exposed_scripts(self, value):
         self._pex_info["exposed_scripts"] = value
+
+    @property
+    def shebang(self):
+        return self._get_safe("shebang")
+
+    @shebang.setter
+    def shebang(self, value):
+        self._pex_info["shebang"] = value
 
     def add_requirement(self, requirement):
         self._requirements.add(str(requirement))


### PR DESCRIPTION
This PR is just intended as a basis for discussion. It provides a prototype for the feature I suggested in #1097.

For this I added two command line arguments:
- `--expose-entry-points` to set entry points (e.g. `pip:main`) to be exposed on PATH.
- `--expose-scripts` to set scripts (e.g. `pip`) to be exposed on PATH.

Also, to be able to call the PEX entry point (path to PEX file or path to unzipped PEX) I needed to record the PEX file's shebang in PEX-INFO.

If any `exposed_entry_points` or `exposed_scripts` are defined, they will be rendered as scripts under `$PEX_ROOT/bin/<hash>/<name>`. Where `<hash>` ensures the directory is unique with respect to PEX shebang, PEX entry point and exposed entry points/scripts.

For a regular PEX exposing the script `pip` such a file might look like:
```bash
#!/bin/sh

PEX_SCRIPT=pip exec /usr/bin/env python3.8 /home/user/scratch/pex-1097/my.pex $@
```
Or for an unzipped PEX exposing the entry point `pip:main`:
```bash
#!/bin/sh

PEX_MODULE=pip:main exec /usr/bin/env python3.8 /home/user/.pex/unzipped_pexes/d7e4fb19eea99444d4ce8b85e5cffb4aca950bca $@
```

It turned out, the main problem was how to call the PEX. Because when running an unzipped PEX, the path to the original PEX file is lost. That is why I had to record the shebang in PEX-INFO, to being able to call an unzipped PEX the same way as running the PEX file.

The exposed entry points work with this prototype:
```
~/scratch/pex-1097 » ./my.pex                                                                                                                                                                                           d0301508@kaxpi00000122
Python 3.8.6 (default, Sep 25 2020, 00:00:00) 
[GCC 10.2.1 20200826 (Red Hat 10.2.1-3)] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> import subprocess
>>> subprocess.check_call("pip:main")
WARNING: pip is being invoked by an old script wrapper. This will fail in a future version of pip.
Please see https://github.com/pypa/pip/issues/5599 for advice on fixing the underlying issue.
To avoid this problem you can invoke Python with '-m pip' instead of running pip directly.

Usage:   
  my.pex <command> [options]
..
```

Whereas exposed scripts do not:
```
>>> subprocess.check_call("pip")
Python 3.8.6 (default, Sep 25 2020, 00:00:00) 
[GCC 10.2.1 20200826 (Red Hat 10.2.1-3)] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
```
Calling `pip` dropped me into another Python interpreter. Probably, I broke resolving scripts. I'll dig into it.

Obviously, a lot is missing here, tests for instance. As I said this is just a prototype to serve as a basis for discussion. So, I'd be glad to get some feedback on this.