### PR TITLE
Fix req parsing for local archives & projects.

### DIFF
--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -385,21 +385,25 @@ def _try_parse_pip_local_formats(
     project_requirement = os.path.basename(path)
 
     # Requirements strings can optionally include:
-    # + Trailing extras denoted by `[...]`.
-    #   See: https://www.python.org/dev/peps/pep-0508/#extras
-    # + A version specifier denoted by a leading `!=`, `==`, `===`, `>=`, `<=` or `~=`.
-    #   See: https://www.python.org/dev/peps/pep-0508/#grammar
-    # + Environment markers denoted by `;...`
-    #   See: https://www.python.org/dev/peps/pep-0508/#environment-markers
-    REQUIREMENT_PARTS_START = r"!=<>~\[;"
+    REQUIREMENT_PARTS_START = (
+        # + Trailing extras denoted by `[...]`.
+        #   See: https://www.python.org/dev/peps/pep-0508/#extras
+        r"\[",
+        # + A version specifier denoted by a leading `!=`, `==`, `===`, `>=`, `<=` or `~=`.
+        #   See: https://www.python.org/dev/peps/pep-0508/#grammar
+        r"!=><~",
+        # + Environment markers denoted by `;...`
+        #   See: https://www.python.org/dev/peps/pep-0508/#environment-markers
+        r";",
+    )
     match = re.match(
         r"""
         ^
-        (?P<directory_name>[^{req_parts_start}]+)
-        (?P<requirement_parts>[{req_parts_start}].+)?
+        (?P<directory_name>[^{REQUIREMENT_PARTS_START}]+)
+        (?P<requirement_parts>.*)?
         $
         """.format(
-            req_parts_start=REQUIREMENT_PARTS_START
+            REQUIREMENT_PARTS_START="".join(REQUIREMENT_PARTS_START)
         ),
         project_requirement,
         re.VERBOSE,

--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -383,13 +383,24 @@ def _try_parse_pip_local_formats(
 ):
     # type: (...) -> Tuple[Optional[str], Optional[Marker]]
     project_requirement = os.path.basename(path)
+
+    # Requirements strings can optionally include:
+    # + Trailing extras denoted by `[...]`.
+    #   See: https://www.python.org/dev/peps/pep-0508/#extras
+    # + A version specifier denoted by a leading `!=`, `==`, `===`, `>=`, `<=` or `~=`.
+    #   See: https://www.python.org/dev/peps/pep-0508/#grammar
+    # + Environment markers denoted by `;...`
+    #   See: https://www.python.org/dev/peps/pep-0508/#environment-markers
+    REQUIREMENT_PARTS_START = r"!=<>~\[;"
     match = re.match(
         r"""
         ^
-        (?P<directory_name>[^!=<>\[;]+)
-        (?P<requirement_parts>[!=<>\[;].+)?
+        (?P<directory_name>[^{req_parts_start}]+)
+        (?P<requirement_parts>[{req_parts_start}].+)?
         $
-        """,
+        """.format(
+            req_parts_start=REQUIREMENT_PARTS_START
+        ),
         project_requirement,
         re.VERBOSE,
     )

--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -396,10 +396,11 @@ def _try_parse_pip_local_formats(
         #   See: https://www.python.org/dev/peps/pep-0508/#environment-markers
         r";",
     )
+    # N.B.: The basename of the current directory (.) is '' and we allow this.
     match = re.match(
         r"""
         ^
-        (?P<directory_name>[^{REQUIREMENT_PARTS_START}]+)
+        (?P<directory_name>[^{REQUIREMENT_PARTS_START}]*)?
         (?P<requirement_parts>.*)?
         $
         """.format(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -208,9 +208,7 @@ def test_pex_repl_cli():
     with temporary_dir() as output_dir:
         # Create a temporary pex containing just `requests` with no entrypoint.
         pex_path = os.path.join(output_dir, "pex.pex")
-        results = run_pex_command(
-            ["--disable-cache", "requests", "./", "-e", "pex.bin.pex:main", "-o", pex_path]
-        )
+        results = run_pex_command(["requests", "-o", pex_path])
         results.assert_success()
 
         # Test that the REPL is functional.

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -189,6 +189,7 @@ def test_parse_requirements_stress(chroot):
                 a/local/project[foo]; python_full_version == "2.7.8"
                 ./another/local/project;python_version == "2.7.*"
                 ./another/local/project
+                ./
                 # Local projects with basenames that are invalid Python project names (trailing _):
                 tmp/tmpW8tdb_ 
                 tmp/tmpW8tdb_[foo]
@@ -206,6 +207,7 @@ def test_parse_requirements_stress(chroot):
                 """
             )
         )
+    touch("extra/pyproject.toml")
     touch("extra/a/local/project/pyproject.toml")
     touch("extra/another/local/project/setup.py")
     touch("extra/tmp/tmpW8tdb_/setup.py")
@@ -297,6 +299,7 @@ def test_parse_requirements_stress(chroot):
             is_local_project=True,
         ),
         req(url=os.path.realpath("extra/another/local/project"), is_local_project=True),
+        req(url=os.path.realpath("extra"), is_local_project=True),
         req(url=os.path.realpath("extra/tmp/tmpW8tdb_"), is_local_project=True),
         req(url=os.path.realpath("extra/tmp/tmpW8tdb_"), is_local_project=True),
         req(

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -189,6 +189,10 @@ def test_parse_requirements_stress(chroot):
                 a/local/project[foo]; python_full_version == "2.7.8"
                 ./another/local/project;python_version == "2.7.*"
                 ./another/local/project
+                # Local projects with basenames that are invalid Python project names (trailing _):
+                tmp/tmpW8tdb_ 
+                tmp/tmpW8tdb_[foo]
+                tmp/tmpW8tdb_[foo];python_version == "3.9"
 
                 hg+http://hg.example.com/MyProject@da39a3ee5e6b#egg=AnotherProject[extra,more];python_version=="3.9.*"&subdirectory=foo/bar
 
@@ -204,6 +208,7 @@ def test_parse_requirements_stress(chroot):
         )
     touch("extra/a/local/project/pyproject.toml")
     touch("extra/another/local/project/setup.py")
+    touch("extra/tmp/tmpW8tdb_/setup.py")
 
     with safe_open(os.path.join(chroot, "subdir", "more-requirements.txt"), "w") as fp:
         fp.write(
@@ -292,6 +297,13 @@ def test_parse_requirements_stress(chroot):
             is_local_project=True,
         ),
         req(url=os.path.realpath("extra/another/local/project"), is_local_project=True),
+        req(url=os.path.realpath("extra/tmp/tmpW8tdb_"), is_local_project=True),
+        req(url=os.path.realpath("extra/tmp/tmpW8tdb_"), is_local_project=True),
+        req(
+            url=os.path.realpath("extra/tmp/tmpW8tdb_"),
+            marker="python_version == '3.9'",
+            is_local_project=True,
+        ),
         req(
             project_name="AnotherProject",
             url="hg+http://hg.example.com/MyProject@da39a3ee5e6b",


### PR DESCRIPTION
Previously, we did not handle the case where a local project directory
basename was not a well formed requirement project name. Pro-actively
parse the local project directory basename to separate out any
requirements parts for further parsing and add regression tests for
this.