### PR TITLE
Add an `is_exe` helper.

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -425,6 +425,16 @@ def chmod_plus_w(path):
     os.chmod(path, path_mode)
 
 
+def is_exe(path):
+    # type: (str) -> bool
+    """Determines if the given path is a file executable by the current user.
+
+    :param path: The path to check.
+    :return: `True if the given path is an file executable by the current user.
+    """
+    return os.path.isfile(path) and os.access(path, os.R_OK | os.X_OK)
+
+
 def can_write_dir(path):
     # type: (str) -> bool
     """Determines if the directory at path can be written to by the current process.

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -15,6 +15,7 @@ from pex.common import (
     atomic_directory,
     can_write_dir,
     chmod_plus_x,
+    is_exe,
     open_zip,
     safe_open,
     temporary_dir,
@@ -278,3 +279,21 @@ def test_safe_open_relative(temporary_working_dir):
     abs_path = os.path.join(temporary_working_dir, rel_path)
     with open(abs_path) as fp:
         assert "contents" == fp.read()
+
+
+def test_is_exe(temporary_working_dir):
+    # type: (str) -> None
+    touch("all_exe")
+    chmod_plus_x("all_exe")
+    assert is_exe("all_exe")
+
+    touch("other_exe")
+    os.chmod("other_exe", 0o665)
+    assert not is_exe("other_exe")
+
+    touch("not_exe")
+    assert not is_exe("not_exe")
+
+    os.mkdir("exe_dir")
+    chmod_plus_x("exe_dir")
+    assert not is_exe("exe_dir")


### PR DESCRIPTION
An upcoming change to support creating virtualenvs from PEX files
requires this.