### PR TITLE
Fix `PythonInterpreter` binary normalization.

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -561,18 +561,18 @@ class PythonInterpreter(object):
 
     @classmethod
     def _spawn_from_binary(cls, binary):
-        normalized_binary = cls.canonicalize_path(binary)
-        if not os.path.exists(normalized_binary):
-            raise cls.InterpreterNotFound(normalized_binary)
+        canonicalized_binary = cls.canonicalize_path(binary)
+        if not os.path.exists(canonicalized_binary):
+            raise cls.InterpreterNotFound(canonicalized_binary)
 
         # N.B.: The cache is written as the last step in PythonInterpreter instance initialization.
-        cached_interpreter = cls._PYTHON_INTERPRETER_BY_NORMALIZED_PATH.get(normalized_binary)
+        cached_interpreter = cls._PYTHON_INTERPRETER_BY_NORMALIZED_PATH.get(canonicalized_binary)
         if cached_interpreter is not None:
             return SpawnedJob.completed(cached_interpreter)
-        if normalized_binary == cls.canonicalize_path(sys.executable):
+        if canonicalized_binary == cls.canonicalize_path(sys.executable):
             current_interpreter = cls(PythonIdentity.get())
             return SpawnedJob.completed(current_interpreter)
-        return cls._spawn_from_binary_external(normalized_binary)
+        return cls._spawn_from_binary_external(canonicalized_binary)
 
     @classmethod
     def from_binary(cls, binary):

--- a/pex/interpreter_constraints.py
+++ b/pex/interpreter_constraints.py
@@ -65,7 +65,7 @@ class UnsatisfiableInterpreterConstraintsError(Exception):
             seen = set()
             broken_interpreters = []
             for python, error in self.failures:
-                canonical_python = os.path.realpath(python)
+                canonical_python = PythonInterpreter.canonicalize_path(python)
                 if canonical_python not in seen:
                     broken_interpreters.append((canonical_python, error))
                     seen.add(canonical_python)

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
         Iterable,
         Iterator,
         List,
-        MutableSet,
         NoReturn,
         Optional,
         Tuple,
@@ -76,7 +75,9 @@ def iter_compatible_interpreters(
         seen = set()
 
         normalized_paths = (
-            OrderedSet(os.path.realpath(p) for p in path.split(os.pathsep)) if path else None
+            OrderedSet(PythonInterpreter.canonicalize_path(p) for p in path.split(os.pathsep))
+            if path
+            else None
         )
 
         # Prefer the current interpreter, if valid.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -238,7 +238,7 @@ def test_pex_repl_built():
 def test_pex_python_symlink():
     # type: () -> None
     with temporary_dir() as td:
-        symlink_path = os.path.join(td, "python-symlink")
+        symlink_path = os.path.join(td, "python")
         os.symlink(sys.executable, symlink_path)
         pexrc_path = os.path.join(td, ".pexrc")
         with open(pexrc_path, "w") as pexrc:
@@ -600,7 +600,7 @@ def test_interpreter_constraints_honored_without_ppp_or_pp():
         # If the constraints are honored, it will have run python3.6 and not python3.5
         # Without constraints, we would expect it to use python3.5 as it is the minimum interpreter
         # in the PATH.
-        assert str(py36_path).encode() in stdout
+        assert os.path.dirname(py36_path).encode() in stdout
 
 
 def test_interpreter_resolution_pex_python_path_precedence_over_pex_python():
@@ -1922,7 +1922,7 @@ def _assert_exec_chain(
         assert "PEX_PYTHON_PATH" not in final_env
         assert "_PEX_SHOULD_EXIT_BOOTSTRAP_REEXEC" not in final_env
 
-        expected_exec_chain = [os.path.realpath(i) for i in [sys.executable] + (exec_chain or [])]
+        expected_exec_chain = [sys.executable] + (exec_chain or [])
         assert expected_exec_chain == final_env["_PEX_EXEC_CHAIN"].split(os.pathsep)
 
 
@@ -1933,7 +1933,7 @@ def test_pex_no_reexec_no_constraints():
 
 def test_pex_reexec_no_constraints_pythonpath_present():
     # type: () -> None
-    _assert_exec_chain(exec_chain=[os.path.realpath(sys.executable)], pythonpath=["."])
+    _assert_exec_chain(exec_chain=[sys.executable], pythonpath=["."])
 
 
 def test_pex_no_reexec_constraints_match_current():
@@ -1946,7 +1946,7 @@ def test_pex_reexec_constraints_match_current_pythonpath_present():
     # type: () -> None
     current_version = ".".join(str(component) for component in sys.version_info[0:3])
     _assert_exec_chain(
-        exec_chain=[os.path.realpath(sys.executable)],
+        exec_chain=[sys.executable],
         pythonpath=["."],
         interpreter_constraints=["=={}".format(current_version)],
     )

--- a/tests/test_pex_bootstrapper.py
+++ b/tests/test_pex_bootstrapper.py
@@ -163,8 +163,8 @@ def test_find_compatible_interpreters_with_valid_basenames_and_constraints():
 def test_find_compatible_interpreters_bias_current():
     # type: () -> None
     py36 = ensure_python_interpreter(PY36)
-    assert [os.path.realpath(sys.executable), py36] == find_interpreters([py36, sys.executable])
-    assert [os.path.realpath(sys.executable), py36] == find_interpreters([sys.executable, py36])
+    assert [sys.executable, py36] == find_interpreters([py36, sys.executable])
+    assert [sys.executable, py36] == find_interpreters([sys.executable, py36])
 
 
 def test_find_compatible_interpreters_siblings_of_current_issues_1109():


### PR DESCRIPTION
Previously this used `os.path.realpath` which follows symlinks and
breaks out of venvs created by Python 3. Although this is fine for PEX
use since it scrubs the `sys.path` anyhow, it will not be fine for
upcoming use when creating venvs from PEX files.