### PR TITLE
Fix `PythonInterpreter` binary normalization.

### DIFF
--- a/pex/interpreter_constraints.py
+++ b/pex/interpreter_constraints.py
@@ -65,7 +65,7 @@ class UnsatisfiableInterpreterConstraintsError(Exception):
             seen = set()
             broken_interpreters = []
             for python, error in self.failures:
-                canonical_python = os.path.realpath(python)
+                canonical_python = PythonInterpreter.canonicalize_path(python)
                 if canonical_python not in seen:
                     broken_interpreters.append((canonical_python, error))
                     seen.add(canonical_python)

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
         Iterable,
         Iterator,
         List,
-        MutableSet,
         NoReturn,
         Optional,
         Tuple,
@@ -76,7 +75,9 @@ def iter_compatible_interpreters(
         seen = set()
 
         normalized_paths = (
-            OrderedSet(os.path.realpath(p) for p in path.split(os.pathsep)) if path else None
+            OrderedSet(PythonInterpreter.canonicalize_path(p) for p in path.split(os.pathsep))
+            if path
+            else None
         )
 
         # Prefer the current interpreter, if valid.


### PR DESCRIPTION
Previously this always used `os.path.realpath` which follows symlinks
and breaks out of venvs created by Python 3. Although this is fine for
PEX use since it scrubs the `sys.path` anyhow, it will not be fine for
upcoming use when creating venvs from PEX files.