### PR TITLE
Add an interpreter tool.

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -20,6 +20,7 @@ from pex.common import is_exe, safe_rmtree
 from pex.compatibility import string
 from pex.executor import Executor
 from pex.jobs import ErrorHandler, Job, Retain, SpawnedJob, execute_parallel
+from pex.orderedset import OrderedSet
 from pex.platforms import Platform
 from pex.third_party.packaging import markers, tags
 from pex.third_party.pkg_resources import Distribution, Requirement
@@ -469,7 +470,7 @@ class PythonInterpreter(object):
     def _paths(paths=None):
         # type: (Optional[Iterable[str]]) -> Iterable[str]
         # NB: If `paths=[]`, we will not read $PATH.
-        return paths if paths is not None else os.getenv("PATH", "").split(os.pathsep)
+        return OrderedSet(paths if paths is not None else os.getenv("PATH", "").split(os.pathsep))
 
     @classmethod
     def iter(cls, paths=None):
@@ -804,8 +805,9 @@ class PythonInterpreter(object):
         seen = set()
         for interp in pythons:
             version = interp.identity.version
-            if version not in seen and version_filter(version):
-                seen.add(version)
+            identity = version, interp.identity.abi_tag
+            if identity not in seen and version_filter(version):
+                seen.add(identity)
                 yield interp
 
     @classmethod

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -90,6 +90,11 @@ class PEX(object):  # noqa: T000
         pex_info.merge_pex_path(self._vars.PEX_PATH)
         return pex_info
 
+    @property
+    def interpreter(self):
+        # type: () -> PythonInterpreter
+        return self._interpreter
+
     def _activate(self):
         if not self._working_set:
             working_set = WorkingSet([])

--- a/pex/tools/commands/__init__.py
+++ b/pex/tools/commands/__init__.py
@@ -3,6 +3,7 @@
 
 from pex.tools.command import Command
 from pex.tools.commands.info import Info
+from pex.tools.commands.interpreter import Interpreter
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -11,4 +12,4 @@ if TYPE_CHECKING:
 
 def all_commands():
     # type: () -> Iterable[Command]
-    return [Info()]
+    return Info(), Interpreter()

--- a/pex/tools/commands/interpreter.py
+++ b/pex/tools/commands/interpreter.py
@@ -1,0 +1,93 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import logging
+from argparse import ArgumentParser, Namespace
+
+from pex import pex_bootstrapper
+from pex.interpreter import PythonInterpreter
+from pex.interpreter_constraints import UnsatisfiableInterpreterConstraintsError
+from pex.pex import PEX
+from pex.tools.command import Command, Error, JsonMixin, Ok, OutputMixin, Result
+from pex.typing import TYPE_CHECKING
+from pex.variables import ENV
+
+if TYPE_CHECKING:
+    from typing import Iterator
+
+logger = logging.getLogger(__name__)
+
+
+class Interpreter(JsonMixin, OutputMixin, Command):
+    """Prints the path of the preferred interpreter to run the given PEX file with, if any."""
+
+    def add_arguments(self, parser):
+        # type: (ArgumentParser) -> None
+        self.add_output_option(parser, entity="Python interpreter path"),
+        parser.add_argument(
+            "-a",
+            "--all",
+            action="store_true",
+            help="Print all compatible interpreters, preferred first.",
+        )
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            action="store_true",
+            help="Print the interpreter requirement in addition to it's path.",
+        )
+        self.add_json_options(parser, entity="verbose output"),
+
+    @staticmethod
+    def _find_interpreters(
+        pex,  # type: PEX
+        all=False,  # type: bool
+    ):
+        # type: (...) -> Iterator[PythonInterpreter]
+        if not all:
+            yield pex.interpreter
+            return
+
+        if ENV.PEX_PYTHON:
+            logger.warning(
+                "Ignoring PEX_PYTHON={} in order to scan for all compatible "
+                "interpreters.".format(ENV.PEX_PYTHON)
+            )
+        for interpreter in pex_bootstrapper.iter_compatible_interpreters(
+            path=ENV.PEX_PYTHON_PATH,
+            interpreter_constraints=pex.pex_info().interpreter_constraints,
+        ):
+            yield interpreter
+
+    def run(
+        self,
+        pex,  # type: PEX
+        options,  # type: Namespace
+    ):
+        # type: (...) -> Result
+        if options.indent and not options.verbose:
+            logger.warning(
+                "Ignoring --indent={} since --verbose mode is not enabled.".format(options.indent)
+            )
+        with self.output(options) as out:
+            try:
+                for interpreter in self._find_interpreters(pex, all=options.all):
+                    if options.verbose:
+                        self.dump_json(
+                            options,
+                            {
+                                "path": interpreter.binary,
+                                "requirement": str(interpreter.identity.requirement),
+                                "platform": str(interpreter.platform),
+                            },
+                            out,
+                        )
+                    else:
+                        out.write(interpreter.binary)
+                    out.write("\n")
+            except UnsatisfiableInterpreterConstraintsError as e:
+                return Error(str(e))
+
+        return Ok()


### PR DESCRIPTION
The tool can be used to print information about the preferred
interpreter(s) for a PEX. This tool is now referenced as the way to
find out about `--platform` strings and `--interpreter-constraint`
strings.