### PR TITLE
Support a --venv mode similar to --unzip mode.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -337,7 +337,8 @@ def configure_clp_pex_options(parser):
         "complete pex file, including dependencies, to be unzipped.",
     )
 
-    group.add_argument(
+    runtime_mode = group.add_mutually_exclusive_group()
+    runtime_mode.add_argument(
         "--unzip",
         "--no-unzip",
         dest="unzip",
@@ -347,18 +348,17 @@ def configure_clp_pex_options(parser):
         "be run multiple times under a stable runtime PEX_ROOT the unzipping will only be "
         "performed once and subsequent runs will enjoy lower startup latency.",
     )
-
-    group.add_argument(
+    runtime_mode.add_argument(
         "--venv",
         dest="venv",
         metavar="{prepend,append}",
         default=False,
         action=HandleVenvAction,
         help="Convert the pex file to a venv before executing it. If 'prepend' or 'append' is "
-        "specified then all scripts and console scripts provided by distributions in the pex file "
-        "will be added to the PATH. If the the pex file will be run multiple times under a stable "
-        "runtime PEX_ROOT the venv creation will only be done once and subsequent runs will enjoy "
-        "lower startup latency.",
+        "specified, then all scripts and console scripts provided by distributions in the pex file "
+        "will be added to the PATH in the corresponding position. If the the pex file will be run "
+        "multiple times under a stable runtime PEX_ROOT, the venv creation will only be done once "
+        "and subsequent runs will enjoy lower startup latency.",
     )
 
     group.add_argument(

--- a/pex/common.py
+++ b/pex/common.py
@@ -24,7 +24,7 @@ from uuid import uuid4
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, DefaultDict, Iterable, Iterator, NoReturn, Optional, Set
+    from typing import Any, DefaultDict, Iterable, Iterator, NoReturn, Optional, Set, Sized
 
 # We use the start of MS-DOS time, which is what zipfiles use (see section 4.4.6 of
 # https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT).
@@ -58,6 +58,22 @@ def die(msg, exit_code=1):
     # type: (str, int) -> NoReturn
     print(msg, file=sys.stderr)
     sys.exit(exit_code)
+
+
+def pluralize(
+    subject,  # type: Sized
+    noun,  # type: str
+):
+    # type: (...) -> str
+    if noun == "":
+        return ""
+    count = len(subject)
+    if count == 1:
+        return noun
+    if noun[-1] in ("s", "x", "z") or noun[-2:] in ("sh", "ch"):
+        return noun + "es"
+    else:
+        return noun + "s"
 
 
 def safe_copy(source, dest, overwrite=False):

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -25,7 +25,7 @@ from pex.typing import TYPE_CHECKING
 from pex.util import CacheHelper, DistributionHelper
 
 if TYPE_CHECKING:
-    from typing import Container, Optional
+    from typing import Container, Iterator, Optional, Tuple, Iterable
 
 
 def _import_pkg_resources():
@@ -114,7 +114,7 @@ class PEXEnvironment(Environment):
         dest_dir,  # type: str
         exclude=(),  # type: Container[str]
     ):
-        # type: (...) -> None
+        # type: (...) -> Iterable[Tuple[str, str]]
         with TRACER.timed("Unzipping {}".format(pex_file)):
             with open_zip(pex_file) as pex_zip:
                 pex_files = (
@@ -125,6 +125,13 @@ class PEXEnvironment(Environment):
                     and name not in exclude
                 )
                 pex_zip.extractall(dest_dir, pex_files)
+                return [
+                    (
+                        "{pex_file}:{zip_path}".format(pex_file=pex_file, zip_path=f),
+                        os.path.join(dest_dir, f),
+                    )
+                    for f in pex_files
+                ]
 
     @classmethod
     def _force_local(cls, pex_file, pex_info):

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -609,7 +609,7 @@ class PythonInterpreter(object):
         # See cls._REGEXEN for a related affordance.
         #
         # N.B.: The path for --venv mode interpreters can be quite long; so we just used a fixed
-        # length hash of the interpreter binary path to ensure uniqeness and not run afoul of file
+        # length hash of the interpreter binary path to ensure uniqueness and not run afoul of file
         # name length limits.
         path_id = hashlib.sha1(binary.encode("utf-8")).hexdigest()
 

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -607,7 +607,11 @@ class PythonInterpreter(object):
         # would otherwise be unstable.
         #
         # See cls._REGEXEN for a related affordance.
-        path_id = binary.replace(os.sep, ".").lstrip(".")
+        #
+        # N.B.: The path for --venv mode interpreters can be quite long; so we just used a fixed
+        # length hash of the interpreter binary path to ensure uniqeness and not run afoul of file
+        # name length limits.
+        path_id = hashlib.sha1(binary.encode("utf-8")).hexdigest()
 
         cache_dir = os.path.join(os_cache_dir, interpreter_hash, path_id)
         cache_file = os.path.join(cache_dir, cls.INTERP_INFO_FILE)

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -314,7 +314,7 @@ class IntegResults(object):
     """Convenience object to return integration run results."""
 
     def __init__(self, output, error, return_code):
-        # type: (Text, Text, int) -> None
+        # type: (str, str, int) -> None
         super(IntegResults, self).__init__()
         self.output = output
         self.error = error

--- a/pex/tools/commands/graph.py
+++ b/pex/tools/commands/graph.py
@@ -12,7 +12,6 @@ from contextlib import contextmanager
 
 from pex.common import safe_mkdir
 from pex.dist_metadata import requires_dists
-from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.tools.command import Command, Ok, OutputMixin, Result, try_open_file, try_run_program
 from pex.tools.commands.digraph import DiGraph

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -170,9 +170,9 @@ def populate_venv_with_pex(
             os.environ["PATH"] = os.pathsep.join(PATH)
 
         PEX_EXEC_OVERRIDE_KEYS = ("PEX_INTERPRETER", "PEX_SCRIPT", "PEX_MODULE")
-        pex_overrides = dict(
-            (key, os.environ.pop(key)) for key in PEX_EXEC_OVERRIDE_KEYS if key in os.environ
-        )
+        pex_overrides = {{
+            key: os.environ.pop(key) for key in PEX_EXEC_OVERRIDE_KEYS if key in os.environ
+        }}
         if len(pex_overrides) > 1:
             sys.stderr.write(
                 "Can only specify one of {{overrides}}; found: {{found}}\\n".format(

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -8,19 +8,21 @@ import os
 import shutil
 import zipfile
 from argparse import ArgumentParser, Namespace
+from collections import defaultdict
 from textwrap import dedent
 
 from pex import pex_builder, pex_warnings
-from pex.common import chmod_plus_x, safe_mkdir
+from pex.common import chmod_plus_x, pluralize, safe_mkdir
 from pex.environment import PEXEnvironment
 from pex.pex import PEX
 from pex.tools.command import Command, Error, Ok, Result
 from pex.tools.commands.virtualenv import PipUnavailableError, Virtualenv
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
+from pex.venv_bin_path import BinPath
 
 if TYPE_CHECKING:
-    from typing import Tuple
+    from typing import Iterable, Iterator, Optional, Tuple
 
 
 # N.B.: We can't use shutil.copytree since we copy from multiple source locations to the same site
@@ -30,9 +32,8 @@ def _copytree(
     src,  # type: str
     dst,  # type: str
     exclude=(),  # type: Tuple[str, ...]
-    collisions_ok=False,  # type: bool
 ):
-    # type: (...) -> None
+    # type: (...) -> Iterator[Tuple[str, str]]
     safe_mkdir(dst)
     link = True
     for root, dirs, files in os.walk(src, topdown=True, followlinks=False):
@@ -50,6 +51,7 @@ def _copytree(
         for f in files:
             src_entry = os.path.join(root, f)
             dst_entry = os.path.join(dst, os.path.relpath(src_entry, src))
+            yield src_entry, dst_entry
             try:
                 if link:
                     try:
@@ -61,12 +63,206 @@ def _copytree(
                         link = False
                 shutil.copy(src_entry, dst_entry)
             except OSError as e:
-                if e.errno == errno.EEXIST:
-                    pex_warnings.warn(
-                        "Failed to overwrite {} with {}: {}".format(dst_entry, src_entry, e)
+                if e.errno != errno.EEXIST:
+                    raise e
+
+
+class CollisionError(Exception):
+    """Indicates multiple distributions provided the same file when merging a PEX into a venv."""
+
+
+def populate_venv_with_pex(
+    venv,  # type: Virtualenv
+    pex,  # type: PEX
+    bin_path=BinPath.FALSE,  # type: BinPath.Value
+    python=None,  # type: Optional[str]
+    collisions_ok=True,  # type: bool
+):
+    # type: (...) -> None
+
+    venv_python = python or venv.interpreter.binary
+    venv_bin_dir = os.path.dirname(python) if python else venv.bin_dir
+    venv_dir = os.path.dirname(venv_bin_dir) if python else venv.venv_dir
+
+    # 1. Populate the venv with the PEX contents.
+    provenance = defaultdict(list)
+
+    def record_provenance(src_to_dst):
+        # type: (Iterable[Tuple[str, str]]) -> None
+        for src, dst in src_to_dst:
+            provenance[dst].append(src)
+
+    pex_info = pex.pex_info()
+    if zipfile.is_zipfile(pex.path()):
+        record_provenance(
+            PEXEnvironment.explode_code(
+                pex.path(), pex_info, venv.site_packages_dir, exclude=("__main__.py",)
+            )
+        )
+    else:
+        record_provenance(
+            _copytree(
+                src=pex.path(),
+                dst=venv.site_packages_dir,
+                exclude=(pex_info.internal_cache, pex_builder.BOOTSTRAP_DIR, "__main__.py"),
+            )
+        )
+
+    for dist in pex.activate():
+        record_provenance(
+            _copytree(src=dist.location, dst=venv.site_packages_dir, exclude=("bin",))
+        )
+        dist_bin_dir = os.path.join(dist.location, "bin")
+        if os.path.isdir(dist_bin_dir):
+            record_provenance(_copytree(dist_bin_dir, venv.bin_dir))
+
+    collisions = {dst: srcs for dst, srcs in provenance.items() if len(srcs) > 1}
+    if collisions:
+        message_lines = [
+            "Encountered {collision} building venv at {venv_dir} from {pex}:".format(
+                collision=pluralize(collisions, "collision"), venv_dir=venv_dir, pex=pex.path()
+            )
+        ]
+        for index, (dst, srcs) in enumerate(collisions.items(), start=1):
+            message_lines.append(
+                "{index}. {dst} was provided by:\n\t{srcs}".format(
+                    index=index, dst=dst, srcs="\n\t".join(srcs)
+                )
+            )
+        message = "\n".join(message_lines)
+        if not collisions_ok:
+            raise CollisionError(message)
+        pex_warnings.warn(message)
+
+    # 2. Add a __main__ to the root of the venv for running the venv dir like a loose PEX dir
+    # and a main.py for running as a script.
+    main_contents = dedent(
+        """\
+        #!{venv_python} -sE
+
+        import os
+        import sys
+
+        python = {venv_python!r}
+        if sys.executable != python:
+            sys.stderr.write("Re-execing from {{}}\\n".format(sys.executable))
+            os.execv(python, [python, "-sE"] + sys.argv)
+
+        os.environ["VIRTUAL_ENV"] = {venv_dir!r}
+        sys.path.extend(os.environ.get("PEX_EXTRA_SYS_PATH", "").split(os.pathsep))
+
+        bin_dir = {venv_bin_dir!r}
+        bin_path = os.environ.get("PEX_VENV_BIN_PATH", {bin_path!r})
+        if bin_path != "false":
+            PATH = os.environ.get("PATH", "").split(os.pathsep)
+            if bin_path == "prepend":
+                PATH.insert(0, bin_dir)
+            elif bin_path == "append":
+                PATH.append(bin_dir)
+            else:
+                sys.stderr.write(
+                    "PEX_VENV_BIN_PATH must be one of 'false', 'prepend' or 'append', given: "
+                    "{{!r}}\\n".format(
+                        bin_path
                     )
-                    if not collisions_ok:
-                        raise e
+                )
+                sys.exit(1)
+            os.environ["PATH"] = os.pathsep.join(PATH)
+
+        PEX_EXEC_OVERRIDE_KEYS = ("PEX_INTERPRETER", "PEX_SCRIPT", "PEX_MODULE")
+        pex_overrides = dict(
+            (key, os.environ.pop(key)) for key in PEX_EXEC_OVERRIDE_KEYS if key in os.environ
+        )
+        if len(pex_overrides) > 1:
+            sys.stderr.write(
+                "Can only specify one of {{overrides}}; found: {{found}}\\n".format(
+                    overrides=", ".join(PEX_EXEC_OVERRIDE_KEYS),
+                    found=" ".join("{{}}={{}}".format(k, v) for k, v in pex_overrides.items())
+                )
+            )
+            sys.exit(1)
+
+        pex_script = pex_overrides.get("PEX_SCRIPT")
+        if pex_script:
+            script_path = os.path.join(bin_dir, pex_script)
+            os.execv(script_path, [script_path] + sys.argv[1:])
+
+        pex_interpreter = pex_overrides.get("PEX_INTERPRETER", "").lower() in ("1", "true")
+        PEX_INTERPRETER_ENTRYPOINT = "code:interact"
+        entry_point = (
+            PEX_INTERPRETER_ENTRYPOINT
+            if pex_interpreter
+            else pex_overrides.get("PEX_MODULE", {entry_point!r} or PEX_INTERPRETER_ENTRYPOINT)
+        )
+        if entry_point == PEX_INTERPRETER_ENTRYPOINT and len(sys.argv) > 1:
+            args = sys.argv[1:]
+            arg = args[0]
+            if arg == "-m":
+                if len(args) < 2:
+                    sys.stderr.write("Argument expected for the -m option\\n")
+                    sys.exit(2)
+                entry_point = module = args[1]
+                sys.argv = args[1:]
+                # Fall through to entry_point handling below.
+            else:
+                filename = arg
+                sys.argv = args
+                if arg == "-c":
+                    if len(args) < 2:
+                        sys.stderr.write("Argument expected for the -c option\\n")
+                        sys.exit(2)
+                    filename = "-c <cmd>"
+                    content = args[1]
+                    sys.argv = ["-c"] + args[2:]
+                elif arg == "-":
+                    content = sys.stdin.read()
+                else:
+                    with open(arg) as fp:
+                        content = fp.read()
+
+                ast = compile(content, filename, "exec", flags=0, dont_inherit=1)
+                globals_map = globals().copy()
+                globals_map["__name__"] = "__main__"
+                globals_map["__file__"] = filename
+                locals_map = globals_map
+                {exec_ast}
+                sys.exit(0)
+
+        module_name, _, function = entry_point.partition(":")
+        if not function:
+            import runpy
+            runpy.run_module(module_name, run_name="__main__")
+        else:
+            import importlib
+            module = importlib.import_module(module_name)
+            # N.B.: Functions may be hung off top-level objects in the module namespace,
+            # e.g.: Class.method; so we drill down through any attributes to the final function
+            # object.
+            namespace, func = module, None
+            for attr in function.split("."):
+                func = namespace = getattr(namespace, attr)
+            func()
+        """.format(
+            venv_python=venv_python,
+            venv_bin_dir=venv_bin_dir,
+            venv_dir=venv_dir,
+            bin_path=bin_path,
+            entry_point=pex_info.entry_point,
+            exec_ast=(
+                "exec ast in globals_map, locals_map"
+                if venv.interpreter.version[0] == 2
+                else "exec(ast, globals_map, locals_map)"
+            ),
+        )
+    )
+    with open(venv.join_path("__main__.py"), "w") as fp:
+        fp.write(main_contents)
+    chmod_plus_x(fp.name)
+    os.symlink(os.path.basename(fp.name), venv.join_path("pex"))
+
+    # 3. Re-write any (console) scripts to use the venv Python.
+    for script in venv.rewrite_scripts(python=python, python_args="-sE"):
+        TRACER.log("Re-writing {}".format(script))
 
 
 class Venv(Command):
@@ -83,8 +279,8 @@ class Venv(Command):
         parser.add_argument(
             "-b",
             "--bin-path",
-            choices=("prepend", "append"),
-            default=None,
+            choices=[choice.value for choice in BinPath.values],
+            default=BinPath.FALSE.value,
             help="Add the venv bin dir to the PATH in the __main__.py script.",
         )
         parser.add_argument(
@@ -100,7 +296,7 @@ class Venv(Command):
             default=False,
             help=(
                 "Don't error if population of the venv encounters distributions in the PEX file "
-                "with colliding files."
+                "with colliding files, just emit a warning."
             ),
         )
         parser.add_argument(
@@ -118,154 +314,13 @@ class Venv(Command):
     ):
         # type: (...) -> Result
 
-        # 0. Create an empty virtual environment to populate with the PEX code and dependencies.
         venv = Virtualenv.create(options.venv[0], interpreter=pex.interpreter, force=options.force)
-
-        # 1. Populate the venv with the PEX contents.
-        pex_info = pex.pex_info()
-        if zipfile.is_zipfile(pex.path()):
-            PEXEnvironment.explode_code(
-                pex.path(), pex_info, venv.site_packages_dir, exclude=("__main__.py",)
-            )
-        else:
-            _copytree(
-                src=pex.path(),
-                dst=venv.site_packages_dir,
-                exclude=(pex_info.internal_cache, pex_builder.BOOTSTRAP_DIR, "__main__.py"),
-            )
-
-        for dist in pex.activate():
-            _copytree(
-                src=dist.location,
-                dst=venv.site_packages_dir,
-                exclude=("bin",),
-                collisions_ok=options.collisions_ok,
-            )
-            dist_bin_dir = os.path.join(dist.location, "bin")
-            if os.path.isdir(dist_bin_dir):
-                _copytree(dist_bin_dir, venv.bin_dir, collisions_ok=options.collisions_ok)
-
-        # 2. Add a __main__ to the root of the venv for running the venv dir like a loose PEX dir
-        # and a main.py for running as a script.
-        main_contents = dedent(
-            """\
-            #!{venv_python} -sE
-
-            import os
-            import sys
-
-            python = {venv_python!r}
-            if sys.executable != python:
-                os.execv(python, [python, "-sE"] + sys.argv)
-
-            os.environ["VIRTUAL_ENV"] = {venv_dir!r}
-            sys.path.extend(os.environ.get("PEX_EXTRA_SYS_PATH", "").split(os.pathsep))
-
-            bin_dir = {venv_bin_dir!r}
-            bin_path = {bin_path!r}
-            if bin_path:
-                PATH = os.environ.get("PATH", "").split(os.pathsep)
-                if bin_path == "prepend":
-                    PATH = [bin_dir] + PATH
-                else:
-                    PATH.append(bin_dir)
-                os.environ["PATH"] = os.pathsep.join(PATH)
-
-            PEX_OVERRIDE_KEYS = ("PEX_INTERPRETER", "PEX_SCRIPT", "PEX_MODULE")
-            pex_overrides = dict(
-                (key, os.environ.pop(key)) for key in PEX_OVERRIDE_KEYS if key in os.environ
-            )
-            if len(pex_overrides) > 1:
-                sys.stderr.write(
-                    "Can only specify one of {{overrides}}; found: {{found}}\\n".format(
-                        overrides=", ".join(PEX_OVERRIDE_KEYS),
-                        found=" ".join("{{}}={{}}".format(k, v) for k, v in pex_overrides.items())
-                    )
-                )
-                sys.exit(1)
-
-            pex_script = pex_overrides.get("PEX_SCRIPT")
-            if pex_script:
-                script_path = os.path.join(bin_dir, pex_script)
-                os.execv(script_path, [script_path] + sys.argv[1:])
-
-            pex_interpreter = pex_overrides.get("PEX_INTERPRETER", "").lower() in ("1", "true")
-            PEX_INTERPRETER_ENTRYPOINT = "code:interact"
-            entry_point = (
-                PEX_INTERPRETER_ENTRYPOINT
-                if pex_interpreter
-                else pex_overrides.get("PEX_MODULE", {entry_point!r} or PEX_INTERPRETER_ENTRYPOINT)
-            )
-            if entry_point == PEX_INTERPRETER_ENTRYPOINT and len(sys.argv) > 1:
-                args = sys.argv[1:]
-                arg = args[0]
-                if arg == "-m":
-                    if len(args) < 2:
-                        sys.stderr.write("Argument expected for the -m option\\n")
-                        sys.exit(2)
-                    entry_point = module = args[1]
-                    sys.argv = args[1:]
-                    # Fall through to entry_point handling below.
-                else:
-                    filename = arg
-                    sys.argv = args
-                    if arg == "-c":
-                        if len(args) < 2:
-                            sys.stderr.write("Argument expected for the -c option\\n")
-                            sys.exit(2)
-                        filename = "-c <cmd>"
-                        content = args[1]
-                        sys.argv = ["-c"] + args[2:]
-                    elif arg == "-":
-                        content = sys.stdin.read()
-                    else:
-                        with open(arg) as fp:
-                            content = fp.read()
-                    
-                    ast = compile(content, filename, "exec", flags=0, dont_inherit=1)
-                    globals_map = globals().copy()
-                    globals_map["__name__"] = "__main__"
-                    globals_map["__file__"] = filename
-                    locals_map = globals_map
-                    {exec_ast}
-                    sys.exit(0)
-
-            module_name, _, function = entry_point.partition(":")
-            if not function:
-                import runpy
-                runpy.run_module(module_name, run_name="__main__")
-            else:
-                import importlib
-                module = importlib.import_module(module_name)
-                # N.B.: Functions may be hung off top-level objects in the module namespace,
-                # e.g.: Class.method; so we drill down through any attributes to the final function
-                # object.
-                namespace, func = module, None
-                for attr in function.split("."):
-                    func = namespace = getattr(namespace, attr)
-                func()
-            """.format(
-                venv_python=venv.interpreter.binary,
-                bin_path=options.bin_path,
-                venv_dir=venv.venv_dir,
-                venv_bin_dir=venv.bin_dir,
-                entry_point=pex_info.entry_point,
-                exec_ast=(
-                    "exec ast in globals_map, locals_map"
-                    if venv.interpreter.version[0] == 2
-                    else "exec(ast, globals_map, locals_map)"
-                ),
-            )
+        populate_venv_with_pex(
+            venv,
+            pex,
+            bin_path=BinPath.for_value(options.bin_path),
+            collisions_ok=options.collisions_ok,
         )
-        with open(venv.join_path("__main__.py"), "w") as fp:
-            fp.write(main_contents)
-        chmod_plus_x(fp.name)
-        os.symlink(os.path.basename(fp.name), venv.join_path("pex"))
-
-        # 3. Re-write any (console) scripts to use the venv Python.
-        for script in venv.rewrite_scripts(python_args="-sE"):
-            TRACER.log("Re-writing {}".format(script))
-
         if options.pip:
             try:
                 venv.install_pip()

--- a/pex/tools/commands/virtualenv.py
+++ b/pex/tools/commands/virtualenv.py
@@ -91,7 +91,7 @@ class Virtualenv(object):
             interpreter.execute(args=["-m", "venv", "--without-pip", venv_dir])
         else:
             virtualenv_py = resource_string(__name__, "virtualenv_16.7.10_py")
-            with named_temporary_file(mode="w") as fp:
+            with named_temporary_file(mode="wb") as fp:
                 fp.write(virtualenv_py)
                 fp.close()
                 interpreter.execute(
@@ -156,8 +156,12 @@ class Virtualenv(object):
         # type: () -> Iterator[str]
         return _iter_executables(self._bin_dir)
 
-    def rewrite_scripts(self, python_args=None):
-        # type: (Optional[str]) -> Iterator[str]
+    def rewrite_scripts(
+        self,
+        python=None,  # type: Optional[str]
+        python_args=None,  # type: Optional[str]
+    ):
+        # type: (...) -> Iterator[str]
         python_scripts = []
         for executable in self.iter_executables():
             if executable in self._base_executables:
@@ -172,7 +176,7 @@ class Virtualenv(object):
                 # which is has moved aside.
                 for line in fi:
                     if fi.isfirstline():
-                        shebang = [self._interpreter.binary]
+                        shebang = [python or self._interpreter.binary]
                         if python_args:
                             shebang.append(python_args)
                         print("#!{shebang}".format(shebang=" ".join(shebang)))

--- a/pex/util.py
+++ b/pex/util.py
@@ -142,7 +142,7 @@ class CacheHelper(object):
                 yield os.path.relpath(os.path.join(root, f), normpath)
 
     @classmethod
-    def pex_hash(cls, d):
+    def pex_code_hash(cls, d):
         # type: (str) -> str
         """Return a reproducible hash of the contents of a loose PEX; excluding all `.pyc` files."""
         names = sorted(f for f in cls._iter_non_pyc_files(d) if not f.startswith("."))

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -103,7 +103,7 @@ class DefaultedProperty(Generic["_O", "_P"]):
         # type: (...) -> _P
         """Return the value of this property without the default value applied or else the fallback.
 
-        If the property is not set `fallback` will be validated and returned.
+        If the property is not set, `fallback` will be validated and returned.
 
         :param instance: The instance to check for the non-defaulted property value.
         :return: The property value or `fallback` if not set.

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import
 
+import hashlib
 import os
 import sys
 from contextlib import contextmanager
@@ -14,9 +15,10 @@ from pex import pex_warnings
 from pex.common import can_write_dir, die, safe_mkdtemp
 from pex.inherit_path import InheritPath
 from pex.typing import TYPE_CHECKING, Generic, overload
+from pex.venv_bin_path import BinPath
 
 if TYPE_CHECKING:
-    from typing import Callable, Dict, Iterator, Optional, Tuple, TypeVar, Type, Union
+    from typing import Callable, Dict, Iterable, Iterator, Optional, Tuple, TypeVar, Type, Union
 
     _O = TypeVar("_O")
     _P = TypeVar("_P")
@@ -92,6 +94,25 @@ class DefaultedProperty(Generic["_O", "_P"]):
             return self._validate(instance, self._func(instance))
         except NoValueError:
             return None
+
+    def value_or(
+        self,
+        instance,  # type: _O
+        fallback,  # type: _P
+    ):
+        # type: (...) -> _P
+        """Return the value of this property without the default value applied or else the fallback.
+
+        If the property is not set `fallback` will be validated and returned.
+
+        :param instance: The instance to check for the non-defaulted property value.
+        :return: The property value or `fallback` if not set.
+        """
+        try:
+            value = self._func(instance)
+        except NoValueError:
+            value = fallback
+        return self._validate(instance, value)
 
     def validator(self, func):
         # type: (Callable[[_O, _P], _P]) -> Callable[[_O, _P], _P]
@@ -330,6 +351,31 @@ class Variables(object):
         Default: false.
         """
         return self._get_bool("PEX_UNZIP")
+
+    @defaulted_property(default=False)
+    def PEX_VENV(self):
+        # type: () -> bool
+        """Boolean.
+
+        Force this PEX to create a venv under $PEX_ROOT and re-execute from there.  If the pex file
+        will be run multiple times under a stable $PEX_ROOT the venv creation will only be performed
+        once and subsequent runs will enjoy lower startup latency.
+
+        Default: false.
+        """
+        return self._get_bool("PEX_VENV")
+
+    @defaulted_property(default=BinPath.FALSE)
+    def PEX_VENV_BIN_PATH(self):
+        # type: () -> BinPath.Value
+        """String (false|prepend|append).
+
+        When running in PEX_VENV mode, optionally add the scripts and console scripts of
+        distributions in the PEX file to the $PATH.
+
+        Default: false.
+        """
+        return BinPath.for_value(self._get_string("PEX_VENV_BIN_PATH"))
 
     @defaulted_property(default=False)
     def PEX_IGNORE_ERRORS(self):
@@ -581,3 +627,42 @@ class Variables(object):
 
 # Global singleton environment
 ENV = Variables()
+
+
+# TODO(John Sirois): Extract a runtime.modes package to hold code dealing with runtime mode
+#  calculations: https://github.com/pantsbuild/pex/issues/1154
+def _expand_pex_root(pex_root):
+    # type: (str) -> str
+    fallback = os.path.expanduser(pex_root)
+    return os.path.expanduser(Variables.PEX_ROOT.value_or(ENV, fallback=fallback))
+
+
+def unzip_dir(
+    pex_root,  # type: str
+    pex_hash,  # type: str
+):
+    # type: (...) -> str
+    return os.path.join(_expand_pex_root(pex_root), "unzipped_pexes", pex_hash)
+
+
+def venv_dir(
+    pex_root,  # type: str
+    pex_hash,  # type: str
+    interpreter_constraints,  # type: Iterable[str]
+):
+    # type: (...) -> str
+    hasher = hashlib.sha1()
+    hasher.update(
+        "interpreter_constraints:{}".format(" or ".join(sorted(interpreter_constraints))).encode(
+            "utf-8"
+        )
+    )
+    hasher.update("PEX_PYTHON:{}".format(ENV.PEX_PYTHON).encode("utf-8"))
+    hasher.update("PEX_PYTHON_PATH:{}".format(ENV.PEX_PYTHON_PATH).encode("utf-8"))
+    interpreter_selection_hash = hasher.hexdigest()
+    return os.path.join(
+        _expand_pex_root(pex_root),
+        "venvs",
+        pex_hash,
+        interpreter_selection_hash,
+    )

--- a/pex/venv_bin_path.py
+++ b/pex/venv_bin_path.py
@@ -3,35 +3,30 @@
 
 from __future__ import absolute_import
 
-from pex.typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from typing import Union
-
-
-class InheritPath(object):
+class BinPath(object):
     class Value(object):
         def __init__(self, value):
             # type: (str) -> None
             self.value = value
+
+        def __str__(self):
+            # type: () -> str
+            return str(self.value)
 
         def __repr__(self):
             # type: () -> str
             return repr(self.value)
 
     FALSE = Value("false")
-    PREFER = Value("prefer")
-    FALLBACK = Value("fallback")
+    PREPEND = Value("prepend")
+    APPEND = Value("append")
 
-    values = FALSE, PREFER, FALLBACK
+    values = FALSE, PREPEND, APPEND
 
     @classmethod
     def for_value(cls, value):
-        # type: (Union[str, bool]) -> InheritPath.Value
-        if value is False:
-            return InheritPath.FALSE
-        elif value is True:
-            return InheritPath.PREFER
+        # type: (str) -> BinPath.Value
         for v in cls.values:
             if v.value == value:
                 return v

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,7 +21,6 @@ from zipfile import ZipFile
 
 import pytest
 
-from pex import pex_builder
 from pex.common import (
     safe_copy,
     safe_mkdir,
@@ -62,6 +61,7 @@ from pex.testing import (
 from pex.third_party import pkg_resources
 from pex.typing import TYPE_CHECKING
 from pex.util import DistributionHelper, named_temporary_file
+from pex.variables import unzip_dir
 
 if TYPE_CHECKING:
     from typing import (
@@ -2325,7 +2325,9 @@ def test_unzip_mode():
         )
         assert ["quit re-exec", os.path.realpath(pex_file)] == output1.decode("utf-8").splitlines()
 
-        unzipped_cache = os.path.join(pex_root, pex_builder.UNZIPPED_DIR)
+        pex_hash = PexInfo.from_pex(pex_file).pex_hash
+        assert pex_hash is not None
+        unzipped_cache = unzip_dir(pex_root, pex_hash)
         assert os.path.isdir(unzipped_cache)
         shutil.rmtree(unzipped_cache)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2669,11 +2669,13 @@ def test_venv_mode(
     def run_isort_pex(**env):
         # type: (**Any) -> str
         pex_root = str(tmpdir)
-        stdout, _ = Executor.execute(
-            [pex_file, "-c", "import sys; print(sys.executable)"],
+        stdout, returncode = run_simple_pex(
+            pex_file,
+            args=["-c", "import sys; print(sys.executable)"],
             env=make_env(PEX_ROOT=pex_root, PEX_INTERPRETER=1, **env),
         )
-        pex_interpreter = cast(str, stdout.strip())
+        assert returncode == 0, stdout
+        pex_interpreter = cast(str, stdout.decode("utf-8").strip())
         with ENV.patch(**env):
             pex_info = PexInfo.from_pex(pex_file)
             pex_hash = pex_info.pex_hash

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,6 +11,7 @@ import json
 import multiprocessing
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -59,9 +60,9 @@ from pex.testing import (
     temporary_content,
 )
 from pex.third_party import pkg_resources
-from pex.typing import TYPE_CHECKING
+from pex.typing import TYPE_CHECKING, cast
 from pex.util import DistributionHelper, named_temporary_file
-from pex.variables import unzip_dir
+from pex.variables import ENV, unzip_dir, venv_dir
 
 if TYPE_CHECKING:
     from typing import (
@@ -2633,3 +2634,83 @@ def test_issues_1031(py_version):
     assert system_site_packages_path in get_system_site_packages_pex_sys_path(
         PEX_INHERIT_PATH="fallback"
     )
+
+
+@pytest.fixture
+def isort_pex_args(tmpdir):
+    # type: (Any) -> Tuple[str, List[str]]
+    pex_file = os.path.join(str(tmpdir), "pex")
+
+    requirements = [
+        # For Python 2.7 and Python 3.5:
+        "isort==4.3.21; python_version<'3.6'",
+        "setuptools==44.1.1; python_version<'3.6'",
+        # For Python 3.6+:
+        "isort==5.6.4; python_version>='3.6'",
+    ]
+    return pex_file, requirements + ["-c", "isort", "-o", pex_file]
+
+
+def test_venv_mode(
+    tmpdir,  # type: Any
+    isort_pex_args,  # type: Tuple[str, List[str]]
+):
+    # type: (...) -> None
+    other_interpreter_version = PY36 if sys.version_info[0] == 2 else PY27
+    other_interpreter = ensure_python_interpreter(other_interpreter_version)
+
+    pex_file, args = isort_pex_args
+    results = run_pex_command(
+        args=args + ["--python", sys.executable, "--python", other_interpreter, "--venv"],
+        quiet=True,
+    )
+    results.assert_success()
+
+    def run_isort_pex(**env):
+        # type: (**Any) -> str
+        pex_root = str(tmpdir)
+        stdout, _ = Executor.execute(
+            [pex_file, "-c", "import sys; print(sys.executable)"],
+            env=make_env(PEX_ROOT=pex_root, PEX_INTERPRETER=1, **env),
+        )
+        pex_interpreter = cast(str, stdout.strip())
+        with ENV.patch(**env):
+            pex_info = PexInfo.from_pex(pex_file)
+            pex_hash = pex_info.pex_hash
+            assert pex_hash is not None
+            expected_venv_home = venv_dir(pex_root, pex_hash, interpreter_constraints=[])
+        assert expected_venv_home == os.path.commonprefix([pex_interpreter, expected_venv_home])
+        return pex_interpreter
+
+    isort_pex_interpreter1 = run_isort_pex()
+    assert isort_pex_interpreter1 == run_isort_pex()
+
+    isort_pex_interpreter2 = run_isort_pex(PEX_PYTHON=other_interpreter)
+    assert other_interpreter != isort_pex_interpreter2
+    assert isort_pex_interpreter1 != isort_pex_interpreter2
+    assert isort_pex_interpreter2 == run_isort_pex(PEX_PYTHON=other_interpreter)
+
+
+@pytest.mark.parametrize(
+    "mode_args",
+    [
+        pytest.param([], id="PEX"),
+        pytest.param(["--unzip"], id="unzip"),
+        pytest.param(["--venv"], id="venv"),
+    ],
+)
+def test_seed(
+    isort_pex_args,  # type: Tuple[str, List[str]]
+    mode_args,  # type: List[str]
+):
+    # type: (...) -> None
+    pex_file, args = isort_pex_args
+    results = run_pex_command(args=args + mode_args + ["--seed"], quiet=True)
+    results.assert_success()
+
+    seed_argv = shlex.split(results.output)
+    isort_args = ["--version"]
+    seed_stdout, seed_stderr = Executor.execute(seed_argv + isort_args)
+    pex_stdout, pex_stderr = Executor.execute([pex_file] + isort_args)
+    assert pex_stdout == seed_stdout
+    assert pex_stderr == seed_stderr

--- a/tests/test_pex_info.py
+++ b/tests/test_pex_info.py
@@ -117,15 +117,6 @@ def test_merge_split():
     assert result == ["/pex/path/3", "/pex/path/4"]
 
 
-def test_pex_root_set_none():
-    # type: () -> None
-    pex_info = PexInfo.default()
-    pex_info.pex_root = None
-
-    assert PexInfo.default().pex_root == pex_info.pex_root
-    assert os.path.expanduser("~/.pex") == pex_info.pex_root
-
-
 def test_pex_root_set_unwriteable():
     # type: () -> None
     with temporary_dir() as td:

--- a/tests/test_unified_install_cache.py
+++ b/tests/test_unified_install_cache.py
@@ -109,8 +109,10 @@ def test_issues_789_demo():
 
     # Force the standard pex to extract its code. An external tool like Pants would already know the
     # orignal source code file paths, but we need to discover here.
+    code_hash = colorized_isort_pex_info.code_hash
+    assert code_hash is not None
     colorized_isort_pex_code_dir = os.path.join(
-        colorized_isort_pex_info.zip_unsafe_cache, colorized_isort_pex_info.code_hash
+        colorized_isort_pex_info.zip_unsafe_cache, code_hash
     )
     env = os.environ.copy()
     env.update(PEX_ROOT=ptex_cache, PEX_INTERPRETER="1", PEX_FORCE_LOCAL="1")


### PR DESCRIPTION
The new --venv execution mode builds a PEX file that includes pex.tools
and extracts itself into a venv under PEX_ROOT upon 1st execution or any
execution that might select a diffrent interpreter than the default.

In order to speed up the local build and execute case, --seed mode is
added to seed the PEX_ROOT caches that will be used at runtime. This is
important for --venv mode since venv seeding depends on the selected
interpreter and one is already selected during the PEX file build
process.

Fixes #962
Fixes #1097
Fixes #1115