### PR TITLE
docs: fix simple typo, orignal -> original

### DIFF
--- a/tests/test_unified_install_cache.py
+++ b/tests/test_unified_install_cache.py
@@ -108,7 +108,7 @@ def test_issues_789_demo():
     colorized_isort_pex_info.pex_root = ptex_cache
 
     # Force the standard pex to extract its code. An external tool like Pants would already know the
-    # orignal source code file paths, but we need to discover here.
+    # original source code file paths, but we need to discover here.
     code_hash = colorized_isort_pex_info.code_hash
     assert code_hash is not None
     colorized_isort_pex_code_dir = os.path.join(


### PR DESCRIPTION
There is a small typo in tests/test_unified_install_cache.py.

Should read `original` rather than `orignal`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md