### PR TITLE
Add support for -r / --constraints URL to the CLI.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -676,7 +676,7 @@ def configure_clp():
         "-r",
         "--requirement",
         dest="requirement_files",
-        metavar="FILE",
+        metavar="FILE or URL",
         default=[],
         type=str,
         action="append",
@@ -687,7 +687,7 @@ def configure_clp():
     parser.add_argument(
         "--constraints",
         dest="constraint_files",
-        metavar="FILE",
+        metavar="FILE or URL",
         default=[],
         type=str,
         action="append",

--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -222,7 +222,7 @@ class Source(namedtuple("Source", ["origin", "is_file", "is_constraints", "lines
                     "The source is a url but no fetcher was supplied to resolve its contents with."
                 )
             try:
-                with self.from_url(fetcher, origin) as source:
+                with self.from_url(fetcher, origin, is_constraints=is_constraints) as source:
                     yield source
             except OSError as e:
                 raise create_parse_error(str(e))
@@ -708,12 +708,24 @@ def parse_requirements(
 
 
 def parse_requirement_file(
-    path,  # type: str
+    location,  # type: str
     is_constraints=False,  # type: bool
     fetcher=None,  # type: Optional[URLFetcher]
 ):
     # type: (...) -> Iterator[Union[ReqInfo, Constraint]]
-    with Source.from_file(path, is_constraints=is_constraints) as source:
+    def open_source():
+        url = urlparse.urlparse(location)
+        if url.scheme and url.netloc:
+            if fetcher is None:
+                raise ValueError(
+                    "The location is a url but no fetcher was supplied to resolve its contents "
+                    "with."
+                )
+            return Source.from_url(fetcher=fetcher, url=location, is_constraints=is_constraints)
+        else:
+            return Source.from_file(path=location, is_constraints=is_constraints)
+
+    with open_source() as source:
         for req_info in parse_requirements(source, fetcher=fetcher):
             yield req_info
 

--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -722,8 +722,9 @@ def parse_requirement_file(
                     "with."
                 )
             return Source.from_url(fetcher=fetcher, url=location, is_constraints=is_constraints)
-        else:
-            return Source.from_file(path=location, is_constraints=is_constraints)
+
+        path = url.path if url.scheme == "file" else location
+        return Source.from_file(path=path, is_constraints=is_constraints)
 
     with open_source() as source:
         for req_info in parse_requirements(source, fetcher=fetcher):

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -16,6 +16,7 @@ from pex.requirements import (
     ReqInfo,
     Source,
     URLFetcher,
+    parse_requirement_file,
     parse_requirements,
 )
 from pex.testing import environment_as
@@ -24,7 +25,7 @@ from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Iterator, Iterable, List, Optional, Union
+    from typing import Any, Iterable, Iterator, List, Optional, Union
 
 
 @pytest.fixture
@@ -197,7 +198,7 @@ def test_parse_requirements_stress(chroot):
             # https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format.
             dedent(
                 """\
-                -c subdir/more-requirements.txt
+                -c file:subdir/more-requirements.txt
 
                 a/local/project[foo]; python_full_version == "2.7.8"
                 ./another/local/project;python_version == "2.7.*"
@@ -388,6 +389,37 @@ def test_parse_constraints_from_url():
     )
     results = normalize_results(req_iter)
     assert [Constraint(req) for req in EXPECTED_EXAMPLE_PYTHON_REQ_INFOS] == results
+
+
+def test_parse_requirement_file_from_url():
+    # type: () -> None
+    req_iter = parse_requirement_file(EXAMPLE_PYTHON_REQUIREMENTS_URL, fetcher=URLFetcher())
+    results = normalize_results(req_iter)
+    assert EXPECTED_EXAMPLE_PYTHON_REQ_INFOS == results
+
+
+def test_parse_requirement_file_from_file_url(tmpdir):
+    # type: (Any) -> None
+    requirements_file = os.path.join(str(tmpdir), "requirements.txt")
+    with open(requirements_file, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                foo==1.0.0
+                bar>3
+                """
+            )
+        )
+
+    req_iter = parse_requirement_file(requirements_file)
+    expected = normalize_results(req_iter)
+
+    req_iter = parse_requirement_file("file:{}".format(requirements_file))
+    results = normalize_results(req_iter)
+    assert expected == results
+    req_iter = parse_requirement_file("file://{}".format(requirements_file))
+    results = normalize_results(req_iter)
+    assert expected == results
 
 
 def test_parse_requirements_from_url_no_fetcher():


### PR DESCRIPTION
This retrofits parse_requirement_file to accept either a file path or
an URL and fixes plumbing of the is_constraints marker for URL sources.
The Pex CLI support for -r and --constraints is now at parity with Pip
-r / -c.