### PR TITLE
Record original requirements in PEX-INFO.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -12,7 +12,6 @@ import os
 import sys
 import tempfile
 from argparse import Action, ArgumentDefaultsHelpFormatter, ArgumentParser, ArgumentTypeError
-from shlex import shlex
 from textwrap import TextWrapper
 
 from pex import pex_warnings
@@ -935,12 +934,9 @@ def build_pex(reqs, options, cache=None):
             )
 
             for resolved_dist in resolveds:
-                log(
-                    "  %s -> %s" % (resolved_dist.requirement, resolved_dist.distribution),
-                    V=options.verbosity,
-                )
                 pex_builder.add_distribution(resolved_dist.distribution)
-                pex_builder.add_requirement(resolved_dist.requirement)
+                if resolved_dist.direct_requirement:
+                    pex_builder.add_requirement(resolved_dist.direct_requirement)
         except Unsatisfiable as e:
             die(str(e))
 

--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -303,10 +303,13 @@ def parse_requirement_from_dist(
             "Failed to find a project name and version from the given wheel path: "
             "{wheel}".format(wheel=dist)
         )
+    project_name_and_specifier = ProjectNameAndSpecifier.from_project_name_and_version(
+        project_name_and_version
+    )
     return parse_requirement_from_project_name_and_specifier(
-        project_name_and_version.project_name,
+        project_name_and_specifier.project_name,
         extras=extras,
-        specifier=SpecifierSet("=={}".format(project_name_and_version.version)),
+        specifier=project_name_and_specifier.specifier,
         marker=marker,
     )
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -161,8 +161,9 @@ def assert_force_local_implicit_ns_packages_issues_598(
     def add_requirements(builder, cache):
         # type: (PEXBuilder, str) -> None
         for resolved_dist in resolve(requirements, cache=cache, interpreter=builder.interpreter):
-            builder.add_requirement(resolved_dist.requirement)
             builder.add_distribution(resolved_dist.distribution)
+            if resolved_dist.direct_requirement:
+                builder.add_requirement(resolved_dist.direct_requirement)
 
     def add_wheel(builder, content):
         # type: (PEXBuilder, Dict[str, str]) -> None
@@ -375,7 +376,8 @@ def test_activate_extras_issue_615():
     # type: () -> None
     with yield_pex_builder() as pb:
         for resolved_dist in resolver.resolve(["pex[requests]==1.6.3"], interpreter=pb.interpreter):
-            pb.add_requirement(resolved_dist.requirement)
+            if resolved_dist.direct_requirement:
+                pb.add_requirement(resolved_dist.direct_requirement)
             pb.add_dist_location(resolved_dist.distribution.location)
         pb.set_script("pex")
         pb.freeze()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2805,3 +2805,45 @@ def test_constraint_file_from_url(tmpdir):
     dist_paths.remove("fasteners-0.15-py2.py3-none-any.whl")
     for dist_path in dist_paths:
         assert dist_path.startswith(("six-", "monotonic-")) and dist_path.endswith(".whl")
+
+
+def test_top_level_environment_markers_issues_899(tmpdir):
+    # type: (Any) -> None
+    python27 = ensure_python_interpreter(PY27)
+    python36 = ensure_python_interpreter(PY36)
+
+    pex_file = os.path.join(str(tmpdir), "pex")
+
+    requirement = "subprocess32==3.2.7; python_version<'3'"
+    results = run_pex_command(
+        args=["--python", python27, "--python", python36, requirement, "-o", pex_file]
+    )
+    results.assert_success()
+    requirements = PexInfo.from_pex(pex_file).requirements
+    assert len(requirements) == 1
+    assert Requirement.parse(requirement) == Requirement.parse(requirements.pop())
+
+    output, returncode = run_simple_pex(
+        pex_file,
+        args=["-c", "import subprocess32"],
+        interpreter=PythonInterpreter.from_binary(python27),
+    )
+    assert 0 == returncode
+
+    py36_interpreter = PythonInterpreter.from_binary(python36)
+    output, returncode = run_simple_pex(
+        pex_file,
+        args=["-c", "import subprocess"],
+        interpreter=py36_interpreter,
+    )
+    assert 0 == returncode
+
+    py36_interpreter = PythonInterpreter.from_binary(python36)
+    output, returncode = run_simple_pex(
+        pex_file,
+        args=["-c", "import subprocess32"],
+        interpreter=py36_interpreter,
+    )
+    assert (
+        1 == returncode
+    ), "Expected subprocess32 to be present in the PEX file but not activated for Python 3."


### PR DESCRIPTION
Previously we recorded the post-resolve exact requirements of all
resolved distributions. This necessitated a good deal of work to recover
environment markers and still left out any top-level environment markers
specified in direct requirements / requirement files passed to Pex. Now
we record all requirements as we received them, only filling in project
name and version for local loose-source requirements in our resolve
post-processing. This saves time (~O(500ms) for medium to large PEX
builds) and fixes bugs.

Fixes #899