### PR TITLE
PEXEnvironment for a DistributionTarget.

### DIFF
--- a/pex/distribution_target.py
+++ b/pex/distribution_target.py
@@ -6,6 +6,13 @@ from __future__ import absolute_import
 import os
 
 from pex.interpreter import PythonInterpreter
+from pex.platforms import Platform
+from pex.third_party.packaging import tags
+from pex.third_party.pkg_resources import Requirement
+from pex.typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from typing import Any, Optional, Tuple
 
 
 class DistributionTarget(object):
@@ -13,53 +20,108 @@ class DistributionTarget(object):
 
     @classmethod
     def current(cls):
-        return cls(interpreter=None, platform=None)
+        # type: () -> DistributionTarget
+        return cls()
 
     @classmethod
     def for_interpreter(cls, interpreter):
-        return cls(interpreter=interpreter, platform=None)
+        # type: (PythonInterpreter) -> DistributionTarget
+        return cls(interpreter=interpreter)
 
     @classmethod
-    def for_platform(cls, platform):
-        return cls(interpreter=None, platform=platform)
+    def for_platform(
+        cls,
+        platform,  # type: Platform
+        manylinux=None,  # type: Optional[str]
+    ):
+        # type: (...) -> DistributionTarget
+        return cls(platform=platform, manylinux=manylinux)
 
-    def __init__(self, interpreter=None, platform=None):
+    def __init__(
+        self,
+        interpreter=None,  # type: Optional[PythonInterpreter]
+        platform=None,  # type:Optional[Platform]
+        manylinux=None,  # type: Optional[str]
+    ):
+        # type: (...) -> None
+        if interpreter and platform:
+            raise ValueError(
+                "A {class_name} can represent an interpreter or a platform but not both at the "
+                "same time. Given interpreter {interpreter} and platform {platform}.".format(
+                    class_name=self.__class__.__name__, interpreter=interpreter, platform=platform
+                )
+            )
+        if manylinux and not platform:
+            raise ValueError(
+                "A value for manylinux only makes sense for platform distribution targets. Given "
+                "manylinux={!r} but no platform.".format(manylinux)
+            )
         self._interpreter = interpreter
         self._platform = platform
+        self._manylinux = manylinux
 
     @property
     def is_foreign(self):
+        # type: () -> bool
         if self._platform is None:
             return False
         return self._platform not in self.get_interpreter().supported_platforms
 
     def get_interpreter(self):
+        # type: () -> PythonInterpreter
         return self._interpreter or PythonInterpreter.get()
 
-    def get_platform(self):
-        return self._platform or self.get_interpreter().platform
+    def get_python_version_str(self):
+        # type: () -> Optional[str]
+        if self._platform is not None:
+            return None
+        return self.get_interpreter().identity.version_str
 
-    def requirement_applies(self, requirement):
+    def get_platform(self):
+        # type: () -> Tuple[Platform, Optional[str]]
+        if self._platform is not None:
+            return self._platform, self._manylinux
+        return self.get_interpreter().platform, None
+
+    def get_supported_tags(self):
+        # type: () -> Tuple[tags.Tag, ...]
+        if self._platform is not None:
+            return self._platform.supported_tags(manylinux=self._manylinux)
+        return self.get_interpreter().identity.supported_tags
+
+    def requirement_applies(
+        self,
+        requirement,  # type: Requirement
+        extras=None,  # type: Optional[Tuple[str, ...]]
+    ):
+        # type: (...) -> bool
         """Determines if the given requirement applies to this distribution target.
 
         :param requirement: The requirement to evaluate.
-        :type requirement: :class:`pex.third_party.pkg_resources.Requirement`
-        :rtype: bool
+        :param extras: Optional active extras.
         """
-        if not requirement.marker:
+        if requirement.marker is None:
             return True
 
-        if self._interpreter is None:
+        if self._platform is not None:
             return True
 
-        return requirement.marker.evaluate(self._interpreter.identity.env_markers)
+        if not extras:
+            # Provide an empty extra to safely evaluate the markers without matching any extra.
+            extras = ("",)
+        for extra in extras:
+            # N.B.: This nets us a copy of the markers so we're free to mutate.
+            environment = self.get_interpreter().identity.env_markers
+            environment["extra"] = extra
+            if requirement.marker.evaluate(environment=environment):
+                return True
+
+        return False
 
     @property
     def id(self):
-        """A unique id for this distribution target suitable as a path name component.
-
-        :rtype: str
-        """
+        # type: () -> str
+        """A unique id for this distribution target suitable as a path name component."""
         if self._platform is None:
             interpreter = self.get_interpreter()
             return interpreter.binary.replace(os.sep, ".").lstrip(".")
@@ -67,18 +129,22 @@ class DistributionTarget(object):
             return str(self._platform)
 
     def __repr__(self):
+        # type: () -> str
         if self._platform is None:
             return "{}(interpreter={!r})".format(self.__class__.__name__, self.get_interpreter())
         else:
             return "{}(platform={!r})".format(self.__class__.__name__, self._platform)
 
     def _tup(self):
+        # type: () -> Tuple[Any, ...]
         return self._interpreter, self._platform
 
     def __eq__(self, other):
-        if type(other) is not type(self):
+        # type: (Any) -> bool
+        if type(other) is not DistributionTarget:
             return NotImplemented
-        return self._tup() == other._tup()
+        return self._tup() == cast(DistributionTarget, other)._tup()
 
     def __hash__(self):
+        # type: () -> int
         return hash(self._tup())

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -15,6 +15,7 @@ from pex import third_party
 from pex.bootstrap import Bootstrap
 from pex.common import die
 from pex.compatibility import PY3
+from pex.distribution_target import DistributionTarget
 from pex.environment import PEXEnvironment
 from pex.executor import Executor
 from pex.finders import get_entry_point_from_console_script, get_script_from_distributions
@@ -99,7 +100,8 @@ class PEX(object):  # noqa: T000
 
         # set up the local .pex environment
         pex_info = self.pex_info()
-        self._envs.append(PEXEnvironment(self._pex, pex_info, interpreter=self._interpreter))
+        target = DistributionTarget.for_interpreter(self._interpreter)
+        self._envs.append(PEXEnvironment(self._pex, pex_info, target=target))
         # N.B. by this point, `pex_info.pex_path` will contain a single pex path
         # merged from pex_path in `PEX-INFO` and `PEX_PATH` set in the environment.
         # `PEX_PATH` entries written into `PEX-INFO` take precedence over those set
@@ -109,7 +111,7 @@ class PEX(object):  # noqa: T000
             for pex_path in filter(None, pex_info.pex_path.split(os.pathsep)):
                 pex_info = PexInfo.from_pex(pex_path)
                 pex_info.update(self._pex_info_overrides)
-                self._envs.append(PEXEnvironment(pex_path, pex_info, interpreter=self._interpreter))
+                self._envs.append(PEXEnvironment(pex_path, pex_info, target=target))
 
         # activate all of them
         activated_dists = []  # type: List[Distribution]

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -376,13 +376,12 @@ class Pip(object):
         package_index_configuration=None,  # type: Optional[PackageIndexConfiguration]
         cache=None,  # type: Optional[str]
         build=True,  # type: bool
-        manylinux=None,  # type: Optional[str]
         use_wheel=True,  # type: bool
     ):
         # type: (...) -> Job
         target = target or DistributionTarget.current()
 
-        platform = target.get_platform()
+        platform, manylinux = target.get_platform()
         if not use_wheel:
             if not build:
                 raise ValueError(

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -240,7 +240,7 @@ def make_bdist(
         get_pip().spawn_install_wheel(
             wheel=dist_location,
             install_dir=install_dir,
-            target=DistributionTarget.for_interpreter(interpreter),
+            target=DistributionTarget(interpreter=interpreter),
         ).wait()
         dist = DistributionHelper.distribution_from_path(install_dir)
         assert dist is not None

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -95,8 +95,8 @@ def populate_venv_with_pex(
     pex_info = pex.pex_info()
     if zipfile.is_zipfile(pex.path()):
         record_provenance(
-            PEXEnvironment.explode_code(
-                pex.path(), pex_info, venv.site_packages_dir, exclude=("__main__.py",)
+            PEXEnvironment(pex.path()).explode_code(
+                venv.site_packages_dir, exclude=("__main__.py",)
             )
         )
     else:


### PR DESCRIPTION
Instead of requiring a PythonIntepreter to resolve distributions in a
PEXEnvironment, a DistributionTarget is enough. This allows for
resolving distributions from a PEXEnvironment given only a Platform
which we need to support resolving from a `--pex-repository` for
foreign platforms in #1108.