### PR TITLE
Support resolving from a PEX file repository.

### DIFF
--- a/pex/distribution_target.py
+++ b/pex/distribution_target.py
@@ -94,17 +94,21 @@ class DistributionTarget(object):
         requirement,  # type: Requirement
         extras=None,  # type: Optional[Tuple[str, ...]]
     ):
-        # type: (...) -> bool
+        # type: (...) -> Optional[bool]
         """Determines if the given requirement applies to this distribution target.
 
         :param requirement: The requirement to evaluate.
         :param extras: Optional active extras.
+        :returns: `True` if the requirement definitely applies, `False` if it definitely does not
+                  and `None` if it might apply but not enough information is at hand to determine
+                  if it does apply.
         """
         if requirement.marker is None:
             return True
 
         if self._platform is not None:
-            return True
+            # We can have no opinion for foreign platforms.
+            return None
 
         if not extras:
             # Provide an empty extra to safely evaluate the markers without matching any extra.

--- a/pex/util.py
+++ b/pex/util.py
@@ -181,7 +181,7 @@ class CacheHelper(object):
         """
         with atomic_directory(target_dir, source=source, exclusive=True) as target_dir_tmp:
             if target_dir_tmp is None:
-                TRACER.log("Using cached {}".format(target_dir))
+                TRACER.log("Using cached {}".format(target_dir), V=3)
             else:
                 with TRACER.timed("Caching {}:{} in {}".format(zf.filename, source, target_dir)):
                     for name in zf.namelist():

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -556,7 +556,7 @@ def create_pex_repository(
         if resolved_dist.direct_requirement:
             pex_builder.add_requirement(resolved_dist.direct_requirement)
     pex_builder.freeze()
-    return cast(str, pex_builder.path())
+    return os.path.realpath(cast(str, pex_builder.path()))
 
 
 def create_constraints_file(*requirements):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -672,7 +672,7 @@ def test_resolve_from_pex(
     assert "cryptography" in distribution_locations_by_key
     assert 3 == len(distribution_locations_by_key["cryptography"]), (
         "The cryptography requirement of the security extra is platform specific; so we expect a "
-        "unique distribution to be resolved for each of the three distributin targets"
+        "unique distribution to be resolved for each of the three distribution targets"
     )
 
 


### PR DESCRIPTION
Introduce a `--pex-repository` option to the Pex CLI to switch
requirement resolution from using index servers and find-links
repositories to using a local PEX file with pre-resolved requirements.
This can be useful when a number of projects share a consistent resolve
via a shared requirement file. You can resolve the full requirement file
into a requirements PEX and then later resolve just the portions needed
by each individual project from the fully resolved requirements PEX.

Fixes #1108