### PR TITLE
Improve PEX repository error for local projects.

### DIFF
--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -1413,9 +1413,8 @@ def resolve_from_pex(
     for direct_requirement in direct_requirements:
         if isinstance(direct_requirement, LocalProjectRequirement):
             raise Untranslatable(
-                "Cannot resolve local project {path} from the PEX repository {pex}.".format(
-                    path=direct_requirement.path, pex=pex
-                )
+                "Cannot resolve local projects from PEX repositories. Asked to resolve {path} "
+                "from {pex}.".format(path=direct_requirement.path, pex=pex)
             )
         direct_requirements_by_key[
             direct_requirement.requirement.key


### PR DESCRIPTION
Make it clear local projects can't be resolved from PEX repositories in
general. Previously you might take the error to mean the particular
local project was not resolvable from the particular PEX repository.