### PR TITLE
Requirement parsing handles local non-dist files.

### DIFF
--- a/pex/dist_metadata.py
+++ b/pex/dist_metadata.py
@@ -28,6 +28,10 @@ class MetadataError(Exception):
     """Indicates an error reading distribution metadata."""
 
 
+class UnrecognizedDistributionFormat(MetadataError):
+    """Indicates a distribution file is not of any recognized format."""
+
+
 _PKG_INFO_BY_DIST = {}  # type: Dict[Distribution, Optional[Message]]
 
 
@@ -177,7 +181,7 @@ class ProjectNameAndVersion(namedtuple("ProjectNameAndVersion", ["project_name",
             project_name, version = fname.rsplit("-", 1)
             return cls(project_name=project_name, version=version)
 
-        raise MetadataError(
+        raise UnrecognizedDistributionFormat(
             "The distribution at path {!r} does not have a file name matching known sdist or wheel "
             "file name formats.".format(path)
         )

--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -612,10 +612,17 @@ def _parse_requirement_line(
                 marker=marker,
                 editable=editable,
             )
-        requirement = parse_requirement_from_dist(
-            archive_or_project_path, extras=extras, marker=marker
-        )
-        return URLRequirement.create(line, archive_or_project_path, requirement, editable=editable)
+        try:
+            requirement = parse_requirement_from_dist(
+                archive_or_project_path, extras=extras, marker=marker
+            )
+            return URLRequirement.create(
+                line, archive_or_project_path, requirement, editable=editable
+            )
+        except dist_metadata.UnrecognizedDistributionFormat:
+            # This is not a recognized local archive distribution. Fall through and try parsing as a
+            # PEP-440 requirement.
+            pass
 
     # Handle PEP-440. See: https://www.python.org/dev/peps/pep-0440.
     #

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -309,6 +309,11 @@ def test_parse_requirements_stress(chroot):
             ),
         )
     )
+
+    # Ensure local non-distribution files matching distribution names are not erroneously probed
+    # as distributions to find name and version metadata.
+    touch("nose")
+
     touch("downloads/numpy-1.9.2-cp34-none-win32.whl")
     with environment_as(PROJECT_NAME="Project"):
         results = normalize_results(req_iter)


### PR DESCRIPTION
Previously a file (not directory) in the CWD with the same name as the
project name of a requirement being resolved would lead to an error.
Modify the requirement parsing stress test to cause this error and fix
parsing so the test passes.

Fixes #1188