### PR TITLE
Support relative paths in `Chroot.symlink`.

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -604,7 +604,7 @@ class Chroot(object):
         dst = self._normalize(dst)
         self._tag(dst, label)
         self._ensure_parent(dst)
-        abs_src = src
+        abs_src = os.path.abspath(src)
         abs_dst = os.path.join(self.chroot, dst)
         os.symlink(abs_src, abs_dst)
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -231,10 +231,17 @@ def test_chroot_zip_symlink():
             os.path.join(chroot.path(), "directory/subdirectory/file"),
             "directory/subdirectory/symlinked",
         )
-        chroot.symlink(
-            "file",
-            "directory/subdirectory/rel-symlinked",
-        )
+
+        cwd = os.getcwd()
+        try:
+            os.chdir(os.path.join(chroot.path(), "directory/subdirectory"))
+            chroot.symlink(
+                "file",
+                "directory/subdirectory/rel-symlinked",
+            )
+        finally:
+            os.chdir(cwd)
+
         chroot.symlink(os.path.join(chroot.path(), "directory"), "symlinked")
         zip_dst = os.path.join(tmp, "chroot.zip")
         chroot.zip(zip_dst)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -231,6 +231,10 @@ def test_chroot_zip_symlink():
             os.path.join(chroot.path(), "directory/subdirectory/file"),
             "directory/subdirectory/symlinked",
         )
+        chroot.symlink(
+            "file",
+            "directory/subdirectory/rel-symlinked",
+        )
         chroot.symlink(os.path.join(chroot.path(), "directory"), "symlinked")
         zip_dst = os.path.join(tmp, "chroot.zip")
         chroot.zip(zip_dst)
@@ -239,19 +243,23 @@ def test_chroot_zip_symlink():
                 "directory/",
                 "directory/subdirectory/",
                 "directory/subdirectory/file",
+                "directory/subdirectory/rel-symlinked",
                 "directory/subdirectory/symlinked",
                 "symlinked/",
                 "symlinked/subdirectory/",
                 "symlinked/subdirectory/file",
+                "symlinked/subdirectory/rel-symlinked",
                 "symlinked/subdirectory/symlinked",
             ] == sorted(zip.namelist())
             assert b"" == zip.read("directory/")
             assert b"" == zip.read("directory/subdirectory/")
             assert b"data" == zip.read("directory/subdirectory/file")
+            assert b"data" == zip.read("directory/subdirectory/rel-symlinked")
             assert b"data" == zip.read("directory/subdirectory/symlinked")
             assert b"" == zip.read("symlinked/")
             assert b"" == zip.read("symlinked/subdirectory/")
             assert b"data" == zip.read("symlinked/subdirectory/file")
+            assert b"data" == zip.read("symlinked/subdirectory/rel-symlinked")
             assert b"data" == zip.read("symlinked/subdirectory/symlinked")
 
 

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -175,15 +175,17 @@ def test_pex_builder_copy_or_link():
             pb.clone(into=path_clone)
 
             for root in path, path_clone:
-                if copy_mode == CopyMode.SYMLINK:
-                    assert os.path.islink(os.path.join(root, "exe.py"))
-                    continue
                 s1 = os.stat(src)
                 s2 = os.stat(os.path.join(root, "exe.py"))
                 is_link = (s1[stat.ST_INO], s1[stat.ST_DEV]) == (s2[stat.ST_INO], s2[stat.ST_DEV])
                 if copy_mode == CopyMode.COPY:
                     assert not is_link
-                elif copy_mode == CopyMode.LINK:
+                else:
+                    # Since os.stat follows symlinks; so in CopyMode.SYMLINK, this just proves the
+                    # symlink points to the original file. Going further and checking path and
+                    # path_clone for the presence of a symlink (an os.islink test) is trickier since
+                    # a Linux hardlink of a symlink produces a symlink whereas a maxOS hardlink of a
+                    # symlink produces a hardlink.
                     assert is_link
 
         build_and_check(td2, CopyMode.LINK)

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -174,6 +174,9 @@ def test_pex_builder_copy_or_link():
             pb.clone(into=path_clone)
 
             for root in path, path_clone:
+                if copy_mode == CopyMode.SYMLINK:
+                    assert os.path.islink(os.path.join(root, "exe.py"))
+                    continue
                 s1 = os.stat(src)
                 s2 = os.stat(os.path.join(root, "exe.py"))
                 is_link = (s1[stat.ST_INO], s1[stat.ST_DEV]) == (s2[stat.ST_INO], s2[stat.ST_DEV])


### PR DESCRIPTION
Previously, when a relative path was given to `Chroot.symlink`, the
underlying symlink would be created as relative. This led to issues when
the CWD changed between Chroot creation time and Chroot resolution time.
Fix `Chroot.symlink` to use absolute symlink paths.

Fixes #1192