### PR TITLE
Fix resolve post-processing to use markers.

### DIFF
--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -773,7 +773,9 @@ class BuildAndInstallRequest(object):
             direct_reqs = [
                 req
                 for req in direct_requirements_by_key.get(distribution.key, ())
-                if req and distribution in req
+                if req
+                and distribution in req
+                and installed_distribution.target.requirement_applies(req)
             ]
             if len(direct_reqs) > 1:
                 raise AssertionError(

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -534,6 +534,27 @@ def test_resolve_arbitrary_equality_issues_940():
     assert requirement.marker is None
 
 
+def test_resolve_overlapping_requirements_discriminated_by_markers_issues_1196(py27):
+    # type: (PythonInterpreter) -> None
+    resolved_distributions = resolve_multi(
+        requirements=[
+            "setuptools<45; python_full_version == '2.7.*'",
+            "setuptools; python_version > '2.7'",
+        ],
+        interpreters=[py27],
+    )
+    assert 1 == len(resolved_distributions)
+    resolved_distribution = resolved_distributions[0]
+    assert (
+        Requirement.parse("setuptools<45; python_full_version == '2.7.*'")
+        == resolved_distribution.direct_requirement
+    )
+    assert (
+        Requirement.parse("setuptools==44.1.1")
+        == resolved_distribution.distribution.as_requirement()
+    )
+
+
 def create_pex_repository(
     interpreters=None,  # type: Optional[Iterable[PythonInterpreter]]
     platforms=None,  # type: Optional[Iterable[Platform]]


### PR DESCRIPTION
Previously environment markers were not considered when calculating
which resolved distributions satisfied direct requirements leading
to spurious AssertionErrors.

Fixes #1196

