### PR TITLE
Fix all test warnings.

### DIFF
--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -98,21 +98,6 @@ else:
     # This will result in `exec_function` being defined at runtime.
     eval(compile(_PY3_EXEC_FUNCTION, "<exec_function>", "exec"))
 
-if PY3:
-    from contextlib import contextmanager, ExitStack
-
-    @contextmanager
-    def nested(*context_managers):
-        enters = []
-        with ExitStack() as stack:
-            for manager in context_managers:
-                enters.append(stack.enter_context(manager))
-            yield tuple(enters)
-
-
-else:
-    from contextlib import nested as nested
-
 
 if PY3:
     import urllib.parse as urlparse

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -31,7 +31,7 @@ from pex.common import (
     temporary_dir,
     touch,
 )
-from pex.compatibility import WINDOWS, nested, to_bytes
+from pex.compatibility import WINDOWS, to_bytes
 from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
 from pex.network_configuration import NetworkConfiguration
@@ -113,11 +113,10 @@ def assert_installed_wheels(label, pex_root):
 
 def test_pex_root_build():
     # type: () -> None
-    with nested(temporary_dir(), temporary_dir(), temporary_dir()) as (
-        buildtime_pex_root,
-        output_dir,
-        home,
-    ):
+    with temporary_dir() as td, temporary_dir() as home:
+        buildtime_pex_root = os.path.join(td, "buildtime_pex_root")
+        output_dir = os.path.join(td, "output_dir")
+
         output_path = os.path.join(output_dir, "pex.pex")
         args = [
             "pex",
@@ -135,12 +134,10 @@ def test_pex_root_build():
 
 def test_pex_root_run():
     # type: () -> None
-    with nested(temporary_dir(), temporary_dir(), temporary_dir(), temporary_dir()) as (
-        buildtime_pex_root,
-        runtime_pex_root,
-        output_dir,
-        home,
-    ):
+    with temporary_dir() as td, temporary_dir() as runtime_pex_root, temporary_dir() as home:
+        buildtime_pex_root = os.path.join(td, "buildtime_pex_root")
+        output_dir = os.path.join(td, "output_dir")
+
         output_path = os.path.join(output_dir, "pex.pex")
         args = [
             "pex",
@@ -172,7 +169,7 @@ def test_pex_root_run():
 
 def test_cache_disable():
     # type: () -> None
-    with nested(temporary_dir(), temporary_dir(), temporary_dir()) as (td, output_dir, tmp_home):
+    with temporary_dir() as td, temporary_dir() as output_dir, temporary_dir() as tmp_home:
         output_path = os.path.join(output_dir, "pex.pex")
         args = [
             "pex",

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -15,7 +15,7 @@ from types import ModuleType
 import pytest
 
 from pex.common import safe_mkdir, safe_open, temporary_dir
-from pex.compatibility import PY2, WINDOWS, nested, to_bytes
+from pex.compatibility import PY2, WINDOWS, to_bytes
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
@@ -204,10 +204,9 @@ def test_minimum_sys_modules():
 
 def test_site_libs():
     # type: () -> None
-    with nested(mock.patch.object(PEX, "_get_site_packages"), temporary_dir()) as (
-        mock_site_packages,
-        tempdir,
-    ):
+    with mock.patch.object(
+        PEX, "_get_site_packages"
+    ) as mock_site_packages, temporary_dir() as tempdir:
         site_packages = os.path.join(tempdir, "site-packages")
         os.mkdir(site_packages)
         mock_site_packages.return_value = set([site_packages])
@@ -218,10 +217,9 @@ def test_site_libs():
 @pytest.mark.skipif(WINDOWS, reason="No symlinks on windows")
 def test_site_libs_symlink():
     # type: () -> None
-    with nested(mock.patch.object(PEX, "_get_site_packages"), temporary_dir()) as (
-        mock_site_packages,
-        tempdir,
-    ):
+    with mock.patch.object(
+        PEX, "_get_site_packages"
+    ) as mock_site_packages, temporary_dir() as tempdir:
         site_packages = os.path.join(tempdir, "site-packages")
         os.mkdir(site_packages)
         site_packages_link = os.path.join(tempdir, "site-packages-link")
@@ -240,10 +238,9 @@ def test_site_libs_excludes_prefix():
     Make sure to exclude it.
     """
 
-    with nested(mock.patch.object(PEX, "_get_site_packages"), temporary_dir()) as (
-        mock_site_packages,
-        tempdir,
-    ):
+    with mock.patch.object(
+        PEX, "_get_site_packages"
+    ) as mock_site_packages, temporary_dir() as tempdir:
         site_packages = os.path.join(tempdir, "site-packages")
         os.mkdir(site_packages)
         mock_site_packages.return_value = set([site_packages, sys.prefix])

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -8,7 +8,7 @@ import zipfile
 import pytest
 
 from pex.common import safe_open, temporary_dir
-from pex.compatibility import WINDOWS, nested
+from pex.compatibility import WINDOWS
 from pex.executor import Executor
 from pex.pex import PEX
 from pex.pex_builder import BOOTSTRAP_DIR, CopyMode, PEXBuilder
@@ -42,7 +42,7 @@ with open(sys.argv[1], 'w') as fp:
 def test_pex_builder():
     # type: () -> None
     # test w/ and w/o zipfile dists
-    with nested(temporary_dir(), make_bdist("p1")) as (td, p1):
+    with temporary_dir() as td, make_bdist("p1") as p1:
         pb = write_pex(td, exe_main, dists=[p1])
 
         success_txt = os.path.join(td, "success.txt")
@@ -52,7 +52,7 @@ def test_pex_builder():
             assert fp.read() == "success"
 
     # test w/ and w/o zipfile dists
-    with nested(temporary_dir(), temporary_dir(), make_bdist("p1")) as (td1, td2, p1):
+    with temporary_dir() as td1, temporary_dir() as td2, make_bdist("p1") as p1:
         pb = write_pex(td1, exe_main, dists=[p1])
 
         success_txt = os.path.join(td1, "success.txt")
@@ -66,7 +66,7 @@ def test_pex_builder_wheeldep():
     # type: () -> None
     """Repeat the pex_builder test, but this time include an import of something from a wheel that
     doesn't come in importable form."""
-    with nested(temporary_dir(), make_bdist("p1")) as (td, p1):
+    with temporary_dir() as td, make_bdist("p1") as p1:
         pyparsing_path = "./tests/example_packages/pyparsing-2.1.10-py2.py3-none-any.whl"
         pb = write_pex(td, wheeldeps_exe_main, dists=[p1, pyparsing_path])
         success_txt = os.path.join(td, "success.txt")
@@ -119,7 +119,7 @@ def test_pex_builder_preamble():
 
 def test_pex_builder_compilation():
     # type: () -> None
-    with nested(temporary_dir(), temporary_dir(), temporary_dir()) as (td1, td2, td3):
+    with temporary_dir() as td1, temporary_dir() as td2, temporary_dir() as td3:
         src = os.path.join(td1, "src.py")
         with open(src, "w") as fp:
             fp.write(exe_main)
@@ -156,19 +156,15 @@ def test_pex_builder_compilation():
 @pytest.mark.skipif(WINDOWS, reason="No hardlinks on windows")
 def test_pex_builder_copy_or_link():
     # type: () -> None
-    with nested(temporary_dir(), temporary_dir(), temporary_dir(), temporary_dir()) as (
-        td1,
-        td2,
-        td3,
-        td4,
-    ):
-        src = os.path.join(td1, "exe.py")
-        with open(src, "w") as fp:
+    with temporary_dir() as td:
+        src = os.path.join(td, "exe.py")
+        with safe_open(src, "w") as fp:
             fp.write(exe_main)
 
-        def build_and_check(path, copy_mode):
-            # type: (str, CopyMode.Value) -> None
-            pb = PEXBuilder(path=path, copy_mode=copy_mode)
+        def build_and_check(copy_mode):
+            # type: (CopyMode.Value) -> None
+            pb = PEXBuilder(copy_mode=copy_mode)
+            path = pb.path()
             pb.add_source(src, "exe.py")
 
             path_clone = os.path.join(path, "__clone")
@@ -181,16 +177,16 @@ def test_pex_builder_copy_or_link():
                 if copy_mode == CopyMode.COPY:
                     assert not is_link
                 else:
-                    # Since os.stat follows symlinks; so in CopyMode.SYMLINK, this just proves the
-                    # symlink points to the original file. Going further and checking path and
-                    # path_clone for the presence of a symlink (an os.islink test) is trickier since
-                    # a Linux hardlink of a symlink produces a symlink whereas a maxOS hardlink of a
-                    # symlink produces a hardlink.
+                    # Since os.stat follows symlinks; so in CopyMode.SYMLINK, this just proves
+                    # the symlink points to the original file. Going further and checking path
+                    # and path_clone for the presence of a symlink (an os.islink test) is
+                    # trickier since a Linux hardlink of a symlink produces a symlink whereas a
+                    # macOS hardlink of a symlink produces a hardlink.
                     assert is_link
 
-        build_and_check(td2, CopyMode.LINK)
-        build_and_check(td3, CopyMode.COPY)
-        build_and_check(td4, CopyMode.SYMLINK)
+        build_and_check(CopyMode.LINK)
+        build_and_check(CopyMode.COPY)
+        build_and_check(CopyMode.SYMLINK)
 
 
 @pytest.fixture
@@ -257,14 +253,14 @@ def test_pex_builder_from_requirements_pex():
 
     # Build from pex dir.
     with temporary_dir() as td2:
-        with nested(temporary_dir(), make_bdist("p1")) as (td1, p1):
+        with temporary_dir() as td1, make_bdist("p1") as p1:
             pb1 = write_pex(td1, dists=[p1])
             pb2 = build_from_req_pex(td2, pb1.path())
         verify(pb2)
 
     # Build from .pex file.
     with temporary_dir() as td4:
-        with nested(temporary_dir(), make_bdist("p1")) as (td3, p1):
+        with temporary_dir() as td3, make_bdist("p1") as p1:
             pb3 = write_pex(td3, dists=[p1])
             target = os.path.join(td3, "foo.pex")
             pb3.build(target)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -11,7 +11,6 @@ import pkginfo
 import pytest
 
 from pex.common import safe_copy, safe_mkdtemp, temporary_dir
-from pex.compatibility import nested
 from pex.distribution_target import DistributionTarget
 from pex.interpreter import PythonInterpreter, spawn_python_job
 from pex.pex_builder import PEXBuilder
@@ -102,7 +101,7 @@ def test_resolve_cache():
     # type: () -> None
     project_wheel = build_wheel(name="project")
 
-    with nested(temporary_dir(), temporary_dir()) as (td, cache):
+    with temporary_dir() as td, temporary_dir() as cache:
         safe_copy(project_wheel, os.path.join(td, os.path.basename(project_wheel)))
 
         # Without a cache, each resolve should be isolated, but otherwise identical.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,7 +7,7 @@ from hashlib import sha1
 from textwrap import dedent
 
 from pex.common import safe_mkdir, safe_open, temporary_dir, touch
-from pex.compatibility import nested, to_bytes
+from pex.compatibility import to_bytes
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.typing import TYPE_CHECKING, cast
@@ -128,7 +128,7 @@ def assert_access_zipped_assets(distribution_helper_import):
             distribution_helper_import=distribution_helper_import
         )
     )
-    with nested(temporary_dir(), temporary_dir()) as (td1, td2):
+    with temporary_dir() as td1, temporary_dir() as td2:
         pb = PEXBuilder(path=td1)
         with open(os.path.join(td1, "exe.py"), "w") as fp:
             fp.write(test_executable)


### PR DESCRIPTION
Save for two tests that exercise pex_warnings and Python 2.7 EOL
warnings.