### PR TITLE
Fix PyPy3 `--venv` mode.

### DIFF
--- a/pex/tools/commands/virtualenv.py
+++ b/pex/tools/commands/virtualenv.py
@@ -87,7 +87,8 @@ class Virtualenv(object):
             )
             interpreter = base_interpreter
 
-        if interpreter.version[0] >= 3:
+        if interpreter.version[0] >= 3 and not interpreter.identity.interpreter == "PyPy":
+            # N.B.: PyPy3 comes equipped with a venv module but it does not seem to work.
             interpreter.execute(args=["-m", "venv", "--without-pip", venv_dir])
         else:
             virtualenv_py = resource_string(__name__, "virtualenv_16.7.10_py")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2654,7 +2654,6 @@ def isort_pex_args(tmpdir):
     return pex_file, requirements + ["-c", "isort", "-o", pex_file]
 
 
-@pytest.mark.xfail(IS_PYPY3, reason="https://github.com/pantsbuild/pex/issues/1210")
 def test_venv_mode(
     tmpdir,  # type: Any
     isort_pex_args,  # type: Tuple[str, List[str]]
@@ -2697,7 +2696,6 @@ def test_venv_mode(
     assert isort_pex_interpreter2 == run_isort_pex(PEX_PYTHON=other_interpreter)
 
 
-@pytest.mark.xfail(IS_PYPY3, reason="https://github.com/pantsbuild/pex/issues/1210")
 def test_venv_mode_issues_1218(tmpdir):
     # type: (Any) -> None
 
@@ -2763,9 +2761,6 @@ def test_seed(
     mode_args,  # type: List[str]
 ):
     # type: (...) -> None
-    if mode_args == ["--venv"] and IS_PYPY3:
-        pytest.xfail(reason="https://github.com/pantsbuild/pex/issues/1210")
-
     pex_file, args = isort_pex_args
     results = run_pex_command(args=args + mode_args + ["--seed"], quiet=True)
     results.assert_success()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -41,7 +41,6 @@ from pex.pip import get_pip
 from pex.requirements import LogicalLine, PyPIRequirement, URLFetcher, parse_requirement_file
 from pex.testing import (
     IS_PYPY,
-    IS_PYPY3,
     NOT_CPYTHON27,
     NOT_CPYTHON27_OR_OSX,
     NOT_CPYTHON36_OR_LINUX,
@@ -232,7 +231,6 @@ def test_pex_repl_built():
         assert b">>>" in stdout
 
 
-@pytest.mark.xfail(IS_PYPY3, reason="https://github.com/pantsbuild/pex/issues/1210")
 @pytest.mark.skipif(WINDOWS, reason="No symlinks on windows")
 def test_pex_python_symlink():
     # type: () -> None

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -93,11 +93,13 @@ class TestPythonInterpreter(object):
     def test_binary_name_matching(self):
         # type: () -> None
         valid_binary_names = (
-            "jython",
-            "pypy",
-            "pypy-1.1",
-            "python",
             "Python",
+            "pypy",
+            "pypy2",
+            "pypy3",
+            "pypy3.6",
+            "pypy3.6m",
+            "python",
             "python2",
             "python2.7",
             "python2.7m",


### PR DESCRIPTION
The PyPy3 `venv` module doesn't work for Pex `--venv` mode so we use
virtualenv instead.

Addresses most of #1210.