### PR TITLE
Fix --venv mode to respect PEX_PATH.

### DIFF
--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -86,7 +86,9 @@ def __maybe_run_venv__(pex):
   from pex.tracer import TRACER
   from pex.variables import venv_dir
 
-  venv_home = venv_dir({pex_root!r}, {pex_hash!r}, {interpreter_constraints!r})
+  venv_home = venv_dir(
+    {pex_root!r}, {pex_hash!r}, {interpreter_constraints!r}, pex_path={pex_path!r}
+  )
   venv_pex = os.path.join(venv_home, 'pex')
   if not is_exe(venv_pex):
     # Code in bootstrap_pex will (re)create the venv after selecting the correct interpreter. 
@@ -512,6 +514,7 @@ class PEXBuilder(object):
             pex_root=self._pex_info.raw_pex_root,
             pex_hash=self._pex_info.pex_hash,
             interpreter_constraints=self._pex_info.interpreter_constraints,
+            pex_path=self._pex_info.pex_path,
             is_unzip=self._pex_info.unzip,
             is_venv=self._pex_info.venv,
         )

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -257,7 +257,9 @@ class PexInfo(object):
             return None
         if self.pex_hash is None:
             raise ValueError("The venv_dir was requested but no pex_hash was set.")
-        return variables.venv_dir(self.pex_root, self.pex_hash, self.interpreter_constraints)
+        return variables.venv_dir(
+            self.pex_root, self.pex_hash, self.interpreter_constraints, pex_path=self.pex_path
+        )
 
     @property
     def strip_pex_env(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2746,6 +2746,80 @@ def test_venv_mode_issues_1218(tmpdir):
     assert invoke_pex_info.pex_hash != fabric_pex_info.pex_hash
 
 
+def test_venv_mode_pex_path_issues_1225(tmpdir):
+    # type: (Any) -> None
+
+    test_file = os.path.join(str(tmpdir), "test.py")
+    with open(test_file, "w") as fp:
+        fp.write(
+            dedent(
+                """
+                import sys
+
+                try:
+                    __import__(sys.argv[1])
+                except ImportError:
+                    sys.exit(int(sys.argv[2]))
+                """
+            )
+        )
+
+    empty_pex = os.path.join(str(tmpdir), "empty.pex")
+    results = run_pex_command(args=["--venv", "-o", empty_pex])
+    results.assert_success()
+
+    output, returncode = run_simple_pex(empty_pex, args=[test_file, "colors", "37"])
+    assert 37 == returncode, output.decode("utf-8")
+
+    colors_pex = os.path.join(str(tmpdir), "colors.pex")
+    results = run_pex_command(args=["ansicolors==1.1.8", "-o", colors_pex])
+    results.assert_success()
+
+    # Exporting PEX_PATH should re-create the venv.
+    output, returncode = run_simple_pex(
+        empty_pex, args=[test_file, "colors", "37"], env=make_env(PEX_PATH=colors_pex)
+    )
+    assert 0 == returncode, output.decode("utf-8")
+
+    results = run_pex_command(args=["--pex-path", colors_pex, "--venv", "-o", empty_pex])
+    results.assert_success()
+
+    output, returncode = run_simple_pex(empty_pex, args=[test_file, "colors", "37"])
+    assert 0 == returncode
+
+    # Exporting PEX_PATH should re-create the venv, adding to --pex-path.
+    pkginfo_pex = os.path.join(str(tmpdir), "pkginfo.pex")
+    results = run_pex_command(args=["pkginfo==1.7.0", "-o", pkginfo_pex])
+    results.assert_success()
+
+    pex_path_env = make_env(PEX_PATH=pkginfo_pex)
+    output, returncode = run_simple_pex(
+        empty_pex, args=[test_file, "colors", "37"], env=pex_path_env
+    )
+    assert 0 == returncode
+    output, returncode = run_simple_pex(
+        empty_pex, args=[test_file, "pkginfo", "42"], env=pex_path_env
+    )
+    assert 0 == returncode
+
+    # Exporting PEX_PATH should re-create the venv since the adjoined pex file's distribution
+    # contents have changed.
+    results = run_pex_command(args=["ascii-ruler==0.0.4", "-o", pkginfo_pex])
+    results.assert_success()
+    output, returncode = run_simple_pex(
+        empty_pex, args=[test_file, "colors", "37"], env=pex_path_env
+    )
+    assert 0 == returncode
+    output, returncode = run_simple_pex(
+        empty_pex, args=[test_file, "ascii_ruler", "19"], env=pex_path_env
+    )
+    assert 0 == returncode
+    output, returncode = run_simple_pex(
+        empty_pex, args=[test_file, "pkginfo", "42"], env=pex_path_env
+    )
+    assert 42 == returncode
+
+
 @pytest.mark.parametrize(
     "mode_args",
     [


### PR DESCRIPTION
Virtual environments are now rebuilt when PEX_PATH is mutated.

Fixes #1225