### PR TITLE
Upgrade MyPy to 0.800.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,4 @@
 [mypy]
-# This is the default. We also run with Python 2.7 in `tox.ini`.
-python_version: 3.5
-
 # TODO: turn on.
 check_untyped_defs = False
 
@@ -23,9 +20,6 @@ show_error_context = True
 show_column_numbers = True
 show_error_codes = True
 pretty = True
-
-[mypy-pex.vendor._vendored.*]
-ignore_errors = True
 
 [mypy-pex.third_party.*]
 ignore_missing_imports = True

--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -100,7 +100,7 @@ else:
 
 
 if PY3:
-    import urllib.parse as urlparse
+    from urllib import parse as urlparse
 
     from urllib.error import HTTPError as HTTPError
     from urllib.request import build_opener as build_opener

--- a/pex/orderedset.py
+++ b/pex/orderedset.py
@@ -73,7 +73,9 @@ class OrderedSet(MutableSet, Generic["_I"]):
         return "{}({!r})".format(self.__class__.__name__, list(self))
 
     def __eq__(self, other):
-        # type: (Any) -> Union[bool, NotImplemented]
+        # type: (Any) -> bool
         if type(other) != type(self):
             return NotImplemented
-        return self._data == other._data
+        # TODO(John Sirois): Type __eq__ as returning Union[bool, NotImplemented] when MyPy fixes:
+        #  https://github.com/python/mypy/issues/4791
+        return self._data == other._data  # type: ignore[no-any-return]

--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -261,7 +261,7 @@ class URLRequirement(namedtuple("URLRequirement", ["line", "url", "requirement",
     def create(
         cls,
         line,  # type: LogicalLine
-        url,  # type: str
+        url,  # type: Text
         requirement,  # type: Requirement
         editable=False,  # type: bool
     ):
@@ -411,7 +411,7 @@ class ProjectNameExtrasAndMarker(
     @classmethod
     def create(
         cls,
-        project_name,  # type: str
+        project_name,  # type: Text
         extras=None,  # type: Optional[Iterable[str]]
         marker=None,  # type: Optional[Marker]
     ):
@@ -464,7 +464,7 @@ def _try_parse_project_name_and_specifier_from_path(path):
 
 
 def _try_parse_pip_local_formats(
-    path,  # type: str
+    path,  # type: Text
     basepath=None,  # type: Optional[str]
 ):
     # type: (...) -> Optional[ProjectNameExtrasAndMarker]

--- a/scripts/typecheck.sh
+++ b/scripts/typecheck.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+FILES_TO_CHECK=(
+  $(
+    find pex/ tests/ -path pex/vendor/_vendored -prune -o -name "*.py" | \
+    grep -E ".py$" | \
+    sort -u
+  )
+)
+
+echo "Typechecking using $(python --version) against Python 3.5 ..."
+mypy --python-version 3.5 "${FILES_TO_CHECK[@]}"
+
+echo "Typechecking using $(python --version) against Python 2.7 ..."
+mypy --python-version 2.7 "${FILES_TO_CHECK[@]}"

--- a/tox.ini
+++ b/tox.ini
@@ -62,10 +62,9 @@ commands =
 
 [testenv:typecheck]
 deps =
-    mypy==0.782
+    mypy==0.800
 commands =
-    mypy pex/ tests/
-    mypy --py2 pex/ tests/
+    bash scripts/typecheck.sh
 
 [testenv:vendor]
 # The vendored dist may contain references to the python version it was built on


### PR DESCRIPTION
This upgrades MyPy to latest and fixes types. It also switches to
passing MyPy a complete list of files to check to avoid syntax errors
encountered parsing (forthcoming) vendored code which happen earlier
than our previous MyPy config could handle:
```ini
[mypy-pex.vendor._vendored.*]
ignore_errors = True
```