### PR TITLE
The `pex` venv script handles entrypoints like PEX.

### DIFF
--- a/docs/buildingpex.rst
+++ b/docs/buildingpex.rst
@@ -186,17 +186,18 @@ get pydoc help on the ``flask.app`` package in Flask:
 
 and so forth.
 
-Entry points can also take the form ``package:target``, such as ``sphinx:main`` or ``fabric.main:main`` for Sphinx
-and Fabric respectively.  This is roughly equivalent to running a script that does ``from package import target; target()``.
+Entry points can also take the form ``package:target``, such as ``sphinx:main`` or
+``fabric.main:main`` for Sphinx and Fabric respectively.  This is roughly equivalent to running a
+script that does ``import sys, from package import target; sys.exit(target())``.
 
 This can be a powerful way to invoke Python applications without ever having to ``pip install``
 anything, for example a one-off invocation of Sphinx with the readthedocs theme available:
 
 .. code-block:: console
 
-    $ pex sphinx sphinx_rtd_theme -e sphinx:main -- --help
+    $ pex sphinx==1.2.2 sphinx_rtd_theme -e sphinx:main -- --help
     Sphinx v1.2.2
-    Usage: /var/folders/4d/9tz0cd5n2n7947xs21gspsxc0000gp/T/tmpLr8ibZ [options] sourcedir outdir [filenames...]
+    Usage: /tmp/tmpydcp6kox [options] sourcedir outdir [filenames...]
 
     General options
     ^^^^^^^^^^^^^^^
@@ -205,12 +206,19 @@ anything, for example a one-off invocation of Sphinx with the readthedocs theme 
     -E            don't use a saved environment, always read all files
     ...
 
+Although sys.exit is applied blindly to the return value of the target function, this probably does
+what you want due to very flexible ``sys.exit`` semantics. Consult your target function and
+`sys.exit <https://docs.python.org/library/sys.html#sys.exit>`_ documentation to be sure.
+
+Almost certainly better and more stable, you can alternatively specify a console script exported by
+the app as explained below.
+
 pex -c
 ~~~~~~
 
-If you don't know the ``package:target`` for the console scripts of
-your favorite python packages, pex allows you to use ``-c`` to specify a console script as defined
-by the distribution.  For example, Fabric provides the ``fab`` tool when pip installed:
+If you don't know the ``package:target`` for the console scripts of your favorite python packages,
+pex allows you to use ``-c`` to specify a console script as defined by the distribution. For
+example, Fabric provides the ``fab`` tool when pip installed:
 
 .. code-block:: console
 
@@ -230,13 +238,13 @@ Even scripts defined by the "scripts" section of a distribution can be used, e.g
                  {bal,hit,hits,new,extend,expire,rm,as,approve,reject,unreject,bonus,notify,give-qual,revoke-qual}
                  ...
     mturk: error: too few arguments
-    
-Note: If you run ``pex -c`` and come across an error similar to 
-``pex.pex_builder.InvalidExecutableSpecification: Could not find script 'mainscript.py' in any distribution within PEX!``, 
-double-check your setup.py and ensure that ``mainscript.py`` is included 
+
+Note: If you run ``pex -c`` and come across an error similar to
+``pex.pex_builder.InvalidExecutableSpecification: Could not find script 'mainscript.py' in any distribution within PEX!``,
+double-check your setup.py and ensure that ``mainscript.py`` is included
 in your setup's ``scripts`` array. If you are using ``console_scripts`` and
 run into this error, double check your ``console_scripts`` syntax - further
-information for both ``scripts`` and ``console_scripts`` can be found in the 
+information for both ``scripts`` and ``console_scripts`` can be found in the
 `Python packaging documentation <https://python-packaging.readthedocs.io/en/latest/command-line-scripts.html>`_.
 
 

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -592,7 +592,8 @@ def configure_clp_pex_entry_points(parser):
         default=None,
         help="Set the entry point to module or module:symbol.  If just specifying module, pex "
         "behaves like python -m, e.g. python -m SimpleHTTPServer.  If specifying "
-        "module:symbol, pex imports that symbol and invokes it as if it were main.",
+        "module:symbol, pex assume symbol is a n0-arg callable and imports that symbol and invokes "
+        "it as if via `sys.exit(symbol())`.",
     )
 
     group.add_argument(

--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -95,7 +95,11 @@ if PY3:
 
 
 else:
-    # This will result in `exec_function` being defined at runtime.
+
+    def exec_function(ast, globals_map):
+        raise AssertionError("Expected this function to be re-defined at runtime.")
+
+    # This will result in `exec_function` being re-defined at runtime.
     eval(compile(_PY3_EXEC_FUNCTION, "<exec_function>", "exec"))
 
 

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -245,7 +245,7 @@ def populate_venv_with_pex(
                 namespace, func = module, None
                 for attr in function.split("."):
                     func = namespace = getattr(namespace, attr)
-                func()
+                sys.exit(func())
         """.format(
             venv_python=venv_python,
             venv_bin_dir=venv_bin_dir,


### PR DESCRIPTION
Previously behavior diverged for entrypoint functions returning a value.
Now both PEXes and the `pex` venv script behave the same and the
behavior is documented and tested.

Fixes #1241