### PR TITLE
Move the pyenv interpreter test cache.

### DIFF
--- a/.github/actions/run-tox/action.yml
+++ b/.github/actions/run-tox/action.yml
@@ -32,5 +32,6 @@ runs:
           #   https://github.com/python-pillow/Pillow/issues/3438#issuecomment-543812237
           export CPATH="$(xcrun --show-sdk-path)/usr/include"
         fi
+        echo "Running tox with PEX_TEST_PYENV_ROOT=${PEX_TEST_PYENV_ROOT}"
         tox --skip-missing-interpreters=false -v -e ${{ inputs.tox-env }}
       shell: bash

--- a/.github/actions/run-tox/action.yml
+++ b/.github/actions/run-tox/action.yml
@@ -32,6 +32,5 @@ runs:
           #   https://github.com/python-pillow/Pillow/issues/3438#issuecomment-543812237
           export CPATH="$(xcrun --show-sdk-path)/usr/include"
         fi
-        echo "Running tox with PEX_TEST_PYENV_ROOT=${PEX_TEST_PYENV_ROOT}"
         tox --skip-missing-interpreters=false -v -e ${{ inputs.tox-env }}
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 on: [push, pull_request]
+env:
+  PEX_TEST_PYENV_ROOT: .pyenv_test
 jobs:
   checks:
     name:  TOXENV=${{ matrix.tox-env }}
@@ -53,8 +55,8 @@ jobs:
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v2
         with:
-          path: .pyenv_test
-          key: ${{ runner.os }}-pyenv-test
+          path: ${{ env.PEX_TEST_PYENV_ROOT }}
+          key: ${{ runner.os }}-pyenv-root
       - name: Run Unit Tests
         uses: ./.github/actions/run-tox
         with:
@@ -75,8 +77,8 @@ jobs:
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v2
         with:
-          path: .pyenv_test
-          key: ${{ runner.os }}-pyenv-test
+          path: ${{ env.PEX_TEST_PYENV_ROOT }}
+          key: ${{ runner.os }}-pyenv-root
       - name: Run Unit Tests
         uses: ./.github/actions/run-tox
         with:
@@ -98,8 +100,8 @@ jobs:
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v2
         with:
-          path: .pyenv_test
-          key: ${{ runner.os }}-pyenv-test
+          path: ${{ env.PEX_TEST_PYENV_ROOT }}
+          key: ${{ runner.os }}-pyenv-root
       - name: Run Integration Tests
         uses: ./.github/actions/run-tox
         with:
@@ -124,8 +126,8 @@ jobs:
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v2
         with:
-          path: .pyenv_test
-          key: ${{ runner.os }}-pyenv-test
+          path: ${{ env.PEX_TEST_PYENV_ROOT }}
+          key: ${{ runner.os }}-pyenv-root
       - name: Run Integration Tests
         uses: ./.github/actions/run-tox
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on: [push, pull_request]
 env:
-  PEX_TEST_PYENV_ROOT: .pyenv_test
+  _PEX_TEST_PYENV_ROOT: .pyenv_test
 jobs:
   checks:
     name:  TOXENV=${{ matrix.tox-env }}
@@ -55,7 +55,7 @@ jobs:
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v2
         with:
-          path: ${{ env.PEX_TEST_PYENV_ROOT }}
+          path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root
       - name: Run Unit Tests
         uses: ./.github/actions/run-tox
@@ -77,7 +77,7 @@ jobs:
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v2
         with:
-          path: ${{ env.PEX_TEST_PYENV_ROOT }}
+          path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root
       - name: Run Unit Tests
         uses: ./.github/actions/run-tox
@@ -100,7 +100,7 @@ jobs:
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v2
         with:
-          path: ${{ env.PEX_TEST_PYENV_ROOT }}
+          path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root
       - name: Run Integration Tests
         uses: ./.github/actions/run-tox
@@ -126,7 +126,7 @@ jobs:
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v2
         with:
-          path: ${{ env.PEX_TEST_PYENV_ROOT }}
+          path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root
       - name: Run Integration Tests
         uses: ./.github/actions/run-tox

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -10,18 +10,9 @@ import random
 import subprocess
 import sys
 from contextlib import contextmanager
-from subprocess import CalledProcessError
 from textwrap import dedent
 
-from pex.common import (
-    atomic_directory,
-    open_zip,
-    safe_mkdir,
-    safe_mkdtemp,
-    safe_rmtree,
-    temporary_dir,
-    touch,
-)
+from pex.common import atomic_directory, open_zip, safe_mkdir, safe_mkdtemp, temporary_dir
 from pex.compatibility import to_unicode
 from pex.distribution_target import DistributionTarget
 from pex.executor import Executor
@@ -433,47 +424,17 @@ PY36 = "3.6.6"
 _ALL_PY_VERSIONS = (PY27, PY35, PY36)
 _ALL_PY3_VERSIONS = (PY35, PY36)
 
-_ROOT_DIR = None  # type: Optional[str]
-
-
-def _calculate_root_dir():
-    # type: () -> str
-    return str(
-        os.path.realpath(
-            subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode("utf-8").strip()
-        )
-    )
-
-
-def root_dir():
-    # type: () -> str
-    global _ROOT_DIR
-    if _ROOT_DIR is None:
-        cwd = os.getcwd()
-        try:
-            _ROOT_DIR = _calculate_root_dir()
-        except CalledProcessError as e:
-            print(
-                "WARNING: Searching for root dir from {}; "
-                "failed to determine root dir from {}: {}".format(__file__, cwd, e),
-                file=sys.stderr,
-            )
-            os.chdir(os.path.dirname(__file__))
-            try:
-                _ROOT_DIR = _calculate_root_dir()
-            finally:
-                os.chdir(cwd)
-    return _ROOT_DIR
-
 
 def ensure_python_distribution(version):
     # type: (str) -> Tuple[str, str, Callable[[Iterable[str]], Text]]
     if version not in _ALL_PY_VERSIONS:
         raise ValueError("Please constrain version to one of {}".format(_ALL_PY_VERSIONS))
 
-    pyenv_root = os.path.join(
-        os.environ.get("_PEX_TEST_PYENV_ROOT", "{}_dev".format(ENV.PEX_ROOT)),
-        "pyenv",
+    pyenv_root = os.path.abspath(
+        os.path.join(
+            os.environ.get("_PEX_TEST_PYENV_ROOT", "{}_dev".format(ENV.PEX_ROOT)),
+            "pyenv",
+        )
     )
     interpreter_location = os.path.join(pyenv_root, "versions", version)
 

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -472,7 +472,7 @@ def ensure_python_distribution(version):
         raise ValueError("Please constrain version to one of {}".format(_ALL_PY_VERSIONS))
 
     pyenv_root = os.path.join(
-        os.environ.get("PEX_TEST_PYENV_ROOT", "{}_dev".format(ENV.PEX_ROOT)),
+        os.environ.get("_PEX_TEST_PYENV_ROOT", "{}_dev".format(ENV.PEX_ROOT)),
         "pyenv",
     )
     interpreter_location = os.path.join(pyenv_root, "versions", version)

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,8 @@ deps =
     py{27,py,py2}: mock==3.0.5
     subprocess: subprocess32
 passenv =
+    # This allows re-locating the pyenv interpreter test cache for CI.
+    PEX_TEST_PYENV_ROOT
     # These are to support directing test environments to the correct headers on OSX.
     CPATH
     CPPFLAGS

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     subprocess: subprocess32
 passenv =
     # This allows re-locating the pyenv interpreter test cache for CI.
-    PEX_TEST_PYENV_ROOT
+    _PEX_TEST_PYENV_ROOT
     # These are to support directing test environments to the correct headers on OSX.
     CPATH
     CPPFLAGS


### PR DESCRIPTION
Previously these lived in the root of each pantsbuild/pex clone. Beyond
being inefficient, this caused problems with pip wheel when building
Pex via `tox -epackage`. Introduce a new `~/.pex_dev` cache as the
default but allow this to be controlled with `_PEX_TEST_PYENV_ROOT`.
Setup CI to configure `_PEX_TEST_PYENV_ROOT` and have it point to the
prior standard of `.pyenv_test` which works well for CI caching needs.