### PR TITLE
Support venvs that can outlive their base python.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -372,6 +372,17 @@ def configure_clp_pex_options(parser):
         "multiple times under a stable runtime PEX_ROOT, the venv creation will only be done once "
         "and subsequent runs will enjoy lower startup latency.",
     )
+    group.add_argument(
+        "--venv-copies",
+        "--no-venv-copies",
+        dest="venv_copies",
+        default=False,
+        action=HandleBoolAction,
+        help=(
+            "If --venv is specified, create the venv using copies of base interpreter files "
+            "instead of symlinks."
+        ),
+    )
 
     group.add_argument(
         "--always-write-cache",
@@ -894,6 +905,7 @@ def build_pex(reqs, options, cache=None):
     pex_info.unzip = options.unzip
     pex_info.venv = bool(options.venv)
     pex_info.venv_bin_path = options.venv
+    pex_info.venv_copies = options.venv_copies
     pex_info.pex_path = options.pex_path
     pex_info.always_write_cache = options.always_write_cache
     pex_info.ignore_errors = options.ignore_errors

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -372,7 +372,11 @@ def ensure_venv(pex):
             from .tools.commands.venv import populate_venv_with_pex
             from .tools.commands.virtualenv import Virtualenv
 
-            virtualenv = Virtualenv.create(venv_dir=venv, interpreter=pex.interpreter)
+            virtualenv = Virtualenv.create(
+                venv_dir=venv,
+                interpreter=pex.interpreter,
+                copies=pex_info.venv_copies,
+            )
             populate_venv_with_pex(
                 virtualenv,
                 pex,

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -251,6 +251,16 @@ class PexInfo(object):
         self._pex_info["venv_bin_path"] = str(value)
 
     @property
+    def venv_copies(self):
+        # type: () -> bool
+        return self._pex_info.get("venv_copies", False)
+
+    @venv_copies.setter
+    def venv_copies(self, value):
+        # type: (bool) -> None
+        self._pex_info["venv_copies"] = value
+
+    @property
     def venv_dir(self):
         # type: () -> Optional[str]
         if not self.venv:

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -310,6 +310,12 @@ class Venv(Command):
             default=False,
             help="Add pip to the venv.",
         )
+        parser.add_argument(
+            "--copies",
+            action="store_true",
+            default=False,
+            help="Create the venv using copies of system files instead of symlinks",
+        )
 
     def run(
         self,
@@ -318,7 +324,10 @@ class Venv(Command):
     ):
         # type: (...) -> Result
 
-        venv = Virtualenv.create(options.venv[0], interpreter=pex.interpreter, force=options.force)
+        venv_dir = options.venv[0]
+        venv = Virtualenv.create(
+            venv_dir, interpreter=pex.interpreter, force=options.force, copies=options.copies
+        )
         populate_venv_with_pex(
             venv,
             pex,

--- a/pex/tools/commands/virtualenv.py
+++ b/pex/tools/commands/virtualenv.py
@@ -72,6 +72,7 @@ class Virtualenv(object):
         venv_dir,  # type: str
         interpreter=None,  # type: Optional[PythonInterpreter]
         force=False,  # type: bool
+        copies=False,  # type: bool
     ):
         # type: (...) -> Virtualenv
         venv_dir = os.path.abspath(venv_dir)
@@ -89,15 +90,19 @@ class Virtualenv(object):
 
         if interpreter.version[0] >= 3 and not interpreter.identity.interpreter == "PyPy":
             # N.B.: PyPy3 comes equipped with a venv module but it does not seem to work.
-            interpreter.execute(args=["-m", "venv", "--without-pip", venv_dir])
+            args = ["-m", "venv", "--without-pip", venv_dir]
+            if copies:
+                args.append("--copies")
+            interpreter.execute(args=args)
         else:
             virtualenv_py = resource_string(__name__, "virtualenv_16.7.10_py")
             with named_temporary_file(mode="wb") as fp:
                 fp.write(virtualenv_py)
                 fp.close()
-                interpreter.execute(
-                    args=[fp.name, "--no-pip", "--no-setuptools", "--no-wheel", venv_dir],
-                )
+                args = [fp.name, "--no-pip", "--no-setuptools", "--no-wheel", venv_dir]
+                if copies:
+                    args.append("--always-copy")
+                interpreter.execute(args=args)
         return cls(venv_dir)
 
     def __init__(


### PR DESCRIPTION
Add support for creating venvs using copies instead of symlinks.

Fixes #1230