### PR TITLE
Harden Pex interpreter identification.

### DIFF
--- a/pex/testing.py
+++ b/pex/testing.py
@@ -528,3 +528,14 @@ def environment_as(**kwargs):
         yield
     finally:
         adjust_environment(existing)
+
+
+@contextmanager
+def pushd(directory):
+    # type: (str) -> Iterator[None]
+    cwd = os.getcwd()
+    try:
+        os.chdir(directory)
+        yield
+    finally:
+        os.chdir(cwd)


### PR DESCRIPTION
Previously, running Pex in a directory with a different version of Pex
installed could lead to interpreter identification failures. Plug this
isolation leak by adding a failing test and fixing it.

Fixes #1231