### PR TITLE
Guard against too long `--venv` mode shebangs.

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2690,17 +2690,25 @@ def test_venv_mode(
         pex_root = str(tmpdir)
         stdout, returncode = run_simple_pex(
             pex_file,
-            args=["-c", "import sys; print(sys.executable)"],
+            args=["-c", "import sys; print(sys.executable); print(sys.prefix)"],
             env=make_env(PEX_ROOT=pex_root, PEX_INTERPRETER=1, **env),
         )
         assert returncode == 0, stdout
-        pex_interpreter = cast(str, stdout.decode("utf-8").strip())
+        pex_interpreter, venv_home = cast(
+            "Tuple[str, str]", stdout.decode("utf-8").strip().splitlines()
+        )
+        actual_venv_home = os.path.realpath(venv_home)
+        assert venv_home != actual_venv_home, "Expected the venv home to be a symlink"
+        assert len(venv_home) < len(
+            actual_venv_home
+        ), "Expected the venv home symlink path length to be shorter than the actual path length"
+
         with ENV.patch(**env):
             pex_info = PexInfo.from_pex(pex_file)
             pex_hash = pex_info.pex_hash
             assert pex_hash is not None
             expected_venv_home = venv_dir(pex_root, pex_hash, interpreter_constraints=[])
-        assert expected_venv_home == os.path.commonprefix([pex_interpreter, expected_venv_home])
+        assert expected_venv_home == os.path.commonprefix([actual_venv_home, expected_venv_home])
         return pex_interpreter
 
     isort_pex_interpreter1 = run_isort_pex()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2688,12 +2688,10 @@ def test_venv_mode(
     def run_isort_pex(**env):
         # type: (**Any) -> str
         pex_root = str(tmpdir)
-        stdout, returncode = run_simple_pex(
-            pex_file,
-            args=["-c", "import sys; print(sys.executable); print(sys.prefix)"],
+        stdout = subprocess.check_output(
+            args=[pex_file, "-c", "import sys; print(sys.executable); print(sys.prefix)"],
             env=make_env(PEX_ROOT=pex_root, PEX_INTERPRETER=1, **env),
         )
-        assert returncode == 0, stdout
         pex_interpreter, venv_home = cast(
             "Tuple[str, str]", stdout.decode("utf-8").strip().splitlines()
         )


### PR DESCRIPTION
The default path length to a `--venv` mode PEX python used in shebangs
for the venv `pex` script and venv console scripts is 102 characters
starting from the PEX_ROOT. Add to that 2 characters for '#!' and 4 for
the trailing ' -sE' we add and that leaves just 20 characters for the
path to the PEX_ROOT (e.g.: /home/jane/.pex) before these scripts start
failing on machines where the shebang length limit is 128 bytes, which
is not uncommon amongst Linux distributions.

Fix this for forseeable cases by keeping the existing cache structure,
which has a primary key path component of the pex hash which is cheap to
compute (pre-computed), convenient for debugging and ~guaranteed unique,
and introducing a "jump table" of venv dir symlinks in
PEX_ROOT/venvs/short. This jump table is computed once at venv
materialization time with a much shorter hash that is checked for
collisions and expanded as needed.

Fixes #1252