### PR TITLE
Fix PEX file reproducibility.

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -687,7 +687,7 @@ class Chroot(object):
                         yield full_path, path
                         continue
                     for root, _, files in os.walk(full_path):
-                        for f in files:
+                        for f in sorted(files):
                             abs_path = os.path.join(root, f)
                             rel_path = os.path.join(path, os.path.relpath(abs_path, full_path))
                             yield abs_path, rel_path

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,6 +7,7 @@ import errno
 import filecmp
 import functools
 import glob
+import itertools
 import json
 import multiprocessing
 import os
@@ -1763,37 +1764,54 @@ def test_issues_539_abi3_resolution():
 def assert_reproducible_build(args):
     # type: (List[str]) -> None
     with temporary_dir() as td:
-        pex1 = os.path.join(td, "1.pex")
-        pex2 = os.path.join(td, "2.pex")
-
         # Note that we change the `PYTHONHASHSEED` to ensure that there are no issues resulting
         # from the random seed, such as data structures, as Tox sets this value by default. See
         # https://tox.readthedocs.io/en/latest/example/basic.html#special-handling-of-pythonhashseed.
         def create_pex(path, seed):
-            result = run_pex_command(args + ["-o", path], env=make_env(PYTHONHASHSEED=seed))
+            result = run_pex_command(
+                args + ["-o", path, "--disable-cache"], env=make_env(PYTHONHASHSEED=seed)
+            )
             result.assert_success()
 
-        create_pex(pex1, seed=111)
-        # We sleep to ensure that there is no non-reproducibility from timestamps or
-        # anything that may depend on the system time. Note that we must sleep for at least
-        # 2 seconds, because the zip format uses 2 second precision per section 4.4.6 of
-        # https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT.
-        safe_sleep(2)
-        create_pex(pex2, seed=22222)
-        # First explode the PEXes to compare file-by-file for easier debugging.
-        with ZipFile(pex1) as zf1, ZipFile(pex2) as zf2:
-            unzipped1 = os.path.join(td, "pex1")
-            unzipped2 = os.path.join(td, "pex2")
-            zf1.extractall(path=unzipped1)
-            zf2.extractall(path=unzipped2)
-            for member1, member2 in zip(sorted(zf1.namelist()), sorted(zf2.namelist())):
-                member1_path = os.path.join(unzipped1, member1)
-                if os.path.isdir(member1_path):
+        def create_multiple_pexes():
+            paths = []
+            for index in range(3):
+                path = os.path.join(td, "{}.pex".format(index))
+                paths.append(path)
+                # We sleep to ensure that there is no non-reproducibility from timestamps or
+                # anything that may depend on the system time. Note that we must sleep for at least
+                # 2 seconds, because the zip format uses 2 second precision per section 4.4.6 of
+                # https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT.
+                if index > 0:
+                    safe_sleep(2)
+                create_pex(path, seed=(index * 497) + 4)
+            return paths
+
+        def explode_pex(path):
+            with ZipFile(path) as zf:
+                pex_name, _ = os.path.splitext(path)
+                destination_dir = os.path.join(td, "pex{}".format(pex_name))
+                zf.extractall(path=destination_dir)
+                return [os.path.join(destination_dir, member) for member in sorted(zf.namelist())]
+
+        pexes = create_multiple_pexes()
+        pex_members = {pex: explode_pex(path=pex) for pex in pexes}
+
+        for pex1, pex2 in itertools.combinations(pexes, r=2):
+            # First compare file-by-file for easier debugging.
+            for member1, member2 in zip(pex_members[pex1], pex_members[pex2]):
+                assert not os.path.isdir(member1) ^ os.path.isdir(member2)
+                if os.path.isdir(member1):
                     continue
-                member2_path = os.path.join(unzipped2, member2)
-                assert filecmp.cmp(member1_path, member2_path, shallow=False)
-        # Then compare the original .pex files. This is the assertion we truly care about.
-        assert filecmp.cmp(pex1, pex2, shallow=False)
+                # Check that each file has the same content.
+                with open(member1, "rb") as f1, open(member2, "rb") as f2:
+                    assert list(f1.readlines()) == list(
+                        f2.readlines()
+                    ), "{} and {} have different content.".format(member1, member2)
+                # Check that the entire file is equal, including metadata.
+                assert filecmp.cmp(member1, member2, shallow=False)
+            # Finally, check that the .pex files are byte-for-byte identical.
+            assert filecmp.cmp(pex1, pex2, shallow=False)
 
 
 def test_reproducible_build_no_args():
@@ -1809,7 +1827,7 @@ def test_reproducible_build_bdist_requirements():
 
 def test_reproducible_build_sdist_requirements():
     # type: () -> None
-    assert_reproducible_build(["pycparser==2.19", "--no-wheel"])
+    assert_reproducible_build(["python-crontab==2.3.6"])
 
 
 def test_reproducible_build_m_flag():


### PR DESCRIPTION
Two sources of non-reproducibility remained:
1. When zipping a PEX file, symlinked directory walks were not sorted.
2. When installing wheels in chroots, Pip direct_url.json retained a
   system-specific path that varied as PEX_ROOT varied.

The first is fixed with an explicit sort and the second is fixed by
simply deleting problematic direct_url.json files post-install.

Concludes the #1249 audit for PEX files.