### PR TITLE
Support console scripts found in the PEX_PATH.

### DIFF
--- a/pex/environment.py
+++ b/pex/environment.py
@@ -11,7 +11,7 @@ import sys
 import zipfile
 from collections import OrderedDict, defaultdict
 
-from pex import dist_metadata, pex_builder, pex_warnings
+from pex import dist_metadata, pex_warnings
 from pex.bootstrap import Bootstrap
 from pex.common import atomic_directory, open_zip
 from pex.distribution_target import DistributionTarget
@@ -198,7 +198,7 @@ class PEXEnvironment(object):
                 pex_files = (
                     name
                     for name in pex_zip.namelist()
-                    if not name.startswith(pex_builder.BOOTSTRAP_DIR)
+                    if not name.startswith(self._pex_info.bootstrap)
                     and not name.startswith(self._pex_info.internal_cache)
                     and name not in exclude
                 )

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -434,6 +434,10 @@ class PexInfo(object):
             self._pex_info["pex_root"] = value
 
     @property
+    def bootstrap(self):
+        return ".bootstrap"
+
+    @property
     def internal_cache(self):
         return ".deps"
 

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -1386,7 +1386,7 @@ def resolve_from_pex(
     for target in unique_targets:
         pex_env = PEXEnvironment(pex, target=target)
         try:
-            distributions = pex_env.resolve(all_reqs)
+            distributions = pex_env.resolve_dists(all_reqs)
         except ResolveError as e:
             raise Unsatisfiable(str(e))
 

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -202,6 +202,7 @@ def built_wheel(
     zip_safe=True,  # type: bool
     install_reqs=None,  # type: Optional[List[str]]
     extras_require=None,  # type: Optional[Dict[str, List[str]]]
+    entry_points=None,  # type: Optional[Union[str, Dict[str, List[str]]]]
     interpreter=None,  # type: Optional[PythonInterpreter]
     python_requires=None,  # type: Optional[str]
     **kwargs  # type: Any
@@ -213,6 +214,7 @@ def built_wheel(
         zip_safe=zip_safe,
         install_reqs=install_reqs,
         extras_require=extras_require,
+        entry_points=entry_points,
         python_requires=python_requires,
     ) as td:
         builder = WheelBuilder(td, interpreter=interpreter, **kwargs)

--- a/pex/tools/commands/graph.py
+++ b/pex/tools/commands/graph.py
@@ -40,8 +40,8 @@ class Graph(OutputMixin, Command):
         )
         marker_environment = pex.interpreter.identity.env_markers.copy()
         marker_environment["extra"] = []
-        present_dists = frozenset(dist.project_name for dist in pex.activate())
-        for dist in pex.activate():
+        present_dists = frozenset(dist.project_name for dist in pex.resolve())
+        for dist in pex.resolve():
             graph.add_node(
                 name=dist.project_name,
                 label="{name} {version}".format(name=dist.project_name, version=dist.version),

--- a/pex/tools/commands/repository.py
+++ b/pex/tools/commands/repository.py
@@ -177,7 +177,7 @@ class Repository(JsonMixin, OutputMixin, Command):
     ):
         # type: (...) -> Iterator[Tuple[Iterable[Distribution], IO]]
         with self.output(options) as out:
-            yield pex.activate(), out
+            yield tuple(pex.resolve()), out
 
     def _info(
         self,

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -11,7 +11,7 @@ from argparse import ArgumentParser, Namespace
 from collections import defaultdict
 from textwrap import dedent
 
-from pex import pex_builder, pex_warnings
+from pex import pex_warnings
 from pex.common import chmod_plus_x, pluralize, safe_mkdir
 from pex.environment import PEXEnvironment
 from pex.pex import PEX
@@ -107,7 +107,7 @@ def populate_venv_with_pex(
             _copytree(
                 src=pex.path(),
                 dst=venv.site_packages_dir,
-                exclude=(pex_info.internal_cache, pex_builder.BOOTSTRAP_DIR, "__main__.py"),
+                exclude=(pex_info.internal_cache, pex_info.bootstrap, "__main__.py"),
             )
         )
 

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -111,7 +111,7 @@ def populate_venv_with_pex(
             )
         )
 
-    for dist in pex.activate():
+    for dist in pex.resolve():
         record_provenance(
             _copytree(src=dist.location, dst=venv.site_packages_dir, exclude=("bin",))
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3194,3 +3194,19 @@ def test_requires_metadata_issues_1201(tmpdir):
     result = run_pex_command(args=["et-xmlfile==1.0.1", "-o", pex_file])
     result.assert_success()
     subprocess.check_call(args=[pex_file, "-c", "import et_xmlfile"])
+
+
+def test_console_script_from_pex_path(tmpdir):
+    # type: (Any) -> None
+    pex_with_script = os.path.join(str(tmpdir), "script.pex")
+    with built_wheel(
+        name="my_project",
+        entry_points={"console_scripts": ["my_app = my_project.my_module:do_something"]},
+    ) as my_whl:
+        run_pex_command(args=[my_whl, "-o", pex_with_script]).assert_success()
+
+    pex_file = os.path.join(str(tmpdir), "app.pex")
+    result = run_pex_command(args=["-c", "my_app", "--pex-path", pex_with_script, "-o", pex_file])
+    result.assert_success()
+
+    assert "hello world!\n" == subprocess.check_output(args=[pex_file]).decode("utf-8")


### PR DESCRIPTION
Include the distributions found in any PEXes present on the PEX_PATH in
the search for console scripts at PEX build time.

Fixes #1257 