### PR TITLE
Guard against concurrent re-imports.

### DIFF
--- a/pex/bootstrap.py
+++ b/pex/bootstrap.py
@@ -43,6 +43,7 @@ class Bootstrap(object):
 
         # N.B.: We mutate the sys.path before un-importing modules so that any re-imports triggered
         # by concurrent code will pull from the desired sys.path ordering.
+        # See here for how this situation might arise: https://github.com/pantsbuild/pex/issues/1272
 
         sys.path[:] = [path for path in sys.path if os.path.realpath(path) != self._realpath]
         sys.path.append(self._sys_path_entry)

--- a/pex/bootstrap.py
+++ b/pex/bootstrap.py
@@ -41,13 +41,16 @@ class Bootstrap(object):
         """
         import sys  # Grab a hold of `sys` early since we'll be un-importing our module in this process.
 
+        # N.B.: We mutate the sys.path before un-importing modules so that any re-imports triggered
+        # by concurrent code will pull from the desired sys.path ordering.
+
+        sys.path[:] = [path for path in sys.path if os.path.realpath(path) != self._realpath]
+        sys.path.append(self._sys_path_entry)
+
         unimported_modules = []
         for name, module in reversed(sorted(sys.modules.items())):
             if self.imported_from_bootstrap(module):
                 unimported_modules.append(sys.modules.pop(name))
-
-        sys.path[:] = [path for path in sys.path if os.path.realpath(path) != self._realpath]
-        sys.path.append(self._sys_path_entry)
 
         return unimported_modules
 


### PR DESCRIPTION
Although there is currently no identified way this can happen, this fix
is known to work for one victim of #1272.

Fixes #1272