### PR TITLE
allow cli arguments to be specified in a file

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -637,7 +637,11 @@ def configure_clp():
         "sources, requirements, their dependencies and other options."
     )
 
-    parser = ArgumentParser(usage=usage, formatter_class=ArgumentDefaultsHelpFormatter)
+    parser = ArgumentParser(
+        usage=usage,
+        formatter_class=ArgumentDefaultsHelpFormatter,
+        fromfile_prefix_chars="@",
+    )
 
     parser.add_argument("--version", action="version", version=__version__)
     parser.add_argument("requirements", nargs="*", help="Requirements to add to the pex")

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -635,6 +635,9 @@ def configure_clp():
         "%(prog)s [-o OUTPUT.PEX] [options] [-- arg1 arg2 ...]\n\n"
         "%(prog)s builds a PEX (Python Executable) file based on the given specifications: "
         "sources, requirements, their dependencies and other options."
+        "\n"
+        "Command-line options can be provided in one or more files by prefixing the filenames "
+        "with an @ symbol. These files must contain one argument per line."
     )
 
     parser = ArgumentParser(

--- a/tests/test_pex_binary.py
+++ b/tests/test_pex_binary.py
@@ -124,6 +124,17 @@ def test_clp_constraints_txt():
     assert options.constraint_files == ["requirements1.txt"]
 
 
+def test_clp_arg_file():
+    # type: () -> None
+    with NamedTemporaryFile() as tmpfile:
+        tmpfile.write(to_bytes("-r\nrequirements1.txt\r-r\nrequirements2.txt"))
+        tmpfile.flush()
+
+        parser = configure_clp()
+        options = parser.parse_args(args=["@" + tmpfile.name])
+        assert options.requirement_files == ["requirements1.txt", "requirements2.txt"]
+
+
 def test_clp_preamble_file():
     # type: () -> None
     with NamedTemporaryFile() as tmpfile:


### PR DESCRIPTION
Allow command line arguments to be specified in a file which is passed
on the command line with an @ symbol before the filename.

Add a corresponding tests for this behavior which verifies that two
requirements files can be passed in this manner.

closes #1271