### PR TITLE
Fix module entrypoints.

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -660,6 +660,14 @@ class PEX(object):  # noqa: T000
         if ":" in entry_point:
             return self.execute_pkg_resources(entry_point)
 
+        # When running as a zipapp we can't usefully `alter_sys` to point to the module we're
+        # executing as argv[0] since that module will be contained in a zipfile. In other words, if
+        # we did do this, sys.argv[0] would be `/path/to/pex.zip/path/to/module.py` and that value
+        # would not be usable in the standard way. Its not a file you can read or re-execute
+        # against like a loose python module source file would be.
+        #
+        # Python itself disallows this case altogether in the standard zipapp module (probably for
+        # similar reasons). See: https://docs.python.org/3/library/zipapp.html#cmdoption-zipapp-m
         alter_sys = not zipfile.is_zipfile(self._pex)
         return self.execute_module(entry_point, alter_sys)
 

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -7,6 +7,7 @@ import os
 import re
 import sys
 import warnings
+import zipfile
 from distutils import sysconfig
 from site import USER_SITE
 from types import ModuleType
@@ -576,7 +577,7 @@ class PEX(object):  # noqa: T000
         log("  * - paths that do not exist or will be imported via zipimport")
 
     def execute_interpreter(self):
-        # type: () -> Optional[str]
+        # type: () -> Any
         args = sys.argv[1:]
         if args:
             # NB: We take care here to setup sys.argv to match how CPython does it for each case.
@@ -588,7 +589,7 @@ class PEX(object):  # noqa: T000
             elif arg == "-m":
                 module = args[1]
                 sys.argv = args[1:]
-                return self.execute_module(module)
+                return self.execute_module(module, alter_sys=True)
             else:
                 try:
                     if arg == "-":
@@ -654,20 +655,25 @@ class PEX(object):  # noqa: T000
         exec_function(ast, globals_map)
         return None
 
-    @classmethod
-    def execute_entry(cls, entry_point):
+    def execute_entry(self, entry_point):
         # type: (str) -> Any
-        runner = cls.execute_pkg_resources if ":" in entry_point else cls.execute_module
-        return runner(entry_point)
+        if ":" in entry_point:
+            return self.execute_pkg_resources(entry_point)
 
-    @classmethod
-    def execute_module(cls, module_name):
-        # type: (str) -> None
-        cls.demote_bootstrap()
+        alter_sys = not zipfile.is_zipfile(self._pex)
+        return self.execute_module(entry_point, alter_sys)
+
+    def execute_module(
+        self,
+        module_name,  # type: str
+        alter_sys,  # type: bool
+    ):
+        # type: (...) -> None
+        self.demote_bootstrap()
 
         import runpy
 
-        runpy.run_module(module_name, run_name="__main__")
+        runpy.run_module(module_name, run_name="__main__", alter_sys=alter_sys)
 
     @classmethod
     def execute_pkg_resources(cls, spec):

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 
 PY_VER = sys.version_info[:2]
 IS_PYPY = hasattr(sys, "pypy_version_info")
+IS_PYPY2 = IS_PYPY and sys.version_info[0] == 2
 IS_PYPY3 = IS_PYPY and sys.version_info[0] == 3
 NOT_CPYTHON27 = IS_PYPY or PY_VER != (2, 7)
 NOT_CPYTHON36 = IS_PYPY or PY_VER != (3, 6)

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -238,7 +238,7 @@ def populate_venv_with_pex(
             module_name, _, function = entry_point.partition(":")
             if not function:
                 import runpy
-                runpy.run_module(module_name, run_name="__main__")
+                runpy.run_module(module_name, run_name="__main__", alter_sys=True)
             else:
                 import importlib
                 module = importlib.import_module(module_name)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2364,9 +2364,10 @@ def test_unzip_mode():
         assert pex_hash is not None
         unzipped_cache = unzip_dir(pex_root, pex_hash)
         assert os.path.isdir(unzipped_cache)
-        assert ["quit re-exec", os.path.join(unzipped_cache, "example.py")] == output1.decode(
-            "utf-8"
-        ).splitlines()
+        assert [
+            "quit re-exec",
+            os.path.realpath(os.path.join(unzipped_cache, "example.py")),
+        ] == output1.decode("utf-8").splitlines()
 
         shutil.rmtree(unzipped_cache)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -42,6 +42,7 @@ from pex.pip import get_pip
 from pex.requirements import LogicalLine, PyPIRequirement, URLFetcher, parse_requirement_file
 from pex.testing import (
     IS_PYPY,
+    IS_PYPY2,
     NOT_CPYTHON27,
     NOT_CPYTHON27_OR_OSX,
     NOT_CPYTHON36_OR_LINUX,
@@ -2324,7 +2325,7 @@ def test_unzip_mode():
         with safe_open(os.path.join(src_dir, "example.py"), "w") as fp:
             fp.write(
                 dedent(
-                    """
+                    """\
                     import os
                     import sys
 
@@ -2334,7 +2335,7 @@ def test_unzip_mode():
 
                     print(' '.join(sys.argv[1:]))
                     sys.stdout.flush()
-                    os.execv(sys.argv[0], sys.argv[:-1])
+                    os.execv(sys.executable, [sys.executable] + sys.argv[:-1])
                     """
                 )
             )
@@ -2358,18 +2359,21 @@ def test_unzip_mode():
         output1 = subprocess.check_output(
             args=[pex_file, "quit", "re-exec"],
         )
-        assert ["quit re-exec", os.path.realpath(pex_file)] == output1.decode("utf-8").splitlines()
 
         pex_hash = PexInfo.from_pex(pex_file).pex_hash
         assert pex_hash is not None
         unzipped_cache = unzip_dir(pex_root, pex_hash)
         assert os.path.isdir(unzipped_cache)
+        assert ["quit re-exec", os.path.join(unzipped_cache, "example.py")] == output1.decode(
+            "utf-8"
+        ).splitlines()
+
         shutil.rmtree(unzipped_cache)
 
         output2 = subprocess.check_output(
             args=[pex_file, "quit", "re-exec"], env=make_env(PEX_UNZIP=False)
         )
-        assert output1 == output2
+        assert ["quit re-exec", os.path.realpath(pex_file)] == output2.decode("utf-8").splitlines()
         assert not os.path.exists(unzipped_cache)
 
 
@@ -3210,3 +3214,93 @@ def test_console_script_from_pex_path(tmpdir):
     result.assert_success()
 
     assert "hello world!\n" == subprocess.check_output(args=[pex_file]).decode("utf-8")
+
+
+def test_execute_module_issues_1018(tmpdir):
+    # type: (Any) -> None
+    src_dir = os.path.join(str(tmpdir), "src")
+    with safe_open(os.path.join(src_dir, "issues_1018.py"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                import pickle
+
+                def add(a, b):
+                    return a + b
+
+                def main():
+                    pickle_add = pickle.dumps(add)
+                    add_clone = pickle.loads(pickle_add)
+                    print(add_clone(1, 2))
+
+                if __name__ == "__main__":
+                    main()
+                """
+            )
+        )
+    expected_output = b"3\n"
+
+    # There are 9 ways we can invoke the module above using Pex corresponding to the 2D matrix with
+    # axes: {zipapp, unzip, venv} x {entrypoint-function, entrypoint-module, ad-hoc (-m) module}.
+    # Of these, zipapp + entrypoint-module is the only combination where we can't both satisfy being
+    # able to re-exec a PEX based on argv[0] and support pickling.
+
+    unzip_env = make_env(PEX_UNZIP=1)
+
+    with_ep_pex = os.path.join(str(tmpdir), "test_with_ep.pex")
+    run_pex_command(
+        args=["-D", src_dir, "-e", "issues_1018:main", "-o", with_ep_pex]
+    ).assert_success()
+    assert expected_output == subprocess.check_output(args=[with_ep_pex], env=unzip_env)
+    assert expected_output == subprocess.check_output(args=[with_ep_pex])
+
+    no_ep_pex = os.path.join(str(tmpdir), "test_no_ep.pex")
+    run_pex_command(args=["-D", src_dir, "-o", no_ep_pex]).assert_success()
+    assert expected_output == subprocess.check_output(
+        args=[no_ep_pex, "-m", "issues_1018"], env=unzip_env
+    )
+    assert expected_output == subprocess.check_output(args=[no_ep_pex, "-m", "issues_1018"])
+
+    with_module_pex = os.path.join(str(tmpdir), "test_with_module.pex")
+    run_pex_command(
+        args=["-D", src_dir, "-m", "issues_1018", "-o", with_module_pex]
+    ).assert_success()
+    assert expected_output == subprocess.check_output(args=[with_module_pex], env=unzip_env)
+
+    # For the case of a PEX zip with a module entrypoint we cannot both get pickling working and
+    # support re-execution of the PEX file using sys.argv[0]. Prospective picklers need to either
+    # use a function entrypoint as in with_ep_pex or else re-structure their pickling to happen
+    # anywhere but in a __name__ == '__main__' module.
+    process = subprocess.Popen(args=[with_module_pex], stderr=subprocess.PIPE)
+    _, stderr = process.communicate()
+    assert process.returncode != 0
+    traceback_root = stderr.decode("utf-8").splitlines()[-1]
+    if IS_PYPY2:
+        assert "TypeError: can't pickle zipimporter objects" == traceback_root, traceback_root
+    else:
+        assert re.search(r"\bPicklingError\b", traceback_root) is not None, traceback_root
+        assert re.search(r"\b__main__\b", traceback_root) is not None
+        assert re.search(r"\badd\b", traceback_root) is not None
+        assert (
+            re.search(r"<function add at 0x[a-f0-9]+>", traceback_root) is not None
+        ), traceback_root
+
+    with_ep_venv_pex = os.path.join(str(tmpdir), "test_with_ep_venv.pex")
+    run_pex_command(
+        args=["-D", src_dir, "-e", "issues_1018:main", "-o", with_ep_venv_pex, "--venv"]
+    ).assert_success()
+    assert expected_output == subprocess.check_output(args=[with_ep_venv_pex])
+
+    no_ep_venv_pex = os.path.join(str(tmpdir), "test_no_ep_venv.pex")
+    result = run_pex_command(args=["-D", src_dir, "-o", no_ep_venv_pex, "--venv", "--seed"])
+    result.assert_success()
+    no_ep_venv_pex_bin = result.output.strip()
+    assert expected_output == subprocess.check_output(
+        args=[no_ep_venv_pex_bin, "-m", "issues_1018"]
+    )
+
+    with_module_venv_pex = os.path.join(str(tmpdir), "test_with_module_venv.pex")
+    run_pex_command(
+        args=["-D", src_dir, "-m", "issues_1018", "-o", with_module_venv_pex, "--venv"]
+    ).assert_success()
+    assert expected_output == subprocess.check_output(args=[with_module_venv_pex])

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -626,7 +626,9 @@ def test_execute_interpreter_dashm_module():
         stdout, stderr = process.communicate()
 
         assert 0 == process.returncode
-        assert b"foo.bar one two\n" == stdout
+        assert "{} one two\n".format(os.path.join(pex_chroot, "foo/bar.py")) == stdout.decode(
+            "utf-8"
+        )
         assert b"" == stderr
 
 

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -611,8 +611,17 @@ def test_execute_interpreter_dashm_module():
     with temporary_dir() as pex_chroot:
         pex_builder = PEXBuilder(path=pex_chroot)
         pex_builder.add_source(None, "foo/__init__.py")
-        with tempfile.NamedTemporaryFile() as fp:
-            fp.write(b'import sys; print(" ".join(sys.argv))')
+        with tempfile.NamedTemporaryFile(mode="w") as fp:
+            fp.write(
+                dedent(
+                    """\
+                    import os
+                    import sys
+
+                    print("{} {}".format(os.path.realpath(sys.argv[0]), " ".join(sys.argv[1:])))
+                    """
+                )
+            )
             fp.flush()
             pex_builder.add_source(fp.name, "foo/bar.py")
         pex_builder.freeze()

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -626,9 +626,9 @@ def test_execute_interpreter_dashm_module():
         stdout, stderr = process.communicate()
 
         assert 0 == process.returncode
-        assert "{} one two\n".format(os.path.join(pex_chroot, "foo/bar.py")) == stdout.decode(
-            "utf-8"
-        )
+        assert "{} one two\n".format(
+            os.path.realpath(os.path.join(pex_chroot, "foo/bar.py"))
+        ) == stdout.decode("utf-8")
         assert b"" == stderr
 
 


### PR DESCRIPTION
Previously we did not invoke module entrypoints identically to Python
which could lead to unexpected errors using the pickle module.

Now we match Python for all cases except a PEX in zipapp mode with a
module entrypoint. This is a case that is also not handled by Python
itself since its zipapp module requires a function entrypoint; ie
mod:func.

Fixes #1018