### PR TITLE
Re-structure `atomic_directory`.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -1136,10 +1136,10 @@ def seed_cache(
                     )
                 )
             with atomic_directory(unzip_dir, exclusive=True) as chroot:
-                if chroot:
+                if not chroot.is_finalized:
                     with TRACER.timed("Extracting {}".format(pex_path)):
                         with open_zip(options.pex_name) as pex_zip:
-                            pex_zip.extractall(chroot)
+                            pex_zip.extractall(chroot.work_dir)
             return [pex.interpreter.binary, unzip_dir]
         elif options.venv:
             with TRACER.timed("Creating venv from {}".format(pex_path)):

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -218,8 +218,8 @@ class PEXEnvironment(object):
         explode_dir = os.path.join(self._pex_info.zip_unsafe_cache, self._pex_info.code_hash)
         TRACER.log("PEX is not zip safe, exploding to %s" % explode_dir)
         with atomic_directory(explode_dir, exclusive=True) as explode_tmp:
-            if explode_tmp:
-                self.explode_code(explode_tmp)
+            if not explode_tmp.is_finalized:
+                self.explode_code(explode_tmp.work_dir)
         return explode_dir
 
     def _update_module_paths(self):

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -644,8 +644,10 @@ class PythonInterpreter(object):
                         encoded_identity = PythonIdentity.get(binary={binary!r}).encode()
                         sys.stdout.write(encoded_identity)
                         with atomic_directory({cache_dir!r}, exclusive=False) as cache_dir:
-                            if cache_dir:
-                                with safe_open(os.path.join(cache_dir, {info_file!r}), 'w') as fp:
+                            if not cache_dir.is_finalized:
+                                with safe_open(
+                                    os.path.join(cache_dir.work_dir, {info_file!r}), 'w'
+                                ) as fp:
                                     fp.write(encoded_identity)
                         """.format(
                             binary=binary, cache_dir=cache_dir, info_file=cls.INTERP_INFO_FILE

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -370,12 +370,12 @@ def ensure_venv(pex):
             "Expected PEX-INFO for {} to have the components of a venv directory".format(pex.path())
         )
     with atomic_directory(venv_dir, exclusive=True) as venv:
-        if venv:
+        if not venv.is_finalized:
             from .tools.commands.venv import populate_venv_with_pex
             from .tools.commands.virtualenv import Virtualenv
 
             virtualenv = Virtualenv.create(
-                venv_dir=venv,
+                venv_dir=venv.work_dir,
                 interpreter=pex.interpreter,
                 copies=pex_info.venv_copies,
             )

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -68,10 +68,10 @@ def __maybe_run_unzipped__(pex_zip):
 
   unzip_to = unzip_dir({pex_root!r}, {pex_hash!r})
   with atomic_directory(unzip_to, exclusive=True) as chroot:
-    if chroot:
+    if not chroot.is_finalized:
       with TRACER.timed('Extracting {{}} to {{}}'.format(pex_zip, unzip_to)):
         with open_zip(pex_zip) as zip:
-          zip.extractall(chroot)
+          zip.extractall(chroot.work_dir)
   TRACER.log('Executing unzipped pex for {{}} at {{}}'.format(pex_zip, unzip_to))
 
   # N.B.: This is read by pex.PEX and used to point sys.argv[0] back to the original pex_zip before

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -188,10 +188,10 @@ class Pip(object):
         """
         pip_pex_path = os.path.join(path, isolated().pex_hash)
         with atomic_directory(pip_pex_path, exclusive=True) as chroot:
-            if chroot is not None:
+            if not chroot.is_finalized:
                 from pex.pex_builder import PEXBuilder
 
-                isolated_pip_builder = PEXBuilder(path=chroot)
+                isolated_pip_builder = PEXBuilder(path=chroot.work_dir)
                 for dist_location in third_party.expose(["pip", "setuptools", "wheel"]):
                     isolated_pip_builder.add_dist_location(dist=dist_location)
                 with open(os.path.join(isolated_pip_builder.path(), "run_pip.py"), "w") as fp:

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -190,7 +190,7 @@ class Platform(object):
             components.append(manylinux)
         disk_cache_key = os.path.join(ENV.PEX_ROOT, "platforms", self.SEP.join(components))
         with atomic_directory(target_dir=disk_cache_key, exclusive=False) as cache_dir:
-            if cache_dir:
+            if not cache_dir.is_finalized:
                 # Missed both caches - spawn calculation.
                 plat_info = attr.asdict(self)
                 plat_info.update(
@@ -200,7 +200,7 @@ class Platform(object):
                     ],
                 )
                 # Write level 2.
-                with safe_open(os.path.join(cache_dir, self.PLAT_INFO_FILE), "w") as fp:
+                with safe_open(os.path.join(cache_dir.work_dir, self.PLAT_INFO_FILE), "w") as fp:
                     json.dump(plat_info, fp)
 
         with open(os.path.join(disk_cache_key, self.PLAT_INFO_FILE)) as fp:

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -448,12 +448,12 @@ class InstallResult(object):
         #
         wheel_dir_hash = CacheHelper.dir_hash(self.install_chroot)
         runtime_key_dir = os.path.join(self._installation_root, wheel_dir_hash)
-        with atomic_directory(runtime_key_dir, exclusive=False) as work_dir:
-            if work_dir:
+        with atomic_directory(runtime_key_dir, exclusive=False) as atomic_dir:
+            if not atomic_dir.is_finalized:
                 # Note: Create a relative path symlink between the two directories so that the
                 # PEX_ROOT can be used within a chroot environment where the prefix of the path may
                 # change between programs running inside and outside of the chroot.
-                source_path = os.path.join(work_dir, self.request.wheel_file)
+                source_path = os.path.join(atomic_dir.work_dir, self.request.wheel_file)
                 start_dir = os.path.dirname(source_path)
                 relative_target_path = os.path.relpath(self.install_chroot, start_dir)
                 os.symlink(relative_target_path, source_path)

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -448,13 +448,13 @@ def ensure_python_distribution(version):
     pip = os.path.join(interpreter_location, "bin", "pip")
 
     with atomic_directory(target_dir=os.path.join(pyenv_root), exclusive=True) as target_dir:
-        if target_dir:
-            bootstrap_python_installer(target_dir)
+        if not target_dir.is_finalized:
+            bootstrap_python_installer(target_dir.work_dir)
 
     with atomic_directory(
         target_dir=interpreter_location, exclusive=True
     ) as interpreter_target_dir:
-        if interpreter_target_dir:
+        if not interpreter_target_dir.is_finalized:
             subprocess.check_call(
                 [
                     "git",

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -391,9 +391,9 @@ def isolated():
 
         with _tracer().timed("Isolating pex"):
             with atomic_directory(isolated_dir, exclusive=True) as chroot:
-                if chroot:
+                if not chroot.is_finalized:
                     with _tracer().timed("Extracting pex to {}".format(isolated_dir)):
-                        recursive_copy("", os.path.join(chroot, "pex"))
+                        recursive_copy("", os.path.join(chroot.work_dir, "pex"))
 
         _ISOLATED = IsolationResult(pex_hash=dir_hash, chroot_path=isolated_dir)
     return _ISOLATED

--- a/pex/util.py
+++ b/pex/util.py
@@ -210,13 +210,13 @@ class CacheHelper(object):
         :returns: The cached distribution.
         """
         with atomic_directory(target_dir, source=source, exclusive=True) as target_dir_tmp:
-            if target_dir_tmp is None:
+            if target_dir_tmp.is_finalized:
                 TRACER.log("Using cached {}".format(target_dir), V=3)
             else:
                 with TRACER.timed("Caching {}:{} in {}".format(zf.filename, source, target_dir)):
                     for name in zf.namelist():
                         if name.startswith(source) and not name.endswith("/"):
-                            zf.extract(name, target_dir_tmp)
+                            zf.extract(name, target_dir_tmp.work_dir)
 
         dist = DistributionHelper.distribution_from_path(target_dir)
         assert dist is not None, "Failed to cache distribution: {} ".format(source)


### PR DESCRIPTION
It now always yields the associated `AtomicDirectory` object to allow
callers complete access to the atomic directory state.

Work towards #1276.