### PR TITLE
Fix auto-created `--venv` core scripts.

### DIFF
--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -374,8 +374,8 @@ def ensure_venv(pex):
             from .tools.commands.venv import populate_venv_with_pex
             from .tools.commands.virtualenv import Virtualenv
 
-            virtualenv = Virtualenv.create(
-                venv_dir=venv.work_dir,
+            virtualenv = Virtualenv.create_atomic(
+                venv_dir=venv,
                 interpreter=pex.interpreter,
                 copies=pex_info.venv_copies,
             )


### PR DESCRIPTION
Previously the `python-config` and various activation scripts had bad
paths embedded that prevented proper operation.

Fixes #1276