### PR TITLE
Fix Pex dist publishing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
           - check-name: Vendoring
             python-version: 3.8
             tox-env: vendor-check
+          - check-name: Packaging
+            python-version: 3.9
+            tox-env: build
     steps:
       - name: Checkout Pex
         uses: actions/checkout@v2

--- a/pex/__init__.py
+++ b/pex/__init__.py
@@ -5,6 +5,6 @@
 
 from __future__ import absolute_import
 
-from pex.version import __version__ as __pex_version__
+from .version import __version__ as __pex_version__
 
 __version__ = __pex_version__  # N.B.: Flit uses this as out distribution version.

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -11,7 +11,7 @@ from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path, PurePath
 from typing import Tuple
 
-import pytoml as toml
+import toml
 
 PROJECT_METADATA = Path("pyproject.toml")
 DIST_DIR = Path("dist")
@@ -89,6 +89,7 @@ def build_pex_dists(dist_fmt: Format, *additional_dist_fmts: Format, verbose: bo
         ["flit", "build", *[f"--format={fmt}" for fmt in [dist_fmt, *additional_dist_fmts]]],
         stdout=output,
         stderr=output,
+        check=True,
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -116,24 +116,42 @@ deps =
 commands =
     python scripts/package.py {posargs}
 
-[testenv:serve]
-skip_install = true
+[_flit]
 basepython = python3
 deps =
     flit
     pygments
-    pytoml
+
+[testenv:serve]
+skip_install = true
+basepython = {[_flit]basepython}
+deps =
+    {[_flit]deps}
+    toml
 commands =
     python scripts/package.py --additional-format wheel --local --serve {posargs}
 
 [testenv:publish]
 skip_install = true
+basepython = {[_flit]basepython}
 passenv =
     # These are used in CI.
     FLIT_USERNAME
     FLIT_PASSWORD
 deps =
-    flit
-    pygments
+    {[_flit]deps}
 commands =
     flit publish
+
+[testenv:build]
+skip_install = true
+basepython = {[_flit]basepython}
+passenv =
+    # These are used in CI.
+    FLIT_USERNAME
+    FLIT_PASSWORD
+deps =
+    {[_flit]deps}
+commands =
+    flit build
+


### PR DESCRIPTION
Flit parsing of `pex/__init__.py` stopped working with our
fully-qualifed `pex.version` import. Switch the import to a relative
import and beef up CI with a check that creating distributions works.