### PR TITLE
Fix wheel building for certain macOS system interpreters.

### DIFF
--- a/.github/actions/run-tox/action.yml
+++ b/.github/actions/run-tox/action.yml
@@ -31,6 +31,12 @@ runs:
           # Needed for Pillow to build successfully:
           #   https://github.com/python-pillow/Pillow/issues/3438#issuecomment-543812237
           export CPATH="$(xcrun --show-sdk-path)/usr/include"
+
+          if [[ "$(uname -m)" == "x86_64" ]]; then
+            # Works around bad `-arch arm64` flag embedded in Xcode 12.x Python interpreters on
+            # intel machines. See: https://github.com/giampaolo/psutil/issues/1832
+            export ARCHFLAGS="-arch x86_64"
+          fi
         fi
         tox --skip-missing-interpreters=false -v -e ${{ inputs.tox-env }}
       shell: bash

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -55,12 +55,6 @@ class PEX(object):  # noqa: T000
     @classmethod
     def _clean_environment(cls, env=None, strip_pex_env=True):
         env = env or os.environ
-
-        try:
-            del env["MACOSX_DEPLOYMENT_TARGET"]
-        except KeyError:
-            pass
-
         if strip_pex_env:
             for key in list(env):
                 if key.startswith("PEX_"):
@@ -698,10 +692,8 @@ class PEX(object):  # noqa: T000
         :keyword args: Additional arguments to be passed to the application being invoked by the
           environment.
         """
-        cmds = [self._interpreter.binary]
-        cmds.append(self._pex)
-        cmds.extend(args)
-        return cmds
+        cmd, _ = self._interpreter.create_isolated_cmd([self._pex] + list(args))
+        return cmd
 
     def run(self, args=(), with_chroot=False, blocking=True, setsid=False, env=None, **kwargs):
         """Run the PythonEnvironment in an interpreter in a subprocess.
@@ -717,16 +709,15 @@ class PEX(object):  # noqa: T000
         Remaining keyword arguments are passed directly to subprocess.Popen.
         """
         if env is not None:
-            # If explicit env vars are passed, we don't want clean any of these.
+            # If explicit env vars are passed, we don't want to clean any of these.
             env = env.copy()
         else:
             env = os.environ.copy()
             self._clean_environment(env=env)
 
-        cmdline = self.cmdline(args)
-        TRACER.log("PEX.run invoking %s" % " ".join(cmdline))
-        process = Executor.open_process(
-            cmdline,
+        TRACER.log("PEX.run invoking {}".format(" ".join(self.cmdline(args))))
+        _, process = self._interpreter.open_process(
+            [self._pex] + list(args),
             cwd=self._pex if with_chroot else os.getcwd(),
             preexec_fn=os.setsid if setsid else None,
             stdin=kwargs.pop("stdin", None),

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -207,7 +207,7 @@ class Pip(object):
                             # it needs to perform.
                             os.environ['__PEX_UNVENDORED__'] = '1'
                             os.environ['PYTHONPATH'] = os.pathsep.join(sys.path)
-                            
+
                             runpy.run_module('pip', run_name='__main__')
                             """
                         )

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -49,6 +49,7 @@ IS_PYPY3 = IS_PYPY and sys.version_info[0] == 3
 NOT_CPYTHON27 = IS_PYPY or PY_VER != (2, 7)
 NOT_CPYTHON36 = IS_PYPY or PY_VER != (3, 6)
 IS_LINUX = platform.system() == "Linux"
+IS_MAC = platform.system() == "Darwin"
 IS_NOT_LINUX = not IS_LINUX
 NOT_CPYTHON27_OR_OSX = NOT_CPYTHON27 or IS_NOT_LINUX
 NOT_CPYTHON36_OR_LINUX = NOT_CPYTHON36 or IS_LINUX

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3305,3 +3305,21 @@ def test_execute_module_issues_1018(tmpdir):
         args=["-D", src_dir, "-m", "issues_1018", "-o", with_module_venv_pex, "--venv"]
     ).assert_success()
     assert expected_output == subprocess.check_output(args=[with_module_venv_pex])
+
+
+def test_invalid_macosx_platform_tag(tmpdir):
+    # type: (Any) -> None
+    if not any((3, 8) == pi.version[:2] for pi in PythonInterpreter.iter()):
+        pytest.skip("Test requires a system Python 3.8 interpreter.")
+
+    repository_pex = os.path.join(str(tmpdir), "repository.pex")
+    ic_args = ["--interpreter-constraint", "==3.8.*"]
+    args = ic_args + ["setproctitle==1.2", "-o", repository_pex]
+    run_pex_command(args=args).assert_success()
+
+    setproctitle_pex = os.path.join(str(tmpdir), "setproctitle.pex")
+    run_pex_command(
+        args=ic_args + ["setproctitle", "--pex-repository", repository_pex, "-o", setproctitle_pex]
+    ).assert_success()
+
+    subprocess.check_call(args=[setproctitle_pex, "-c", "import setproctitle"])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -41,6 +41,7 @@ from pex.pex_info import PexInfo
 from pex.pip import get_pip
 from pex.requirements import LogicalLine, PyPIRequirement, URLFetcher, parse_requirement_file
 from pex.testing import (
+    IS_MAC,
     IS_PYPY,
     IS_PYPY2,
     NOT_CPYTHON27,
@@ -3307,6 +3308,9 @@ def test_execute_module_issues_1018(tmpdir):
     assert expected_output == subprocess.check_output(args=[with_module_venv_pex])
 
 
+@pytest.mark.skipif(
+    not IS_MAC, reason="This is a test of a problem specific to macOS interpreters."
+)
 def test_invalid_macosx_platform_tag(tmpdir):
     # type: (Any) -> None
     if not any((3, 8) == pi.version[:2] for pi in PythonInterpreter.iter()):

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,8 @@ deps =
     py{27,py,py2}: mock==3.0.5
     subprocess: subprocess32
 passenv =
+    # This allows working around broken xcode Python SDKs.
+    ARCHFLAGS
     # This allows re-locating the pyenv interpreter test cache for CI.
     _PEX_TEST_PYENV_ROOT
     # These are to support directing test environments to the correct headers on OSX.


### PR DESCRIPTION
Some macOS system interpreters mis-report their platform for the
purposes of wheel generation and consumption. Ensure the all macOS
interpreters report a proper platform with the major and minor version
components of the mac release via a sysconfig backdoor present in
CPython 2.7 through 3.9.

Add a previously failing test that is fixed by this change.

Fixes #1294