### PR TITLE
Spruce up `pex` and `pex-tools` CLIs.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -691,7 +691,7 @@ def configure_clp():
         fromfile_prefix_chars="@",
     )
 
-    parser.add_argument("--version", action="version", version=__version__)
+    parser.add_argument("-V", "--version", action="version", version=__version__)
     parser.add_argument("requirements", nargs="*", help="Requirements to add to the pex")
 
     configure_clp_pex_resolution(parser)

--- a/pex/tools/main.py
+++ b/pex/tools/main.py
@@ -7,7 +7,7 @@ import functools
 import logging
 import os
 import sys
-from argparse import ArgumentParser, Namespace, ArgumentDefaultsHelpFormatter
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, Namespace
 
 from pex import pex_bootstrapper
 from pex.pex import PEX
@@ -82,7 +82,7 @@ def main(
                 name,
                 formatter_class=ArgumentDefaultsHelpFormatter,
                 help=help_text,
-                description=description
+                description=description,
             )
             command.add_arguments(command_parser)
             command_parser.set_defaults(func=command.run)

--- a/pex/tools/main.py
+++ b/pex/tools/main.py
@@ -7,7 +7,7 @@ import functools
 import logging
 import os
 import sys
-from argparse import ArgumentParser, Namespace
+from argparse import ArgumentParser, Namespace, ArgumentDefaultsHelpFormatter
 
 from pex import pex_bootstrapper
 from pex.pex import PEX
@@ -16,6 +16,7 @@ from pex.tools import commands
 from pex.tools.command import Command, Result
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING, cast
+from pex.version import __version__
 
 if TYPE_CHECKING:
     from typing import Callable, Optional
@@ -58,8 +59,10 @@ def main(
 
         parser = ArgumentParser(
             prog=prog,
+            formatter_class=ArgumentDefaultsHelpFormatter,
             description="Tools for working with {}.".format(pex_prog_path if pex else "PEX files"),
         )
+        parser.add_argument("-V", "--version", action="version", version=__version__)
         if pex is None:
             parser.add_argument(
                 "pex", nargs=1, metavar="PATH", help="The path of the PEX file to operate on."
@@ -75,7 +78,12 @@ def main(
             # N.B.: We want to trigger the default argparse description if the doc string is empty.
             description = command.__doc__ or None
             help_text = description.splitlines()[0] if description else None
-            command_parser = subparsers.add_parser(name, help=help_text, description=description)
+            command_parser = subparsers.add_parser(
+                name,
+                formatter_class=ArgumentDefaultsHelpFormatter,
+                help=help_text,
+                description=description
+            )
             command.add_arguments(command_parser)
             command_parser.set_defaults(func=command.run)
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -47,6 +47,8 @@ def test_pex_tools_script():
     output = subprocess.check_output(args=[script_path("pex-tools"), "-h"])
     first_line = output.decode("utf-8").splitlines()[0]
     assert (
-        "usage: pex-tools [-h] PATH {{{command_names}}} ...".format(command_names=command_names)
+        "usage: pex-tools [-h] [-V] PATH {{{command_names}}} ...".format(
+            command_names=command_names
+        )
         == first_line
     )


### PR DESCRIPTION
Add uniform `-V` / `--version` support and ensure pex-tools displays
argument defaults.