### PR TITLE
Fix --pex-repository requirement canonicalization.

### DIFF
--- a/pex/pep_503.py
+++ b/pex/pep_503.py
@@ -1,0 +1,38 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from pex.third_party.packaging.utils import canonicalize_name
+from pex.third_party.pkg_resources import Distribution, Requirement
+from pex.typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    import attr  # vendor:skip
+    from typing import Union
+else:
+    from pex.third_party import attr
+
+
+def _canonicalize_project_name(project_nameable):
+    # type: (Union[Distribution, Requirement, str]) -> str
+    project_name = (
+        project_nameable.project_name
+        if isinstance(project_nameable, (Distribution, Requirement))
+        else project_nameable
+    )
+    return cast(str, canonicalize_name(project_name))
+
+
+@attr.s(frozen=True)
+class ProjectName(object):
+    """Encodes a canonicalized project name as per PEP-502.
+
+    See: https://www.python.org/dev/peps/pep-0503/#normalized-names
+    """
+
+    project_name = attr.ib(converter=_canonicalize_project_name)  # type: str
+
+    def __str__(self):
+        # type: () -> str
+        return self.project_name

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3367,3 +3367,26 @@ def test_invalid_macosx_platform_tag(tmpdir):
     ).assert_success()
 
     subprocess.check_call(args=[setproctitle_pex, "-c", "import setproctitle"])
+
+
+def test_pex_repository_pep503_issues_1302(tmpdir):
+    # type: (Any) -> None
+    repository_pex = os.path.join(str(tmpdir), "repository.pex")
+    with built_wheel(name="foo_bar", version="1.0.0") as wheel_path:
+        run_pex_command(
+            args=[
+                "--no-pypi",
+                "--find-links",
+                os.path.dirname(wheel_path),
+                "Foo._-BAR==1.0.0",
+                "-o",
+                repository_pex,
+            ]
+        ).assert_success()
+
+    foo_bar_pex = os.path.join(str(tmpdir), "foo-bar.pex")
+    run_pex_command(
+        args=["--pex-repository", repository_pex, "Foo._-BAR==1.0.0", "-o", foo_bar_pex]
+    ).assert_success()
+
+    subprocess.check_call(args=[foo_bar_pex, "-c", "import foo_bar"])


### PR DESCRIPTION
Previously the keys used to lookup requirements were not PEP-503
conformant and could lead to different results than resolves via Pip
which is PEP-503 conformant.

Fixes #1302