### PR TITLE
Remove unused fail_on_unmatched_files parameter.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,4 +88,3 @@ jobs:
           draft: false
           prerelease: false
           files: dist/pex
-          fail_on_unmatched_files: true


### PR DESCRIPTION
The `fail_on_unmatched_files` parameter is documented at
https://github.com/softprops/action-gh-release#inputs, but GitHub
actions emits the following warning:
```
Unexpected input(s) fail_on_unmatched_files, valid inputs are
[body, body_path, name, tag_name, draft, prerelease, files]
```