### PR TITLE
Fix pyenv shim identification.

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -253,7 +253,7 @@ def register_rmtree(directory):
 
 
 def safe_mkdir(directory, clean=False):
-    # type: (str, bool) -> None
+    # type: (str, bool) -> str
     """Safely create a directory.
 
     Ensures a directory is present.  If it's not there, it is created.  If it is, it's a no-op. If
@@ -266,6 +266,8 @@ def safe_mkdir(directory, clean=False):
     except OSError as e:
         if e.errno != errno.EEXIST:
             raise
+    finally:
+        return directory
 
 
 def safe_open(filename, *args, **kwargs):

--- a/pex/pyenv.py
+++ b/pex/pyenv.py
@@ -1,0 +1,185 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os
+import re
+import subprocess
+
+from pex.common import is_exe
+from pex.compatibility import to_unicode
+from pex.tracer import TRACER
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import attr  # vendor:skip
+    from typing import Iterator, List, Optional, Text, Tuple
+else:
+    from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class Pyenv(object):
+    root = attr.ib()  # type: Text
+
+    @classmethod
+    def find(cls):
+        # type: () -> Optional[Pyenv]
+        """Finds the active pyenv installation if any."""
+        with TRACER.timed("Searching for pyenv root...", V=3):
+            pyenv_root = to_unicode(os.environ.get("PYENV_ROOT", ""))
+            if not pyenv_root:
+                for path_entry in os.environ.get("PATH", "").split(os.pathsep):
+                    pyenv_exe = os.path.join(path_entry, "pyenv")
+                    if is_exe(pyenv_exe):
+                        process = subprocess.Popen(args=[pyenv_exe, "root"], stdout=subprocess.PIPE)
+                        stdout, _ = process.communicate()
+                        if process.returncode == 0:
+                            pyenv_root = stdout.decode("utf-8").strip()
+                            break
+
+            if pyenv_root:
+                pyenv = cls(pyenv_root)
+                TRACER.log("A pyenv installation was found: {}".format(pyenv), V=6)
+                return pyenv
+
+            TRACER.log("No pyenv installation was found.", V=6)
+            return None
+
+    @attr.s(frozen=True)
+    class Shim(object):
+        pyenv = attr.ib()  # type: Pyenv
+        path = attr.ib()  # type: str
+        name = attr.ib()  # type: str
+        major = attr.ib()  # type: Optional[str]
+        minor = attr.ib()  # type: Optional[str]
+
+        _SHIM_REGEX = re.compile(
+            r"""
+            ^
+            (?P<name>
+                python |
+                pypy
+            )
+            (?:
+                # Major version
+                (?P<major>[2-9])
+                (?:
+                    \.
+                    # Minor version
+                    (?P<minor>[0-9])
+                    # Some pyenv pythons include a suffix on the interpreter name, similar to
+                    # PEP-3149. For example, python3.6m to indicate it was built with pymalloc.
+                    [a-z]?
+                )?
+            )?
+            $
+            """,
+            flags=re.VERBOSE,
+        )
+
+        @classmethod
+        def parse(cls, pyenv, binary):
+            # type: (Pyenv, str) -> Optional[Pyenv.Shim]
+            """Parses shim information from a python binary path if it looks like a pyenv shim."""
+            if os.path.dirname(binary) != os.path.join(pyenv.root, "shims"):
+                return None
+            match = cls._SHIM_REGEX.match(os.path.basename(binary))
+            if match is None:
+                return None
+            return cls(
+                pyenv=pyenv,
+                path=binary,
+                name=match.group("name"),
+                major=match.group("major"),
+                minor=match.group("minor"),
+            )
+
+        _PYENV_CPYTHON_VERSION_LEADING_CHARS = frozenset(str(digit) for digit in range(2, 10))
+
+        def select_version(self, search_dir=None):
+            # type: (Optional[str]) -> Optional[Text]
+            """Reports the active shim version for the given directory or $PWD.
+
+            If the shim is not activated, returns `None`.
+            """
+            with TRACER.timed("Calculating active version for {}...".format(self), V=6):
+                active_versions = self.pyenv.active_versions(search_dir=search_dir)
+                if active_versions:
+                    if self.name == "python" and not self.major and not self.minor:
+                        for pyenv_version in active_versions:
+                            if pyenv_version[0] in self._PYENV_CPYTHON_VERSION_LEADING_CHARS:
+                                TRACER.log(
+                                    "{} has active version {}".format(self, pyenv_version), V=6
+                                )
+                                return pyenv_version
+
+                    prefix = "{name}{major}{minor}".format(
+                        name="" if self.name == "python" else self.name,
+                        major=self.major or "",
+                        minor=".{}".format(self.minor) if self.minor else "",
+                    )
+                    for pyenv_version in active_versions:
+                        if pyenv_version.startswith(prefix):
+                            TRACER.log("{} has active version {}".format(self, pyenv_version), V=6)
+                            return pyenv_version
+
+                TRACER.log("{} is not activated.".format(self), V=6)
+                return None
+
+    def as_shim(self, binary):
+        # type: (str) -> Optional[Shim]
+        """View the given binary path as a pyenv shim script if it is one."""
+        return self.Shim.parse(self, binary)
+
+    @staticmethod
+    def _read_pyenv_versions(version_file):
+        # type: (Text) -> Iterator[Text]
+        with open(version_file) as fp:
+            for line in fp:
+                for version in line.strip().split():
+                    yield version
+
+    @staticmethod
+    def _find_local_version_file(search_dir):
+        # type: (str) -> Optional[str]
+        while True:
+            local_version_file = os.path.join(search_dir, ".python-version")
+            if os.path.exists(local_version_file):
+                return local_version_file
+            parent_dir = os.path.dirname(search_dir)
+            if parent_dir == search_dir:
+                return None
+            search_dir = parent_dir
+
+    def active_versions(self, search_dir=None):
+        # type: (Optional[str]) -> Tuple[Text, ...]
+        """Reports the active pyenv versions for the given starting search directory or $PWD."""
+
+        # See: https://github.com/pyenv/pyenv#choosing-the-python-version
+        with TRACER.timed("Finding {} active versions...".format(self), V=6):
+            shell_version = os.environ.get("PYENV_VERSION")
+            if shell_version:
+                TRACER.log(
+                    "Found active pyenv version of PYENV_VERSION={}".format(shell_version), V=6
+                )
+                return (shell_version,)
+
+            cwd = search_dir if search_dir is not None else os.getcwd()
+            TRACER.log("Looking for pyenv version files starting from {}.".format(cwd), V=6)
+
+            versions = []  # type: List[Text]
+            local_version = self._find_local_version_file(search_dir=cwd)
+            if local_version:
+                versions.extend(self._read_pyenv_versions(local_version))
+                TRACER.log("Found active versions in {}: {}".format(local_version, versions), V=6)
+            else:
+                global_version = os.path.join(self.root, "version")
+                if os.path.exists(global_version):
+                    versions.extend(self._read_pyenv_versions(global_version))
+                    TRACER.log(
+                        "Found active versions in {}: {}".format(global_version, versions), V=6
+                    )
+
+            return tuple(versions)

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -517,15 +517,15 @@ def ensure_python_interpreter(version):
 
 @contextmanager
 def environment_as(**kwargs):
-    # type: (**str) -> Iterator[None]
+    # type: (**Any) -> Iterator[None]
     existing = {key: os.environ.get(key) for key in kwargs}
 
     def adjust_environment(mapping):
         for key, value in mapping.items():
             if value is not None:
-                os.environ[key] = value
+                os.environ[key] = str(value)
             else:
-                del os.environ[key]
+                os.environ.pop(key, None)
 
     adjust_environment(kwargs)
     try:

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -222,16 +222,16 @@ class TestPythonInterpreter(object):
             run_pyenv(["local"] + list(versions))
 
         @contextmanager
-        def pyenv_shell(version):
-            # type: (Optional[str]) -> Iterator[None]
-            with environment_as(PYENV_VERSION=version):
+        def pyenv_shell(*versions):
+            # type: (*str) -> Iterator[None]
+            with environment_as(PYENV_VERSION=":".join(versions)):
                 yield
 
         pex_root = os.path.join(str(tmpdir), "pex_root")
         cwd = safe_mkdir(os.path.join(str(tmpdir), "home", "jake", "project"))
         with ENV.patch(PEX_ROOT=pex_root) as pex_env, environment_as(
             PYENV_ROOT=pyenv_root, PEX_PYTHON_PATH=pyenv_shims, **pex_env
-        ), pyenv_shell(version=None), pushd(cwd):
+        ), pyenv_shell(), pushd(cwd):
             pyenv = Pyenv.find()
             assert pyenv is not None
             assert pyenv_root == pyenv.root
@@ -277,6 +277,12 @@ class TestPythonInterpreter(object):
                 assert_shim("python3", py36)
                 assert_shim("python3.6", py36)
                 assert_shim_inactive("python3.5")
+
+            with pyenv_shell(PY35, PY36):
+                assert_shim("python", py35)
+                assert_shim("python3", py35)
+                assert_shim("python3.5", py35)
+                assert_shim("python3.6", py36)
 
             # The shim pointer is now invalid since python3.5 was uninstalled and so
             # should be re-read and found invalid.

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -5,12 +5,14 @@ import glob
 import json
 import os
 import subprocess
+import sys
 from collections import defaultdict
+from contextlib import contextmanager
 
 import pytest
 
 from pex import interpreter
-from pex.common import safe_mkdtemp, temporary_dir, touch
+from pex.common import safe_mkdir, safe_mkdtemp, temporary_dir, touch
 from pex.compatibility import PY3
 from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
@@ -203,8 +205,8 @@ class TestPythonInterpreter(object):
             )
             assert os.path.basename(expected_interpreter.binary) != "jake"
 
-    def test_pyenv_shims(self):
-        # type: () -> None
+    def test_pyenv_shims(self, tmpdir):
+        # type: (Any) -> None
         py35, _, run_pyenv = ensure_python_distribution(PY35)
         py36 = ensure_python_interpreter(PY36)
 
@@ -212,31 +214,76 @@ class TestPythonInterpreter(object):
         pyenv_shims = os.path.join(pyenv_root, "shims")
 
         def pyenv_global(*versions):
+            # type: (*str) -> None
             run_pyenv(["global"] + list(versions))
 
-        def assert_shim(shim_name, expected_binary_path):
-            python = PythonInterpreter.from_binary(os.path.join(pyenv_shims, shim_name))
+        def pyenv_local(*versions):
+            # type: (*str) -> None
+            run_pyenv(["local"] + list(versions))
+
+        @contextmanager
+        def pyenv_shell(version):
+            # type: (str) -> Iterator[None]
+            with environment_as(PYENV_VERSION=version):
+                yield
+
+        def interpreter_for_shim(shim_name):
+            # type: (str) -> PythonInterpreter
+            return PythonInterpreter.from_binary(os.path.join(pyenv_shims, shim_name))
+
+        def assert_shim(
+            shim_name,  # type: str
+            expected_binary_path,  # type: str
+        ):
+            # type: (...) -> None
+            python = interpreter_for_shim(shim_name)
             assert expected_binary_path == python.binary
 
-        with temporary_dir() as pex_root:
-            with ENV.patch(PEX_ROOT=pex_root) as pex_env:
-                with environment_as(PYENV_ROOT=pyenv_root, **pex_env):
-                    pyenv_global(PY35, PY36)
-                    assert_shim("python3", py35)
+        def assert_shim_inactive(shim_name):
+            # type: (str) -> None
+            with pytest.raises(PythonInterpreter.IdentificationError):
+                interpreter_for_shim(shim_name)
 
-                    pyenv_global(PY36, PY35)
-                    # The python3 shim is now pointing at python3.6 but the Pex cache has a valid
-                    # entry for the old python3.5 association (the interpreter still exists.)
-                    assert_shim("python3", py35)
+        pex_root = os.path.join(str(tmpdir), "pex_root")
+        cwd = safe_mkdir(os.path.join(str(tmpdir), "home", "jake", "project"))
+        with ENV.patch(PEX_ROOT=pex_root) as pex_env, environment_as(
+            PYENV_ROOT=pyenv_root, PEX_PYTHON_PATH=pyenv_shims, **pex_env
+        ), pushd(cwd):
+            pyenv_global(PY35, PY36)
+            assert_shim("python", py35)
+            assert_shim("python3", py35)
+            assert_shim("python3.5", py35)
+            assert_shim("python3.6", py36)
 
-                    # The shim pointer is now invalid since python3.5 was uninstalled and so should
-                    # be re-read.
-                    py35_deleted = "{}.uninstalled".format(py35)
-                    os.rename(py35, py35_deleted)
-                    try:
-                        assert_shim("python3", py36)
-                    finally:
-                        os.rename(py35_deleted, py35)
+            pyenv_global(PY36, PY35)
+            assert_shim("python", py36)
+            assert_shim("python3", py36)
+            assert_shim("python3.6", py36)
+            assert_shim("python3.5", py35)
+
+            pyenv_local(PY35)
+            assert_shim("python", py35)
+            assert_shim("python3", py35)
+            assert_shim("python3.5", py35)
+            assert_shim_inactive("python3.6")
+
+            with pyenv_shell(PY36):
+                assert_shim("python", py36)
+                assert_shim("python3", py36)
+                assert_shim("python3.6", py36)
+                assert_shim_inactive("python3.5")
+
+            # The shim pointer is now invalid since python3.6 was uninstalled and so
+            # should be re-read and found invalid.
+            py35_version_dir = os.path.dirname(os.path.dirname(py35))
+            py35_deleted = "{}.uninstalled".format(py35_version_dir)
+            os.rename(py35_version_dir, py35_deleted)
+            try:
+                assert_shim_inactive("python")
+                assert_shim_inactive("python3")
+                assert_shim_inactive("python3.5")
+            finally:
+                os.rename(py35_deleted, py35_version_dir)
 
 
 def test_latest_release_of_min_compatible_version():

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -278,7 +278,7 @@ class TestPythonInterpreter(object):
                 assert_shim("python3.6", py36)
                 assert_shim_inactive("python3.5")
 
-            # The shim pointer is now invalid since python3.6 was uninstalled and so
+            # The shim pointer is now invalid since python3.5 was uninstalled and so
             # should be re-read and found invalid.
             py35_version_dir = os.path.dirname(os.path.dirname(py35))
             py35_deleted = "{}.uninstalled".format(py35_version_dir)
@@ -289,6 +289,8 @@ class TestPythonInterpreter(object):
                 assert_shim_inactive("python3.5")
             finally:
                 os.rename(py35_deleted, py35_version_dir)
+
+            assert_shim("python", py35)
 
 
 def test_latest_release_of_min_compatible_version():


### PR DESCRIPTION
Previously shims were improperly cached without regard to their
activation status. Now a dedicated Pyenv class is used to test if an
interpreter binary is a pyenv shim, and, if so, resolve it to its
activated version if any. This fixes cache keying and also improves
bulk interpreter identification by allowing de-duping active shims and
skipping inactive shims.

An existing test is updated and expanded to test for this as well as
verifying the pyenv version configuration hierarchy of methods.

Fixes #1324