### PR TITLE
Better isolate Pip.

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -64,13 +64,14 @@ class PEX(object):  # noqa: T000
         self,
         pex=sys.argv[0],  # type: str
         interpreter=None,  # type: Optional[PythonInterpreter]
+        pex_info=None,  # type: Optional[PexInfo]
         env=ENV,  # type: Variables
         verify_entry_point=False,  # type: bool
     ):
         # type: (...) -> None
         self._pex = pex
         self._interpreter = interpreter or PythonInterpreter.get()
-        self._pex_info = PexInfo.from_pex(self._pex)
+        self._pex_info = pex_info or PexInfo.from_pex(self._pex)
         self._pex_info_overrides = PexInfo.from_env(env=env)
         self._vars = env
         self._envs = None  # type: Optional[Iterable[PEXEnvironment]]

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -445,7 +445,7 @@ class PEXBuilder(object):
 
     def _add_dist_wheel_file(self, path, dist_name):
         with temporary_dir() as install_dir:
-            get_pip().spawn_install_wheel(
+            get_pip(interpreter=self._interpreter).spawn_install_wheel(
                 wheel=path,
                 install_dir=install_dir,
                 target=DistributionTarget.for_interpreter(self.interpreter),
@@ -498,7 +498,7 @@ class PEXBuilder(object):
         dist_path = dist
         if os.path.isfile(dist_path) and dist_path.endswith(".whl"):
             dist_path = os.path.join(safe_mkdtemp(), os.path.basename(dist))
-            get_pip().spawn_install_wheel(
+            get_pip(interpreter=self._interpreter).spawn_install_wheel(
                 wheel=dist,
                 install_dir=dist_path,
                 target=DistributionTarget.for_interpreter(self.interpreter),

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import json
 import os
+import zipfile
 
 from pex import pex_warnings, variables
 from pex.common import can_write_dir, open_zip, safe_mkdtemp
@@ -92,10 +93,13 @@ class PexInfo(object):
     @classmethod
     def from_pex(cls, pex):
         # type: (str) -> PexInfo
-        if os.path.isfile(pex):
+        if zipfile.is_zipfile(pex):  # Zip App
             with open_zip(pex) as zf:
                 pex_info = zf.read(cls.PATH)
-        else:
+        elif os.path.isfile(pex):  # Venv
+            with open(os.path.join(os.path.dirname(pex), cls.PATH)) as fp:
+                pex_info = fp.read()
+        else:  # Directory (Unzip mode or PEXBuilder.freeze)
             with open(os.path.join(pex, cls.PATH)) as fp:
                 pex_info = fp.read()
         return cls.from_json(pex_info)

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -149,7 +149,7 @@ class DownloadRequest(object):
     ):
         # type: (...) -> SpawnedJob[DownloadResult]
         download_dir = os.path.join(resolved_dists_dir, target.id)
-        download_job = get_pip().spawn_download_distributions(
+        download_job = get_pip(interpreter=target.get_interpreter()).spawn_download_distributions(
             download_dir=download_dir,
             requirements=self.requirements,
             requirement_files=self.requirement_files,
@@ -523,7 +523,7 @@ class BuildAndInstallRequest(object):
     ):
         # type: (...) -> SpawnedJob[BuildResult]
         build_result = build_request.result(built_wheels_dir)
-        build_job = get_pip().spawn_build_wheels(
+        build_job = get_pip(interpreter=build_request.target.get_interpreter()).spawn_build_wheels(
             distributions=[build_request.source_path],
             wheel_dir=build_result.build_dir,
             cache=self._cache,
@@ -566,7 +566,9 @@ class BuildAndInstallRequest(object):
     ):
         # type: (...) -> SpawnedJob[InstallResult]
         install_result = install_request.result(installed_wheels_dir)
-        install_job = get_pip().spawn_install_wheel(
+        install_job = get_pip(
+            interpreter=install_request.target.get_interpreter()
+        ).spawn_install_wheel(
             wheel=install_request.wheel_path,
             install_dir=install_result.build_chroot,
             compile=self._compile,

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -183,7 +183,7 @@ class WheelBuilder(object):
 
     def bdist(self):
         # type: () -> str
-        get_pip().spawn_build_wheels(
+        get_pip(interpreter=self._interpreter).spawn_build_wheels(
             distributions=[self._source_dir],
             wheel_dir=self._wheel_dir,
             interpreter=self._interpreter,
@@ -251,7 +251,7 @@ def make_bdist(
     ) as dist_location:
 
         install_dir = os.path.join(safe_mkdtemp(), os.path.basename(dist_location))
-        get_pip().spawn_install_wheel(
+        get_pip(interpreter=interpreter).spawn_install_wheel(
             wheel=dist_location,
             install_dir=install_dir,
             target=DistributionTarget(interpreter=interpreter),

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -99,7 +99,7 @@ def populate_venv_with_pex(
     if zipfile.is_zipfile(pex.path()):
         record_provenance(
             PEXEnvironment(pex.path()).explode_code(
-                venv.site_packages_dir, exclude=("__main__.py",)
+                venv.site_packages_dir, exclude=("__main__.py", pex_info.PATH)
             )
         )
     else:
@@ -107,9 +107,12 @@ def populate_venv_with_pex(
             _copytree(
                 src=pex.path(),
                 dst=venv.site_packages_dir,
-                exclude=(pex_info.internal_cache, pex_info.bootstrap, "__main__.py"),
+                exclude=(pex_info.internal_cache, pex_info.bootstrap, "__main__.py", pex_info.PATH),
             )
         )
+
+    with open(os.path.join(venv.venv_dir, pex_info.PATH), "w") as fp:
+        fp.write(pex_info.dump())
 
     for dist in pex.resolve():
         record_provenance(


### PR DESCRIPTION
Switch to running Pip from a venv so that its sys.executable is
naturally isolated. This leads to properly isolated subprocesses
being spawned by Pip itself.

Fixes #1336