### PR TITLE
Debug setup for PEX file dist caching failure.

### DIFF
--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -476,12 +476,12 @@ class PexInfo(object):
         data["distributions"] = self._distributions.copy()
         return data
 
-    def dump(self):
+    def dump(self, **json_dump_kwargs):
         # type: (...) -> str
         data = self.as_json_dict()
         data["requirements"].sort()
         data["interpreter_constraints"].sort()
-        return json.dumps(data, sort_keys=True)
+        return json.dumps(data, sort_keys=True, **json_dump_kwargs)
 
     def copy(self):
         # type: () -> PexInfo


### PR DESCRIPTION
To use in pants:

1. Grab this PR in a local Pex clone and run `tox -epackage`. Be ready
   to cut and paste the PEX version, sha256 and size from the output:
    ```
    ...
    Built Pex PEX @ v2.1.42-4-g92d859f:
    sha256: 7df03171518c19f9d76467b1b87d9a6c725eff5ed9c06cca7f980ab15f400a36
      size: 3614998
    ________________________________ summary ________________________________
      package: commands succeeded
      congratulations :)
    ```
2. Run pants like so substituting the path to the pex clone you ran
    `tox -e package` in for `/home/jsirois/dev/pantsbuild/jsirois-pex` 
    as well as the Pex version, sha256 and size from above:
    ```
    ./pants \
      --download-pex-bin-url-template="file:///home/jsirois/dev/pantsbuild/jsirois-pex/dist/pex" \
      --download-pex-bin-version="v2.1.42-4-g92d859f" \
      --download-pex-bin-known-versions="v2.1.42-4-g92d859f|darwin|7df03171518c19f9d76467b1b87d9a6c725eff5ed9c06cca7f980ab15f400a36|3614998" \
      --download-pex-bin-known-versions="v2.1.42-4-g92d859f|linux|7df03171518c19f9d76467b1b87d9a6c725eff5ed9c06cca7f980ab15f400a36|3614998" test src/python/pants/util/strutil_test.py
    ```
