### PR TITLE
Add -s option, like -m, -s sets the console-script to execute

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -585,6 +585,10 @@ class PEX(object):  # noqa: T000
                 module = args[1]
                 sys.argv = args[1:]
                 return self.execute_module(module, alter_sys=True)
+            elif arg == "-s":
+                script = args[1]
+                sys.argv = args[1:]
+                return self.execute_script(script)
             else:
                 try:
                     if arg == "-":


### PR DESCRIPTION
Today the only way to choose console-scripts after the build is
complete is to set PEX_SCRIPT env var.