### PR TITLE
Allow switching compilation toolchain in tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
           key: ${{ runner.os }}-pyenv-root
       - name: Run Unit Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        env:
+          # If CC is propagated to tests, things fail on macOS.
+          CC: ""
         with:
           tox-env: py${{ join(matrix.python-version, '') }}
   pypy-unit-tests:
@@ -121,6 +124,9 @@ jobs:
           key: ${{ runner.os }}-pyenv-root
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        env:
+          # If CC is propagated to tests, things fail on macOS.
+          CC: ""
         with:
           tox-env: py${{ join(matrix.python-version, '') }}-integration
   pypy-integration-tests:

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,8 @@ passenv =
     ARCHFLAGS
     # This allows re-locating the pyenv interpreter test cache for CI.
     _PEX_TEST_PYENV_ROOT
+    # Allow switching the native compilation toolchain.
+    CC
     # These are to support directing test environments to the correct headers on OSX.
     CPATH
     CPPFLAGS


### PR DESCRIPTION
This is a hack allowing me to `CC=clang tox -e...` to workaround Python
3.5 and 3.6 compilation issues when building pyenv interpreters in
`pex/testing.py` (similar to?) the one detailed here:
https://bugs.python.org/issue27987