### PR TITLE
Fix execution modes.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -947,7 +947,6 @@ def build_pex(reqs, options, cache=None):
         interpreter=interpreter,
         preamble=preamble,
         copy_mode=CopyMode.SYMLINK,
-        include_tools=options.include_tools or options.venv,
     )
 
     if options.resources_directory:
@@ -968,8 +967,9 @@ def build_pex(reqs, options, cache=None):
     pex_info.zip_safe = options.zip_safe
     pex_info.unzip = options.unzip
     pex_info.venv = bool(options.venv)
-    pex_info.venv_bin_path = options.venv
+    pex_info.venv_bin_path = options.venv or BinPath.FALSE
     pex_info.venv_copies = options.venv_copies
+    pex_info.includes_tools = options.include_tools or options.venv
     pex_info.pex_path = options.pex_path
     pex_info.always_write_cache = options.always_write_cache
     pex_info.ignore_errors = options.ignore_errors

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -469,14 +469,13 @@ class PEX(object):  # noqa: T000
 
         try:
             if self._vars.PEX_TOOLS:
-                try:
-                    from pex.tools import main as tools
-                except ImportError as e:
+                if not self._pex_info.includes_tools:
                     die(
                         "The PEX_TOOLS environment variable was set, but this PEX was not built "
-                        "with tools (Re-build the PEX file with `pex --include-tools ...`):"
-                        " {}".format(e)
+                        "with tools (Re-build the PEX file with `pex --include-tools ...`)"
                     )
+
+                from pex.tools import main as tools
 
                 exit_value = tools.main(pex=self, pex_prog_path=sys.argv[0])
             else:

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -280,6 +280,16 @@ class PexInfo(object):
         )
 
     @property
+    def includes_tools(self):
+        # type: () -> bool
+        return self._pex_info.get("includes_tools", self.venv)
+
+    @includes_tools.setter
+    def includes_tools(self, value):
+        # type: (bool) -> None
+        self._pex_info["includes_tools"] = bool(value)
+
+    @property
     def strip_pex_env(self):
         """Whether or not this PEX should strip `PEX_*` env vars before executing its entrypoint.
 

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -523,7 +523,7 @@ class Variables(object):
         """
         return self._maybe_get_string("PEX_EXTRA_SYS_PATH")
 
-    @defaulted_property(default=os.path.expanduser("~/.pex"))
+    @defaulted_property(default="~/.pex")
     def PEX_ROOT(self):
         # type: () -> str
         """Directory.
@@ -536,7 +536,8 @@ class Variables(object):
         return self._get_path("PEX_ROOT")
 
     @PEX_ROOT.validator
-    def _ensure_writeable_pex_root(self, pex_root):
+    def _ensure_writeable_pex_root(self, raw_pex_root):
+        pex_root = os.path.expanduser(raw_pex_root)
         if not can_write_dir(pex_root):
             tmp_root = os.path.realpath(safe_mkdtemp())
             pex_warnings.warn(

--- a/tests/test_execution_mode.py
+++ b/tests/test_execution_mode.py
@@ -1,0 +1,81 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os.path
+import subprocess
+from subprocess import CalledProcessError
+
+import pytest
+
+from pex.testing import run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Callable, Dict, Iterable, Tuple
+
+    CreateColorsPex = Callable[[Iterable[str]], str]
+    ExecuteColorsPex = Callable[[str, Dict[str, str]], Tuple[str, str]]
+
+
+@pytest.fixture
+def create_colors_pex(tmpdir):
+    # type: (Any) -> CreateColorsPex
+    def create(extra_args):
+        pex_file = os.path.join(str(tmpdir), "colors.pex")
+        results = run_pex_command(["ansicolors==1.1.8", "-o", pex_file] + list(extra_args))
+        results.assert_success()
+        return pex_file
+
+    return create
+
+
+@pytest.fixture
+def execute_colors_pex(tmpdir):
+    # type: (Any) -> ExecuteColorsPex
+    def execute(colors_pex, extra_env):
+        pex_root = os.path.join(str(tmpdir), "pex_root")
+        env = os.environ.copy()
+        env.update(extra_env)
+        env["PEX_ROOT"] = pex_root
+        output = subprocess.check_output(
+            [colors_pex, "-c", "import colors; print(colors.__file__)"], env=env
+        )
+        return output.strip().decode("utf-8"), pex_root
+
+    return execute
+
+
+@pytest.mark.parametrize(
+    ["extra_args", "default_dir", "venv_exception_expected"],
+    [
+        pytest.param([], "installed_wheels", True, id="ZIPAPP"),
+        pytest.param(["--include-tools"], "installed_wheels", False, id="ZIPAPP --include-tools"),
+        pytest.param(["--unzip"], "unzipped", True, id="UNZIP"),
+        pytest.param(["--unzip", "--include-tools"], "unzipped", False, id="UNZIP --include-tools"),
+        pytest.param(["--venv"], "venvs", False, id="VENV"),
+    ],
+)
+def test_execution_mode(
+    create_colors_pex,  # type: CreateColorsPex
+    execute_colors_pex,  # type: ExecuteColorsPex
+    extra_args,  # type: Iterable[str]
+    default_dir,  # type: str
+    venv_exception_expected,  # type: bool
+):
+    # type: (...) -> None
+    pex_file = create_colors_pex(extra_args)
+
+    output, pex_root = execute_colors_pex(pex_file, {})
+    assert output.startswith(os.path.join(pex_root, default_dir))
+
+    output, pex_root = execute_colors_pex(pex_file, {"PEX_UNZIP": "1"})
+    assert output.startswith(os.path.join(pex_root, "unzipped"))
+
+    if venv_exception_expected:
+        with pytest.raises(CalledProcessError):
+            execute_colors_pex(pex_file, {"PEX_VENV": "1"})
+    else:
+        output, pex_root = execute_colors_pex(pex_file, {"PEX_VENV": "1"})
+        assert output.startswith(os.path.join(pex_root, "venvs"))

--- a/tests/tools/commands/test_interpreter_command.py
+++ b/tests/tools/commands/test_interpreter_command.py
@@ -47,7 +47,8 @@ class InterpreterTool(object):
         *other_interpreters  # type: PythonInterpreter
     ):
         # type: (...) -> InterpreterTool
-        pex_builder = PEXBuilder(include_tools=True, interpreter=interpreter)
+        pex_builder = PEXBuilder(interpreter=interpreter)
+        pex_builder.info.includes_tools = True
         pex_builder.freeze()
         return cls(
             tools_pex=pex_builder.path(),


### PR DESCRIPTION
Previously you could not ask a `--venv` PEX to run in unzip mode. This
regularizes all PEX files so that they can be asked to operate in unzip
mode or venv mode whenever possible (venv mode requires the PEX was
built with `--include-tools` or `--venv`).

Work towards #1343.