### PR TITLE
Warn for PEX env vars unsupported by venv.

### DIFF
--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -175,6 +175,39 @@ def populate_venv_with_pex(
                 os.environ[current_interpreter_blessed_env_var] = "1"
                 os.execv(python, [python, "-sE"] + sys.argv)
 
+            ignored_pex_env_vars = [
+                "{{}}={{}}".format(name, value)
+                for name, value in os.environ.items()
+                if name.startswith(("PEX_", "_PEX_", "__PEX_")) and name not in (
+                    # These are used inside this script.
+                    "_PEX_SHOULD_EXIT_VENV_REEXEC",
+                    "PEX_EXTRA_SYS_PATH",
+                    "PEX_VENV_BIN_PATH",
+                    "PEX_INTERPRETER",
+                    "PEX_SCRIPT",
+                    "PEX_MODULE",
+                    # This is used when loading ENV (Variables()):
+                    "PEX_IGNORE_RCFILES",
+                    # And ENV is used to access these during PEX bootstrap when delegating here via
+                    # a --venv mode PEX file.
+                    "PEX_ROOT",
+                    "PEX_VENV",
+                    "PEX_PATH",
+                    "PEX_PYTHON",
+                    "PEX_PYTHON_PATH",
+                    "PEX_VERBOSE",
+                    "__PEX_EXE__",
+                    "__PEX_UNVENDORED__",
+                )
+            ]
+            if ignored_pex_env_vars:
+                sys.stderr.write(
+                    "Ignoring the following environment variables in Pex venv mode:\\n"
+                    "{{}}\\n\\n".format(
+                        os.linesep.join(sorted(ignored_pex_env_vars))
+                    )
+                )
+
             os.environ["VIRTUAL_ENV"] = venv_dir
             sys.path.extend(os.environ.get("PEX_EXTRA_SYS_PATH", "").split(os.pathsep))
 

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -198,6 +198,9 @@ def populate_venv_with_pex(
                     "PEX_VERBOSE",
                     "__PEX_EXE__",
                     "__PEX_UNVENDORED__",
+                    # This is _not_ used (it is ignored), but it's present under CI and simplest to
+                    # add an exception for here and not warn about in CI runs.
+                    "_PEX_TEST_PYENV_ROOT",
                 )
             ]
             if ignored_pex_env_vars:

--- a/tests/tools/commands/test_venv.py
+++ b/tests/tools/commands/test_venv.py
@@ -15,7 +15,7 @@ from textwrap import dedent
 
 import pytest
 
-from pex.common import safe_open, temporary_dir, touch
+from pex.common import safe_mkdtemp, safe_open, temporary_dir, touch
 from pex.compatibility import PY2
 from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
@@ -633,9 +633,13 @@ def test_strip_pex_env(tmpdir):
     assert 2 == process.wait()
 
 
-def test_warn_unused_pex_env_vars(tmpdir):
-    # type: (Any) -> None
-    venv_pex = os.path.join(str(tmpdir), "venv.pex")
+def test_warn_unused_pex_env_vars():
+    # type: () -> None
+    # N.B.: We don't use the pytest tmpdir fixture here since it creates fairly length paths under
+    # /tmp and under macOS, where TMPDIR is already fairly deeply nested, we trigger Pex warinings
+    # about script shebang length. Those warnings pollute stderr.
+    tmpdir = safe_mkdtemp()
+    venv_pex = os.path.join(tmpdir, "venv.pex")
     run_pex_command(["--venv", "-o", venv_pex]).assert_success()
 
     def assert_execute_venv_pex(expected_stderr, **env_vars):
@@ -650,7 +654,7 @@ def test_warn_unused_pex_env_vars(tmpdir):
         assert expected_stderr.strip() == stderr.decode("utf-8").strip()
 
     assert_execute_venv_pex(expected_stderr="")
-    assert_execute_venv_pex(expected_stderr="", PEX_ROOT=os.path.join(str(tmpdir), "pex_root"))
+    assert_execute_venv_pex(expected_stderr="", PEX_ROOT=os.path.join(tmpdir, "pex_root"))
     assert_execute_venv_pex(expected_stderr="", PEX_UNZIP="1")
     assert_execute_venv_pex(expected_stderr="", PEX_EXTRA_SYS_PATH="more")
     assert_execute_venv_pex(expected_stderr="", PEX_VERBOSE="0")


### PR DESCRIPTION
Previously these were silently ignored which was confusing at best.

Fixes #1343