### PR TITLE
Do not suppress pex output in bidst_pex

### DIFF
--- a/pex/commands/bdist_pex.py
+++ b/pex/commands/bdist_pex.py
@@ -134,3 +134,10 @@ class bdist_pex(Command):  # noqa
                     ),
                     result,
                 )
+            else:
+                die(
+                    "Successfully created pex via {}:\n{}".format(
+                        " ".join(cmd), stderr.decode("utf-8")
+                    ),
+                    result,
+                )


### PR DESCRIPTION
Always print out the pex command output regardless of failure or success.

Fixes #1356