### PR TITLE
Allow --platform resolves for current interpreter.

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -509,6 +509,7 @@ class PythonInterpreter(object):
 
     @classmethod
     def get(cls):
+        # type: () -> PythonInterpreter
         return cls.from_binary(sys.executable)
 
     @staticmethod

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
         List,
         NoReturn,
         Optional,
+        Set,
         Tuple,
         Union,
     )
@@ -73,7 +74,7 @@ def iter_compatible_interpreters(
 
     def _iter_interpreters():
         # type: () -> Iterator[InterpreterOrError]
-        seen = set()
+        seen = set()  # type: Set[InterpreterOrError]
 
         normalized_paths = (
             OrderedSet(PythonInterpreter.canonicalize_path(p) for p in path.split(os.pathsep))

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -414,14 +414,14 @@ class Pip(object):
                     "Cannot both ignore wheels (use_wheel=False) and refrain from building "
                     "distributions (build=False)."
                 )
-            elif target.is_foreign:
+            elif target.is_platform:
                 raise ValueError(
-                    "Cannot ignore wheels (use_wheel=False) when resolving for a foreign "
-                    "platform: {}".format(platform)
+                    "Cannot ignore wheels (use_wheel=False) when resolving for a platform: "
+                    "{}".format(platform)
                 )
 
         download_cmd = ["download", "--dest", download_dir]
-        if target.is_foreign:
+        if target.is_platform:
             # We're either resolving for a different host / platform or a different interpreter for
             # the current platform that we have no access to; so we need to let pip know and not
             # otherwise pickup platform info from the interpreter we execute pip with.
@@ -435,7 +435,7 @@ class Pip(object):
                 )
             )
 
-        if target.is_foreign or not build:
+        if target.is_platform or not build:
             download_cmd.extend(["--only-binary", ":all:"])
 
         if not use_wheel:

--- a/tests/test_distribution_target.py
+++ b/tests/test_distribution_target.py
@@ -1,0 +1,58 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import pytest
+
+from pex.distribution_target import DistributionTarget
+from pex.interpreter import PythonInterpreter
+
+
+@pytest.fixture
+def current_interpreter():
+    # type: () -> PythonInterpreter
+    return PythonInterpreter.get()
+
+
+def test_interpreter_platform_mutex(current_interpreter):
+    # type: (PythonInterpreter) -> None
+
+    def assert_is_platform(target):
+        # type: (DistributionTarget) -> None
+        assert target.is_platform
+        assert not target.is_interpreter
+
+    def assert_is_interpreter(target):
+        # type: (DistributionTarget) -> None
+        assert target.is_interpreter
+        assert not target.is_platform
+
+    assert_is_interpreter(DistributionTarget.current())
+    assert_is_interpreter(DistributionTarget())
+    assert_is_interpreter(DistributionTarget.for_interpreter(current_interpreter))
+    assert_is_platform(DistributionTarget.for_platform(current_interpreter.platform))
+
+    with pytest.raises(DistributionTarget.AmbiguousTargetError):
+        DistributionTarget(interpreter=current_interpreter, platform=current_interpreter.platform)
+
+
+def test_manylinux(current_interpreter):
+    # type: (PythonInterpreter) -> None
+
+    current_platform = current_interpreter.platform
+
+    target = DistributionTarget.for_platform(current_platform, manylinux="foo")
+    assert (current_platform, "foo") == target.get_platform()
+
+    target = DistributionTarget(platform=current_platform, manylinux="bar")
+    assert (current_platform, "bar") == target.get_platform()
+
+    with pytest.raises(DistributionTarget.ManylinuxOutOfContextError):
+        DistributionTarget(manylinux="baz")
+
+    with pytest.raises(DistributionTarget.ManylinuxOutOfContextError):
+        DistributionTarget(interpreter=PythonInterpreter.get(), manylinux="baz")
+
+    target = DistributionTarget.for_interpreter(current_interpreter)
+    assert (current_platform, None) == target.get_platform()


### PR DESCRIPTION
Previously, if a `--platform` resolve was being executed with an
interpreter that matched the platform, a regular full-featured
interpreter resolve was performed. This prevented, for example,
resolving using a CPython 3.8 interpreter on a manylinux2014 capable
host for deployment to a host that is only manylinux2010 capable. The
`--resolve-local-platforms` option exists to force this sort of
fallback to a full-featured interpreter resolve when that is desired.

Fixes #1355