### PR TITLE
Fix `--platform` resolve handling of env markers.

### DIFF
--- a/pex/distribution_target.py
+++ b/pex/distribution_target.py
@@ -138,17 +138,15 @@ class DistributionTarget(object):
         if requirement.marker is None:
             return True
 
-        if not self.is_interpreter:
-            # We can have no opinion without an interpreter to answer questions about enviornment
-            # markers.
-            return None
-
         if not extras:
             # Provide an empty extra to safely evaluate the markers without matching any extra.
             extras = ("",)
         for extra in extras:
-            # N.B.: This nets us a copy of the markers so we're free to mutate.
-            environment = self.get_interpreter().identity.env_markers
+            # N.B.: These each net us a copy of the markers so we're free to mutate.
+            if self._platform is not None:
+                environment = self._platform.marker_environment()
+            else:
+                environment = self.get_interpreter().identity.env_markers
             environment["extra"] = extra
             if requirement.marker.evaluate(environment=environment):
                 return True

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -631,7 +631,11 @@ class Pip(object):
         if target.is_platform:
             env_markers_dir = safe_mkdtemp()
             platform, _ = target.get_platform()
-            patched_environment = platform.marker_environment()
+            patched_environment = platform.marker_environment(
+                # We want to fail a resolve when it needs to evaluate environment markers we can't
+                # calculate given just the platform information.
+                default_unknown=False
+            )
             with open(
                 os.path.join(env_markers_dir, "env_markers.{}.json".format(platform)), "w"
             ) as fp:

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -328,8 +328,6 @@ class Pip(object):
                     fp.write(
                         dedent(
                             """\
-                            from __future__ import print_function
-
                             import os
                             import runpy
 

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -261,11 +261,44 @@ class Platform(object):
             safe_rmtree(disk_cache_key)
             return self.supported_tags(manylinux=manylinux)
 
-    def marker_environment(self):
-        # type: () -> Dict[str, str]
-        major_version = int(self.version[0])
+    def marker_environment(self, default_unknown=True):
+        # type: (bool) -> Dict[str, str]
+        """Populate a partial marker environment given what we know from platform information.
 
-        env = {}
+        Since Pex support is (currently) restricted to:
+        + interpreters: CPython and PyPy
+        + os: Linux and Mac
+
+        We can fill in most of the environment markers used in these environments in practice in the
+        wild.
+
+        For any environment markers that can't be derived from the platform information, the value
+        is either defaulted as specified in PEP 508 or else omitted entirely as per
+        `default_unknown`. Defaulting will cause tests against those environment markers to always
+        fail; thus marking the requirement as not applying. Leaving the marker out will cause the
+        same test to error; thus failing the resolve outright.
+
+        See: https://www.python.org/dev/peps/pep-0508/#environment-markers
+        """
+        env = (
+            {
+                "implementation_name": "",
+                "implementation_version": "0",
+                "os_name": "",
+                "platform_machine": "",
+                "platform_python_implementation": "",
+                "platform_release": "",
+                "platform_system": "",
+                "platform_version": "",
+                "python_full_version": "0",
+                "python_version": "0",
+                "sys_platform": "",
+            }
+            if default_unknown
+            else {}
+        )
+
+        major_version = int(self.version[0])
 
         if major_version == 2:
             env["implementation_name"] = ""

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -261,6 +261,38 @@ class Platform(object):
             safe_rmtree(disk_cache_key)
             return self.supported_tags(manylinux=manylinux)
 
+    def marker_environment(self):
+        # type: () -> Dict[str, str]
+        major_version = int(self.version[0])
+
+        env = {}
+
+        if major_version == 2:
+            env["implementation_name"] = ""
+            env["implementation_version"] = "0"
+        elif self.impl == "cp":
+            env["implementation_name"] = "cpython"
+        elif self.impl == "pp":
+            env["implementation_name"] = "pypy"
+
+        if "linux" in self.platform:
+            env["os_name"] = "posix"
+            env["platform_system"] = "Linux"
+            env["sys_platform"] = "linux2" if major_version == 2 else "linux"
+        elif "mac" in self.platform:
+            env["os_name"] = "posix"
+            env["platform_system"] = "Darwin"
+            env["sys_platform"] = "darwin"
+
+        if self.impl == "cp":
+            env["platform_python_implementation"] = "CPython"
+        elif self.impl == "pp":
+            env["platform_python_implementation"] = "PyPy"
+
+        env["python_version"] = ".".join(self.version)
+
+        return env
+
     def __str__(self):
         # type: () -> str
         return cast(str, self.SEP.join(attr.astuple(self)))

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -436,7 +436,7 @@ def ensure_python_distribution(version):
 
     pyenv_root = os.path.abspath(
         os.path.join(
-            os.environ.get("_PEX_TEST_PYENV_ROOT", "{}_dev".format(ENV.PEX_ROOT)),
+            os.path.expanduser(os.environ.get("_PEX_TEST_PYENV_ROOT", "~/.pex_dev")),
             "pyenv",
         )
     )

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -201,6 +201,9 @@ def populate_venv_with_pex(
                     # This is _not_ used (it is ignored), but it's present under CI and simplest to
                     # add an exception for here and not warn about in CI runs.
                     "_PEX_TEST_PYENV_ROOT",
+                    # This is used by Pex's Pip venv to work around
+                    # https://github.com/pypa/pip/issues/10050:
+                    "_PEX_PATCHED_MARKERS_FILE",
                 )
             ]
             if ignored_pex_env_vars:

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -128,7 +128,6 @@ def test_download_platform_issues_1355(
 
 def test_download_platform_markers_issue_1366(
     create_pip,  # type: CreatePip
-    current_interpreter,  # type: PythonInterpreter
     tmpdir,  # type: Any
 ):
     # type: (...) -> None
@@ -149,7 +148,6 @@ def test_download_platform_markers_issue_1366(
 
 def test_download_platform_markers_issue_1366_indeterminate(
     create_pip,  # type: CreatePip
-    current_interpreter,  # type: PythonInterpreter
     tmpdir,  # type: Any
 ):
     # type: (...) -> None

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -13,7 +13,9 @@ from pex.common import safe_rmtree
 from pex.distribution_target import DistributionTarget
 from pex.interpreter import PythonInterpreter
 from pex.jobs import Job
-from pex.pip import PackageIndexConfiguration, Pip
+from pex.pip import PackageIndexConfiguration, Pip, ResolverVersion
+from pex.platforms import Platform
+from pex.testing import PY27, PY36, ensure_python_interpreter
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
 
@@ -122,3 +124,50 @@ def test_download_platform_issues_1355(
         target=current_platform, package_index_configuration=local_wheel_repo
     ).wait()
     assert [os.path.basename(ansicolors_wheel)] == os.listdir(download_dir)
+
+
+def test_download_platform_markers_issue_1366(
+    create_pip,  # type: CreatePip
+    current_interpreter,  # type: PythonInterpreter
+    tmpdir,  # type: Any
+):
+    # type: (...) -> None
+    python36_interpreter = PythonInterpreter.from_binary(ensure_python_interpreter(PY36))
+    pip = create_pip(python36_interpreter)
+
+    python27_platform = Platform.create("manylinux_2_33_x86_64-cp-27-cp27mu")
+    download_dir = os.path.join(str(tmpdir), "downloads")
+    pip.spawn_download_distributions(
+        target=DistributionTarget.for_platform(python27_platform),
+        requirements=["typing_extensions==3.7.4.2; python_version < '3.6'"],
+        download_dir=download_dir,
+        transitive=False,
+    ).wait()
+
+    assert ["typing_extensions-3.7.4.2-py2-none-any.whl"] == os.listdir(download_dir)
+
+
+def test_download_platform_markers_issue_1366_indeterminate(
+    create_pip,  # type: CreatePip
+    current_interpreter,  # type: PythonInterpreter
+    tmpdir,  # type: Any
+):
+    # type: (...) -> None
+    python36_interpreter = PythonInterpreter.from_binary(ensure_python_interpreter(PY36))
+    pip = create_pip(python36_interpreter)
+
+    python27_platform = Platform.create("manylinux_2_33_x86_64-cp-27-cp27mu")
+    download_dir = os.path.join(str(tmpdir), "downloads")
+
+    with pytest.raises(Job.Error) as exc_info:
+        pip.spawn_download_distributions(
+            target=DistributionTarget.for_platform(python27_platform),
+            requirements=["typing_extensions==3.7.4.2; python_full_version < '3.6'"],
+            download_dir=download_dir,
+            transitive=False,
+        ).wait()
+    assert (
+        "Failed to resolve for platform manylinux_2_33_x86_64-cp-27-cp27mu. Resolve requires "
+        "evaluation of unknown environment marker: 'python_full_version' does not exist in "
+        "evaluation environment."
+    ) in str(exc_info.value)

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -7,7 +7,12 @@ import pkgutil
 import pytest
 
 from pex.platforms import Platform
-from pex.third_party.packaging import tags
+from pex.third_party.packaging import markers, tags
+from pex.typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from typing import Dict
+
 
 EXPECTED_BASE = [("py27", "none", "any"), ("py2", "none", "any")]
 
@@ -55,19 +60,18 @@ def test_platform_create_noop():
 
 
 def test_platform_supported_tags():
+    # type: () -> None
     platform = Platform.create("macosx-10.13-x86_64-cp-36-m")
 
     # A golden file test. This could break if we upgrade Pip and it upgrades packaging which, from
     # time to time, corrects omissions in tag sets.
+    golden_tags = pkgutil.get_data(__name__, "data/platforms/macosx_10_13_x86_64-cp-36-m.tags.txt")
+    assert golden_tags is not None
     assert (
         tuple(
             itertools.chain.from_iterable(
                 tags.parse_tag(tag)
-                for tag in pkgutil.get_data(
-                    __name__, "data/platforms/macosx_10_13_x86_64-cp-36-m.tags.txt"
-                )
-                .decode("utf-8")
-                .splitlines()
+                for tag in golden_tags.decode("utf-8").splitlines()
                 if not tag.startswith("#")
             )
         )
@@ -76,9 +80,47 @@ def test_platform_supported_tags():
 
 
 def test_platform_supported_tags_manylinux():
+    # type: () -> None
     platform = Platform.create("linux-x86_64-cp-37-cp37m")
     tags = frozenset(platform.supported_tags())
     manylinux1_tags = frozenset(platform.supported_tags(manylinux="manylinux1"))
     manylinux2010_tags = frozenset(platform.supported_tags(manylinux="manylinux2010"))
     manylinux2014_tags = frozenset(platform.supported_tags(manylinux="manylinux2014"))
     assert manylinux2014_tags > manylinux2010_tags > manylinux1_tags > tags
+
+
+def test_platform_marker_environment():
+    # type: () -> None
+    platform = Platform.create("linux-x86_64-cp-37-cp37m")
+    env_defaulted = platform.marker_environment(default_unknown=True)
+    env_sparse = platform.marker_environment(default_unknown=False)
+
+    assert set(env_sparse.items()).issubset(set(env_defaulted.items()))
+
+    def evaluate_marker(
+        expression,  # type: str
+        environment,  # type: Dict[str, str]
+    ):
+        # type: (...) -> bool
+        markers.default_environment = environment.copy
+        return cast(bool, markers.Marker(expression).evaluate())
+
+    def assert_known_marker(expression):
+        # type: (str) -> None
+        assert evaluate_marker(expression, env_defaulted)
+        assert evaluate_marker(expression, env_sparse)
+
+    assert_known_marker("python_version == '3.7'")
+    assert_known_marker("implementation_name == 'cpython'")
+    assert_known_marker("platform_system == 'Linux'")
+
+    def assert_unknown_marker(expression):
+        # type: (str) -> None
+        assert not evaluate_marker(expression, env_defaulted)
+        with pytest.raises(markers.UndefinedEnvironmentName):
+            evaluate_marker(expression, env_sparse)
+
+    assert_unknown_marker("python_full_version == '3.7.10'")
+    assert_unknown_marker("platform_release == '5.12.12-arch1-1'")
+    assert_unknown_marker("platform_version == '#1 SMP PREEMPT Fri, 18 Jun 2021 21:59:22 +0000'")
+    assert_unknown_marker("platform_machine == 'x86_64'")


### PR DESCRIPTION
Previously we relied on Pip, but it turns out Pip does not correctly
handle environment markers for `--platform` + `--implementation` +
`--python-version` + `--abi` (aka "foreign") resolves. Instead of
waiting on resolution of https://github.com/pypa/pip/issues/10050, patch
Pip's vendored copy of `packaging` to see a default environment that
corresponds to what we know about the foreign platform. It turns out
what we know covers the most commonly used environment markers making
this workaround both safe and useful in practice.

Fixes #1366