### PR TITLE
Modernize test pyenv interpreters.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root
+          key: ${{ runner.os }}-pyenv-root-v2
       - name: Run Unit Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -103,7 +103,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root
+          key: ${{ runner.os }}-pyenv-root-v2
       - name: Run Unit Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -129,7 +129,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root
+          key: ${{ runner.os }}-pyenv-root-v2
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -158,7 +158,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root
+          key: ${{ runner.os }}-pyenv-root-v2
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -47,12 +47,10 @@ IS_PYPY = hasattr(sys, "pypy_version_info")
 IS_PYPY2 = IS_PYPY and sys.version_info[0] == 2
 IS_PYPY3 = IS_PYPY and sys.version_info[0] == 3
 NOT_CPYTHON27 = IS_PYPY or PY_VER != (2, 7)
-NOT_CPYTHON36 = IS_PYPY or PY_VER != (3, 6)
 IS_LINUX = platform.system() == "Linux"
 IS_MAC = platform.system() == "Darwin"
 IS_NOT_LINUX = not IS_LINUX
 NOT_CPYTHON27_OR_OSX = NOT_CPYTHON27 or IS_NOT_LINUX
-NOT_CPYTHON36_OR_LINUX = NOT_CPYTHON36 or IS_LINUX
 
 
 @contextlib.contextmanager
@@ -421,12 +419,12 @@ def bootstrap_python_installer(dest):
 # otherwise encountered when fetching and building too many on a cache miss. In the past we had
 # issues with the combination of 7 total unique interpreter versions and a Travis-CI timeout of 50
 # minutes for a shard.
-PY27 = "2.7.15"
-PY35 = "3.5.6"
-PY36 = "3.6.6"
+PY27 = "2.7.18"
+PY37 = "3.7.11"
+PY38 = "3.8.11"
 
-_ALL_PY_VERSIONS = (PY27, PY35, PY36)
-_ALL_PY3_VERSIONS = (PY35, PY36)
+_ALL_PY_VERSIONS = (PY27, PY37, PY38)
+_ALL_PY3_VERSIONS = (PY37, PY38)
 
 
 def ensure_python_distribution(version):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -46,10 +46,9 @@ from pex.testing import (
     IS_PYPY2,
     NOT_CPYTHON27,
     NOT_CPYTHON27_OR_OSX,
-    NOT_CPYTHON36_OR_LINUX,
     PY27,
-    PY35,
-    PY36,
+    PY37,
+    PY38,
     IntegResults,
     WheelBuilder,
     built_wheel,
@@ -144,11 +143,11 @@ def test_pex_root_build():
 
 def test_pex_root_run():
     # type: () -> None
-    python35 = ensure_python_interpreter(PY35)
-    python36 = ensure_python_interpreter(PY36)
+    python37 = ensure_python_interpreter(PY37)
+    python38 = ensure_python_interpreter(PY38)
 
     with temporary_dir() as td, temporary_dir() as runtime_pex_root, temporary_dir() as home:
-        pex_env = make_env(HOME=home, PEX_PYTHON_PATH=os.pathsep.join((python35, python36)))
+        pex_env = make_env(HOME=home, PEX_PYTHON_PATH=os.pathsep.join((python37, python38)))
 
         buildtime_pex_root = os.path.join(td, "buildtime_pex_root")
         output_dir = os.path.join(td, "output_dir")
@@ -163,9 +162,9 @@ def test_pex_root_run():
             "--not-zip-safe",
             "--pex-root={}".format(buildtime_pex_root),
             "--runtime-pex-root={}".format(runtime_pex_root),
-            "--interpreter-constraint=CPython=={version}".format(version=PY35),
+            "--interpreter-constraint=CPython=={version}".format(version=PY37),
         ]
-        results = run_pex_command(args=args, env=pex_env, python=python36)
+        results = run_pex_command(args=args, env=pex_env, python=python38)
         results.assert_success()
         assert ["pex.pex"] == os.listdir(output_dir), "Expected built pex file."
         assert [] == os.listdir(home), "Expected empty home dir."
@@ -178,7 +177,7 @@ def test_pex_root_run():
             runtime_pex_root
         ), "Expected runtime pex root to be empty prior to any runs."
 
-        subprocess.check_call(args=[python36, pex_pex, "--version"], env=pex_env)
+        subprocess.check_call(args=[python38, pex_pex, "--version"], env=pex_env)
         assert_interpreters(label="runtime", pex_root=runtime_pex_root)
         assert_installed_wheels(label="runtime", pex_root=runtime_pex_root)
         assert [] == os.listdir(
@@ -301,24 +300,22 @@ def test_entry_point_exit_code():
         assert rc == 1
 
 
-# TODO: https://github.com/pantsbuild/pex/issues/479
-@pytest.mark.skipif(
-    NOT_CPYTHON36_OR_LINUX, reason="inherits linux abi on linux w/ no backing packages"
-)
 def test_pex_multi_resolve():
     # type: () -> None
     """Tests multi-interpreter + multi-platform resolution."""
+    python27 = ensure_python_interpreter(PY27)
+    python37 = ensure_python_interpreter(PY37)
     with temporary_dir() as output_dir:
         pex_path = os.path.join(output_dir, "pex.pex")
         results = run_pex_command(
             [
                 "--disable-cache",
-                "lxml==3.8.0",
+                "lxml==4.2.4",
                 "--no-build",
-                "--platform=linux-x86_64",
-                "--platform=macosx-10.6-x86_64",
-                "--python=python2.7",
-                "--python=python3.6",
+                "--platform=linux-x86_64-cp-36-m",
+                "--platform=macosx-10.6-x86_64-cp-36-m",
+                "--python={}".format(python27),
+                "--python={}".format(python37),
                 "-o",
                 pex_path,
             ]
@@ -327,7 +324,7 @@ def test_pex_multi_resolve():
 
         included_dists = get_dep_dist_names_from_pex(pex_path, "lxml")
         assert len(included_dists) == 4
-        for dist_substr in ("-cp27-", "-cp36-", "-manylinux1_x86_64", "-macosx_"):
+        for dist_substr in ("-cp27-", "-cp36-", "-cp37-", "-manylinux1_x86_64", "-macosx_"):
             assert any(dist_substr in f for f in included_dists)
 
 
@@ -501,7 +498,7 @@ def test_interpreter_constraints_to_pex_info_py2():
 
 def test_interpreter_constraints_to_pex_info_py3():
     # type: () -> None
-    py3_interpreter = ensure_python_interpreter(PY36)
+    py3_interpreter = ensure_python_interpreter(PY38)
     with temporary_dir() as output_dir:
         # target python 3
         pex_out_path = os.path.join(output_dir, "pex_py3.pex")
@@ -555,7 +552,7 @@ def test_interpreter_resolution_with_pex_python_path():
         with open(pexrc_path, "w") as pexrc:
             # set pex python path
             pex_python_path = ":".join(
-                [ensure_python_interpreter(PY27), ensure_python_interpreter(PY36)]
+                [ensure_python_interpreter(PY27), ensure_python_interpreter(PY37)]
             )
             pexrc.write("PEX_PYTHON_PATH=%s" % pex_python_path)
 
@@ -591,21 +588,21 @@ def test_interpreter_constraints_honored_without_ppp_or_pp():
     # type: () -> None
     # Create a pex with interpreter constraints, but for not the default interpreter in the path.
     with temporary_dir() as td:
-        py36_path = ensure_python_interpreter(PY36)
-        py35_path = ensure_python_interpreter(PY35)
+        py38_path = ensure_python_interpreter(PY38)
+        py37_path = ensure_python_interpreter(PY37)
 
         pex_out_path = os.path.join(td, "pex.pex")
         env = make_env(
             PEX_IGNORE_RCFILES="1",
             PATH=os.pathsep.join(
                 [
-                    os.path.dirname(py35_path),
-                    os.path.dirname(py36_path),
+                    os.path.dirname(py37_path),
+                    os.path.dirname(py38_path),
                 ]
             ),
         )
         res = run_pex_command(
-            ["--disable-cache", "--interpreter-constraint===%s" % PY36, "-o", pex_out_path], env=env
+            ["--disable-cache", "--interpreter-constraint===%s" % PY38, "-o", pex_out_path], env=env
         )
         res.assert_success()
 
@@ -615,10 +612,10 @@ def test_interpreter_constraints_honored_without_ppp_or_pp():
         stdout, rc = run_simple_pex(pex_out_path, stdin=stdin_payload, env=env)
         assert rc == 0
 
-        # If the constraints are honored, it will have run python3.6 and not python3.5
-        # Without constraints, we would expect it to use python3.5 as it is the minimum interpreter
+        # If the constraints are honored, it will have run python3.8 and not python3.7
+        # Without constraints, we would expect it to use python3.7 as it is the minimum interpreter
         # in the PATH.
-        assert str(py36_path).encode() in stdout
+        assert str(py38_path).encode() in stdout
 
 
 def test_interpreter_resolution_pex_python_path_precedence_over_pex_python():
@@ -628,7 +625,7 @@ def test_interpreter_resolution_pex_python_path_precedence_over_pex_python():
         with open(pexrc_path, "w") as pexrc:
             # set both PPP and PP
             pex_python_path = ":".join(
-                [ensure_python_interpreter(PY27), ensure_python_interpreter(PY36)]
+                [ensure_python_interpreter(PY27), ensure_python_interpreter(PY37)]
             )
             pexrc.write("PEX_PYTHON_PATH=%s\n" % pex_python_path)
             pex_python = "/path/to/some/python"
@@ -676,7 +673,7 @@ def test_pex_exec_with_pex_python_path_only():
         with open(pexrc_path, "w") as pexrc:
             # set pex python path
             pex_python_path = ":".join(
-                [ensure_python_interpreter(PY27), ensure_python_interpreter(PY36)]
+                [ensure_python_interpreter(PY27), ensure_python_interpreter(PY38)]
             )
             pexrc.write("PEX_PYTHON_PATH=%s" % pex_python_path)
 
@@ -699,7 +696,7 @@ def test_pex_exec_with_pex_python_path_and_pex_python_but_no_constraints():
         with open(pexrc_path, "w") as pexrc:
             # set both PPP and PP
             pex_python_path = ":".join(
-                [ensure_python_interpreter(PY27), ensure_python_interpreter(PY36)]
+                [ensure_python_interpreter(PY27), ensure_python_interpreter(PY38)]
             )
             pexrc.write("PEX_PYTHON_PATH=%s\n" % pex_python_path)
             pex_python = "/path/to/some/python"
@@ -720,13 +717,13 @@ def test_pex_exec_with_pex_python_path_and_pex_python_but_no_constraints():
 def test_pex_python():
     # type: () -> None
     py2_path_interpreter = ensure_python_interpreter(PY27)
-    py3_path_interpreter = ensure_python_interpreter(PY36)
+    py3_path_interpreter = ensure_python_interpreter(PY37)
     path = ":".join([os.path.dirname(py2_path_interpreter), os.path.dirname(py3_path_interpreter)])
     env = make_env(PATH=path)
     with temporary_dir() as td:
         pexrc_path = os.path.join(td, ".pexrc")
         with open(pexrc_path, "w") as pexrc:
-            pex_python = ensure_python_interpreter(PY36)
+            pex_python = ensure_python_interpreter(PY37)
             pexrc.write("PEX_PYTHON=%s" % pex_python)
 
         # test PEX_PYTHON with valid constraints
@@ -794,7 +791,7 @@ def test_entry_point_targeting():
     with temporary_dir() as td:
         pexrc_path = os.path.join(td, ".pexrc")
         with open(pexrc_path, "w") as pexrc:
-            pex_python = ensure_python_interpreter(PY36)
+            pex_python = ensure_python_interpreter(PY38)
             pexrc.write("PEX_PYTHON=%s" % pex_python)
 
         # test pex with entry point
@@ -824,7 +821,7 @@ def test_interpreter_selection_using_os_environ_for_bootstrap_reexec():
         # execute with. The child interpreter is the interpreter we expect the
         # child pex to execute with.
         if (sys.version_info[0], sys.version_info[1]) == (3, 6):
-            child_pex_interpreter_version = PY36
+            child_pex_interpreter_version = PY38
         else:
             child_pex_interpreter_version = PY27
 
@@ -1208,11 +1205,11 @@ def test_pex_source_bundling_pep420():
                 )
 
             pex_path = os.path.join(output_dir, "pex1.pex")
-            py36 = ensure_python_interpreter(PY36)
-            res = run_pex_command(["-o", pex_path, "-D", input_dir, "-e", "exe"], python=py36)
+            py38 = ensure_python_interpreter(PY38)
+            res = run_pex_command(["-o", pex_path, "-D", input_dir, "-e", "exe"], python=py38)
             res.assert_success()
 
-            stdout, rc = run_simple_pex(pex_path, interpreter=PythonInterpreter.from_binary(py36))
+            stdout, rc = run_simple_pex(pex_path, interpreter=PythonInterpreter.from_binary(py38))
 
             assert rc == 0
             assert stdout == b"hello\n"
@@ -1281,15 +1278,15 @@ def test_multiplatform_entrypoint():
     # type: () -> None
     with temporary_dir() as td:
         pex_out_path = os.path.join(td, "p537.pex")
-        interpreter = ensure_python_interpreter(PY36)
+        interpreter = ensure_python_interpreter(PY37)
         res = run_pex_command(
             [
-                "p537==1.0.3",
+                "p537==1.0.4",
                 "--no-build",
                 "--python={}".format(interpreter),
                 "--python-shebang=#!{}".format(interpreter),
-                "--platform=linux-x86_64-cp-36-m",
-                "--platform=macosx-10.13-x86_64-cp-36-m",
+                "--platform=linux-x86_64-cp-37-m",
+                "--platform=macosx-10.13-x86_64-cp-37-m",
                 "-c",
                 "p537",
                 "-o",
@@ -1419,7 +1416,7 @@ def test_setup_python_path():
     # type: () -> None
     """Check that `--python-path` is used rather than the default $PATH."""
     py27_interpreter_dir = os.path.dirname(ensure_python_interpreter(PY27))
-    py36_interpreter_dir = os.path.dirname(ensure_python_interpreter(PY36))
+    py37_interpreter_dir = os.path.dirname(ensure_python_interpreter(PY37))
     with temporary_dir() as out:
         pex = os.path.join(out, "pex.pex")
         # Even though we set $PATH="", we still expect for both interpreters to be used when
@@ -1428,10 +1425,9 @@ def test_setup_python_path():
             [
                 "more-itertools==5.0.0",
                 "--disable-cache",
-                "--interpreter-constraint=CPython=={}".format(PY27),
-                "--interpreter-constraint=CPython=={}".format(PY36),
+                "--interpreter-constraint=CPython>={},<={}".format(PY27, PY37),
                 "--python-path={}".format(
-                    os.pathsep.join([py27_interpreter_dir, py36_interpreter_dir])
+                    os.pathsep.join([py27_interpreter_dir, py37_interpreter_dir])
                 ),
                 "-o",
                 pex,
@@ -1440,25 +1436,33 @@ def test_setup_python_path():
         )
         results.assert_success()
 
+        py38_interpreter = PythonInterpreter.from_binary(ensure_python_interpreter(PY38))
+
         py27_env = make_env(PEX_IGNORE_RCFILES="1", PATH=py27_interpreter_dir)
         stdout, rc = run_simple_pex(
-            pex, env=py27_env, stdin=b"import more_itertools, sys; print(sys.version_info[:2])"
+            pex,
+            interpreter=py38_interpreter,
+            env=py27_env,
+            stdin=b"import more_itertools, sys; print(sys.version_info[:2])",
         )
         assert rc == 0
         assert b"(2, 7)" in stdout
 
-        py36_env = make_env(PEX_IGNORE_RCFILES="1", PATH=py36_interpreter_dir)
+        py37_env = make_env(PEX_IGNORE_RCFILES="1", PATH=py37_interpreter_dir)
         stdout, rc = run_simple_pex(
-            pex, env=py36_env, stdin=b"import more_itertools, sys; print(sys.version_info[:2])"
+            pex,
+            interpreter=py38_interpreter,
+            env=py37_env,
+            stdin=b"import more_itertools, sys; print(sys.version_info[:2])",
         )
         assert rc == 0
-        assert b"(3, 6)" in stdout
+        assert b"(3, 7)" in stdout
 
 
 def test_setup_python_multiple_transitive_markers():
     # type: () -> None
     py27_interpreter = ensure_python_interpreter(PY27)
-    py36_interpreter = ensure_python_interpreter(PY36)
+    py38_interpreter = ensure_python_interpreter(PY38)
     with temporary_dir() as out:
         pex = os.path.join(out, "pex.pex")
         results = run_pex_command(
@@ -1467,7 +1471,7 @@ def test_setup_python_multiple_transitive_markers():
                 "--disable-cache",
                 "--python-shebang=#!/usr/bin/env python",
                 "--python={}".format(py27_interpreter),
-                "--python={}".format(py36_interpreter),
+                "--python={}".format(py38_interpreter),
                 "-o",
                 pex,
             ]
@@ -1486,18 +1490,18 @@ def test_setup_python_multiple_transitive_markers():
         stdout = subprocess.check_output(both_program, env=py27_env)
         assert to_bytes(os.path.realpath(py27_interpreter)) == stdout.strip()
 
-        py36_env = make_env(PATH=os.path.dirname(py36_interpreter))
+        py38_env = make_env(PATH=os.path.dirname(py38_interpreter))
         with pytest.raises(subprocess.CalledProcessError) as err:
-            subprocess.check_output(py2_only_program, stderr=subprocess.STDOUT, env=py36_env)
+            subprocess.check_output(py2_only_program, stderr=subprocess.STDOUT, env=py38_env)
         assert b"ModuleNotFoundError: No module named 'functools32'" in err.value.output
 
-        stdout = subprocess.check_output(both_program, env=py36_env)
-        assert to_bytes(os.path.realpath(py36_interpreter)) == stdout.strip()
+        stdout = subprocess.check_output(both_program, env=py38_env)
+        assert to_bytes(os.path.realpath(py38_interpreter)) == stdout.strip()
 
 
 def test_setup_python_direct_markers():
     # type: () -> None
-    py36_interpreter = ensure_python_interpreter(PY36)
+    py38_interpreter = ensure_python_interpreter(PY38)
     with temporary_dir() as out:
         pex = os.path.join(out, "pex.pex")
         results = run_pex_command(
@@ -1505,7 +1509,7 @@ def test_setup_python_direct_markers():
                 'subprocess32==3.2.7; python_version<"3"',
                 "--disable-cache",
                 "--python-shebang=#!/usr/bin/env python",
-                "--python={}".format(py36_interpreter),
+                "--python={}".format(py38_interpreter),
                 "-o",
                 pex,
             ]
@@ -1518,14 +1522,14 @@ def test_setup_python_direct_markers():
             subprocess.check_output(
                 py2_only_program,
                 stderr=subprocess.STDOUT,
-                env=make_env(PATH=os.path.dirname(py36_interpreter)),
+                env=make_env(PATH=os.path.dirname(py38_interpreter)),
             )
         assert b"ModuleNotFoundError: No module named 'subprocess32'" in err.value.output
 
 
 def test_setup_python_multiple_direct_markers():
     # type: () -> None
-    py36_interpreter = ensure_python_interpreter(PY36)
+    py38_interpreter = ensure_python_interpreter(PY38)
     py27_interpreter = ensure_python_interpreter(PY27)
     with temporary_dir() as out:
         pex = os.path.join(out, "pex.pex")
@@ -1534,7 +1538,7 @@ def test_setup_python_multiple_direct_markers():
                 'subprocess32==3.2.7; python_version<"3"',
                 "--disable-cache",
                 "--python-shebang=#!/usr/bin/env python",
-                "--python={}".format(py36_interpreter),
+                "--python={}".format(py38_interpreter),
                 "--python={}".format(py27_interpreter),
                 "-o",
                 pex,
@@ -1548,7 +1552,7 @@ def test_setup_python_multiple_direct_markers():
             subprocess.check_output(
                 py2_only_program,
                 stderr=subprocess.STDOUT,
-                env=make_env(PATH=os.path.dirname(py36_interpreter)),
+                env=make_env(PATH=os.path.dirname(py38_interpreter)),
             )
         assert (
             re.search(b"ModuleNotFoundError: No module named 'subprocess32'", err.value.output)
@@ -2010,27 +2014,27 @@ def test_pex_reexec_constraints_match_current_pythonpath_present():
 
 def test_pex_reexec_constraints_dont_match_current_pex_python_path():
     # type: () -> None
-    py36_interpreter = ensure_python_interpreter(PY36)
+    py38_interpreter = ensure_python_interpreter(PY38)
     py27_interpreter = ensure_python_interpreter(PY27)
     _assert_exec_chain(
-        exec_chain=[py36_interpreter],
-        pex_python_path=[py27_interpreter, py36_interpreter],
-        interpreter_constraints=["=={}".format(PY36)],
+        exec_chain=[py38_interpreter],
+        pex_python_path=[py27_interpreter, py38_interpreter],
+        interpreter_constraints=["=={}".format(PY38)],
     )
 
 
 def test_pex_reexec_constraints_dont_match_current_pex_python_path_min_py_version_selected():
     # type: () -> None
-    py36_interpreter = ensure_python_interpreter(PY36)
+    py38_interpreter = ensure_python_interpreter(PY38)
     py27_interpreter = ensure_python_interpreter(PY27)
     _assert_exec_chain(
-        exec_chain=[py27_interpreter], pex_python_path=[py36_interpreter, py27_interpreter]
+        exec_chain=[py27_interpreter], pex_python_path=[py38_interpreter, py27_interpreter]
     )
 
 
 def test_pex_reexec_constraints_dont_match_current_pex_python():
     # type: () -> None
-    version = PY27 if sys.version_info[0:2] == (3, 6) else PY36
+    version = PY27 if sys.version_info[0:2] == (3, 6) else PY38
     interpreter = ensure_python_interpreter(version)
     _assert_exec_chain(
         exec_chain=[interpreter],
@@ -2119,7 +2123,7 @@ def issues_1025_pth():
 
 
 def test_issues_1025_extras_isolation(issues_1025_pth):
-    python, pip = ensure_python_venv(PY36)
+    python, pip = ensure_python_venv(PY38)
     interpreter = PythonInterpreter.from_binary(python)
     _, stdout, _ = interpreter.execute(args=["-c", "import site; print(site.getsitepackages()[0])"])
     with temporary_dir() as tmpdir:
@@ -2171,7 +2175,7 @@ def test_trusted_host_handling():
 def test_issues_898():
     # type: () -> None
     python27 = ensure_python_interpreter(PY27)
-    python36 = ensure_python_interpreter(PY36)
+    python38 = ensure_python_interpreter(PY38)
     with temporary_dir() as td:
         src_dir = os.path.join(td, "src")
         with safe_open(os.path.join(src_dir, "test_issues_898.py"), "w") as fp:
@@ -2190,7 +2194,7 @@ def test_issues_898():
         results = run_pex_command(
             args=[
                 "--python={}".format(python27),
-                "--python={}".format(python36),
+                "--python={}".format(python38),
                 "zipp>=1,<=3.1.0",
                 "--sources-directory={}".format(src_dir),
                 "--entry-point=test_issues_898",
@@ -2201,7 +2205,7 @@ def test_issues_898():
         results.assert_success()
 
         pex_root = os.path.realpath(os.path.join(td, "pex_root"))
-        for python in python27, python36:
+        for python in python27, python38:
             output = subprocess.check_output([python, pex_file], env=make_env(PEX_ROOT=pex_root))
             zipp_location = os.path.realpath(output.decode("utf-8").strip())
             assert zipp_location.startswith(
@@ -2279,7 +2283,7 @@ def iter_distributions(pex_root, project_name):
 
 def test_pex_cache_dir_and_pex_root():
     # type: () -> None
-    python = ensure_python_interpreter(PY36)
+    python = ensure_python_interpreter(PY37)
     with temporary_dir() as td:
         cache_dir = os.path.join(td, "cache_dir")
         pex_root = os.path.join(td, "pex_root")
@@ -2288,7 +2292,7 @@ def test_pex_cache_dir_and_pex_root():
         pex_file = os.path.join(td, "pex_file")
         run_pex_command(
             python=python,
-            args=["--cache-dir", cache_dir, "--pex-root", cache_dir, "p537==1.0.3", "-o", pex_file],
+            args=["--cache-dir", cache_dir, "--pex-root", cache_dir, "p537==1.0.4", "-o", pex_file],
         ).assert_success()
 
         dists = list(iter_distributions(pex_root=cache_dir, project_name="p537"))
@@ -2300,7 +2304,7 @@ def test_pex_cache_dir_and_pex_root():
         # When the options have conflicting values they should be rejected.
         run_pex_command(
             python=python,
-            args=["--cache-dir", cache_dir, "--pex-root", pex_root, "p537==1.0.3", "-o", pex_file],
+            args=["--cache-dir", cache_dir, "--pex-root", pex_root, "p537==1.0.4", "-o", pex_file],
         ).assert_failure()
 
         assert not os.path.exists(cache_dir)
@@ -2309,13 +2313,13 @@ def test_pex_cache_dir_and_pex_root():
 
 def test_disable_cache():
     # type: () -> None
-    python = ensure_python_interpreter(PY36)
+    python = ensure_python_interpreter(PY37)
     with temporary_dir() as td:
         pex_root = os.path.join(td, "pex_root")
         pex_file = os.path.join(td, "pex_file")
         run_pex_command(
             python=python,
-            args=["--disable-cache", "p537==1.0.3", "-o", pex_file],
+            args=["--disable-cache", "p537==1.0.4", "-o", pex_file],
             env=make_env(PEX_ROOT=pex_root),
         ).assert_success()
 
@@ -2387,13 +2391,13 @@ def test_unzip_mode():
 def test_issues_996():
     # type: () -> None
     python27 = ensure_python_interpreter(PY27)
-    python36 = ensure_python_interpreter(PY36)
-    pex_python_path = os.pathsep.join((python27, python36))
+    python38 = ensure_python_interpreter(PY38)
+    pex_python_path = os.pathsep.join((python27, python38))
 
     def create_platform_pex(args):
         # type: (List[str]) -> IntegResults
         return run_pex_command(
-            args=["--platform", str(PythonInterpreter.from_binary(python36).platform)] + args,
+            args=["--platform", str(PythonInterpreter.from_binary(python38).platform)] + args,
             python=python27,
             env=make_env(PEX_PYTHON_PATH=pex_python_path),
         )
@@ -2417,7 +2421,7 @@ def test_issues_996():
         output, returncode = run_simple_pex(
             pex=pex_file,
             args=("-c", "import psutil; print(psutil.cpu_count())"),
-            interpreter=PythonInterpreter.from_binary(python36),
+            interpreter=PythonInterpreter.from_binary(python38),
         )
         assert 0 == returncode
         assert int(output.strip()) >= multiprocessing.cpu_count()
@@ -2498,9 +2502,9 @@ def test_resolve_arbitrary_equality_issues_940():
 
 def test_resolve_python_requires_full_version_issues_1017():
     # type: () -> None
-    python36 = ensure_python_interpreter(PY36)
+    python38 = ensure_python_interpreter(PY38)
     result = run_pex_command(
-        python=python36,
+        python=python38,
         args=[
             "pandas==1.0.5",
             "--",
@@ -2516,7 +2520,7 @@ def test_resolve_python_requires_full_version_issues_1017():
 @pytest.fixture(scope="module")
 def mitmdump():
     # type: () -> Tuple[str, str]
-    python, pip = ensure_python_venv(PY36)
+    python, pip = ensure_python_venv(PY38)
     subprocess.check_call([pip, "install", "mitmproxy==5.3.0"])
     mitmdump = os.path.join(os.path.dirname(python), "mitmdump")
     return mitmdump, os.path.expanduser("~/.mitmproxy/mitmproxy-ca-cert.pem")
@@ -2615,7 +2619,7 @@ def test_requirements_network_configuration(run_proxy, tmp_workdir):
     "py_version",
     [
         pytest.param(PY27, id="virtualenv-16.7.10"),
-        pytest.param(PY36, id="pyvenv"),
+        pytest.param(PY38, id="pyvenv"),
     ],
 )
 def test_issues_1031(py_version):
@@ -2704,7 +2708,7 @@ def test_venv_mode(
     isort_pex_args,  # type: Tuple[str, List[str]]
 ):
     # type: (...) -> None
-    other_interpreter_version = PY36 if sys.version_info[0] == 2 else PY27
+    other_interpreter_version = PY38 if sys.version_info[0] == 2 else PY27
     other_interpreter = ensure_python_interpreter(other_interpreter_version)
 
     pex_file, args = isort_pex_args
@@ -2945,7 +2949,7 @@ def test_pip_issues_9420_workaround():
     # type: () -> None
 
     # N.B.: isort 5.7.0 needs Python >=3.6
-    python = ensure_python_interpreter(PY36)
+    python = ensure_python_interpreter(PY38)
 
     results = run_pex_command(
         args=["--resolver-version", "pip-2020-resolver", "isort[colors]==5.7.0", "colorama==0.4.1"],
@@ -2993,7 +2997,7 @@ def test_constraint_file_from_url(tmpdir):
     # type: (Any) -> None
 
     # N.B.: The fasteners library requires Python >=3.6.
-    python = ensure_python_interpreter(PY36)
+    python = ensure_python_interpreter(PY38)
 
     pex_file = os.path.join(str(tmpdir), "pex")
 
@@ -3032,13 +3036,13 @@ def test_constraint_file_from_url(tmpdir):
 def test_top_level_environment_markers_issues_899(tmpdir):
     # type: (Any) -> None
     python27 = ensure_python_interpreter(PY27)
-    python36 = ensure_python_interpreter(PY36)
+    python38 = ensure_python_interpreter(PY38)
 
     pex_file = os.path.join(str(tmpdir), "pex")
 
     requirement = "subprocess32==3.2.7; python_version<'3'"
     results = run_pex_command(
-        args=["--python", python27, "--python", python36, requirement, "-o", pex_file]
+        args=["--python", python27, "--python", python38, requirement, "-o", pex_file]
     )
     results.assert_success()
     requirements = PexInfo.from_pex(pex_file).requirements
@@ -3052,19 +3056,19 @@ def test_top_level_environment_markers_issues_899(tmpdir):
     )
     assert 0 == returncode
 
-    py36_interpreter = PythonInterpreter.from_binary(python36)
+    py38_interpreter = PythonInterpreter.from_binary(python38)
+
     output, returncode = run_simple_pex(
         pex_file,
         args=["-c", "import subprocess"],
-        interpreter=py36_interpreter,
+        interpreter=py38_interpreter,
     )
     assert 0 == returncode
 
-    py36_interpreter = PythonInterpreter.from_binary(python36)
     output, returncode = run_simple_pex(
         pex_file,
         args=["-c", "import subprocess32"],
-        interpreter=py36_interpreter,
+        interpreter=py38_interpreter,
     )
     assert (
         1 == returncode
@@ -3091,10 +3095,10 @@ def test_isolated_pex_zip_issues_1232(tmpdir):
 
     pex_root = os.path.join(str(tmpdir), "pex_root")
 
-    python35 = ensure_python_interpreter(PY35)
-    python36 = ensure_python_interpreter(PY36)
+    python37 = ensure_python_interpreter(PY37)
+    python38 = ensure_python_interpreter(PY38)
 
-    pex_env = make_env(PEX_PYTHON_PATH=os.pathsep.join((python35, python36)))
+    pex_env = make_env(PEX_PYTHON_PATH=os.pathsep.join((python37, python38)))
 
     def add_pex_args(*args):
         # type: (*str) -> List[str]
@@ -3104,7 +3108,7 @@ def test_isolated_pex_zip_issues_1232(tmpdir):
             "--runtime-pex-root",
             pex_root,
             "--interpreter-constraint",
-            "CPython=={version}".format(version=PY35),
+            "CPython=={version}".format(version=PY37),
         ]
 
     def tally_isolated_vendoreds():
@@ -3134,7 +3138,7 @@ def test_isolated_pex_zip_issues_1232(tmpdir):
     # ===
     current_pex_pex = os.path.join(str(tmpdir), "pex-current.pex")
     results = run_pex_command(
-        args=add_pex_args(".", "-c", "pex", "-o", current_pex_pex), env=pex_env, python=python35
+        args=add_pex_args(".", "-c", "pex", "-o", current_pex_pex), env=pex_env, python=python37
     )
     results.assert_success()
 
@@ -3161,7 +3165,7 @@ def test_isolated_pex_zip_issues_1232(tmpdir):
     modified_pex = os.path.join(str(tmpdir), "modified.pex")
     subprocess.check_call(
         args=add_pex_args(
-            python36, current_pex_pex, modified_pex_src, "-c", "pex", "-o", modified_pex
+            python38, current_pex_pex, modified_pex_src, "-c", "pex", "-o", modified_pex
         ),
         env=pex_env,
     )
@@ -3182,7 +3186,7 @@ def test_isolated_pex_zip_issues_1232(tmpdir):
     ansicolors_pex = os.path.join(str(tmpdir), "ansicolors.pex")
     subprocess.check_call(
         args=add_pex_args(
-            python36,
+            python38,
             modified_pex,
             "ansicolors==1.1.8",
             "-o",
@@ -3206,7 +3210,7 @@ def test_isolated_pex_zip_issues_1232(tmpdir):
     # ===
     # Force the bootstrap to run interpreter identification which will force a Pex isolation.
     shutil.rmtree(os.path.join(pex_root, "interpreters"))
-    subprocess.check_call(args=[python36, ansicolors_pex, "-c", "import colors"], env=pex_env)
+    subprocess.check_call(args=[python38, ansicolors_pex, "-c", "import colors"], env=pex_env)
     ansicolors_pex_isolated_vendoreds = tally_isolated_vendoreds()
     ansicolors_pex_isolation = set(modified_pex_isolated_vendoreds.keys()) ^ set(
         ansicolors_pex_isolated_vendoreds.keys()
@@ -3224,7 +3228,7 @@ def test_isolated_pex_zip_issues_1232(tmpdir):
     ansicolors_pex = os.path.join(str(tmpdir), "ansicolors.old.pex")
     subprocess.check_call(
         args=add_pex_args(
-            python36,
+            python38,
             modified_pex,
             "ansicolors==1.0.2",
             "-o",
@@ -3235,7 +3239,7 @@ def test_isolated_pex_zip_issues_1232(tmpdir):
 
     # Force the bootstrap to run interpreter identification which will force a Pex isolation.
     shutil.rmtree(os.path.join(pex_root, "interpreters"))
-    subprocess.check_call(args=[python36, ansicolors_pex, "-c", "import colors"], env=pex_env)
+    subprocess.check_call(args=[python38, ansicolors_pex, "-c", "import colors"], env=pex_env)
     assert (
         ansicolors_pex_isolated_vendoreds == tally_isolated_vendoreds()
     ), "Expecting no new Pex isolations."
@@ -3532,7 +3536,7 @@ def test_issues_1316_resolve_cyclic_dependency_graph(tmpdir):
 
 def test_pip_leak_issues_1336(tmpdir):
     # type: (Any) -> None
-    python = ensure_python_interpreter(PY36)
+    python = ensure_python_interpreter(PY38)
     pip = os.path.join(os.path.dirname(python), "pip")
     subprocess.check_call(args=[pip, "install", "setuptools_scm==6.0.1"])
     run_pex_command(args=["--python", python, "bitstring==3.1.7"], python=python).assert_success()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -820,7 +820,7 @@ def test_interpreter_selection_using_os_environ_for_bootstrap_reexec():
         # The parent interpreter is the interpreter we expect the parent pex to
         # execute with. The child interpreter is the interpreter we expect the
         # child pex to execute with.
-        if (sys.version_info[0], sys.version_info[1]) == (3, 6):
+        if sys.version_info[:2] == (3, 8):
             child_pex_interpreter_version = PY38
         else:
             child_pex_interpreter_version = PY27
@@ -2034,7 +2034,7 @@ def test_pex_reexec_constraints_dont_match_current_pex_python_path_min_py_versio
 
 def test_pex_reexec_constraints_dont_match_current_pex_python():
     # type: () -> None
-    version = PY27 if sys.version_info[0:2] == (3, 6) else PY38
+    version = PY27 if sys.version_info[:2] == (3, 8) else PY38
     interpreter = ensure_python_interpreter(version)
     _assert_exec_chain(
         exec_chain=[interpreter],

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -323,8 +323,8 @@ def test_latest_release_of_min_compatible_version():
 def test_detect_pyvenv(tmpdir):
     # type: (Any) -> None
     venv = str(tmpdir)
-    py35 = ensure_python_interpreter(PY37)
-    real_interpreter = PythonInterpreter.from_binary(py35)
+    py37 = ensure_python_interpreter(PY37)
+    real_interpreter = PythonInterpreter.from_binary(py37)
     real_interpreter.execute(["-m", "venv", venv])
     with pytest.raises(Executor.NonZeroExit):
         real_interpreter.execute(["-c", "import colors"])
@@ -343,7 +343,7 @@ def test_detect_pyvenv(tmpdir):
     ), "Expected exactly one canonical venv python, found: {}".format(canonical_to_python)
     canonical, pythons = canonical_to_python.popitem()
 
-    real_python = os.path.realpath(py35)
+    real_python = os.path.realpath(py37)
     assert canonical != real_python
     assert os.path.dirname(canonical) == venv_bin_dir
     assert os.path.realpath(canonical) == real_python
@@ -400,13 +400,13 @@ def test_resolve_venv_ambient():
 def test_identify_cwd_isolation_issues_1231(tmpdir):
     # type: (Any) -> None
 
-    python36, pip = ensure_python_venv(PY38)
+    python38, pip = ensure_python_venv(PY38)
     polluted_cwd = os.path.join(str(tmpdir), "dir")
     subprocess.check_call(args=[pip, "install", "--target", polluted_cwd, "pex==2.1.16"])
 
     pex_root = os.path.join(str(tmpdir), "pex_root")
     with pushd(polluted_cwd), ENV.patch(PEX_ROOT=pex_root):
-        interp = PythonInterpreter.from_binary(python36)
+        interp = PythonInterpreter.from_binary(python38)
 
     interp_info_files = {
         os.path.join(root, f)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -18,8 +18,8 @@ from pex.interpreter import PythonInterpreter
 from pex.pyenv import Pyenv
 from pex.testing import (
     PY27,
-    PY35,
-    PY36,
+    PY37,
+    PY38,
     PY_VER,
     ensure_python_distribution,
     ensure_python_interpreter,
@@ -62,7 +62,7 @@ class TestPythonInterpreter(object):
     TEST_INTERPRETER1_VERSION = PY27
     TEST_INTERPRETER1_VERSION_TUPLE = tuple_from_version(TEST_INTERPRETER1_VERSION)
 
-    TEST_INTERPRETER2_VERSION = PY35
+    TEST_INTERPRETER2_VERSION = PY37
     TEST_INTERPRETER2_VERSION_TUPLE = tuple_from_version(TEST_INTERPRETER2_VERSION)
 
     @pytest.fixture
@@ -207,8 +207,8 @@ class TestPythonInterpreter(object):
 
     def test_pyenv_shims(self, tmpdir):
         # type: (Any) -> None
-        py35, _, run_pyenv = ensure_python_distribution(PY35)
-        py36 = ensure_python_interpreter(PY36)
+        py37, _, run_pyenv = ensure_python_distribution(PY37)
+        py38 = ensure_python_interpreter(PY38)
 
         pyenv_root = str(run_pyenv(["root"]).strip())
         pyenv_shims = os.path.join(pyenv_root, "shims")
@@ -254,49 +254,49 @@ class TestPythonInterpreter(object):
                 with pytest.raises(PythonInterpreter.IdentificationError):
                     interpreter_for_shim(shim_name)
 
-            pyenv_global(PY35, PY36)
-            assert_shim("python", py35)
-            assert_shim("python3", py35)
-            assert_shim("python3.5", py35)
-            assert_shim("python3.6", py36)
+            pyenv_global(PY37, PY38)
+            assert_shim("python", py37)
+            assert_shim("python3", py37)
+            assert_shim("python3.7", py37)
+            assert_shim("python3.8", py38)
 
-            pyenv_global(PY36, PY35)
-            assert_shim("python", py36)
-            assert_shim("python3", py36)
-            assert_shim("python3.6", py36)
-            assert_shim("python3.5", py35)
+            pyenv_global(PY38, PY37)
+            assert_shim("python", py38)
+            assert_shim("python3", py38)
+            assert_shim("python3.8", py38)
+            assert_shim("python3.7", py37)
 
-            pyenv_local(PY35)
-            assert_shim("python", py35)
-            assert_shim("python3", py35)
-            assert_shim("python3.5", py35)
-            assert_shim_inactive("python3.6")
+            pyenv_local(PY37)
+            assert_shim("python", py37)
+            assert_shim("python3", py37)
+            assert_shim("python3.7", py37)
+            assert_shim_inactive("python3.8")
 
-            with pyenv_shell(PY36):
-                assert_shim("python", py36)
-                assert_shim("python3", py36)
-                assert_shim("python3.6", py36)
-                assert_shim_inactive("python3.5")
+            with pyenv_shell(PY38):
+                assert_shim("python", py38)
+                assert_shim("python3", py38)
+                assert_shim("python3.8", py38)
+                assert_shim_inactive("python3.7")
 
-            with pyenv_shell(PY35, PY36):
-                assert_shim("python", py35)
-                assert_shim("python3", py35)
-                assert_shim("python3.5", py35)
-                assert_shim("python3.6", py36)
+            with pyenv_shell(PY37, PY38):
+                assert_shim("python", py37)
+                assert_shim("python3", py37)
+                assert_shim("python3.7", py37)
+                assert_shim("python3.8", py38)
 
-            # The shim pointer is now invalid since python3.5 was uninstalled and so
+            # The shim pointer is now invalid since python3.7 was uninstalled and so
             # should be re-read and found invalid.
-            py35_version_dir = os.path.dirname(os.path.dirname(py35))
-            py35_deleted = "{}.uninstalled".format(py35_version_dir)
-            os.rename(py35_version_dir, py35_deleted)
+            py37_version_dir = os.path.dirname(os.path.dirname(py37))
+            py37_deleted = "{}.uninstalled".format(py37_version_dir)
+            os.rename(py37_version_dir, py37_deleted)
             try:
                 assert_shim_inactive("python")
                 assert_shim_inactive("python3")
-                assert_shim_inactive("python3.5")
+                assert_shim_inactive("python3.7")
             finally:
-                os.rename(py35_deleted, py35_version_dir)
+                os.rename(py37_deleted, py37_version_dir)
 
-            assert_shim("python", py35)
+            assert_shim("python", py37)
 
 
 def test_latest_release_of_min_compatible_version():
@@ -323,7 +323,7 @@ def test_latest_release_of_min_compatible_version():
 def test_detect_pyvenv(tmpdir):
     # type: (Any) -> None
     venv = str(tmpdir)
-    py35 = ensure_python_interpreter(PY35)
+    py35 = ensure_python_interpreter(PY37)
     real_interpreter = PythonInterpreter.from_binary(py35)
     real_interpreter.execute(["-m", "venv", venv])
     with pytest.raises(Executor.NonZeroExit):
@@ -384,7 +384,7 @@ def check_resolve_venv(real_interpreter):
 
 def test_resolve_venv():
     # type: () -> None
-    real_interpreter = PythonInterpreter.from_binary(ensure_python_interpreter(PY35))
+    real_interpreter = PythonInterpreter.from_binary(ensure_python_interpreter(PY37))
     check_resolve_venv(real_interpreter)
 
 
@@ -400,7 +400,7 @@ def test_resolve_venv_ambient():
 def test_identify_cwd_isolation_issues_1231(tmpdir):
     # type: (Any) -> None
 
-    python36, pip = ensure_python_venv(PY36)
+    python36, pip = ensure_python_venv(PY38)
     polluted_cwd = os.path.join(str(tmpdir), "dir")
     subprocess.check_call(args=[pip, "install", "--target", polluted_cwd, "pex==2.1.16"])
 

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -23,7 +23,7 @@ from pex.resolver import resolve
 from pex.testing import (
     IS_PYPY3,
     PY27,
-    PY36,
+    PY38,
     WheelBuilder,
     built_wheel,
     ensure_python_interpreter,
@@ -566,7 +566,7 @@ def test_pex_verify_entry_point_module_should_fail():
 def test_activate_interpreter_different_from_current():
     # type: () -> None
     with temporary_dir() as pex_root:
-        interp_version = PY36 if PY2 else PY27
+        interp_version = PY38 if PY2 else PY27
         custom_interpreter = PythonInterpreter.from_binary(
             ensure_python_interpreter(interp_version)
         )

--- a/tests/test_pex_bootstrapper.py
+++ b/tests/test_pex_bootstrapper.py
@@ -15,7 +15,7 @@ from pex.interpreter_constraints import UnsatisfiableInterpreterConstraintsError
 from pex.pex import PEX
 from pex.pex_bootstrapper import ensure_venv, iter_compatible_interpreters
 from pex.pex_builder import PEXBuilder
-from pex.testing import PY27, PY35, PY36, ensure_python_interpreter
+from pex.testing import PY27, PY37, PY38, ensure_python_interpreter
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -48,16 +48,16 @@ def find_interpreters(
 def test_find_compatible_interpreters():
     # type: () -> None
     py27 = ensure_python_interpreter(PY27)
-    py35 = ensure_python_interpreter(PY35)
-    py36 = ensure_python_interpreter(PY36)
-    path = [py27, py35, py36]
+    py37 = ensure_python_interpreter(PY37)
+    py38 = ensure_python_interpreter(PY38)
+    path = [py27, py37, py38]
 
-    assert [py35, py36] == find_interpreters(path, constraints=[">3"])
+    assert [py37, py38] == find_interpreters(path, constraints=[">3"])
     assert [py27] == find_interpreters(path, constraints=["<3"])
 
-    assert [py36] == find_interpreters(path, constraints=[">{}".format(PY35)])
-    assert [py35] == find_interpreters(path, constraints=[">{}, <{}".format(PY27, PY36)])
-    assert [py36] == find_interpreters(path, constraints=[">=3.6"])
+    assert [py38] == find_interpreters(path, constraints=[">{}".format(PY37)])
+    assert [py37] == find_interpreters(path, constraints=[">{}, <{}".format(PY27, PY38)])
+    assert [py38] == find_interpreters(path, constraints=[">=3.8"])
 
     with pytest.raises(UnsatisfiableInterpreterConstraintsError):
         find_interpreters(path, constraints=["<2"])
@@ -66,7 +66,7 @@ def test_find_compatible_interpreters():
         find_interpreters(path, constraints=[">4"])
 
     with pytest.raises(UnsatisfiableInterpreterConstraintsError):
-        find_interpreters(path, constraints=[">{}, <{}".format(PY27, PY35)])
+        find_interpreters(path, constraints=[">{}, <{}".format(PY27, PY37)])
 
     # All interpreters on PATH including whatever interpreter is currently running.
     all_known_interpreters = set(PythonInterpreter.all())
@@ -96,44 +96,44 @@ def test_find_compatible_interpreters_none():
 def test_find_compatible_interpreters_none_with_valid_basenames():
     # type: () -> None
     py27 = ensure_python_interpreter(PY27)
-    py35 = ensure_python_interpreter(PY35)
-    path = [py27, py35]
+    py37 = ensure_python_interpreter(PY37)
+    path = [py27, py37]
 
     with pytest.raises(UnsatisfiableInterpreterConstraintsError) as exec_info:
         find_interpreters(path, valid_basenames=["python3.6"])
 
     exception_message = str(exec_info.value)
     assert py27 not in exception_message
-    assert py35 not in exception_message
+    assert py37 not in exception_message
 
 
 def test_find_compatible_interpreters_none_with_constraints():
     # type: () -> None
     py27 = ensure_python_interpreter(PY27)
-    py35 = ensure_python_interpreter(PY35)
-    path = [py27, py35]
+    py37 = ensure_python_interpreter(PY37)
+    path = [py27, py37]
 
     with pytest.raises(UnsatisfiableInterpreterConstraintsError) as exec_info:
-        find_interpreters(path, constraints=[">=3.6"])
+        find_interpreters(path, constraints=[">=3.8"])
 
     exception_message = str(exec_info.value)
     assert py27 in exception_message
-    assert py35 in exception_message
-    assert ">=3.6" in exception_message
+    assert py37 in exception_message
+    assert ">=3.8" in exception_message
 
 
 def test_find_compatible_interpreters_none_with_valid_basenames_and_constraints():
     # type: () -> None
     py27 = ensure_python_interpreter(PY27)
-    py35 = ensure_python_interpreter(PY35)
-    path = [py27, py35]
+    py37 = ensure_python_interpreter(PY37)
+    path = [py27, py37]
 
     with pytest.raises(UnsatisfiableInterpreterConstraintsError) as exec_info:
         find_interpreters(path, valid_basenames=basenames(py27), constraints=[">=3.6"])
 
     exception_message = str(exec_info.value)
     assert py27 in exception_message
-    assert py35 not in exception_message
+    assert py37 not in exception_message
     assert os.path.basename(py27) in exception_message, exception_message
     assert ">=3.6" in exception_message
 
@@ -141,50 +141,50 @@ def test_find_compatible_interpreters_none_with_valid_basenames_and_constraints(
 def test_find_compatible_interpreters_with_valid_basenames():
     # type: () -> None
     py27 = ensure_python_interpreter(PY27)
-    py35 = ensure_python_interpreter(PY35)
-    py36 = ensure_python_interpreter(PY36)
-    path = [py27, py35, py36]
+    py37 = ensure_python_interpreter(PY37)
+    py38 = ensure_python_interpreter(PY38)
+    path = [py27, py37, py38]
 
-    assert [py35] == find_interpreters(path, valid_basenames=basenames(py35))
-    assert [py27, py36] == find_interpreters(
-        path, valid_basenames=basenames(*reversed([py27, py36]))
+    assert [py37] == find_interpreters(path, valid_basenames=basenames(py37))
+    assert [py27, py38] == find_interpreters(
+        path, valid_basenames=basenames(*reversed([py27, py38]))
     )
 
 
 def test_find_compatible_interpreters_with_valid_basenames_and_constraints():
     # type: () -> None
     py27 = ensure_python_interpreter(PY27)
-    py35 = ensure_python_interpreter(PY35)
-    py36 = ensure_python_interpreter(PY36)
-    path = [py27, py35, py36]
+    py37 = ensure_python_interpreter(PY37)
+    py38 = ensure_python_interpreter(PY38)
+    path = [py27, py37, py38]
 
-    assert [py35] == find_interpreters(
-        path, valid_basenames=basenames(py27, py35), constraints=[">=3"]
+    assert [py37] == find_interpreters(
+        path, valid_basenames=basenames(py27, py37), constraints=[">=3"]
     )
 
 
 def test_find_compatible_interpreters_bias_current():
     # type: () -> None
-    py36 = ensure_python_interpreter(PY36)
+    py38 = ensure_python_interpreter(PY38)
     current_interpreter = PythonInterpreter.get()
-    assert [current_interpreter.binary, py36] == find_interpreters([py36, sys.executable])
-    assert [current_interpreter.binary, py36] == find_interpreters([sys.executable, py36])
+    assert [current_interpreter.binary, py38] == find_interpreters([py38, sys.executable])
+    assert [current_interpreter.binary, py38] == find_interpreters([sys.executable, py38])
 
 
 def test_find_compatible_interpreters_siblings_of_current_issues_1109():
     # type: () -> None
     py27 = ensure_python_interpreter(PY27)
-    py36 = ensure_python_interpreter(PY36)
+    py38 = ensure_python_interpreter(PY38)
 
     with temporary_dir() as path_entry:
         python27 = os.path.join(path_entry, "python2.7")
         shutil.copy(py27, python27)
 
-        python36 = os.path.join(path_entry, "python3.6")
-        shutil.copy(py36, python36)
+        python38 = os.path.join(path_entry, "python3.8")
+        shutil.copy(py38, python38)
 
-        assert [os.path.realpath(p) for p in (python36, python27)] == find_interpreters(
-            path=[path_entry], preferred_interpreter=PythonInterpreter.from_binary(python36)
+        assert [os.path.realpath(p) for p in (python38, python27)] == find_interpreters(
+            path=[path_entry], preferred_interpreter=PythonInterpreter.from_binary(python38)
         )
 
 

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -15,7 +15,7 @@ from pex.interpreter import PythonInterpreter
 from pex.jobs import Job
 from pex.pip import PackageIndexConfiguration, Pip, ResolverVersion
 from pex.platforms import Platform
-from pex.testing import PY27, PY36, ensure_python_interpreter
+from pex.testing import PY38, ensure_python_interpreter
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
 
@@ -131,14 +131,14 @@ def test_download_platform_markers_issue_1366(
     tmpdir,  # type: Any
 ):
     # type: (...) -> None
-    python36_interpreter = PythonInterpreter.from_binary(ensure_python_interpreter(PY36))
-    pip = create_pip(python36_interpreter)
+    python38_interpreter = PythonInterpreter.from_binary(ensure_python_interpreter(PY38))
+    pip = create_pip(python38_interpreter)
 
     python27_platform = Platform.create("manylinux_2_33_x86_64-cp-27-cp27mu")
     download_dir = os.path.join(str(tmpdir), "downloads")
     pip.spawn_download_distributions(
         target=DistributionTarget.for_platform(python27_platform),
-        requirements=["typing_extensions==3.7.4.2; python_version < '3.6'"],
+        requirements=["typing_extensions==3.7.4.2; python_version < '3.8'"],
         download_dir=download_dir,
         transitive=False,
     ).wait()
@@ -151,8 +151,8 @@ def test_download_platform_markers_issue_1366_indeterminate(
     tmpdir,  # type: Any
 ):
     # type: (...) -> None
-    python36_interpreter = PythonInterpreter.from_binary(ensure_python_interpreter(PY36))
-    pip = create_pip(python36_interpreter)
+    python38_interpreter = PythonInterpreter.from_binary(ensure_python_interpreter(PY38))
+    pip = create_pip(python38_interpreter)
 
     python27_platform = Platform.create("manylinux_2_33_x86_64-cp-27-cp27mu")
     download_dir = os.path.join(str(tmpdir), "downloads")
@@ -160,7 +160,7 @@ def test_download_platform_markers_issue_1366_indeterminate(
     with pytest.raises(Job.Error) as exc_info:
         pip.spawn_download_distributions(
             target=DistributionTarget.for_platform(python27_platform),
-            requirements=["typing_extensions==3.7.4.2; python_full_version < '3.6'"],
+            requirements=["typing_extensions==3.7.4.2; python_full_version < '3.8'"],
             download_dir=download_dir,
             transitive=False,
         ).wait()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -30,8 +30,8 @@ from pex.testing import (
     IS_LINUX,
     IS_PYPY,
     PY27,
-    PY35,
-    PY36,
+    PY37,
+    PY38,
     PY_VER,
     built_wheel,
     ensure_python_interpreter,
@@ -262,7 +262,7 @@ def test_resolve_current_platform(p537_resolve_cache):
         resolve_p537_wheel_names, cache=p537_resolve_cache, platforms=["current"]
     )
 
-    other_python_version = PY36 if PY_VER == (3, 5) else PY35
+    other_python_version = PY38 if PY_VER == (3, 5) else PY37
     other_python = PythonInterpreter.from_binary(ensure_python_interpreter(other_python_version))
     current_python = PythonInterpreter.get()
 
@@ -292,7 +292,7 @@ def test_resolve_current_and_foreign_platforms(p537_resolve_cache):
 
     assert 2 == len(resolve_current_and_foreign())
 
-    other_python_version = PY36 if PY_VER == (3, 5) else PY35
+    other_python_version = PY38 if PY_VER == (3, 5) else PY37
     other_python = PythonInterpreter.from_binary(ensure_python_interpreter(other_python_version))
     current_python = PythonInterpreter.get()
 
@@ -347,7 +347,7 @@ def test_resolve_foreign_abi3():
 
 def test_issues_851():
     # type: () -> None
-    # Previously, the PY36 resolve would fail post-resolution checks for configparser, pathlib2 and
+    # Previously, the PY37 resolve would fail post-resolution checks for configparser, pathlib2 and
     # contextlib2 which are only required for python_version<3.
 
     def resolve_pytest(python_version, pytest_version):
@@ -359,7 +359,7 @@ def test_issues_851():
         assert project_to_version["pytest"] == pytest_version
         return project_to_version
 
-    resolved_project_to_version = resolve_pytest(python_version=PY36, pytest_version="5.3.4")
+    resolved_project_to_version = resolve_pytest(python_version=PY37, pytest_version="5.3.4")
     assert "importlib-metadata" in resolved_project_to_version
     assert "configparser" not in resolved_project_to_version
     assert "pathlib2" not in resolved_project_to_version
@@ -383,7 +383,7 @@ def test_issues_892():
         import sys
 
 
-        # This puts python3.6 stdlib on PYTHONPATH.
+        # This puts python3.8 stdlib on PYTHONPATH.
         os.environ['PYTHONPATH'] = os.pathsep.join(sys.path)
 
 
@@ -399,8 +399,8 @@ def test_issues_892():
         )
     )
 
-    python36 = ensure_python_interpreter(PY36)
-    cmd, process = PythonInterpreter.from_binary(python36).open_process(
+    python38 = ensure_python_interpreter(PY38)
+    cmd, process = PythonInterpreter.from_binary(python38).open_process(
         args=["-c", program], stderr=subprocess.PIPE
     )
     _, stderr = process.communicate()
@@ -598,9 +598,9 @@ def py27():
 
 
 @pytest.fixture(scope="module")
-def py36():
+def py38():
     # type: () -> PythonInterpreter
-    return PythonInterpreter.from_binary(ensure_python_interpreter(PY36))
+    return PythonInterpreter.from_binary(ensure_python_interpreter(PY38))
 
 
 @pytest.fixture(scope="module")
@@ -631,7 +631,7 @@ def foreign_platform(
 
 
 @pytest.fixture(scope="module")
-def pex_repository(py27, py36, foreign_platform, manylinux):
+def pex_repository(py27, py38, foreign_platform, manylinux):
     # type () -> str
 
     # N.B.: requests 2.25.1 constrains urllib3 to <1.27,>=1.21.1 and pick 1.26.2 on its own as of
@@ -639,7 +639,7 @@ def pex_repository(py27, py36, foreign_platform, manylinux):
     constraints_file = create_constraints_file("urllib3==1.26.1")
 
     return create_pex_repository(
-        interpreters=[py27, py36],
+        interpreters=[py27, py38],
         platforms=[foreign_platform],
         requirements=["requests[security,socks]==2.25.1"],
         constraint_files=[constraints_file],
@@ -650,7 +650,7 @@ def pex_repository(py27, py36, foreign_platform, manylinux):
 def test_resolve_from_pex(
     pex_repository,  # type: str
     py27,  # type: PythonInterpreter
-    py36,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
     foreign_platform,  # type: Platform
     manylinux,  # type: Optional[str]
 ):
@@ -662,7 +662,7 @@ def test_resolve_from_pex(
     resolved_distributions = resolve_from_pex(
         pex=pex_repository,
         requirements=direct_requirements,
-        interpreters=[py27, py36],
+        interpreters=[py27, py38],
         platforms=[foreign_platform],
         manylinux=manylinux,
     )
@@ -720,7 +720,7 @@ def test_resolve_from_pex_subset(
 
 def test_resolve_from_pex_not_found(
     pex_repository,  # type: str
-    py36,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
 ):
     # type: (...) -> None
 
@@ -728,7 +728,7 @@ def test_resolve_from_pex_not_found(
         resolve_from_pex(
             pex=pex_repository,
             requirements=["pex"],
-            interpreters=[py36],
+            interpreters=[py38],
         )
     assert "A distribution for pex could not be resolved in this environment." in str(
         exec_info.value
@@ -738,13 +738,13 @@ def test_resolve_from_pex_not_found(
         resolve_from_pex(
             pex=pex_repository,
             requirements=["requests==1.0.0"],
-            interpreters=[py36],
+            interpreters=[py38],
         )
     message = str(exec_info.value)
     assert (
         "Failed to resolve requirements from PEX environment @ {}".format(pex_repository) in message
     )
-    assert "Needed {} compatible dependencies for:".format(py36.platform) in message
+    assert "Needed {} compatible dependencies for:".format(py38.platform) in message
     assert "1: requests==1.0.0" in message
     assert "But this pex only contains:" in message
     assert "requests-2.25.1-py2.py3-none-any.whl" in message
@@ -753,7 +753,7 @@ def test_resolve_from_pex_not_found(
 def test_resolve_from_pex_intransitive(
     pex_repository,  # type: str
     py27,  # type: PythonInterpreter
-    py36,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
     foreign_platform,  # type: Platform
     manylinux,  # type: Optional[str]
 ):
@@ -763,7 +763,7 @@ def test_resolve_from_pex_intransitive(
         pex=pex_repository,
         requirements=["requests"],
         transitive=False,
-        interpreters=[py27, py36],
+        interpreters=[py27, py38],
         platforms=[foreign_platform],
         manylinux=manylinux,
     )

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -262,7 +262,7 @@ def test_resolve_current_platform(p537_resolve_cache):
         resolve_p537_wheel_names, cache=p537_resolve_cache, platforms=["current"]
     )
 
-    other_python_version = PY38 if PY_VER == (3, 5) else PY37
+    other_python_version = PY38 if PY_VER == (3, 7) else PY37
     other_python = PythonInterpreter.from_binary(ensure_python_interpreter(other_python_version))
     current_python = PythonInterpreter.get()
 
@@ -292,7 +292,7 @@ def test_resolve_current_and_foreign_platforms(p537_resolve_cache):
 
     assert 2 == len(resolve_current_and_foreign())
 
-    other_python_version = PY38 if PY_VER == (3, 5) else PY37
+    other_python_version = PY38 if PY_VER == (3, 7) else PY37
     other_python = PythonInterpreter.from_binary(ensure_python_interpreter(other_python_version))
     current_python = PythonInterpreter.get()
 

--- a/tests/tools/commands/test_interpreter_command.py
+++ b/tests/tools/commands/test_interpreter_command.py
@@ -11,7 +11,7 @@ import pytest
 from pex.common import safe_mkdtemp
 from pex.interpreter import PythonInterpreter
 from pex.pex_builder import PEXBuilder
-from pex.testing import PY35, PY36, ensure_python_interpreter
+from pex.testing import PY37, PY38, ensure_python_interpreter
 from pex.tools.commands.virtualenv import Virtualenv
 from pex.typing import TYPE_CHECKING
 
@@ -23,15 +23,15 @@ else:
 
 
 @pytest.fixture(scope="module")
-def python35():
+def python37():
     # type: () -> PythonInterpreter
-    return PythonInterpreter.from_binary(ensure_python_interpreter(PY35))
+    return PythonInterpreter.from_binary(ensure_python_interpreter(PY37))
 
 
 @pytest.fixture(scope="module")
-def python36():
+def python38():
     # type: () -> PythonInterpreter
-    return PythonInterpreter.from_binary(ensure_python_interpreter(PY36))
+    return PythonInterpreter.from_binary(ensure_python_interpreter(PY38))
 
 
 @attr.s(frozen=True)
@@ -81,11 +81,11 @@ class InterpreterTool(object):
 
 @pytest.fixture(scope="module")
 def interpreter_tool(
-    python35,  # type: PythonInterpreter
-    python36,  # type: PythonInterpreter
+    python37,  # type: PythonInterpreter
+    python38,  # type: PythonInterpreter
 ):
     # type: (...) -> InterpreterTool
-    return InterpreterTool.create(python35, python36)
+    return InterpreterTool.create(python37, python38)
 
 
 def expected_basic(interpreter):
@@ -94,23 +94,23 @@ def expected_basic(interpreter):
 
 
 def test_basic(
-    python35,  # type: PythonInterpreter
+    python37,  # type: PythonInterpreter
     interpreter_tool,  # type: InterpreterTool
 ):
     # type: (...) -> None
     output = interpreter_tool.run()
-    assert expected_basic(python35) == output.strip()
+    assert expected_basic(python37) == output.strip()
 
 
 def test_basic_all(
-    python35,  # type: PythonInterpreter
-    python36,  # type: PythonInterpreter
+    python37,  # type: PythonInterpreter
+    python38,  # type: PythonInterpreter
     interpreter_tool,  # type: InterpreterTool
 ):
     # type: (...) -> None
     output = interpreter_tool.run("-a")
     assert [
-        expected_basic(interpreter) for interpreter in (python35, python36)
+        expected_basic(interpreter) for interpreter in (python37, python38)
     ] == output.splitlines()
 
 
@@ -124,22 +124,22 @@ def expected_verbose(interpreter):
 
 
 def test_verbose(
-    python35,  # type: PythonInterpreter
+    python37,  # type: PythonInterpreter
     interpreter_tool,  # type: InterpreterTool
 ):
     # type: (...) -> None
     output = interpreter_tool.run("-v")
-    assert expected_verbose(python35) == json.loads(output)
+    assert expected_verbose(python37) == json.loads(output)
 
 
 def test_verbose_all(
-    python35,  # type: PythonInterpreter
-    python36,  # type: PythonInterpreter
+    python37,  # type: PythonInterpreter
+    python38,  # type: PythonInterpreter
     interpreter_tool,  # type: InterpreterTool
 ):
     # type: (...) -> None
     output = interpreter_tool.run("-va")
-    assert [expected_verbose(interpreter) for interpreter in (python35, python36)] == [
+    assert [expected_verbose(interpreter) for interpreter in (python37, python38)] == [
         json.loads(line) for line in output.splitlines()
     ]
 
@@ -152,30 +152,30 @@ def expected_verbose_verbose(interpreter):
 
 
 def test_verbose_verbose(
-    python35,  # type: PythonInterpreter
+    python37,  # type: PythonInterpreter
     interpreter_tool,  # type: InterpreterTool
 ):
     # type: (...) -> None
     output = interpreter_tool.run("-vv")
-    assert expected_verbose_verbose(python35) == json.loads(output)
+    assert expected_verbose_verbose(python37) == json.loads(output)
 
 
 def test_verbose_verbose_verbose(
-    python35,  # type: PythonInterpreter
+    python37,  # type: PythonInterpreter
     interpreter_tool,  # type: InterpreterTool
 ):
     # type: (...) -> None
     output = interpreter_tool.run("-vvv")
-    expected = expected_verbose_verbose(python35)
-    expected.update(env_markers=python35.identity.env_markers, venv=False)
+    expected = expected_verbose_verbose(python37)
+    expected.update(env_markers=python37.identity.env_markers, venv=False)
     assert expected == json.loads(output)
 
 
 def test_verbose_verbose_verbose_venv(
-    python36,  # type: PythonInterpreter
+    python38,  # type: PythonInterpreter
 ):
     # type: (...) -> None
-    venv = Virtualenv.create(venv_dir=safe_mkdtemp(), interpreter=python36, force=True)
+    venv = Virtualenv.create(venv_dir=safe_mkdtemp(), interpreter=python38, force=True)
     assert venv.interpreter.is_venv
 
     # N.B.: Non-venv-mode PEXes always escape venvs to prevent `sys.path` contamination unless
@@ -186,6 +186,6 @@ def test_verbose_verbose_verbose_venv(
     expected.update(
         env_markers=venv.interpreter.identity.env_markers,
         venv=True,
-        base_interpreter=python36.binary,
+        base_interpreter=python38.binary,
     )
     assert expected == json.loads(output)

--- a/tests/tools/commands/test_repository.py
+++ b/tests/tools/commands/test_repository.py
@@ -12,7 +12,7 @@ from textwrap import dedent
 import pytest
 
 from pex.common import safe_open, temporary_dir
-from pex.testing import PY36, ensure_python_venv, run_pex_command
+from pex.testing import PY38, ensure_python_venv, run_pex_command
 from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.third_party.pkg_resources import Distribution, Requirement
 from pex.typing import TYPE_CHECKING
@@ -166,7 +166,7 @@ def test_extract(pex, pex_tools_env, tmpdir):
     )
     result.assert_success()
 
-    _, pip = ensure_python_venv(PY36)
+    _, pip = ensure_python_venv(PY38)
     subprocess.check_call(
         args=[pip, "install", "--no-index", "--find-links", find_links_url, "example"]
     )

--- a/tests/tools/commands/test_venv.py
+++ b/tests/tools/commands/test_venv.py
@@ -20,7 +20,7 @@ from pex.compatibility import PY2
 from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
 from pex.pex_builder import CopyMode, PEXBuilder
-from pex.testing import IS_PYPY, PY36, ensure_python_interpreter, run_pex_command
+from pex.testing import IS_PYPY, PY38, ensure_python_interpreter, run_pex_command
 from pex.tools.commands.virtualenv import Virtualenv
 from pex.typing import TYPE_CHECKING, cast
 from pex.util import named_temporary_file
@@ -427,23 +427,23 @@ def test_venv_entrypoint_function_exit_code_issue_1241(tmpdir):
 def test_venv_copies(tmpdir):
     # type: (Any) -> None
 
-    python36 = ensure_python_interpreter(PY36)
+    python38 = ensure_python_interpreter(PY38)
 
     pex_file = os.path.join(str(tmpdir), "venv.pex")
-    result = run_pex_command(args=["-o", pex_file, "--include-tools"], python=python36)
+    result = run_pex_command(args=["-o", pex_file, "--include-tools"], python=python38)
     result.assert_success()
 
     PEX_TOOLS = make_env(PEX_TOOLS=1)
 
     venv_symlinks = os.path.join(str(tmpdir), "venv.symlinks")
-    subprocess.check_call(args=[python36, pex_file, "venv", venv_symlinks], env=PEX_TOOLS)
+    subprocess.check_call(args=[python38, pex_file, "venv", venv_symlinks], env=PEX_TOOLS)
     venv_symlinks_interpreter = PythonInterpreter.from_binary(
         os.path.join(venv_symlinks, "bin", "python")
     )
     assert os.path.islink(venv_symlinks_interpreter.binary)
 
     venv_copies = os.path.join(str(tmpdir), "venv.copies")
-    subprocess.check_call(args=[python36, pex_file, "venv", "--copies", venv_copies], env=PEX_TOOLS)
+    subprocess.check_call(args=[python38, pex_file, "venv", "--copies", venv_copies], env=PEX_TOOLS)
     venv_copies_interpreter = PythonInterpreter.from_binary(
         os.path.join(venv_copies, "bin", "python")
     )


### PR DESCRIPTION
The older Python 3 interpreters are becoming problematic to install
and run. Move the 3.5 and 3.6 versions to 3.7 and 3.8 latest
respectively.