### PR TITLE
Allow the creation of several pex when the option --bdist-all is used with a setup.py defining several entry points

### DIFF
--- a/pex/commands/bdist_pex.py
+++ b/pex/commands/bdist_pex.py
@@ -135,9 +135,8 @@ class bdist_pex(Command):  # noqa
                     result,
                 )
             else:
-                die(
-                    "Successfully created pex via {}:\n{}".format(
-                        " ".join(cmd), stderr.decode("utf-8")
-                    ),
-                    result,
+                print(
+                    "Successfully created pex via {}\n".format(
+                        " ".join(cmd)
+                    )
                 )


### PR DESCRIPTION
The option -bdist-all did not work correctly, only the first entry point produced pex file.
I propose to change die by print message when the exit code equals to 0