### PR TITLE
Fix flaky Linux Pythons in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push, pull_request]
 env:
   _PEX_TEST_PYENV_ROOT: .pyenv_test
-  # We use this to skip exposing same-versioned Pythons present on the host. These otherwise can
+  # We use this to skip exposing same-versioned Pythons present on Linux hosts. These otherwise can
   # collide when attempting to load libpython<major>.<minor><flags>.so and lead to mysterious errors
   # importing builtins like `fcntl` as outlined in https://github.com/pantsbuild/pex/issues/1391.
   _PEX_TEST_PYENV_VERSIONS: "2.7 3.7 3.8"
@@ -70,6 +70,15 @@ jobs:
           - os: macos-10.15
             python-version: [3, 8]
     steps:
+      - name: Calculate Pythons to Expose
+        id: calculate-pythons-to-expose
+        run: |
+          skip=""
+          if [[ "$(uname -s)" == "Linux" ]]; then
+            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
+          fi
+          echo "::set-output name=skip::${skip}"
+        shell: bash
       - name: Checkout Pex
         uses: actions/checkout@v2
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
@@ -79,7 +88,7 @@ jobs:
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
         with:
-          skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
+          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v2
         with:
@@ -97,6 +106,15 @@ jobs:
       matrix:
         pypy-version: [[2, 7], [3, 6]]
     steps:
+      - name: Calculate Pythons to Expose
+        id: calculate-pythons-to-expose
+        run: |
+          skip=""
+          if [[ "$(uname -s)" == "Linux" ]]; then
+            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
+          fi
+          echo "::set-output name=skip::${skip}"
+        shell: bash
       - name: Checkout Pex
         uses: actions/checkout@v2
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
@@ -106,7 +124,7 @@ jobs:
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
         with:
-          skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
+          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v2
         with:
@@ -125,6 +143,15 @@ jobs:
         python-version: [[2, 7], [3, 9]]
         os: [ubuntu-20.04, macos-10.15]
     steps:
+      - name: Calculate Pythons to Expose
+        id: calculate-pythons-to-expose
+        run: |
+          skip=""
+          if [[ "$(uname -s)" == "Linux" ]]; then
+            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
+          fi
+          echo "::set-output name=skip::${skip}"
+        shell: bash
       - name: Checkout Pex
         uses: actions/checkout@v2
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
@@ -134,7 +161,7 @@ jobs:
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
         with:
-          skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
+          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v2
         with:
@@ -152,6 +179,15 @@ jobs:
       matrix:
         pypy-version: [[2, 7], [3, 6]]
     steps:
+      - name: Calculate Pythons to Expose
+        id: calculate-pythons-to-expose
+        run: |
+          skip=""
+          if [[ "$(uname -s)" == "Linux" ]]; then
+            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
+          fi
+          echo "::set-output name=skip::${skip}"
+        shell: bash
       - name: Checkout Pex
         uses: actions/checkout@v2
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
@@ -161,7 +197,7 @@ jobs:
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
         with:
-          skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
+          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Install Packages
         run: |
           # This is needed for `test_requirement_file_from_url` for building `lxml`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v3
+          key: ${{ runner.os }}-pyenv-root-v4
       - name: Run Unit Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -103,7 +103,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v3
+          key: ${{ runner.os }}-pyenv-root-v4
       - name: Run Unit Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -129,7 +129,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v3
+          key: ${{ runner.os }}-pyenv-root-v4
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -158,7 +158,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v3
+          key: ${{ runner.os }}-pyenv-root-v4
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           python-version: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@35107c9b98fabb71bd935751105dbdea285ff906
+        uses: pantsbuild/actions/expose-pythons@a042ed87bfc5066f3f44ec0085de5908802fdc49
         with:
           skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
       - name: Cache Pyenv Interpreters
@@ -104,7 +104,7 @@ jobs:
         with:
           python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@35107c9b98fabb71bd935751105dbdea285ff906
+        uses: pantsbuild/actions/expose-pythons@a042ed87bfc5066f3f44ec0085de5908802fdc49
         with:
           skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
       - name: Cache Pyenv Interpreters
@@ -132,7 +132,7 @@ jobs:
         with:
           python-version: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@35107c9b98fabb71bd935751105dbdea285ff906
+        uses: pantsbuild/actions/expose-pythons@a042ed87bfc5066f3f44ec0085de5908802fdc49
         with:
           skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
       - name: Cache Pyenv Interpreters
@@ -159,7 +159,7 @@ jobs:
         with:
           python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@35107c9b98fabb71bd935751105dbdea285ff906
+        uses: pantsbuild/actions/expose-pythons@a042ed87bfc5066f3f44ec0085de5908802fdc49
         with:
           skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
       - name: Install Packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,10 @@ name: CI
 on: [push, pull_request]
 env:
   _PEX_TEST_PYENV_ROOT: .pyenv_test
-  _PEX_TEST_PYENV_VERSIONS: 2.7.18 3.7.11 3.8.11
+  # We use this to skip exposing same-versioned Pythons present on the host. These otherwise can
+  # collide when attempting to load libpython<major>.<minor><flags>.so and lead to mysterious errors
+  # importing builtins like `fcntl` as outlined in https://github.com/pantsbuild/pex/issues/1391.
+  _PEX_TEST_PYENV_VERSIONS: "2.7 3.7 3.8"
 jobs:
   org-check:
     name: Check GitHub Organization
@@ -74,23 +77,14 @@ jobs:
         with:
           python-version: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@8c9762e2c1f60aa7411c3b64ff213d2363a1e803
+        uses: pantsbuild/actions/expose-pythons@35107c9b98fabb71bd935751105dbdea285ff906
+        with:
+          skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v2
-      - name: Configure Pyenv Interpreters
-        run: |
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            for version in $(echo ${_PEX_TEST_PYENV_VERSIONS} | tr ' ' '\n'); do
-              pyenv_version_lib_path="${PWD}/${_PEX_TEST_PYENV_ROOT}/versions/${version}/lib"
-              LD_LIBRARY_PATH="${pyenv_version_lib_path}:${LD_LIBRARY_PATH}"
-            done
-            echo "Setting LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
-            echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> $GITHUB_ENV
-          fi
-        shell: bash
       - name: Run Unit Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -110,23 +104,14 @@ jobs:
         with:
           python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@8c9762e2c1f60aa7411c3b64ff213d2363a1e803
+        uses: pantsbuild/actions/expose-pythons@35107c9b98fabb71bd935751105dbdea285ff906
+        with:
+          skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v2
-      - name: Configure Pyenv Interpreters
-        run: |
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            for version in $(echo ${_PEX_TEST_PYENV_VERSIONS} | tr ' ' '\n'); do
-              pyenv_version_lib_path="${PWD}/${_PEX_TEST_PYENV_ROOT}/versions/${version}/lib"
-              LD_LIBRARY_PATH="${pyenv_version_lib_path}:${LD_LIBRARY_PATH}"
-            done
-            echo "Setting LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
-            echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> $GITHUB_ENV
-          fi
-        shell: bash
       - name: Run Unit Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -147,23 +132,14 @@ jobs:
         with:
           python-version: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@8c9762e2c1f60aa7411c3b64ff213d2363a1e803
+        uses: pantsbuild/actions/expose-pythons@35107c9b98fabb71bd935751105dbdea285ff906
+        with:
+          skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v2
-      - name: Configure Pyenv Interpreters
-        run: |
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            for version in $(echo ${_PEX_TEST_PYENV_VERSIONS} | tr ' ' '\n'); do
-              pyenv_version_lib_path="${PWD}/${_PEX_TEST_PYENV_ROOT}/versions/${version}/lib"
-              LD_LIBRARY_PATH="${pyenv_version_lib_path}:${LD_LIBRARY_PATH}"
-            done
-            echo "Setting LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
-            echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> $GITHUB_ENV
-          fi
-        shell: bash
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -183,7 +159,9 @@ jobs:
         with:
           python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@8c9762e2c1f60aa7411c3b64ff213d2363a1e803
+        uses: pantsbuild/actions/expose-pythons@35107c9b98fabb71bd935751105dbdea285ff906
+        with:
+          skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
       - name: Install Packages
         run: |
           # This is needed for `test_requirement_file_from_url` for building `lxml`.
@@ -193,17 +171,6 @@ jobs:
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v2
-      - name: Configure Pyenv Interpreters
-        run: |
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            for version in $(echo ${_PEX_TEST_PYENV_VERSIONS} | tr ' ' '\n'); do
-              pyenv_version_lib_path="${PWD}/${_PEX_TEST_PYENV_ROOT}/versions/${version}/lib"
-              LD_LIBRARY_PATH="${pyenv_version_lib_path}:${LD_LIBRARY_PATH}"
-            done
-            echo "Setting LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
-            echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> $GITHUB_ENV
-          fi
-        shell: bash
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           python-version: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+        uses: pantsbuild/actions/expose-pythons@8c9762e2c1f60aa7411c3b64ff213d2363a1e803
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v2
         with:
@@ -98,7 +98,7 @@ jobs:
         with:
           python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+        uses: pantsbuild/actions/expose-pythons@8c9762e2c1f60aa7411c3b64ff213d2363a1e803
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v2
         with:
@@ -124,7 +124,7 @@ jobs:
         with:
           python-version: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+        uses: pantsbuild/actions/expose-pythons@8c9762e2c1f60aa7411c3b64ff213d2363a1e803
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v2
         with:
@@ -149,7 +149,7 @@ jobs:
         with:
           python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+        uses: pantsbuild/actions/expose-pythons@8c9762e2c1f60aa7411c3b64ff213d2363a1e803
       - name: Install Packages
         run: |
           # This is needed for `test_requirement_file_from_url` for building `lxml`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 on: [push, pull_request]
 env:
   _PEX_TEST_PYENV_ROOT: .pyenv_test
+  _PEX_TEST_PYENV_VERSIONS: 2.7.18 3.7.11 3.8.11
 jobs:
   org-check:
     name: Check GitHub Organization
@@ -78,7 +79,18 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v4
+          key: ${{ runner.os }}-pyenv-root-v2
+      - name: Configure Pyenv Interpreters
+        run: |
+          if [[ "$(uname -s)" == "Linux" ]]; then
+            for version in $(echo ${_PEX_TEST_PYENV_VERSIONS} | tr ' ' '\n'); do
+              pyenv_version_lib_path="${PWD}/${_PEX_TEST_PYENV_ROOT}/versions/${version}/lib"
+              LD_LIBRARY_PATH="${pyenv_version_lib_path}:${LD_LIBRARY_PATH}"
+            done
+            echo "Setting LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
+            echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+          fi
+        shell: bash
       - name: Run Unit Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -103,7 +115,18 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v4
+          key: ${{ runner.os }}-pyenv-root-v2
+      - name: Configure Pyenv Interpreters
+        run: |
+          if [[ "$(uname -s)" == "Linux" ]]; then
+            for version in $(echo ${_PEX_TEST_PYENV_VERSIONS} | tr ' ' '\n'); do
+              pyenv_version_lib_path="${PWD}/${_PEX_TEST_PYENV_ROOT}/versions/${version}/lib"
+              LD_LIBRARY_PATH="${pyenv_version_lib_path}:${LD_LIBRARY_PATH}"
+            done
+            echo "Setting LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
+            echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+          fi
+        shell: bash
       - name: Run Unit Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -129,7 +152,18 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v4
+          key: ${{ runner.os }}-pyenv-root-v2
+      - name: Configure Pyenv Interpreters
+        run: |
+          if [[ "$(uname -s)" == "Linux" ]]; then
+            for version in $(echo ${_PEX_TEST_PYENV_VERSIONS} | tr ' ' '\n'); do
+              pyenv_version_lib_path="${PWD}/${_PEX_TEST_PYENV_ROOT}/versions/${version}/lib"
+              LD_LIBRARY_PATH="${pyenv_version_lib_path}:${LD_LIBRARY_PATH}"
+            done
+            echo "Setting LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
+            echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+          fi
+        shell: bash
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -158,7 +192,18 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v4
+          key: ${{ runner.os }}-pyenv-root-v2
+      - name: Configure Pyenv Interpreters
+        run: |
+          if [[ "$(uname -s)" == "Linux" ]]; then
+            for version in $(echo ${_PEX_TEST_PYENV_VERSIONS} | tr ' ' '\n'); do
+              pyenv_version_lib_path="${PWD}/${_PEX_TEST_PYENV_ROOT}/versions/${version}/lib"
+              LD_LIBRARY_PATH="${pyenv_version_lib_path}:${LD_LIBRARY_PATH}"
+            done
+            echo "Setting LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
+            echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+          fi
+        shell: bash
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           python-version: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@ead2c11c3d17ec18d81fe8a8769199f9a4876afc
+        uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
         with:
           skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
       - name: Cache Pyenv Interpreters
@@ -104,7 +104,7 @@ jobs:
         with:
           python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@ead2c11c3d17ec18d81fe8a8769199f9a4876afc
+        uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
         with:
           skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
       - name: Cache Pyenv Interpreters
@@ -132,7 +132,7 @@ jobs:
         with:
           python-version: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@ead2c11c3d17ec18d81fe8a8769199f9a4876afc
+        uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
         with:
           skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
       - name: Cache Pyenv Interpreters
@@ -159,7 +159,7 @@ jobs:
         with:
           python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@ead2c11c3d17ec18d81fe8a8769199f9a4876afc
+        uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
         with:
           skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
       - name: Install Packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v2
+          key: ${{ runner.os }}-pyenv-root-v3
       - name: Run Unit Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -103,7 +103,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v2
+          key: ${{ runner.os }}-pyenv-root-v3
       - name: Run Unit Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -129,7 +129,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v2
+          key: ${{ runner.os }}-pyenv-root-v3
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -158,7 +158,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v2
+          key: ${{ runner.os }}-pyenv-root-v3
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           python-version: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@a042ed87bfc5066f3f44ec0085de5908802fdc49
+        uses: pantsbuild/actions/expose-pythons@ead2c11c3d17ec18d81fe8a8769199f9a4876afc
         with:
           skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
       - name: Cache Pyenv Interpreters
@@ -104,7 +104,7 @@ jobs:
         with:
           python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@a042ed87bfc5066f3f44ec0085de5908802fdc49
+        uses: pantsbuild/actions/expose-pythons@ead2c11c3d17ec18d81fe8a8769199f9a4876afc
         with:
           skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
       - name: Cache Pyenv Interpreters
@@ -132,7 +132,7 @@ jobs:
         with:
           python-version: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@a042ed87bfc5066f3f44ec0085de5908802fdc49
+        uses: pantsbuild/actions/expose-pythons@ead2c11c3d17ec18d81fe8a8769199f9a4876afc
         with:
           skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
       - name: Cache Pyenv Interpreters
@@ -159,7 +159,7 @@ jobs:
         with:
           python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@a042ed87bfc5066f3f44ec0085de5908802fdc49
+        uses: pantsbuild/actions/expose-pythons@ead2c11c3d17ec18d81fe8a8769199f9a4876afc
         with:
           skip: "${{ env._PEX_TEST_PYENV_VERSIONS }}"
       - name: Install Packages

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -464,18 +464,7 @@ def ensure_python_distribution(version):
                     "https://github.com/pyenv/pyenv.git",
                 ]
             )
-            env = pyenv_env.copy()
-            if sys.platform.lower().startswith("linux"):
-                env["CONFIGURE_OPTS"] = "--enable-shared"
-                # The pyenv builder detects `--enable-shared` and sets up `RPATH` via
-                # `LDFLAGS=-Wl,-rpath=... $LDFLAGS` to ensure the built python binary links the
-                # correct libpython shared lib. Some versions of compiler set the `RUNPATH` instead
-                # though which is searched _after_ the `LD_LIBRARY_PATH` environment variable. To
-                # ensure an inopportune `LD_LIBRARY_PATH` doesn't fool the pyenv python binary into
-                # linking the wrong libpython, force `RPATH`, which is searched 1st by the linker,
-                # with with `--disable-new-dtags`.
-                env["LDFLAGS"] = "-Wl,--disable-new-dtags"
-            subprocess.check_call([pyenv, "install", "--keep", version], env=env)
+            subprocess.check_call([pyenv, "install", "--keep", version], env=pyenv_env)
             subprocess.check_call([pip, "install", "-U", "pip"])
 
     python = os.path.join(interpreter_location, "bin", "python" + version[0:3])

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -24,7 +24,6 @@ from pex.pip import get_pip
 from pex.third_party.pkg_resources import Distribution
 from pex.typing import TYPE_CHECKING
 from pex.util import DistributionHelper, named_temporary_file
-from pex.variables import ENV
 
 if TYPE_CHECKING:
     from typing import (
@@ -464,7 +463,19 @@ def ensure_python_distribution(version):
                     "https://github.com/pyenv/pyenv.git",
                 ]
             )
-            subprocess.check_call([pyenv, "install", "--keep", version], env=pyenv_env)
+            env = pyenv_env.copy()
+            if sys.platform.lower().startswith("linux"):
+                env["CONFIGURE_OPTS"] = "--enable-shared"
+                # The pyenv builder detects `--enable-shared` and sets up `RPATH` via
+                # `LDFLAGS=-Wl,-rpath=... $LDFLAGS` to ensure the built python binary links the
+                # correct libpython shared lib. Some versions of compiler set the `RUNPATH` instead
+                # though which is searched _after_ the `LD_LIBRARY_PATH` environment variable. To
+                # ensure an inopportune `LD_LIBRARY_PATH` doesn't fool the pyenv python binary into
+                # linking the wrong libpython, force `RPATH`, which is searched 1st by the linker,
+                # with with `--disable-new-dtags`.
+                env["CC"] = "clang"
+                env["LDFLAGS"] = "-Wl,--disable-new-dtags"
+            subprocess.check_call([pyenv, "install", "--keep", version], env=env)
             subprocess.check_call([pip, "install", "-U", "pip"])
 
     python = os.path.join(interpreter_location, "bin", "python" + version[0:3])

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -473,7 +473,6 @@ def ensure_python_distribution(version):
                 # ensure an inopportune `LD_LIBRARY_PATH` doesn't fool the pyenv python binary into
                 # linking the wrong libpython, force `RPATH`, which is searched 1st by the linker,
                 # with with `--disable-new-dtags`.
-                env["CC"] = "clang"
                 env["LDFLAGS"] = "-Wl,--disable-new-dtags"
             subprocess.check_call([pyenv, "install", "--keep", version], env=env)
             subprocess.check_call([pip, "install", "-U", "pip"])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3383,7 +3383,16 @@ def test_invalid_macosx_platform_tag(tmpdir):
 
     setproctitle_pex = os.path.join(str(tmpdir), "setproctitle.pex")
     run_pex_command(
-        args=ic_args + ["setproctitle", "--pex-repository", repository_pex, "-o", setproctitle_pex]
+        args=ic_args
+        + [
+            "setproctitle",
+            "--python-shebang",
+            "/usr/bin/env python",
+            "--pex-repository",
+            repository_pex,
+            "-o",
+            setproctitle_pex,
+        ]
     ).assert_success()
 
     subprocess.check_call(args=[setproctitle_pex, "-c", "import setproctitle"])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3383,16 +3383,7 @@ def test_invalid_macosx_platform_tag(tmpdir):
 
     setproctitle_pex = os.path.join(str(tmpdir), "setproctitle.pex")
     run_pex_command(
-        args=ic_args
-        + [
-            "setproctitle",
-            "--python-shebang",
-            "/usr/bin/env python",
-            "--pex-repository",
-            repository_pex,
-            "-o",
-            setproctitle_pex,
-        ]
+        args=ic_args + ["setproctitle", "--pex-repository", repository_pex, "-o", setproctitle_pex]
     ).assert_success()
 
     subprocess.check_call(args=[setproctitle_pex, "-c", "import setproctitle"])


### PR DESCRIPTION
This upgrades to https://github.com/pantsbuild/actions/pull/2 which sets
`LD_LIBRARY_PATH` to include exposed Pythons lib dirs under linux. It
also discontinues using `--enable-shared` to build pyenv pythons under
linux.
    
Fixes #1391