### PR TITLE
Fix --bdist-all handling multiple console_scripts

### DIFF
--- a/pex/commands/bdist_pex.py
+++ b/pex/commands/bdist_pex.py
@@ -135,9 +135,8 @@ class bdist_pex(Command):  # noqa
                     result,
                 )
             else:
-                die(
+                log.debug(
                     "Successfully created pex via {}:\n{}".format(
                         " ".join(cmd), stderr.decode("utf-8")
-                    ),
-                    result,
+                    )
                 )


### PR DESCRIPTION
--bdist-all is broken and only creates the first entry in console_scripts.

This commit fixes this issue and adds a couple of regression tests.