### PR TITLE
Support deterministic repository extract tool.

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -41,6 +41,8 @@ if TYPE_CHECKING:
 DETERMINISTIC_DATETIME = datetime(
     year=1980, month=1, day=1, hour=0, minute=0, second=0, tzinfo=None
 )
+_UNIX_EPOCH = datetime(year=1970, month=1, day=1, hour=0, minute=0, second=0, tzinfo=None)
+DETERMINISTIC_DATETIME_TIMESTAMP = (DETERMINISTIC_DATETIME - _UNIX_EPOCH).total_seconds()
 
 
 def filter_pyc_dirs(dirs):

--- a/pex/common.py
+++ b/pex/common.py
@@ -308,7 +308,7 @@ def safe_rmtree(directory):
 
 
 def safe_sleep(seconds):
-    # type: (int) -> None
+    # type: (float) -> None
     """Ensure that the thread sleeps at a minimum the requested seconds.
 
     Until Python 3.5, there was no guarantee that time.sleep() would actually sleep the requested

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -12,7 +12,15 @@ import sys
 from contextlib import contextmanager
 from textwrap import dedent
 
-from pex.common import atomic_directory, open_zip, safe_mkdir, safe_mkdtemp, temporary_dir
+from pex.common import (
+    atomic_directory,
+    open_zip,
+    safe_mkdir,
+    safe_mkdtemp,
+    safe_rmtree,
+    safe_sleep,
+    temporary_dir,
+)
 from pex.compatibility import to_unicode
 from pex.distribution_target import DistributionTarget
 from pex.executor import Executor
@@ -344,18 +352,34 @@ class IntegResults(object):
         assert self.return_code != 0
 
 
-def run_pex_command(args, env=None, python=None, quiet=False):
-    # type: (Iterable[str], Optional[Dict[str, str]], Optional[str], bool) -> IntegResults
+def create_pex_command(
+    args=None,  # type: Optional[Iterable[str]]
+    python=None,  # type: Optional[str]
+    quiet=False,  # type: bool
+):
+    # type: (...) -> List[str]
+    cmd = [python or sys.executable, "-mpex"]
+    if not quiet:
+        cmd.append("-vvvvv")
+    if args:
+        cmd.extend(args)
+    return cmd
+
+
+def run_pex_command(
+    args,  # type: Iterable[str]
+    env=None,  # type: Optional[Dict[str, str]]
+    python=None,  # type: Optional[str]
+    quiet=False,  # type: bool
+):
+    # type: (...) -> IntegResults
     """Simulate running pex command for integration testing.
 
     This is different from run_simple_pex in that it calls the pex command rather than running a
     generated pex.  This is useful for testing end to end runs with specific command line arguments
     or env options.
     """
-    cmd = [python or sys.executable, "-mpex"]
-    if not quiet:
-        cmd.append("-vvvvv")
-    cmd.extend(args)
+    cmd = create_pex_command(args, python=python, quiet=quiet)
     process = Executor.open_process(
         cmd=cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
@@ -540,3 +564,64 @@ def pushd(directory):
         yield
     finally:
         os.chdir(cwd)
+
+
+def make_env(**kwargs):
+    # type: (**Any) -> Dict[str, str]
+    """Create a copy of the current environment with the given modifications.
+
+    The given kwargs add to or update the environment when they have a non-`None` value. When they
+    have a `None` value, the environment variable is removed from the environment.
+
+    All non-`None` values are converted to strings by apply `str`.
+    """
+    env = os.environ.copy()
+    env.update((k, str(v)) for k, v in kwargs.items() if v is not None)
+    for k, v in kwargs.items():
+        if v is None:
+            env.pop(k, None)
+    return env
+
+
+def run_command_with_jitter(
+    args,  # type: Iterable[str]
+    path_argument,  # type: str
+    extra_env=None,  # type: Optional[Mapping[str, str]]
+    python=None,  # type: Optional[str]
+    delay=2.0,  # type: float
+    count=3,  # type: int
+):
+    # type: (...) -> List[str]
+    """Runs the command `count` times in an attempt to introduce randomness.
+
+    Each run of the command will run against a clean Pex cache with a unique path injected as the
+    value for `path_argument`. A unique `PYTHONHASHSEED` is set in the environment for each
+    execution as well.
+
+    Additionally, a delay is inserted between executions. By default, this delay is 2s to ensure zip
+    precision is stressed. See: https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT.
+    """
+    td = safe_mkdtemp()
+    pex_root = os.path.join(td, "pex_root")
+
+    paths = []
+    for index in range(count):
+        path = os.path.join(td, str(index))
+        cmd = list(args) + [path_argument, path]
+
+        # Note that we change the `PYTHONHASHSEED` to ensure that there are no issues resulting
+        # from the random seed, such as data structures, as Tox sets this value by default.
+        # See:
+        # https://tox.readthedocs.io/en/latest/example/basic.html#special-handling-of-pythonhashseed
+        env = make_env(PEX_ROOT=pex_root, PYTHONHASHSEED=(index * 497) + 4)
+        if extra_env:
+            env.update(extra_env)
+
+        if index > 0:
+            safe_sleep(delay)
+
+        # Ensure the PEX is fully rebuilt.
+        safe_rmtree(pex_root)
+        subprocess.check_call(args=cmd, env=env)
+        paths.append(path)
+    return paths

--- a/pex/tools/commands/repository.py
+++ b/pex/tools/commands/repository.py
@@ -256,6 +256,11 @@ class Repository(JsonMixin, OutputMixin, Command):
             # type: (Distribution) -> SpawnedJob[Text]
             env = os.environ.copy()
             if not options.use_system_time:
+                # N.B.: The `SOURCE_DATE_EPOCH` env var is semi-standard magic for controlling
+                # build tools. Wheel has supported this since 2016.
+                # See:
+                # + https://reproducible-builds.org/docs/source-date-epoch/
+                # + https://github.com/pypa/wheel/blob/1b879e53fed1f179897ed47e55a68bc51df188db/wheel/archive.py#L36-L39
                 env.update(SOURCE_DATE_EPOCH=str(int(DETERMINISTIC_DATETIME_TIMESTAMP)))
             job = spawn_python_job(
                 args=["-m", "wheel", "pack", "--dest-dir", dest_dir, distribution.location],

--- a/pex/tools/commands/repository.py
+++ b/pex/tools/commands/repository.py
@@ -15,7 +15,14 @@ from textwrap import dedent
 from threading import Thread
 
 from pex import dist_metadata, pex_warnings
-from pex.common import pluralize, safe_mkdir, safe_mkdtemp, safe_open
+from pex.common import (
+    DETERMINISTIC_DATETIME,
+    DETERMINISTIC_DATETIME_TIMESTAMP,
+    pluralize,
+    safe_mkdir,
+    safe_mkdtemp,
+    safe_open,
+)
 from pex.compatibility import Queue
 from pex.environment import PEXEnvironment
 from pex.interpreter import PythonIdentity, PythonInterpreter, spawn_python_job
@@ -128,6 +135,20 @@ class Repository(JsonMixin, OutputMixin, Command):
             help="Also extract a wheel for the PEX file sources.",
         )
         extract_parser.add_argument(
+            "--use-system-time",
+            dest="use_system_time",
+            default=False,
+            action="store_true",
+            help=(
+                "Use the current system time to generate timestamps for the extracted "
+                "distributions. Otherwise, Pex will use midnight on January 1, 1980. By using "
+                "system time, the extracted distributions will not be reproducible, meaning that "
+                "if you were to re-run extraction against the same PEX file then the newly "
+                "extracted distributions would not be byte-for-byte identical distributions "
+                "extracted in prior runs."
+            ),
+        )
+        extract_parser.add_argument(
             "--serve",
             action="store_true",
             help="Serve the --find-links repo.",
@@ -233,11 +254,15 @@ class Repository(JsonMixin, OutputMixin, Command):
 
         def spawn_extract(distribution):
             # type: (Distribution) -> SpawnedJob[Text]
+            env = os.environ.copy()
+            if not options.use_system_time:
+                env.update(SOURCE_DATE_EPOCH=str(int(DETERMINISTIC_DATETIME_TIMESTAMP)))
             job = spawn_python_job(
                 args=["-m", "wheel", "pack", "--dest-dir", dest_dir, distribution.location],
                 interpreter=pex.interpreter,
                 expose=["wheel"],
                 stdout=subprocess.PIPE,
+                env=env,
             )
             return SpawnedJob.stdout(
                 job, result_func=lambda out: "{}: {}".format(distribution, out.decode())


### PR DESCRIPTION
Wheels are now extracted with a deterministic timestamp by default but
the same option that the main Pex CLI has is added to control this.

Fixes #1408