### PR TITLE
Don't attempt to parse binary scripts.

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -481,9 +481,32 @@ def is_exe(path):
     """Determines if the given path is a file executable by the current user.
 
     :param path: The path to check.
-    :return: `True if the given path is an file executable by the current user.
+    :return: `True if the given path is a file executable by the current user.
     """
     return os.path.isfile(path) and os.access(path, os.R_OK | os.X_OK)
+
+
+def is_script(
+    path,  # type: str
+    pattern=None,  # type: Optional[str]
+):
+    # type: (...) -> bool
+    """Determines if the given path is a script executable by the current user.
+
+    A script is an executable (`is_exe` is True) that starts with a shebang (#!...) line.
+
+    :param path: The path to check.
+    :param pattern: An optional pattern to match against the shebang (excluding the leading #!).
+    :return: `True if the given path is a script executable by the current user.
+    """
+    if not is_exe(path):
+        return False
+    with open(path, "rb") as fp:
+        if b"#!" != fp.read(2):
+            return False
+        if not pattern:
+            return True
+        return bool(re.match(pattern, fp.readline().decode("utf-8")))
 
 
 def can_write_dir(path):

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -251,7 +251,7 @@ def populate_venv_with_pex(
                     if key.startswith("PEX_"):
                         del os.environ[key]
 
-            pex_script = pex_overrides.get("PEX_SCRIPT")
+            pex_script = pex_overrides.get("PEX_SCRIPT") if pex_overrides else {script!r}
             if pex_script:
                 script_path = os.path.join(venv_bin_dir, pex_script)
                 os.execv(script_path, [script_path] + sys.argv[1:])
@@ -317,6 +317,7 @@ def populate_venv_with_pex(
             bin_path=bin_path,
             strip_pex_env=pex_info.strip_pex_env,
             entry_point=pex_info.entry_point,
+            script=pex_info.script,
             exec_ast=(
                 "exec ast in globals_map, locals_map"
                 if venv.interpreter.version[0] == 2

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -16,6 +16,7 @@ from pex.common import (
     can_write_dir,
     chmod_plus_x,
     is_exe,
+    is_script,
     open_zip,
     safe_open,
     temporary_dir,
@@ -29,7 +30,7 @@ except ImportError:
     import mock  # type: ignore[no-redef]
 
 if TYPE_CHECKING:
-    from typing import Iterator, Optional, Tuple, Type
+    from typing import Any, Iterator, Optional, Tuple, Type
 
 
 @contextmanager
@@ -336,19 +337,51 @@ def test_safe_open_relative(temporary_working_dir):
         assert "contents" == fp.read()
 
 
-def test_is_exe(temporary_working_dir):
-    # type: (str) -> None
-    touch("all_exe")
-    chmod_plus_x("all_exe")
-    assert is_exe("all_exe")
+def test_is_exe(tmpdir):
+    # type: (Any) -> None
+    all_exe = os.path.join(str(tmpdir), "all_exe")
+    touch(all_exe)
+    chmod_plus_x(all_exe)
+    assert is_exe(all_exe)
 
-    touch("other_exe")
-    os.chmod("other_exe", 0o665)
-    assert not is_exe("other_exe")
+    other_exe = os.path.join(str(tmpdir), "other_exe")
+    touch(other_exe)
+    os.chmod(other_exe, 0o665)
+    assert not is_exe(other_exe)
 
-    touch("not_exe")
-    assert not is_exe("not_exe")
+    not_exe = os.path.join(str(tmpdir), "not_exe")
+    touch(not_exe)
+    assert not is_exe(not_exe)
 
-    os.mkdir("exe_dir")
-    chmod_plus_x("exe_dir")
-    assert not is_exe("exe_dir")
+    exe_dir = os.path.join(str(tmpdir), "exe_dir")
+    os.mkdir(exe_dir)
+    chmod_plus_x(exe_dir)
+    assert not is_exe(exe_dir)
+
+
+def test_is_script(tmpdir):
+    # type: (Any) -> None
+    exe = os.path.join(str(tmpdir), "exe")
+
+    touch(exe)
+    assert not is_exe(exe)
+    assert not is_script(exe)
+
+    chmod_plus_x(exe)
+    assert is_exe(exe)
+    assert not is_script(exe)
+
+    with open(exe, "wb") as fp:
+        fp.write(bytearray([0xCA, 0xFE, 0xBA, 0xBE]))
+    assert not is_script(fp.name)
+
+    with open(exe, "wb") as fp:
+        fp.write(b"#!/mystery\n")
+        fp.write(bytearray([0xCA, 0xFE, 0xBA, 0xBE]))
+    assert is_script(exe)
+    assert is_script(exe, pattern=r"^/mystery")
+    assert not is_script(exe, pattern=r"^python")
+
+    os.chmod(exe, 0o665)
+    assert not is_script(exe)
+    assert not is_exe(exe)

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -31,7 +31,7 @@ def test_get_script_from_distributions(tmpdir):
     assert dist_script.dist is dist
     assert os.path.join(install_dir, "bin/cfn-signal") == dist_script.path
     assert dist_script.read_contents().startswith(
-        "#!"
+        b"#!"
     ), "Expected a `scripts`-style script w/shebang."
 
     assert None is get_script_from_distributions("non_existent_script", [dist])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3557,3 +3557,22 @@ def test_pip_leak_issues_1336(tmpdir):
     pip = os.path.join(os.path.dirname(python), "pip")
     subprocess.check_call(args=[pip, "install", "setuptools_scm==6.0.1"])
     run_pex_command(args=["--python", python, "bitstring==3.1.7"], python=python).assert_success()
+
+
+@pytest.mark.parametrize(
+    "mode_args",
+    [
+        pytest.param([], id="PEX"),
+        pytest.param(["--unzip"], id="unzip"),
+        pytest.param(["--venv"], id="venv"),
+    ],
+)
+def test_binary_scripts(tmpdir, mode_args):
+    # The py-spy distribution has a `py-spy` "script" that is a native executable that we should
+    # not try to parse as a traditional script but should still be able to execute.
+    py_spy_pex = os.path.join(str(tmpdir), "py-spy.pex")
+    run_pex_command(
+        args=["py-spy==0.3.8", "-c", "py-spy", "-o", py_spy_pex] + mode_args
+    ).assert_success()
+    output = subprocess.check_output(args=[py_spy_pex, "-V"])
+    assert output == b"py-spy 0.3.8\n"


### PR DESCRIPTION
It turns out some distributuions ship native executables using
distribution "scripts" (like py-spy), and these caused script re-writing
and execution to fail. Adds a failing integration test using py-spy that
this change fixes.

Follow-up on #1381.