### PR TITLE
Clean up resolver internal APIs.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -31,7 +31,7 @@ from pex.pex_bootstrapper import ensure_venv, iter_compatible_interpreters
 from pex.pex_builder import CopyMode, PEXBuilder
 from pex.pip import ResolverVersion
 from pex.platforms import Platform
-from pex.resolver import Unsatisfiable, parsed_platform, resolve_from_pex, resolve_multi
+from pex.resolver import Unsatisfiable, parsed_platform, resolve, resolve_from_pex
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV, Variables
@@ -1024,7 +1024,7 @@ def build_pex(reqs, options, cache=None):
                     )
             else:
                 with TRACER.timed("Resolving requirements."):
-                    resolveds = resolve_multi(
+                    resolveds = resolve(
                         requirements=reqs,
                         requirement_files=options.requirement_files,
                         constraint_files=options.constraint_files,

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -20,7 +20,7 @@ from contextlib import closing
 from textwrap import dedent
 
 from pex import dist_metadata, third_party
-from pex.common import atomic_directory, is_script, safe_mkdtemp
+from pex.common import atomic_directory, safe_mkdtemp
 from pex.compatibility import urlparse
 from pex.dist_metadata import ProjectNameAndVersion
 from pex.distribution_target import DistributionTarget
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
         Mapping,
         Optional,
         Protocol,
+        Sequence,
         Tuple,
         Union,
     )
@@ -96,8 +97,8 @@ class ResolverVersion(object):
 class PackageIndexConfiguration(object):
     @staticmethod
     def _calculate_args(
-        indexes=None,  # type: Optional[List[str]]
-        find_links=None,  # type: Optional[List[str]]
+        indexes=None,  # type: Optional[Sequence[str]]
+        find_links=None,  # type: Optional[Iterable[str]]
         network_configuration=None,  # type: Optional[NetworkConfiguration]
     ):
         # type: (...) -> Iterator[str]
@@ -171,8 +172,8 @@ class PackageIndexConfiguration(object):
     def create(
         cls,
         resolver_version=None,  # type: Optional[ResolverVersion.Value]
-        indexes=None,  # type: Optional[List[str]]
-        find_links=None,  # type: Optional[List[str]]
+        indexes=None,  # type: Optional[Sequence[str]]
+        find_links=None,  # type: Optional[Iterable[str]]
         network_configuration=None,  # type: Optional[NetworkConfiguration]
     ):
         # type: (...) -> PackageIndexConfiguration

--- a/tests/test_bdist_pex.py
+++ b/tests/test_bdist_pex.py
@@ -41,8 +41,8 @@ def bdist_pex_pythonpath():
         # Although the setuptools version is not important, we pick one so the test can leverage the
         # pex cache for speed run over run.
         BDIST_PEX_PYTHONPATH.extend(
-            resolved_distribution.distribution.location
-            for resolved_distribution in resolver.resolve(["setuptools==36.2.7"])
+            installed_distribution.distribution.location
+            for installed_distribution in resolver.resolve(["setuptools==36.2.7"])
         )
     return BDIST_PEX_PYTHONPATH
 

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -13,13 +13,13 @@ from types import ModuleType
 
 import pytest
 
+from pex import resolver
 from pex.common import safe_mkdir, safe_open, temporary_dir
 from pex.compatibility import PY2, WINDOWS, to_bytes
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
-from pex.resolver import resolve
 from pex.testing import (
     IS_PYPY3,
     PY27,
@@ -714,8 +714,8 @@ def test_pex_run_strip_env():
 
 def test_pex_run_custom_setuptools_useable():
     # type: () -> None
-    resolved_dists = resolve(["setuptools==36.2.7"])
-    dists = [resolved_dist.distribution for resolved_dist in resolved_dists]
+    installed_dists = resolver.resolve(["setuptools==36.2.7"])
+    dists = [installed_dist.distribution for installed_dist in installed_dists]
     with temporary_dir() as temp_dir:
         pex = write_simple_pex(
             temp_dir,
@@ -737,8 +737,8 @@ def test_pex_run_conflicting_custom_setuptools_useable():
     # > pkg_resources/py31compat.py
     # > pkg_resources/_vendor/appdirs.py
 
-    resolved_dists = resolve(["setuptools==20.3.1"])
-    dists = [resolved_dist.distribution for resolved_dist in resolved_dists]
+    installed_dists = resolver.resolve(["setuptools==20.3.1"])
+    dists = [installed_dist.distribution for installed_dist in installed_dists]
     with temporary_dir() as temp_dir:
         pex = write_simple_pex(
             temp_dir,
@@ -769,8 +769,8 @@ def test_pex_run_conflicting_custom_setuptools_useable():
 def test_pex_run_custom_pex_useable():
     # type: () -> None
     old_pex_version = "0.7.0"
-    resolved_dists = resolve(["pex=={}".format(old_pex_version), "setuptools==40.6.3"])
-    dists = [resolved_dist.distribution for resolved_dist in resolved_dists]
+    installed_dists = resolver.resolve(["pex=={}".format(old_pex_version), "setuptools==40.6.3"])
+    dists = [installed_dist.distribution for installed_dist in installed_dists]
     with temporary_dir() as temp_dir:
         from pex.version import __version__
 


### PR DESCRIPTION
Kill ~unused resolve and rename resolve_multi to resolve.
Eliminate ResolvedDistribution alias in favor of InstalledDistribution
which better reflects the shap of the distribution (not a wheel, but an
installed wheel). Fix test-use fallout.

Work towards #1401.
Closes #969