### PR TITLE
Cleanup test warnings.

### DIFF
--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -141,5 +141,8 @@ else:
     from Queue import Queue as Queue
     from multiprocessing import cpu_count as cpu_count
 
-
 WINDOWS = os.name == "nt"
+
+
+# Universal newlines is the default in Python 3.
+MODE_READ_UNIVERSAL_NEWLINES = "rU" if PY2 else "r"

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -21,7 +21,7 @@ from textwrap import dedent
 
 from pex import dist_metadata, third_party
 from pex.common import atomic_directory, safe_mkdtemp
-from pex.compatibility import urlparse
+from pex.compatibility import MODE_READ_UNIVERSAL_NEWLINES, urlparse
 from pex.dist_metadata import ProjectNameAndVersion
 from pex.distribution_target import DistributionTarget
 from pex.finders import DistributionScript
@@ -786,7 +786,9 @@ class Pip(object):
 
         # The RECORD is a csv file with the path to each installed file in the 1st column.
         # See: https://www.python.org/dev/peps/pep-0376/#record
-        with closing(fileinput.input(files=[record_abspath], inplace=True, mode="rU")) as record_fi:
+        with closing(
+            fileinput.input(files=[record_abspath], inplace=True, mode=MODE_READ_UNIVERSAL_NEWLINES)
+        ) as record_fi:
             csv_writer = None  # type: Optional[CSVWriter]
             for path, existing_hash, existing_size in csv.reader(
                 record_fi, delimiter=",", quotechar='"'

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -8,7 +8,7 @@ import functools
 import itertools
 import os
 import zipfile
-from collections import OrderedDict, Sequence, defaultdict
+from collections import OrderedDict, defaultdict
 
 from pex.common import AtomicDirectory, atomic_directory, safe_mkdtemp
 from pex.distribution_target import DistributionTarget
@@ -35,7 +35,7 @@ from pex.util import CacheHelper, DistributionHelper
 
 if TYPE_CHECKING:
     import attr  # vendor:skip
-    from typing import DefaultDict, Iterable, Iterator, List, Optional, Tuple, Union
+    from typing import DefaultDict, Iterable, Iterator, List, Optional, Sequence, Tuple, Union
 
     from pex.requirements import ParsedRequirement
 else:


### PR DESCRIPTION
Two fixes:

1. Avoid warnings about universal newlines.

   These flood the end of the unit test log for all unit test environments
   except py27 and pypy2 as it stands.

2. Fixup an errant import of collections.Sequence.