### PR TITLE
Introduce the spread app layout.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -1215,7 +1215,7 @@ def seed_cache(
             # type: (str) -> Dict[str, str]
             return dict(pex_root=pex_root, python=pex.interpreter.binary, pex=final_pex_path)
 
-        if options.unzip:
+        if options.unzip and not options.spread:
             unzip_dir = pex_info.unzip_dir
             if unzip_dir is None:
                 raise AssertionError(

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -463,9 +463,10 @@ class PEX(object):  # noqa: T000
         teardown_verbosity = self._vars.PEX_TEARDOWN_VERBOSE
 
         # N.B.: This is set in `__main__.py` of the executed PEX by `PEXBuilder` when we've been
-        # executed from within a PEX zip file in `--unzip` mode.  We replace `sys.argv[0]` to avoid
-        # confusion and allow the user code we hand off to to provide useful messages and fully
-        # valid re-execs that always re-directed through the PEX file.
+        # executed from within a PEX zip file in `--unzip` or `--venv` modes or a `--spread` PEX.
+        # We replace `sys.argv[0]` to avoid confusion and allow the user code we hand off to to
+        # provide useful messages and fully valid re-execs that are always re-directed through the
+        # PEX file or spread PEX.
         sys.argv[0] = os.environ.pop("__PEX_EXE__", sys.argv[0])
 
         try:

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -65,14 +65,13 @@ class PEX(object):  # noqa: T000
         self,
         pex=sys.argv[0],  # type: str
         interpreter=None,  # type: Optional[PythonInterpreter]
-        pex_info=None,  # type: Optional[PexInfo]
         env=ENV,  # type: Variables
         verify_entry_point=False,  # type: bool
     ):
         # type: (...) -> None
         self._pex = pex
         self._interpreter = interpreter or PythonInterpreter.get()
-        self._pex_info = pex_info or PexInfo.from_pex(self._pex)
+        self._pex_info = PexInfo.from_pex(self._pex)
         self._pex_info_overrides = PexInfo.from_env(env=env)
         self._vars = env
         self._envs = None  # type: Optional[Iterable[PEXEnvironment]]

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 import hashlib
 import logging
 import os
-from textwrap import dedent
 
 from pex import pex_warnings
 from pex.common import (
@@ -714,19 +713,6 @@ class PEXBuilder(object):
                 # Zip up the bootstrap which is constant for a given version of Pex.
                 bootstrap_root = os.path.join(self._chroot.chroot, pex_info.bootstrap)
                 bootstrap_fingerprint = CacheHelper.dir_hash(bootstrap_root)
-                cached_bootstrap_dir = os.path.join(
-                    pex_info.pex_root, "bootstraps", bootstrap_fingerprint
-                )
-                with atomic_directory(cached_bootstrap_dir, exclusive=True) as atomic_bootstrap_dir:
-                    if not atomic_bootstrap_dir.is_finalized:
-                        for root, dirs, files in os.walk(bootstrap_root):
-                            destdir = os.path.join(
-                                atomic_bootstrap_dir.work_dir, os.path.relpath(root, bootstrap_root)
-                            )
-                            for d in dirs:
-                                os.mkdir(os.path.join(destdir, d))
-                            for f in files:
-                                safe_copy(os.path.join(root, f), os.path.join(destdir, f))
                 cached_bootstrap_zip_dir = os.path.join(
                     pex_info.pex_root, "bootstrap_zips", bootstrap_fingerprint
                 )

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -171,7 +171,7 @@ elif Variables.PEX_UNZIP.value_or(ENV, {is_unzip!r}):
     __maybe_run_unzipped__(__entry_point__, __pex_root__)
 
 __spread_info__ = os.path.join(__entry_point__, {spread_info!r})
-if os.path.isfile(__spread_info__) and not '__PEX_SPREAD__' in os.environ:
+if os.path.isfile(__spread_info__) and not '__PEX_EXE__' in os.environ:
     from pex.spread import spread
     from pex.tracer import TRACER
 
@@ -180,7 +180,7 @@ if os.path.isfile(__spread_info__) and not '__PEX_SPREAD__' in os.environ:
 
     # N.B.: This is read by pex.PEX and used to point sys.argv[0] back to the original spread pex
     # before unconditionally scrubbing the env var and handing off to user code.
-    os.environ['__PEX_SPREAD__'] = __entry_point__
+    os.environ['__PEX_EXE__'] = __entry_point__
 
     os.execv(sys.executable, [sys.executable, spread_to] + sys.argv[1:])
 

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -170,9 +170,8 @@ elif Variables.PEX_UNZIP.value_or(ENV, {is_unzip!r}):
   if zipfile.is_zipfile(__entry_point__):
     __maybe_run_unzipped__(__entry_point__, __pex_root__)
 
-__spread_info__ = os.path.join(__entry_point__, {spread_info!r})
-if os.path.isfile(__spread_info__) and not '__PEX_EXE__' in os.environ:
-    from pex.spread import spread
+from pex.spread import is_spread, spread
+if is_spread(__entry_point__) and not '__PEX_EXE__' in os.environ:
     from pex.tracer import TRACER
 
     spread_to = spread(__entry_point__, __pex_root__, {pex_hash!r})
@@ -770,11 +769,14 @@ class PEXBuilder(object):
                             )
                         )
 
-                os.symlink(
-                    os.path.join("src", "__main__.py"), os.path.join(work_dir, "__main__.py")
-                )
+                def link_src_to_spread_root(name):
+                    # type: (str) -> None
+                    os.symlink(os.path.join("src", name), os.path.join(work_dir, name))
+
+                link_src_to_spread_root("__main__.py")
                 os.symlink("__main__.py", os.path.join(work_dir, "pex"))
 
+                link_src_to_spread_root(PexInfo.PATH)
                 SpreadInfo(sources=sources, spreads=spreads).dump(work_dir)
 
     def _build_zipapp(

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -776,7 +776,7 @@ class PEXBuilder(object):
                 )
                 os.symlink("__main__.py", os.path.join(work_dir, "pex"))
 
-                SpreadInfo.create(sources=sources, spreads=spreads).dump(work_dir)
+                SpreadInfo(sources=sources, spreads=spreads).dump(work_dir)
 
     def _build_zipapp(
         self,

--- a/pex/spread.py
+++ b/pex/spread.py
@@ -12,7 +12,7 @@ from pex.typing import TYPE_CHECKING
 from pex.variables import unzip_dir
 
 if TYPE_CHECKING:
-    import attr
+    import attr  # vendor:skip
     from typing import Iterable, Text, Tuple, Union
 else:
     from pex.third_party import attr

--- a/pex/spread.py
+++ b/pex/spread.py
@@ -1,0 +1,127 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import json
+import os
+
+from pex.common import atomic_directory, open_zip, safe_copy, safe_mkdir, safe_open
+from pex.tracer import TRACER
+from pex.typing import TYPE_CHECKING
+from pex.variables import unzip_dir
+
+if TYPE_CHECKING:
+    import attr
+    from typing import Iterable, Text, Tuple, Union
+else:
+    from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class Spread(object):
+    zip_relpath = attr.ib()  # type: str
+    unpack_relpath = attr.ib()  # type: str
+    strip_zip_relpath = attr.ib(default=True)  # type: bool
+
+
+@attr.s(frozen=True)
+class SpreadInfo(object):
+    PATH = "PEX-SPREAD-INFO"
+
+    @classmethod
+    def from_pex(cls, pex):
+        # type: (str) -> SpreadInfo
+        with open(os.path.join(pex, cls.PATH)) as fp:
+            return cls.from_json(fp.read())
+
+    @classmethod
+    def from_json(cls, content):
+        # type: (Union[bytes, Text]) -> SpreadInfo
+        if isinstance(content, bytes):
+            content = content.decode("utf-8")
+        data = json.loads(content)
+        return cls.create(
+            sources=data["sources"],
+            spreads=(
+                Spread(
+                    zip_relpath=s["zip_relpath"],
+                    strip_zip_relpath=s["strip_zip_relpath"],
+                    unpack_relpath=s["unpack_relpath"],
+                )
+                for s in data["spreads"]
+            ),
+        )
+
+    @classmethod
+    def create(
+        cls,
+        sources,  # type: Iterable[str]
+        spreads,  # type: Iterable[Spread]
+    ):
+        # type: (...) -> SpreadInfo
+        return cls(sources=tuple(sources), spreads=tuple(spreads))
+
+    sources = attr.ib()  # type: Tuple[str, ...]
+    spreads = attr.ib()  # type: Tuple[Spread, ...]
+
+    def dump(self, dest_dir):
+        # type: (str) -> str
+        data = {
+            "sources": sorted(self.sources),
+            "spreads": [
+                {
+                    "zip_relpath": s.zip_relpath,
+                    "strip_zip_relpath": s.strip_zip_relpath,
+                    "unpack_relpath": s.unpack_relpath,
+                }
+                for s in sorted(self.spreads)
+            ],
+        }
+        dest = os.path.join(dest_dir, self.PATH)
+        with safe_open(dest, "w") as fp:
+            json.dump(data, fp, sort_keys=True)
+        return dest
+
+
+def spread(
+    spread_pex,  # type: str
+    pex_root,  # type: str
+    pex_hash,  # type: str
+):
+    # type: (...) -> str
+    """Installs a spread pex into the pex root as an unzipped PEX.
+
+    Returns the path of the unzipped PEX.
+    """
+    spread_to = unzip_dir(pex_root=pex_root, pex_hash=pex_hash)
+    with atomic_directory(spread_to, exclusive=True) as chroot:
+        if not chroot.is_finalized:
+            with TRACER.timed("Extracting {} to {}".format(spread_pex, spread_to)):
+                spread_info = SpreadInfo.from_pex(spread_pex)
+
+                for source in spread_info.sources:
+                    dest = os.path.join(spread_to, source)
+                    safe_mkdir(os.path.dirname(dest))
+                    safe_copy(os.path.join(spread_pex, "src", source), dest)
+
+                for s in spread_info.spreads:
+                    spread_dest = os.path.join(pex_root, s.unpack_relpath)
+                    with atomic_directory(
+                        spread_dest,
+                        source=s.zip_relpath if s.strip_zip_relpath else None,
+                        exclusive=True,
+                    ) as spread_chroot:
+                        if not spread_chroot.is_finalized:
+                            with open_zip(os.path.join(spread_pex, s.zip_relpath)) as zfp:
+                                zfp.extractall(spread_chroot.work_dir)
+
+                    symlink_dest = os.path.join(spread_to, s.zip_relpath)
+                    safe_mkdir(os.path.dirname(symlink_dest))
+                    os.symlink(
+                        os.path.relpath(
+                            spread_dest, os.path.join(spread_to, os.path.dirname(s.zip_relpath))
+                        ),
+                        symlink_dest,
+                    )
+    return spread_to

--- a/pex/spread.py
+++ b/pex/spread.py
@@ -9,7 +9,7 @@ import os
 from pex.common import atomic_directory, open_zip, safe_copy, safe_mkdir, safe_open
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
-from pex.variables import unzip_dir
+from pex.variables import ENV, Variables, unzip_dir
 
 if TYPE_CHECKING:
     from typing import Iterable, Text, Union
@@ -85,6 +85,11 @@ class SpreadInfo(object):
         with safe_open(dest, "w") as fp:
             json.dump(data, fp, sort_keys=True)
         return dest
+
+
+def is_spread(pex):
+    # type: (str) -> bool
+    return os.path.isfile(os.path.join(pex, SpreadInfo.PATH))
 
 
 def spread(

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -196,7 +196,10 @@ def populate_venv_with_pex(
                     "PEX_PYTHON",
                     "PEX_PYTHON_PATH",
                     "PEX_VERBOSE",
+                    # These are used in re-exec.
                     "__PEX_EXE__",
+                    "__PEX_SPREAD__",
+                    # This is used by the vendoring system.
                     "__PEX_UNVENDORED__",
                     # This is _not_ used (it is ignored), but it's present under CI and simplest to
                     # add an exception for here and not warn about in CI runs.

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -197,9 +197,8 @@ def populate_venv_with_pex(
                     "PEX_PYTHON_PATH",
                     "PEX_VERBOSE",
                     "PEX_EMIT_WARNINGS",
-                    # These are used in re-exec.
+                    # This is used in re-exec.
                     "__PEX_EXE__",
-                    "__PEX_SPREAD__",
                     # This is used by the vendoring system.
                     "__PEX_UNVENDORED__",
                     # This is _not_ used (it is ignored), but it's present under CI and simplest to

--- a/pex/util.py
+++ b/pex/util.py
@@ -185,7 +185,7 @@ class CacheHelper(object):
                 filter_pyc_files(
                     name
                     for name in zf.namelist()
-                    if not name.endswith("/") and not relpath or name.startswith(relpath)
+                    if not name.endswith("/") and (not relpath or name.startswith(relpath))
                 )
             )
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1507,8 +1507,10 @@ def test_venv_mode(
     "mode_args",
     [
         pytest.param([], id="PEX"),
-        pytest.param(["--unzip"], id="unzip"),
-        pytest.param(["--venv"], id="venv"),
+        pytest.param(["--unzip"], id="UNZIP"),
+        pytest.param(["--venv"], id="VENV"),
+        pytest.param(["--spread"], id="Spread"),
+        pytest.param(["--spread", "--venv"], id="Spread VENV"),
     ],
 )
 def test_seed(
@@ -1524,7 +1526,8 @@ def test_seed(
     seed_argv = shlex.split(results.output, posix=False)
     isort_args = ["--version"]
     seed_stdout, seed_stderr = Executor.execute(seed_argv + isort_args)
-    pex_stdout, pex_stderr = Executor.execute([pex_file] + isort_args)
+    pex_args = [pex_file] if os.path.isfile(pex_file) else [sys.executable, pex_file]
+    pex_stdout, pex_stderr = Executor.execute(pex_args + isort_args)
     assert pex_stdout == seed_stdout
     assert pex_stderr == seed_stderr
 
@@ -1533,8 +1536,10 @@ def test_seed(
     ["mode_args", "seeded_execute_args"],
     [
         pytest.param([], ["python", "pex"], id="PEX"),
-        pytest.param(["--unzip"], ["python", "pex"], id="unzip"),
-        pytest.param(["--venv"], ["pex"], id="venv"),
+        pytest.param(["--unzip"], ["python", "pex"], id="UNZIP"),
+        pytest.param(["--venv"], ["pex"], id="VENV"),
+        pytest.param(["--spread"], ["python", "pex"], id="Spread"),
+        pytest.param(["--spread", "--venv"], ["pex"], id="Spread VENV"),
     ],
 )
 def test_seed_verbose(
@@ -1564,7 +1569,8 @@ def test_seed_verbose(
 
     isort_args = ["--version"]
     seed_stdout, seed_stderr = Executor.execute(seeded_argv0 + isort_args)
-    pex_stdout, pex_stderr = Executor.execute([pex_file] + isort_args)
+    pex_args = [pex_file] if os.path.isfile(pex_file) else [python, pex_file]
+    pex_stdout, pex_stderr = Executor.execute(pex_args + isort_args)
     assert pex_stdout == seed_stdout
     assert pex_stderr == seed_stderr
 

--- a/tests/integration/test_spread.py
+++ b/tests/integration/test_spread.py
@@ -1,0 +1,65 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from pex.common import safe_open, safe_rmtree
+from pex.testing import run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, List
+
+
+@pytest.mark.parametrize(
+    "mode_args",
+    [
+        pytest.param(["--spread"], id="Spread"),
+        pytest.param(["--spread", "--venv"], id="Spread VENV"),
+    ],
+)
+def test_resiliency(
+    tmpdir,  # type: Any
+    mode_args,  # type: List[str]
+):
+    # type: (...) -> None
+    src_dir = os.path.join(str(tmpdir), "src")
+    with safe_open(os.path.join(src_dir, "exe.py"), "w") as fp:
+        fp.write("import colors; print(colors.__version__)")
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    spread = os.path.join(str(tmpdir), "spread")
+
+    run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "ansicolors==1.1.8",
+            "-D",
+            src_dir,
+            "-e",
+            "exe",
+            "-o",
+            spread,
+        ]
+        + mode_args
+    ).assert_success()
+
+    def assert_exe(*args):
+        # type: (*str) -> None
+        output = subprocess.check_output(args=args)
+        assert b"1.1.8\n" == output
+
+    spread_pex = os.path.join(spread, "pex")
+    assert_exe(sys.executable, spread)
+    assert_exe(spread_pex)
+
+    safe_rmtree(pex_root)
+    assert_exe(spread_pex)
+    assert_exe(sys.executable, spread)

--- a/tests/test_execution_mode.py
+++ b/tests/test_execution_mode.py
@@ -14,7 +14,7 @@ from pex.testing import run_pex_command
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import attr
+    import attr  # vendor:skip
     from typing import Any, Callable, Dict, Iterable, Tuple
 
     CreateColorsPex = Callable[[Iterable[str]], str]

--- a/tests/test_execution_mode.py
+++ b/tests/test_execution_mode.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import os.path
 import subprocess
+import sys
 from subprocess import CalledProcessError
 
 import pytest
@@ -13,10 +14,13 @@ from pex.testing import run_pex_command
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    import attr
     from typing import Any, Callable, Dict, Iterable, Tuple
 
     CreateColorsPex = Callable[[Iterable[str]], str]
     ExecuteColorsPex = Callable[[str, Dict[str, str]], Tuple[str, str]]
+else:
+    from pex.third_party import attr
 
 
 @pytest.fixture
@@ -39,41 +43,96 @@ def execute_colors_pex(tmpdir):
         env = os.environ.copy()
         env.update(extra_env)
         env["PEX_ROOT"] = pex_root
+        args = [colors_pex] if os.path.isfile(colors_pex) else [sys.executable, colors_pex]
         output = subprocess.check_output(
-            [colors_pex, "-c", "import colors; print(colors.__file__)"], env=env
+            args=args + ["-c", "import colors; print(colors.__file__)"], env=env
         )
         return output.strip().decode("utf-8"), pex_root
 
     return execute
 
 
+@attr.s(frozen=True)
+class ExecutionMode(object):
+    default_isort_code_dir = attr.ib()  # type: str
+    extra_args = attr.ib(default=())  # type: Iterable[str]
+    unzipped_isort_code_dir = attr.ib(default="unzipped_pexes")  # type: str
+    venv_exception_expected = attr.ib(default=True)  # type: bool
+
+
 @pytest.mark.parametrize(
-    ["extra_args", "default_dir", "venv_exception_expected"],
+    ["execution_mode"],
     [
-        pytest.param([], "installed_wheels", True, id="ZIPAPP"),
-        pytest.param(["--include-tools"], "installed_wheels", False, id="ZIPAPP --include-tools"),
-        pytest.param(["--unzip"], "unzipped", True, id="UNZIP"),
-        pytest.param(["--unzip", "--include-tools"], "unzipped", False, id="UNZIP --include-tools"),
-        pytest.param(["--venv"], "venvs", False, id="VENV"),
+        pytest.param(ExecutionMode(default_isort_code_dir="installed_wheels"), id="ZIPAPP"),
+        pytest.param(
+            ExecutionMode(
+                extra_args=["--include-tools"],
+                default_isort_code_dir="installed_wheels",
+                venv_exception_expected=False,
+            ),
+            id="ZIPAPP --include-tools",
+        ),
+        pytest.param(
+            ExecutionMode(extra_args=["--unzip"], default_isort_code_dir="unzipped_pexes"),
+            id="UNZIP",
+        ),
+        pytest.param(
+            ExecutionMode(
+                extra_args=["--unzip", "--include-tools"],
+                default_isort_code_dir="unzipped_pexes",
+                venv_exception_expected=False,
+            ),
+            id="UNZIP --include-tools",
+        ),
+        pytest.param(
+            ExecutionMode(
+                extra_args=["--venv"], default_isort_code_dir="venvs", venv_exception_expected=False
+            ),
+            id="VENV",
+        ),
+        pytest.param(
+            ExecutionMode(
+                extra_args=["--spread"],
+                default_isort_code_dir="installed_wheels",
+                unzipped_isort_code_dir="installed_wheels",
+            ),
+            id="Spread",
+        ),
+        pytest.param(
+            ExecutionMode(
+                extra_args=["--spread", "--include-tools"],
+                default_isort_code_dir="installed_wheels",
+                unzipped_isort_code_dir="installed_wheels",
+                venv_exception_expected=False,
+            ),
+            id="Spread --include-tools",
+        ),
+        pytest.param(
+            ExecutionMode(
+                extra_args=["--venv", "--spread"],
+                default_isort_code_dir="venvs",
+                unzipped_isort_code_dir="installed_wheels",
+                venv_exception_expected=False,
+            ),
+            id="Spread VENV",
+        ),
     ],
 )
 def test_execution_mode(
     create_colors_pex,  # type: CreateColorsPex
     execute_colors_pex,  # type: ExecuteColorsPex
-    extra_args,  # type: Iterable[str]
-    default_dir,  # type: str
-    venv_exception_expected,  # type: bool
+    execution_mode,  # type: ExecutionMode
 ):
     # type: (...) -> None
-    pex_file = create_colors_pex(extra_args)
+    pex_file = create_colors_pex(execution_mode.extra_args)
 
     output, pex_root = execute_colors_pex(pex_file, {})
-    assert output.startswith(os.path.join(pex_root, default_dir))
+    assert output.startswith(os.path.join(pex_root, execution_mode.default_isort_code_dir))
 
     output, pex_root = execute_colors_pex(pex_file, {"PEX_UNZIP": "1"})
-    assert output.startswith(os.path.join(pex_root, "unzipped"))
+    assert output.startswith(os.path.join(pex_root, execution_mode.unzipped_isort_code_dir))
 
-    if venv_exception_expected:
+    if execution_mode.venv_exception_expected:
         with pytest.raises(CalledProcessError):
             execute_colors_pex(pex_file, {"PEX_VENV": "1"})
     else:


### PR DESCRIPTION
Beyond the top level `pex` and `__main__.py` files, the layout is an
implementation detail, but the current structure sheds some light on the
cache-friendly characteristics:

Given loose sources:
```
$ cat src/main.py
from pex.version import __version__; print(__version__)
```

A spread layout PEX looks like:
```
$ python -mpex pex -Dsrc -emain -opex.spread.venv --spread \
  --seed verbose --venv prepend | jq .
{
  "pex_root": "/home/jsirois/.pex",
  "python": "/usr/bin/python3.9",
  "pex": "/home/jsirois/.pex/venvs/d2f743b9c1ebb156f794419c01b3422653cbdb61/2d1d404c3de23b1810386195be7410700b1feb14/pex"
}
$ tree -a pex.spread.venv
pex.spread.venv
├── .bootstrap
├── .deps
│   └── pex-2.1.46-py2.py3-none-any.whl
├── __main__.py -> src/__main__.py
├── pex -> __main__.py
├── PEX-SPREAD-INFO
└── src
    ├── __main__.py
    ├── main.py
    └── PEX-INFO
```

And the runtime spreading is suggested by the new PEX-SPREAD-INFO
manifest:
```json
{
  "sources": [
    "PEX-INFO",
    "__main__.py",
    "main.py"
  ],
  "spreads": [
    {
      "strip_zip_relpath": false,
      "unpack_relpath": "bootstraps/a54b6ae5e64e5b229388fdffc8adac141f3c416b",
      "zip_relpath": ".bootstrap"
    },
    {
      "strip_zip_relpath": true,
      "unpack_relpath": "installed_wheels/f627f0368a0e29be24aa8cadba74044b9ad990d7/pex-2.1.46-py2.py3-none-any.whl",
      "zip_relpath": ".deps/pex-2.1.46-py2.py3-none-any.whl"
    }
  ]
}
```

The layout adds new PEX_ROOT caches for the `.bootstrap` zip and
installed wheel chroot zips such that neither bootstraps - which are
tied to a version of Pex, nor installed wheel chroot zips, which are
constant for a given distribution version, are created more than once.

Closes #1424