### PR TITLE
Enrich resolve and download with lock data.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -1010,7 +1010,7 @@ def build_pex(reqs, options, cache=None):
                 with TRACER.timed(
                     "Resolving requirements from PEX {}.".format(options.pex_repository)
                 ):
-                    resolveds = resolve_from_pex(
+                    result = resolve_from_pex(
                         pex=options.pex_repository,
                         requirements=reqs,
                         requirement_files=options.requirement_files,
@@ -1024,7 +1024,7 @@ def build_pex(reqs, options, cache=None):
                     )
             else:
                 with TRACER.timed("Resolving requirements."):
-                    resolveds = resolve(
+                    result = resolve(
                         requirements=reqs,
                         requirement_files=options.requirement_files,
                         constraint_files=options.constraint_files,
@@ -1045,10 +1045,10 @@ def build_pex(reqs, options, cache=None):
                         ignore_errors=options.ignore_errors,
                     )
 
-            for resolved_dist in resolveds:
-                pex_builder.add_distribution(resolved_dist.distribution)
-                if resolved_dist.direct_requirement:
-                    pex_builder.add_requirement(resolved_dist.direct_requirement)
+            for installed_dist in result.installed_distributions:
+                pex_builder.add_distribution(installed_dist.distribution)
+                if installed_dist.direct_requirement:
+                    pex_builder.add_requirement(installed_dist.direct_requirement)
         except Unsatisfiable as e:
             die(str(e))
 

--- a/pex/dist_metadata.py
+++ b/pex/dist_metadata.py
@@ -43,7 +43,7 @@ _PKG_INFO_BY_DIST = {}  # type: Dict[Distribution, Optional[Message]]
 
 def _strip_sdist_path(sdist_path):
     # type: (str) -> Optional[str]
-    if not sdist_path.endswith((".sdist", ".tar.gz", ".zip")):
+    if not sdist_path.endswith((".sdist", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".zip")):
         return None
 
     sdist_basename = os.path.basename(sdist_path)

--- a/pex/locked_resolve.py
+++ b/pex/locked_resolve.py
@@ -1,0 +1,130 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import hashlib
+
+from pex.dist_metadata import ProjectNameAndVersion
+from pex.distribution_target import DistributionTarget
+from pex.pep_503 import ProjectName
+from pex.third_party.packaging import utils as packaging_utils
+from pex.third_party.pkg_resources import Requirement
+from pex.typing import TYPE_CHECKING, cast
+from pex.util import CacheHelper
+
+if TYPE_CHECKING:
+    import attr  # vendor:skip
+    from typing import BinaryIO, IO, Tuple
+else:
+    from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class LockConfiguration(object):
+    strict = attr.ib()  # type: bool
+
+
+@attr.s(frozen=True)
+class Fingerprint(object):
+    algorithm = attr.ib()  # type: str
+    hash = attr.ib()  # type: str
+
+    @classmethod
+    def from_stream(
+        cls,
+        stream,  # type: BinaryIO
+        algorithm="sha256",  # type: str
+    ):
+        # type: (...) -> Fingerprint
+        digest = hashlib.new(algorithm)
+        CacheHelper.update_hash(filelike=stream, digest=digest)
+        return cls(algorithm=algorithm, hash=digest.hexdigest())
+
+
+@attr.s(frozen=True)
+class Artifact(object):
+    url = attr.ib()  # type: str
+    fingerprint = attr.ib()  # type: Fingerprint
+
+
+def _canonicalize_version(version):
+    # type: (str) -> str
+    return cast(str, packaging_utils.canonicalize_version(version))
+
+
+@attr.s(frozen=True)
+class Version(object):
+    version = attr.ib(converter=_canonicalize_version)  # type: str
+
+    def __str__(self):
+        # type: () -> str
+        return self.version
+
+
+@attr.s(frozen=True)
+class Pin(object):
+    @classmethod
+    def canonicalize(cls, project_name_and_version):
+        # type: (ProjectNameAndVersion) -> Pin
+        return cls(
+            project_name=ProjectName(project_name_and_version.project_name),
+            version=Version(project_name_and_version.version),
+        )
+
+    project_name = attr.ib()  # type: ProjectName
+    version = attr.ib()  # type: Version
+
+
+@attr.s(frozen=True)
+class LockedRequirement(object):
+    pin = attr.ib()  # type: Pin
+    artifact = attr.ib()  # type: Artifact
+    requirement = attr.ib()  # type: Requirement
+    additional_artifacts = attr.ib(default=())  # type: Tuple[Artifact, ...]
+    via = attr.ib(default=())  # type: Tuple[str, ...]
+
+
+@attr.s(frozen=True)
+class LockedResolve(object):
+    target = attr.ib()  # type: DistributionTarget
+    locked_requirements = attr.ib()  # type: Tuple[LockedRequirement, ...]
+
+    def emit_requirements(self, stream):
+        # type: (IO[str]) -> None
+        def emit_artifact(
+            artifact,  # type: Artifact
+            line_continuation,  # type: bool
+        ):
+            # type: (...) -> None
+            stream.write(
+                "    --hash:{algorithm}={hash} # {url}{line_continuation}\n".format(
+                    algorithm=artifact.fingerprint.algorithm,
+                    hash=artifact.fingerprint.hash,
+                    url=artifact.url,
+                    line_continuation=" \\" if line_continuation else "",
+                )
+            )
+
+        for locked_requirement in sorted(self.locked_requirements, key=lambda lr: lr.pin):
+            stream.write(
+                "{project_name}=={version} # {requirement}".format(
+                    project_name=locked_requirement.pin.project_name,
+                    version=locked_requirement.pin.version,
+                    requirement=locked_requirement.requirement,
+                )
+            )
+            if locked_requirement.via:
+                stream.write(" via -> {}".format(" via -> ".join(locked_requirement.via)))
+            stream.write(" \\\n")
+            emit_artifact(
+                locked_requirement.artifact,
+                line_continuation=bool(locked_requirement.additional_artifacts),
+            )
+            for index, additional_artifact in enumerate(
+                locked_requirement.additional_artifacts, start=1
+            ):
+                emit_artifact(
+                    additional_artifact,
+                    line_continuation=index != len(locked_requirement.additional_artifacts),
+                )

--- a/pex/locked_resolve.py
+++ b/pex/locked_resolve.py
@@ -27,9 +27,6 @@ class LockConfiguration(object):
 
 @attr.s(frozen=True)
 class Fingerprint(object):
-    algorithm = attr.ib()  # type: str
-    hash = attr.ib()  # type: str
-
     @classmethod
     def from_stream(
         cls,
@@ -40,6 +37,9 @@ class Fingerprint(object):
         digest = hashlib.new(algorithm)
         CacheHelper.update_hash(filelike=stream, digest=digest)
         return cls(algorithm=algorithm, hash=digest.hexdigest())
+
+    algorithm = attr.ib()  # type: str
+    hash = attr.ib()  # type: str
 
 
 @attr.s(frozen=True)

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -278,10 +278,6 @@ class _ErrorAnalyzer(_LogAnalyzer):
         Returns a value indicating whether or not analysis is complete.
         """
 
-    def analysis_completed(self):
-        # type: () -> None
-        """Called to indicate the log analysis is complete."""
-
 
 @attr.s
 class _Issue9420Analyzer(_ErrorAnalyzer):
@@ -349,7 +345,11 @@ class PartialArtifact(object):
 @attr.s(frozen=True)
 class ResolvedRequirement(object):
     @classmethod
-    def lock_all(cls, resolved_requirements, url_fetcher):
+    def lock_all(
+        cls,
+        resolved_requirements,  # type: Iterable[ResolvedRequirement]
+        url_fetcher,  # type: URLFetcher
+    ):
         # type: (...) -> Iterator[LockedRequirement]
 
         # TODO(John Sirois): Introduce a thread pool and pump these fetches to workers via a Queue.

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -9,13 +9,14 @@ import csv
 import fileinput
 import functools
 import hashlib
+import itertools
 import json
 import os
 import re
 import subprocess
 import sys
 from abc import abstractmethod
-from collections import deque
+from collections import defaultdict, deque
 from contextlib import closing
 from textwrap import dedent
 
@@ -24,14 +25,25 @@ from pex.common import atomic_directory, safe_mkdtemp
 from pex.compatibility import MODE_READ_UNIVERSAL_NEWLINES, urlparse
 from pex.dist_metadata import ProjectNameAndVersion
 from pex.distribution_target import DistributionTarget
+from pex.fetcher import URLFetcher
 from pex.finders import DistributionScript
 from pex.interpreter import PythonInterpreter
 from pex.jobs import Job
+from pex.locked_resolve import (
+    Artifact,
+    Fingerprint,
+    LockConfiguration,
+    LockedRequirement,
+    LockedResolve,
+    Pin,
+)
 from pex.network_configuration import NetworkConfiguration
+from pex.orderedset import OrderedSet
 from pex.pex import PEX
 from pex.pex_bootstrapper import ensure_venv
 from pex.platforms import Platform
 from pex.third_party import isolated
+from pex.third_party.pkg_resources import Requirement
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING, Generic, cast
 from pex.util import CacheHelper, named_temporary_file
@@ -43,6 +55,7 @@ if TYPE_CHECKING:
     from typing import (
         Any,
         Callable,
+        DefaultDict,
         Dict,
         Iterable,
         Iterator,
@@ -262,9 +275,12 @@ class _ErrorAnalyzer(_LogAnalyzer):
         # type: (str) -> ErrorAnalysis
         """Analyze the given log line.
 
-        Returns a value indicating whether or not analysis is complete. The value may contain text
-        that should be reported as part of the error analysis.
+        Returns a value indicating whether or not analysis is complete.
         """
+
+    def analysis_completed(self):
+        # type: () -> None
+        """Called to indicate the log analysis is complete."""
 
 
 @attr.s
@@ -322,6 +338,179 @@ class _Issue10050Analyzer(_ErrorAnalyzer):
                 )
             )
         return self.Continue()
+
+
+@attr.s(frozen=True)
+class PartialArtifact(object):
+    url = attr.ib()  # type: str
+    fingerprint = attr.ib(default=None)  # type: Optional[Fingerprint]
+
+
+@attr.s(frozen=True)
+class ResolvedRequirement(object):
+    @classmethod
+    def lock_all(cls, resolved_requirements, url_fetcher):
+        # type: (...) -> Iterator[LockedRequirement]
+
+        # TODO(John Sirois): Introduce a thread pool and pump these fetches to workers via a Queue.
+        def fingerprint_url(url):
+            # type: (str) -> Fingerprint
+            with url_fetcher.get_body_stream(url) as body_stream:
+                return Fingerprint.from_stream(body_stream)
+
+        fingerprint_by_url = {
+            url: fingerprint_url(url)
+            for url in set(
+                itertools.chain.from_iterable(
+                    resolved_requirement._iter_urls_to_fingerprint()
+                    for resolved_requirement in resolved_requirements
+                )
+            )
+        }
+
+        def resolve_fingerprint(partial_artifact):
+            # type: (PartialArtifact) -> Artifact
+            return Artifact(
+                url=partial_artifact.url,
+                fingerprint=partial_artifact.fingerprint
+                or fingerprint_by_url[partial_artifact.url],
+            )
+
+        for resolved_requirement in resolved_requirements:
+            yield LockedRequirement(
+                pin=resolved_requirement.pin,
+                artifact=resolve_fingerprint(resolved_requirement.artifact),
+                requirement=resolved_requirement.requirement,
+                additional_artifacts=tuple(
+                    resolve_fingerprint(artifact)
+                    for artifact in resolved_requirement.additional_artifacts
+                ),
+                via=resolved_requirement.via,
+            )
+
+    pin = attr.ib()  # type: Pin
+    artifact = attr.ib()  # type: PartialArtifact
+    requirement = attr.ib()  # type: Requirement
+    additional_artifacts = attr.ib(default=())  # type: Tuple[PartialArtifact, ...]
+    via = attr.ib(default=())  # type: Tuple[str, ...]
+
+    def _iter_urls_to_fingerprint(self):
+        # type: () -> Iterator[str]
+        if not self.artifact.fingerprint:
+            yield self.artifact.url
+        for artifact in self.additional_artifacts:
+            if not artifact.fingerprint:
+                yield artifact.url
+
+
+class Locker(_LogAnalyzer):
+    class StateError(Exception):
+        """Indicates the Locker lifecycle was violated.
+
+        A Locker 1st should be used to collect data from a Pip debug log and only then can a `lock`
+        be requested.
+        """
+
+    def __init__(
+        self,
+        target,  # type: DistributionTarget
+        lock_configuration,  # type: LockConfiguration
+        network_configuration=None,  # type: Optional[NetworkConfiguration]
+    ):
+        # type: (...) -> None
+        self._target = target
+        self._lock_configuration = lock_configuration
+        self._resolved_requirements = []  # type: List[ResolvedRequirement]
+        self._links = defaultdict(OrderedSet)  # type: DefaultDict[Pin, OrderedSet[PartialArtifact]]
+        self._url_fetcher = URLFetcher(
+            network_configuration=network_configuration, handle_file_urls=True
+        )
+        self._analysis_completed = False
+        self._locked_resolve = None  # type: Optional[LockedResolve]
+
+    def should_collect(self, returncode):
+        # type: (int) -> bool
+        return returncode == 0
+
+    @staticmethod
+    def _extract_resolve_data(url):
+        # type: (str) -> Tuple[Pin, PartialArtifact]
+
+        fingerprint = None  # type: Optional[Fingerprint]
+        fingerprint_match = re.search(r"(?P<url>[^#]+)#(?P<algorithm>[^=]+)=(?P<hash>.*)$", url)
+        if fingerprint_match:
+            url = fingerprint_match.group("url")
+            algorithm = fingerprint_match.group("algorithm")
+            hash_ = fingerprint_match.group("hash")
+            fingerprint = Fingerprint(algorithm=algorithm, hash=hash_)
+
+        pin = Pin.canonicalize(ProjectNameAndVersion.from_filename(urlparse.urlparse(url).path))
+        partial_artifact = PartialArtifact(url, fingerprint)
+        return pin, partial_artifact
+
+    def analyze(self, line):
+        # type: (str) -> _LogAnalyzer.Continue[None]
+
+        if self._analysis_completed:
+            raise self.StateError("Line analysis was requested after the log analysis completed.")
+
+        match = re.search(
+            r"Added (?P<requirement>.*) from (?P<url>[^\s]+) (\(from (?P<from>.*)\) )?to build "
+            r"tracker",
+            line,
+        )
+        if match:
+            requirement = Requirement.parse(match.group("requirement"))
+            project_name_and_version, partial_artifact = self._extract_resolve_data(
+                match.group("url")
+            )
+
+            from_ = match.group("from")
+            if from_:
+                via = tuple(from_.split("->"))
+            else:
+                via = ()
+
+            additional_artifacts = self._links[project_name_and_version]
+            additional_artifacts.discard(partial_artifact)
+
+            self._resolved_requirements.append(
+                ResolvedRequirement(
+                    requirement=requirement,
+                    pin=project_name_and_version,
+                    artifact=partial_artifact,
+                    additional_artifacts=tuple(additional_artifacts),
+                    via=via,
+                )
+            )
+        elif not self._lock_configuration.strict:
+            match = re.search(r"Found link (?P<url>[^\s]+)(?: \(from .*\))?, version: ", line)
+            if match:
+                project_name_and_version, partial_artifact = self._extract_resolve_data(
+                    match.group("url")
+                )
+                self._links[project_name_and_version].add(partial_artifact)
+
+        return self.Continue()
+
+    def analysis_completed(self):
+        # type: () -> None
+        self._analysis_completed = True
+
+    def lock(self):
+        # type: () -> LockedResolve
+        if not self._analysis_completed:
+            raise self.StateError(
+                "Lock retrieval was attempted before Pip log analysis was complete."
+            )
+        if self._locked_resolve is None:
+            self._locked_resolve = LockedResolve(
+                target=self._target,
+                locked_requirements=tuple(
+                    ResolvedRequirement.lock_all(self._resolved_requirements, self._url_fetcher)
+                ),
+            )
+        return self._locked_resolve
 
 
 class _LogScrapeJob(Job):
@@ -540,10 +729,11 @@ class Pip(object):
             # See:
             # + https://github.com/pantsbuild/pex/issues/1267
             # + https://github.com/pypa/pip/issues/9420
-            stdout = popen_kwargs.pop("stdout", sys.stderr.fileno())
+            if "stdout" not in popen_kwargs:
+                popen_kwargs["stdout"] = sys.stderr.fileno()
 
             args = [self._pip_pex_path] + command
-            return args, subprocess.Popen(args=args, env=env, stdout=stdout, **popen_kwargs)
+            return args, subprocess.Popen(args=args, env=env, **popen_kwargs)
 
     def _spawn_pip_isolated_job(
         self,
@@ -622,6 +812,7 @@ class Pip(object):
         cache=None,  # type: Optional[str]
         build=True,  # type: bool
         use_wheel=True,  # type: bool
+        locker=None,  # type: Optional[Locker]
     ):
         # type: (...) -> Job
         target = target or DistributionTarget.current()
@@ -680,6 +871,9 @@ class Pip(object):
         extra_env = None
         log_analyzers = []  # type: List[_LogAnalyzer]
 
+        if locker:
+            log_analyzers.append(locker)
+
         # Pip evaluates environment markers in the context of the ambient interpreter instead of
         # failing when encountering them, ignoring them or doing what we do here: evaluate those
         # environment markers positively identified by the platform quadruple and failing for those
@@ -715,16 +909,23 @@ class Pip(object):
             log_analyzers.append(_Issue9420Analyzer())
 
         log = None
+        popen_kwargs = {}
         if log_analyzers:
             log = os.path.join(safe_mkdtemp(), "pip.log")
             download_cmd = ["--log", log] + download_cmd
+            # N.B.: The `pip -q download ...` command is quiet but
+            # `pip -q --log log.txt download ...` leaks download progress bars to stdout. We work
+            # around this by sending stdout to the bit bucket.
+            popen_kwargs["stdout"] = open(os.devnull, "wb")
 
         command, process = self._spawn_pip_isolated(
             download_cmd,
             package_index_configuration=package_index_configuration,
             cache=cache,
             interpreter=target.get_interpreter(),
+            pip_verbosity=0,
             extra_env=extra_env,
+            **popen_kwargs
         )
         if log:
             return _LogScrapeJob(command, process, log, log_analyzers)

--- a/tests/integration/test_locked_resolve.py
+++ b/tests/integration/test_locked_resolve.py
@@ -1,0 +1,196 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import hashlib
+import os
+
+import pytest
+
+from pex import dist_metadata, resolver
+from pex.distribution_target import DistributionTarget
+from pex.locked_resolve import Artifact, LockConfiguration, LockedRequirement, LockedResolve, Pin
+from pex.pep_503 import ProjectName
+from pex.resolver import Downloaded, LocalDistribution
+from pex.third_party.pkg_resources import Requirement
+from pex.typing import TYPE_CHECKING
+from pex.util import CacheHelper
+
+if TYPE_CHECKING:
+    import attr  # vendor:skip
+    from typing import Any, Iterable, Dict
+else:
+    from pex.third_party import attr
+
+
+def normalized_local_dist(local_dist):
+    # type: (LocalDistribution) -> LocalDistribution
+
+    # Each download uses unique temporary dirs as download targets, so paths vary.
+    return attr.evolve(local_dist, path=os.path.basename(local_dist.path))
+
+
+def normalize_artifact(
+    artifact,  # type: Artifact
+    skip_urls=False,  # type: bool
+):
+    # type: (...) -> Artifact
+    return attr.evolve(artifact, url="") if skip_urls else artifact
+
+
+def normalize_locked_req(
+    locked_req,  # type: LockedRequirement
+    skip_additional_artifacts=False,  # type: bool
+    skip_urls=False,  # type: bool
+):
+    # type: (...) -> LockedRequirement
+
+    # We always normalize the following:
+    # 1. If an input requirement is not pinned, its locked equivalent always will be; so just check
+    #    matching project names.
+    # 2. A download using a lock file will differ from a download using requirement strings in its
+    #    via descriptions for each requirement; so don't compare vias at all.
+    return attr.evolve(
+        locked_req,
+        artifact=normalize_artifact(locked_req.artifact, skip_urls=skip_urls),
+        requirement=Requirement.parse(str(ProjectName(locked_req.requirement.project_name))),
+        additional_artifacts=()
+        if skip_additional_artifacts
+        else tuple(
+            sorted(
+                normalize_artifact(a, skip_urls=skip_urls) for a in locked_req.additional_artifacts
+            )
+        ),
+        via=(),
+    )
+
+
+def normalized_lock(
+    lock,  # type: LockedResolve
+    skip_additional_artifacts=False,  # type: bool
+    skip_urls=False,  # type: bool
+):
+    # type: (...) -> LockedResolve
+    return attr.evolve(
+        lock,
+        locked_requirements=tuple(
+            sorted(
+                normalize_locked_req(
+                    locked_req,
+                    skip_additional_artifacts=skip_additional_artifacts,
+                    skip_urls=skip_urls,
+                )
+                for locked_req in lock.locked_requirements
+            )
+        ),
+    )
+
+
+def normalized(
+    downloaded,  # type: Downloaded
+    skip_additional_artifacts=False,  # type: bool
+    skip_urls=False,  # type: bool
+):
+    # type: (...) -> Downloaded
+    return attr.evolve(
+        downloaded,
+        local_distributions=tuple(
+            sorted(
+                normalized_local_dist(local_dist) for local_dist in downloaded.local_distributions
+            )
+        ),
+        locks=tuple(
+            sorted(
+                normalized_lock(
+                    lock, skip_additional_artifacts=skip_additional_artifacts, skip_urls=skip_urls
+                )
+                for lock in downloaded.locks
+            )
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "requirements",
+    (
+        pytest.param(["ansicolors==1.1.8"], id="pinned-no-transitive-deps"),
+        pytest.param(["isort==4.3.21"], id="pinned-transitive-deps"),
+        pytest.param(["isort"], id="float-transitive-deps"),
+    ),
+)
+@pytest.mark.parametrize(
+    "lock_configuration",
+    (
+        pytest.param(LockConfiguration(strict=True), id="strict"),
+        pytest.param(LockConfiguration(strict=False), id="non-strict"),
+    ),
+)
+def test_lock_single_target_pypi(
+    tmpdir,  # type: Any
+    requirements,  # type: Iterable[str]
+    lock_configuration,  # type: LockConfiguration
+):
+    # type: (...) -> None
+
+    downloaded = resolver.download(requirements=requirements, lock_configuration=lock_configuration)
+
+    assert 1 == len(downloaded.locks)
+    lock = downloaded.locks[0]
+
+    assert DistributionTarget.current() == lock.target
+
+    def pin(local_distribution):
+        # type: (LocalDistribution) -> Pin
+        project_name_and_version = dist_metadata.project_name_and_version(local_distribution.path)
+        assert project_name_and_version is not None
+        return Pin.canonicalize(project_name_and_version)
+
+    local_distributions_by_pin = {
+        pin(local_dist): local_dist for local_dist in downloaded.local_distributions
+    }  # type: Dict[Pin, LocalDistribution]
+
+    assert sorted(local_distributions_by_pin) == sorted(
+        locked_req.pin for locked_req in lock.locked_requirements
+    ), (
+        "Expected the actual set of downloaded distributions to match the set of pinned "
+        "requirements in the lock."
+    )
+
+    for locked_req in lock.locked_requirements:
+        fingerprint = locked_req.artifact.fingerprint
+        assert fingerprint.hash == CacheHelper.hash(
+            path=local_distributions_by_pin[locked_req.pin].path,
+            hasher=lambda: hashlib.new(fingerprint.algorithm),
+        ), (
+            "Expected the fingerprint of the downloaded distribution to match the fingerprint "
+            "recorded in the lock."
+        )
+
+    find_links_repo = os.path.join(str(tmpdir), "find-links")
+    os.mkdir(find_links_repo)
+    for local_dist in downloaded.local_distributions:
+        os.symlink(
+            local_dist.path, os.path.join(find_links_repo, os.path.basename(local_dist.path))
+        )
+    assert normalized(downloaded, skip_additional_artifacts=True, skip_urls=True) == normalized(
+        resolver.download(
+            requirements=requirements,
+            lock_configuration=lock_configuration,
+            indexes=[],
+            find_links=[find_links_repo],
+        ),
+        skip_additional_artifacts=True,
+        skip_urls=True,
+    ), (
+        "Expected a find-links lock to match an equivalent PyPI lock except for the primary "
+        "artifact urls and lack of additional artifacts (since these are never downloaded; but "
+        "instead, just recorded)."
+    )
+
+    lock_file = os.path.join(str(tmpdir), "requirements.txt")
+    with open(lock_file, "w") as fp:
+        lock.emit_requirements(fp)
+    assert normalized(downloaded) == normalized(
+        resolver.download(requirement_files=[lock_file], lock_configuration=lock_configuration),
+    ), (
+        "Expected the download used to create a lock to be reproduced by a download using the "
+        "requirements generated from the lock."
+    )

--- a/tests/test_bdist_pex.py
+++ b/tests/test_bdist_pex.py
@@ -44,7 +44,9 @@ def bdist_pex_pythonpath():
         # pex cache for speed run over run.
         BDIST_PEX_PYTHONPATH.extend(
             installed_distribution.distribution.location
-            for installed_distribution in resolver.resolve(["setuptools==36.2.7"])
+            for installed_distribution in resolver.resolve(
+                ["setuptools==36.2.7"]
+            ).installed_distributions
         )
     return BDIST_PEX_PYTHONPATH
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -156,7 +156,7 @@ def assert_force_local_implicit_ns_packages_issues_598(
         # type: (PEXBuilder, str) -> None
         for installed_dist in resolver.resolve(
             requirements, cache=cache, interpreters=[builder.interpreter]
-        ):
+        ).installed_distributions:
             builder.add_distribution(installed_dist.distribution)
             if installed_dist.direct_requirement:
                 builder.add_requirement(installed_dist.direct_requirement)
@@ -324,7 +324,7 @@ def test_osx_platform_intel_issue_523():
         ) as pb, temporary_filename() as pex_file:
             for installed_dist in resolver.resolve(
                 ["psutil==5.4.3"], cache=cache, interpreters=[pb.interpreter]
-            ):
+            ).installed_distributions:
                 pb.add_dist_location(installed_dist.distribution.location)
             pb.build(pex_file)
 
@@ -380,7 +380,7 @@ def test_activate_extras_issue_615():
     with yield_pex_builder() as pb:
         for installed_dist in resolver.resolve(
             ["pex[requests]==1.6.3"], interpreters=[pb.interpreter]
-        ):
+        ).installed_distributions:
             if installed_dist.direct_requirement:
                 pb.add_requirement(installed_dist.direct_requirement)
             pb.add_dist_location(installed_dist.distribution.location)
@@ -404,7 +404,7 @@ def assert_namespace_packages_warning(distribution, version, expected_warning):
     # type: (str, str, bool) -> None
     requirement = "{}=={}".format(distribution, version)
     pb = PEXBuilder()
-    for installed_dist in resolver.resolve([requirement]):
+    for installed_dist in resolver.resolve([requirement]).installed_distributions:
         pb.add_dist_location(installed_dist.distribution.location)
     pb.freeze()
 

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -714,8 +714,8 @@ def test_pex_run_strip_env():
 
 def test_pex_run_custom_setuptools_useable():
     # type: () -> None
-    installed_dists = resolver.resolve(["setuptools==36.2.7"])
-    dists = [installed_dist.distribution for installed_dist in installed_dists]
+    result = resolver.resolve(["setuptools==36.2.7"])
+    dists = [installed_dist.distribution for installed_dist in result.installed_distributions]
     with temporary_dir() as temp_dir:
         pex = write_simple_pex(
             temp_dir,
@@ -737,8 +737,8 @@ def test_pex_run_conflicting_custom_setuptools_useable():
     # > pkg_resources/py31compat.py
     # > pkg_resources/_vendor/appdirs.py
 
-    installed_dists = resolver.resolve(["setuptools==20.3.1"])
-    dists = [installed_dist.distribution for installed_dist in installed_dists]
+    result = resolver.resolve(["setuptools==20.3.1"])
+    dists = [installed_dist.distribution for installed_dist in result.installed_distributions]
     with temporary_dir() as temp_dir:
         pex = write_simple_pex(
             temp_dir,
@@ -769,8 +769,8 @@ def test_pex_run_conflicting_custom_setuptools_useable():
 def test_pex_run_custom_pex_useable():
     # type: () -> None
     old_pex_version = "0.7.0"
-    installed_dists = resolver.resolve(["pex=={}".format(old_pex_version), "setuptools==40.6.3"])
-    dists = [installed_dist.distribution for installed_dist in installed_dists]
+    result = resolver.resolve(["pex=={}".format(old_pex_version), "setuptools==40.6.3"])
+    dists = [installed_dist.distribution for installed_dist in result.installed_distributions]
     with temporary_dir() as temp_dir:
         from pex.version import __version__
 


### PR DESCRIPTION
For now this data is only used in test_locked_resolve, but it forms the
basis for adding lock generation support to Pex.

This is the core of the work for #1401. The remaining work is wiring a
CLI option to generate a lock file (needs to be able to store multiple
platform specific locks since a single resolve can generate many) and
consume the lock file.