### PR TITLE
Fix two leaks in spread mode PEXes.

### DIFF
--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -686,7 +686,8 @@ class PEXBuilder(object):
     ):
         # type: (...) -> None
 
-        pex_info = self._pex_info
+        pex_info = self._pex_info.copy()
+        pex_info.update(PexInfo.from_env())
 
         safe_rmtree(dirname)
 
@@ -705,7 +706,7 @@ class PEXBuilder(object):
                     for f in self._chroot.filesets.get(fileset, ()):
                         dest = os.path.join(work_dir, "src", f)
                         safe_mkdir(os.path.dirname(dest))
-                        safe_copy(os.path.join(self._chroot.chroot, f), dest)
+                        safe_copy(os.path.realpath(os.path.join(self._chroot.chroot, f)), dest)
                         sources.append(f)
 
                 # Zip up the bootstrap which is constant for a given version of Pex.


### PR DESCRIPTION
Previously, files in the spread could be symlinks pointing out of the
spread directory into the PEXBuilder chroot. This would lead to dangling
links when the PEXBuilder chroot was garbage collected.

Also, previously, the cached bootstrap zip and installed wheel chroot
zips created by PEXBuilder did not honor the PEX_ROOT when set via env
var.

Add previously failing tests for both of these leaks.