### PR TITLE
LockConfiguration strict: bool -> style: enum.

### DIFF
--- a/pex/locked_resolve.py
+++ b/pex/locked_resolve.py
@@ -20,9 +20,41 @@ else:
     from pex.third_party import attr
 
 
+class LockStyle(object):
+    class Value(object):
+        def __init__(self, value):
+            # type: (str) -> None
+            self.value = value
+
+        def __str__(self):
+            # type: () -> str
+            return str(self.value)
+
+        def __repr__(self):
+            # type: () -> str
+            return repr(self.value)
+
+    STRICT = Value("strict")
+    SOURCES = Value("sources")
+
+    values = STRICT, SOURCES
+
+    @classmethod
+    def for_value(cls, value):
+        # type: (str) -> LockStyle.Value
+        for v in cls.values:
+            if v.value == value:
+                return v
+        raise ValueError(
+            "{!r} of type {} must be one of {}".format(
+                value, type(value), ", ".join(map(repr, cls.values))
+            )
+        )
+
+
 @attr.s(frozen=True)
 class LockConfiguration(object):
-    strict = attr.ib()  # type: bool
+    style = attr.ib()  # type: LockStyle.Value
 
 
 @attr.s(frozen=True)

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -35,6 +35,7 @@ from pex.locked_resolve import (
     LockConfiguration,
     LockedRequirement,
     LockedResolve,
+    LockStyle,
     Pin,
 )
 from pex.network_configuration import NetworkConfiguration
@@ -483,7 +484,7 @@ class Locker(_LogAnalyzer):
                     via=via,
                 )
             )
-        elif not self._lock_configuration.strict:
+        elif LockStyle.SOURCES == self._lock_configuration.style:
             match = re.search(r"Found link (?P<url>[^\s]+)(?: \(from .*\))?, version: ", line)
             if match:
                 project_name_and_version, partial_artifact = self._extract_resolve_data(

--- a/tests/integration/test_locked_resolve.py
+++ b/tests/integration/test_locked_resolve.py
@@ -7,7 +7,14 @@ import pytest
 
 from pex import dist_metadata, resolver
 from pex.distribution_target import DistributionTarget
-from pex.locked_resolve import Artifact, LockConfiguration, LockedRequirement, LockedResolve, Pin
+from pex.locked_resolve import (
+    Artifact,
+    LockConfiguration,
+    LockedRequirement,
+    LockedResolve,
+    LockStyle,
+    Pin,
+)
 from pex.pep_503 import ProjectName
 from pex.resolver import Downloaded, LocalDistribution
 from pex.third_party.pkg_resources import Requirement
@@ -120,8 +127,8 @@ def normalize(
 @pytest.mark.parametrize(
     "lock_configuration",
     (
-        pytest.param(LockConfiguration(strict=True), id="strict"),
-        pytest.param(LockConfiguration(strict=False), id="non-strict"),
+        pytest.param(LockConfiguration(style=LockStyle.STRICT), id="strict"),
+        pytest.param(LockConfiguration(style=LockStyle.SOURCES), id="sources"),
     ),
 )
 def test_lock_single_target(


### PR DESCRIPTION
This makes way for cross-platform as a style to be added later but
a CLI option to be plumbed now.