### PR TITLE
Avoid re-using old `~/.pex/code/` caches.

### DIFF
--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -418,7 +418,7 @@ class PexInfo(object):
     @property
     def zip_unsafe_cache(self):
         #: type: () -> str
-        return os.path.join(self.pex_root, "code")
+        return os.path.join(self.pex_root, "user_code")
 
     def update(self, other):
         # type: (PexInfo) -> None


### PR DESCRIPTION
The original `$PEX_ROOT/code/<code_hash>` cache scheme was broken since
the `<code_hash>` was calculated just using user code but the contents
of the cache included Pex's `__main__.py` and `PEX-INFO` files. The
latter was luckily never loaded by the Pex runtime to figure out how to
run and so the bug never surfaced.

With the introduction of the zipapp and packed runtime layout support,
these bad cache entries are now used and the `PEX-INFO` is read. This
means, for the case of PEXes with no user code that were also
`--not-zip-safe`, all such PEXes share the `PEX-INFO` of the 1st such
PEX executed in a given `$PEX_ROOT`. This leads to unexpected
dependencies and crashes when executing any such PEX other than the
seeding PEX.

Fix this by simply re-naming the `code/` cache dir root to `user_code`,
allowing previous PEXes to work as prior and new PEXes to also work by
completely ignoring the old buggy `code/` caches.

Fixes #1443