### PR TITLE
Fix zipapp layout identification.

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -491,17 +491,19 @@ def is_exe(path):
 def is_script(
     path,  # type: str
     pattern=None,  # type: Optional[str]
+    check_executable=True,  # type: bool
 ):
     # type: (...) -> bool
-    """Determines if the given path is a script executable by the current user.
+    """Determines if the given path is a script.
 
-    A script is an executable (`is_exe` is True) that starts with a shebang (#!...) line.
+    A script is a file that starts with a shebang (#!...) line.
 
     :param path: The path to check.
     :param pattern: An optional pattern to match against the shebang (excluding the leading #!).
-    :return: `True if the given path is a script executable by the current user.
+    :param check_executable: Check that the script is executable by the current user.
+    :return: True if the given path is a script.
     """
-    if not is_exe(path):
+    if check_executable and not is_exe(path):
         return False
     with open(path, "rb") as fp:
         if b"#!" != fp.read(2):
@@ -511,9 +513,12 @@ def is_script(
         return bool(re.match(pattern, fp.readline().decode("utf-8")))
 
 
-def is_python_script(path):
-    # type: (str) -> bool
-    return is_script(path, pattern=r"(?i)^.*(?:python|pypy)")
+def is_python_script(
+    path,  # type: str
+    check_executable=True,  # type: bool
+):
+    # type: (...) -> bool
+    return is_script(path, pattern=r"(?i)^.*(?:python|pypy)", check_executable=check_executable)
 
 
 def can_write_dir(path):

--- a/pex/layout.py
+++ b/pex/layout.py
@@ -277,7 +277,11 @@ class _PackedPEX(_Layout):
 @contextmanager
 def _identify_layout(pex):
     # type: (str) -> Iterator[Optional[_Layout]]
-    if zipfile.is_zipfile(pex) and is_python_script(pex):
+    if zipfile.is_zipfile(pex) and is_python_script(
+        pex,
+        # N.B.: A PEX file need not be executable since it can always be run via `python a.pex`.
+        check_executable=False,
+    ):
         with open_zip(pex) as zfp:
             yield _ZipAppPEX(pex, zfp)
     elif os.path.isdir(pex) and zipfile.is_zipfile(os.path.join(pex, BOOTSTRAP_DIR)):

--- a/tests/integration/test_issue_1447.py
+++ b/tests/integration/test_issue_1447.py
@@ -1,0 +1,38 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import os
+import shutil
+import subprocess
+import sys
+
+from pex.pex_info import PexInfo
+from pex.testing import run_pex_command
+from pex.typing import TYPE_CHECKING
+from pex.variables import unzip_dir
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_layout_identification(tmpdir):
+    # type: (Any) -> None
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    pex_file = os.path.join(str(tmpdir), "a.pex")
+    run_pex_command(
+        args=["-o", pex_file, "--pex-root", pex_root, "--runtime-pex-root", pex_root]
+    ).assert_success()
+
+    pex_hash = PexInfo.from_pex(pex_file).pex_hash
+    assert pex_hash is not None
+
+    expected_unzip_dir = unzip_dir(pex_root, pex_hash)
+    assert not os.path.exists(expected_unzip_dir)
+
+    subprocess.check_call(args=[pex_file, "-c", ""])
+    assert os.path.isdir(expected_unzip_dir)
+
+    shutil.rmtree(expected_unzip_dir)
+    os.chmod(pex_file, 0o644)
+    subprocess.check_call(args=[sys.executable, pex_file, "-c", ""])
+    assert os.path.isdir(expected_unzip_dir)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -383,5 +383,6 @@ def test_is_script(tmpdir):
     assert not is_script(exe, pattern=r"^python")
 
     os.chmod(exe, 0o665)
+    assert is_script(exe, check_executable=False)
     assert not is_script(exe)
     assert not is_exe(exe)


### PR DESCRIPTION
Previously it was required that the zipapp be executable. In practice
this is not required since a zippapp can be executed by python instead
of being executed directly.

Fixes #1447