### PR TITLE
Pin protobuf in tests below 3.18.0.

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1628,7 +1628,8 @@ def test_requirement_file_from_url(tmpdir):
 
     constraints = os.path.join(str(tmpdir), "constraints.txt")
     with open(constraints, "w") as fp:
-        fp.write("translate>=3.2.1,<3.6.0")
+        print("translate>=3.2.1,<3.6.0", file=fp)
+        print("protobuf<=3.17.3", file=fp)
 
     pex_file = os.path.join(str(tmpdir), "pex")
 

--- a/tests/integration/test_issue_729.py
+++ b/tests/integration/test_issue_729.py
@@ -1,6 +1,8 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import print_function
+
 import os
 from textwrap import dedent
 
@@ -38,7 +40,8 @@ def test_undeclared_setuptools_import_on_pex_path(tmpdir):
     # compilation terminated.
     constraints = os.path.join(str(tmpdir), "constraints.txt")
     with open(constraints, "w") as fp:
-        fp.write("google-crc32c==1.1.2")
+        print("google-crc32c==1.1.2", file=fp)
+        print("protobuf<=3.17.3", file=fp)
 
     bigquery_pex = os.path.join(str(tmpdir), "bigquery.pex")
     run_pex_command(


### PR DESCRIPTION
The 3.18.0 release brought a new py2.py3 wheel that has Python 3 syntax
code in it; so avoid this release in tests.

See: https://github.com/protocolbuffers/protobuf/issues/8984