### PR TITLE
Support `class Sub(Base[Concrete]): pass`.

### DIFF
--- a/pex/orderedset.py
+++ b/pex/orderedset.py
@@ -13,18 +13,18 @@ from __future__ import absolute_import
 from collections import OrderedDict
 
 from pex.compatibility import MutableSet
-from pex.typing import TYPE_CHECKING, Generic
+from pex.typing import TYPE_CHECKING, Generic, cast
 
 if TYPE_CHECKING:
-    from typing import Any, Iterable, Iterator, Optional, TypeVar, Union
-
-    _I = TypeVar("_I")
+    from typing import Any, Iterable, Iterator, Optional
 
 
-class OrderedSet(MutableSet, Generic["_I"]):
+# N.B.: The item type is mixed in only at type checking time below due to class hierarchy metaclass
+# conflicts. As such, we use Any here.
+class _OrderedSet(MutableSet):
     def __init__(self, iterable=None):
-        # type: (Optional[Iterable[_I]]) -> None
-        self._data = OrderedDict()  # type: OrderedDict[_I, None]
+        # type: (Optional[Iterable]) -> None
+        self._data = OrderedDict()  # type: OrderedDict[Any, None]
         if iterable is not None:
             self.update(iterable)
 
@@ -37,28 +37,28 @@ class OrderedSet(MutableSet, Generic["_I"]):
         return key in self._data
 
     def add(self, key):
-        # type: (_I) -> None
+        # type: (Any) -> None
         self._data[key] = None
 
     def update(self, iterable):
-        # type: (Iterable[_I]) -> None
+        # type: (Iterable[Any]) -> None
         for key in iterable:
             self.add(key)
 
     def discard(self, key):
-        # type: (_I) -> None
+        # type: (Any) -> None
         self._data.pop(key, None)
 
     def __iter__(self):
-        # type: () -> Iterator[_I]
+        # type: () -> Iterator[Any]
         return iter(self._data)
 
     def __reversed__(self):
-        # type: () -> Iterator[_I]
+        # type: () -> Iterator[Any]
         return reversed(self._data)
 
     def pop(self, last=True):
-        # type: (bool) -> _I
+        # type: (bool) -> Any
         if not self:
             raise KeyError("set is empty")
         key, _ = self._data.popitem(last=last)
@@ -79,3 +79,45 @@ class OrderedSet(MutableSet, Generic["_I"]):
         # TODO(John Sirois): Type __eq__ as returning Union[bool, NotImplemented] when MyPy fixes:
         #  https://github.com/python/mypy/issues/4791
         return self._data == other._data  # type: ignore[no-any-return]
+
+
+if TYPE_CHECKING:
+    from typing import TypeVar
+
+    _I = TypeVar("_I")
+
+    # N.B.: We mix in Generic only in type checking mode since it uses a custom metaclass in
+    # production which is inconsistent with _OrderedSet's base of MutableSet which has an ABCMeta
+    # metaclass.
+    class OrderedSet(_OrderedSet, Generic["_I"]):
+        def __init__(self, iterable=None):
+            # type: (Optional[Iterable[_I]]) -> None
+            super(OrderedSet, self).__init__(iterable=iterable)
+
+        def add(self, key):
+            # type: (_I) -> None
+            super(OrderedSet, self).add(key)
+
+        def update(self, iterable):
+            # type: (Iterable[_I]) -> None
+            super(OrderedSet, self).update(iterable)
+
+        def discard(self, key):
+            # type: (_I) -> None
+            super(OrderedSet, self).discard(key)
+
+        def __iter__(self):
+            # type: () -> Iterator[_I]
+            return super(OrderedSet, self).__iter__()
+
+        def __reversed__(self):
+            # type: () -> Iterator[_I]
+            return super(OrderedSet, self).__reversed__()
+
+        def pop(self, last=True):
+            # type: (bool) -> _I
+            return cast("_I", super(OrderedSet, self).pop(last=last))
+
+
+else:
+    OrderedSet = _OrderedSet

--- a/pex/typing.py
+++ b/pex/typing.py
@@ -28,14 +28,16 @@ To add type comments, use a conditional import like this:
     ```
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
+
+import sys
 
 TYPE_CHECKING = False
 
 # Unlike most type-hints, `cast` and `overload` get used at runtime. We define no-op versions for
 # runtime use.
 if TYPE_CHECKING:
-    from typing import cast as cast
+    from typing import cast as cast, Any
     from typing import overload as overload
     from typing import Generic as Generic
 else:
@@ -53,10 +55,16 @@ else:
 
         return _never_called_since_structurally_shadowed
 
-    class _Generic(object):
-        def __getitem__(self, type_var):
-            return object
+    class _Generic(type):
+        def __getitem__(cls, type_var):
+            return cls
 
-    Generic = _Generic()
+    if sys.version_info[0] == 2:
+
+        class Generic(object):
+            __metaclass__ = _Generic
+
+    else:
+        eval(compile("class Generic(object, metaclass=_Generic): pass", "<Generic>", "exec"))
 
     del _Generic


### PR DESCRIPTION
The prior implementation of `Generic` at runtime did not allow for this
and upcoming work on Pex CLI command infrastructure will want to do
this.

This new formulation needs a custom metaclass and that causes a problem
for `OrderedSet` since it already has an (indirect) custom metaclass of
ABCMeta via MutableSet. Re-work the typing there to accomodate.

Work towards #1401.