### PR TITLE
Refactor `PEX_TOOLS` `Command` infrastructure.

### DIFF
--- a/pex/tools/commands/__init__.py
+++ b/pex/tools/commands/__init__.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pex.tools.command import Command
+from pex.tools.command import PEXCommand
 from pex.tools.commands.graph import Graph
 from pex.tools.commands.info import Info
 from pex.tools.commands.interpreter import Interpreter
@@ -10,9 +10,9 @@ from pex.tools.commands.venv import Venv
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Iterable
+    from typing import Iterable, Type
 
 
 def all_commands():
-    # type: () -> Iterable[Command]
-    return Info(), Interpreter(), Graph(), Repository(), Venv()
+    # type: () -> Iterable[Type[PEXCommand]]
+    return Info, Interpreter, Graph, Repository, Venv

--- a/pex/tools/commands/info.py
+++ b/pex/tools/commands/info.py
@@ -3,27 +3,24 @@
 
 from __future__ import absolute_import
 
-from argparse import ArgumentParser, Namespace
+from argparse import ArgumentParser
 
 from pex.pex import PEX
-from pex.tools.command import Command, JsonMixin, Ok, OutputMixin, Result
+from pex.tools.command import JsonMixin, Ok, OutputMixin, PEXCommand, Result
 
 
-class Info(JsonMixin, OutputMixin, Command):
+class Info(JsonMixin, OutputMixin, PEXCommand):
     """Dumps the PEX-INFO json contained in a PEX file."""
 
-    def add_arguments(self, parser):
+    @classmethod
+    def add_arguments(cls, parser):
         # type: (ArgumentParser) -> None
-        self.add_output_option(parser, entity="PEX-INFO json")
-        self.add_json_options(parser, entity="PEX-INFO")
+        cls.add_output_option(parser, entity="PEX-INFO json")
+        cls.add_json_options(parser, entity="PEX-INFO")
 
-    def run(
-        self,
-        pex,  # type: PEX
-        options,  # type: Namespace
-    ):
-        # type: (...) -> Result
-        with self.output(options) as out:
-            self.dump_json(options, pex.pex_info().as_json_dict(), out)
+    def run(self, pex):
+        # type: (PEX) -> Result
+        with self.output(self.options) as out:
+            self.dump_json(self.options, pex.pex_info().as_json_dict(), out)
             out.write("\n")
         return Ok()

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -42,7 +42,7 @@ def test_pex_script():
 
 def test_pex_tools_script():
     # type: () -> None
-    command_names = ",".join([command.__class__.__name__.lower() for command in all_commands()])
+    command_names = ",".join([command_type.__name__.lower() for command_type in all_commands()])
 
     output = subprocess.check_output(args=[script_path("pex-tools"), "-h"])
     first_line = output.decode("utf-8").splitlines()[0]


### PR DESCRIPTION
This will allow almost all of its machinery to be re-used for commands
that do not necessarily operate on a built PEX and using a different
`__main__` than `PEX_TOOLS`.

Work towards #1401.