### PR TITLE
Finish extracting resolve configuration.

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -760,20 +760,28 @@ class PythonInterpreter(object):
         return []
 
     @classmethod
-    def from_env(cls, hashbang):
+    def from_env(
+        cls,
+        hashbang,
+        paths=None,  # type: Optional[Iterable[str]]
+    ):
+        # type: (...) -> Optional[PythonInterpreter]
         """Resolve a PythonInterpreter as /usr/bin/env would.
 
-        :param hashbang: A string, e.g. "python3.3" representing some binary on the $PATH.
+        :param hashbang: A string, e.g. "python3.3" representing some binary on the search path.
+        :param paths: The search path to use; defaults to $PATH.
         :return: the first matching interpreter found or `None`.
-        :rtype: :class:`PythonInterpreter`
         """
 
         def hashbang_matches(fn):
             basefile = os.path.basename(fn)
             return hashbang == basefile
 
-        for interpreter in cls._identify_interpreters(filter=hashbang_matches):
+        for interpreter in cls._identify_interpreters(
+            filter=hashbang_matches, error_handler=None, paths=paths
+        ):
             return interpreter
+        return None
 
     @classmethod
     def _spawn_from_binary(cls, binary):

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -35,6 +35,16 @@ if TYPE_CHECKING:
     from pex.pex import PEX
 
 
+def parse_path(path):
+    # type: (Optional[str]) -> Optional[OrderedSet[str]]
+    """Parses a PATH string into a de-duped list of paths."""
+    return (
+        OrderedSet(PythonInterpreter.canonicalize_path(p) for p in path.split(os.pathsep))
+        if path
+        else None
+    )
+
+
 # TODO(John Sirois): Move this to interpreter_constraints.py. As things stand, both pex/bin/pex.py
 #  and this file use this function. The Pex CLI should not depend on this file which hosts code
 #  used at PEX runtime.
@@ -76,11 +86,7 @@ def iter_compatible_interpreters(
         # type: () -> Iterator[InterpreterOrError]
         seen = set()  # type: Set[InterpreterOrError]
 
-        normalized_paths = (
-            OrderedSet(PythonInterpreter.canonicalize_path(p) for p in path.split(os.pathsep))
-            if path
-            else None
-        )
+        normalized_paths = parse_path(path)
 
         # Prefer the current interpreter, if valid.
         current_interpreter = preferred_interpreter or PythonInterpreter.get()

--- a/pex/resolve/requirement_configuration.py
+++ b/pex/resolve/requirement_configuration.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import attr  # vendor:skip
+    from typing import Optional, Iterable
+else:
+    from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class RequirementConfiguration(object):
+    requirements = attr.ib(default=None)  # type: Optional[Iterable[str]]
+    requirement_files = attr.ib(default=None)  # type: Optional[Iterable[str]]
+    constraint_files = attr.ib(default=None)  # type: Optional[Iterable[str]]

--- a/pex/resolve/requirement_options.py
+++ b/pex/resolve/requirement_options.py
@@ -1,0 +1,54 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from argparse import Namespace, _ActionsContainer
+
+from pex.resolve.requirement_configuration import RequirementConfiguration
+
+
+def register(parser):
+    # type: (_ActionsContainer) -> None
+    """Register resolve requirement configuration options with the given parser.
+
+    :param parser: The parser to register requirement configuration options with.
+    """
+
+    parser.add_argument("requirements", nargs="*", help="Requirements to add to the pex")
+    parser.add_argument(
+        "-r",
+        "--requirement",
+        dest="requirement_files",
+        metavar="FILE or URL",
+        default=[],
+        type=str,
+        action="append",
+        help=(
+            "Add requirements from the given requirements file.  This option can be used multiple "
+            "times."
+        ),
+    )
+    parser.add_argument(
+        "--constraints",
+        dest="constraint_files",
+        metavar="FILE or URL",
+        default=[],
+        type=str,
+        action="append",
+        help=(
+            "Add constraints from the given constraints file.  This option can be used multiple "
+            "times."
+        ),
+    )
+
+
+def configure(options):
+    # type: (Namespace) -> RequirementConfiguration
+    """Creates a requirement configuration from options registered by `register`."""
+
+    return RequirementConfiguration(
+        requirements=options.requirements,
+        requirement_files=options.requirement_files,
+        constraint_files=options.constraint_files,
+    )

--- a/pex/resolve/resolve_configuration.py
+++ b/pex/resolve/resolve_configuration.py
@@ -10,7 +10,7 @@ from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import attr  # vendor:skip
-    from typing import Optional, Tuple, Union
+    from typing import Tuple
 else:
     from pex.third_party import attr
 
@@ -19,27 +19,20 @@ PYPI = "https://pypi.org/simple"
 
 
 @attr.s(frozen=True)
-class PackageIndexConfiguration(object):
+class PipConfiguration(object):
     resolver_version = attr.ib(default=ResolverVersion.PIP_LEGACY)  # type: ResolverVersion.Value
     indexes = attr.ib(default=(PYPI,), converter=tuple)  # type: Tuple[str, ...]
     find_links = attr.ib(default=(), converter=tuple)  # type: Tuple[str, ...]
-
-
-class PexRepository(str):
-    pass
-
-
-if TYPE_CHECKING:
-    Repository = Union[PackageIndexConfiguration, PexRepository]
-
-
-@attr.s(frozen=True)
-class ResolveConfiguration(object):
-    repository = attr.ib(default=PackageIndexConfiguration())  # type: Repository
     network_configuration = attr.ib(default=NetworkConfiguration())  # type: NetworkConfiguration
     allow_prereleases = attr.ib(default=False)  # type: bool
     allow_wheels = attr.ib(default=True)  # type: bool
     allow_builds = attr.ib(default=True)  # type: bool
-    assume_manylinux = attr.ib(default="manylinux2014")  # type: Optional[str]
     transitive = attr.ib(default=True)  # type: bool
     max_jobs = attr.ib(default=DEFAULT_MAX_JOBS)  # type: int
+
+
+@attr.s(frozen=True)
+class PexRepositoryConfiguration(object):
+    pex_repository = attr.ib()  # type: str
+    network_configuration = attr.ib(default=NetworkConfiguration())  # type: NetworkConfiguration
+    transitive = attr.ib(default=True)  # type: bool

--- a/pex/resolve/target_configuration.py
+++ b/pex/resolve/target_configuration.py
@@ -1,0 +1,76 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from pex.distribution_target import DistributionTarget
+from pex.interpreter import PythonInterpreter
+from pex.orderedset import OrderedSet
+from pex.platforms import Platform
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import attr  # vendor:skip
+    from typing import Iterable, Iterator, Optional, Tuple, Union
+else:
+    from pex.third_party import attr
+
+
+def _convert_interpreters(interpreters):
+    # type: (Optional[Iterable[PythonInterpreter]]) -> Tuple[PythonInterpreter, ...]
+    return tuple(interpreters) if interpreters else ()
+
+
+def _parsed_platform(platform):
+    # type: (Union[str, Optional[Platform]]) -> Optional[Platform]
+    return Platform.create(platform) if platform and platform != "current" else None
+
+
+def convert_platforms(platforms):
+    # type: (Optional[Iterable[Union[str, Optional[Platform]]]]) -> Tuple[Optional[Platform], ...]
+    return tuple(_parsed_platform(platform) for platform in platforms or ()) if platforms else ()
+
+
+@attr.s(frozen=True)
+class TargetConfiguration(object):
+    interpreters = attr.ib(
+        default=(), converter=_convert_interpreters
+    )  # type: Tuple[PythonInterpreter, ...]
+
+    platforms = attr.ib(
+        default=(), converter=convert_platforms
+    )  # type: Tuple[Optional[Platform], ...]
+
+    assume_manylinux = attr.ib(default="manylinux2014")  # type: Optional[str]
+
+    @property
+    def interpreter(self):
+        # type: () -> Optional[PythonInterpreter]
+        if not self.interpreters:
+            return None
+        return PythonInterpreter.latest_release_of_min_compatible_version(self.interpreters)
+
+    def unique_targets(self):
+        # type: () -> OrderedSet[DistributionTarget]
+        def iter_targets():
+            # type: () -> Iterator[DistributionTarget]
+            if not self.interpreters and not self.platforms:
+                # No specified targets, so just build for the current interpreter (on the current
+                # platform).
+                yield DistributionTarget.current()
+                return
+
+            for interpreter in self.interpreters:
+                # Build for the specified local interpreters (on the current platform).
+                yield DistributionTarget.for_interpreter(interpreter)
+
+            for platform in self.platforms:
+                if platform is None and not self.interpreters:
+                    # Build for the current platform (None) only if not done already (ie: no
+                    # intepreters were specified).
+                    yield DistributionTarget.current()
+                elif platform is not None:
+                    # Build for specific platforms.
+                    yield DistributionTarget.for_platform(platform, manylinux=self.assume_manylinux)
+
+        return OrderedSet(iter_targets())

--- a/pex/resolve/target_options.py
+++ b/pex/resolve/target_options.py
@@ -1,0 +1,248 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os
+import sys
+from argparse import ArgumentTypeError, Namespace, _ActionsContainer
+
+from pex.argparse import HandleBoolAction
+from pex.interpreter import PythonInterpreter
+from pex.interpreter_constraints import (
+    UnsatisfiableInterpreterConstraintsError,
+    validate_constraints,
+)
+from pex.orderedset import OrderedSet
+from pex.pex_bootstrapper import iter_compatible_interpreters, parse_path
+from pex.platforms import Platform
+from pex.resolve.resolve_options import _ManylinuxAction
+from pex.resolve.target_configuration import TargetConfiguration, convert_platforms
+from pex.tracer import TRACER
+from pex.typing import TYPE_CHECKING
+from pex.variables import ENV
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+
+def register(parser):
+    # type: (_ActionsContainer) -> None
+    """Register resolve target selection options with the given parser.
+
+    :param parser: The parser to register target selection options with.
+    """
+
+    parser.add_argument(
+        "--python",
+        dest="python",
+        default=[],
+        type=str,
+        action="append",
+        help=(
+            "The Python interpreter to use to build the PEX (default: current interpreter). This "
+            "cannot be used with `--interpreter-constraint`, which will instead cause PEX to "
+            "search for valid interpreters. Either specify an absolute path to an interpreter, or "
+            "specify a binary accessible on $PATH like `python3.7`. This option can be passed "
+            "multiple times to create a multi-interpreter compatible PEX."
+        ),
+    )
+    parser.add_argument(
+        "--python-path",
+        dest="python_path",
+        default=None,
+        type=str,
+        help=(
+            "Colon-separated paths to search for interpreters when `--interpreter-constraint` "
+            "and/or `--resolve-local-platforms` are specified (default: $PATH). Each element "
+            "can be the absolute path of an interpreter binary or a directory containing "
+            "interpreter binaries."
+        ),
+    )
+
+    current_interpreter = PythonInterpreter.get()
+    program = sys.argv[0]
+    singe_interpreter_info_cmd = (
+        "PEX_TOOLS=1 {current_interpreter} {program} interpreter --verbose --indent 4".format(
+            current_interpreter=current_interpreter.binary, program=program
+        )
+    )
+    all_interpreters_info_cmd = (
+        "PEX_TOOLS=1 {program} interpreter --all --verbose --indent 4".format(program=program)
+    )
+
+    parser.add_argument(
+        "--interpreter-constraint",
+        dest="interpreter_constraint",
+        default=[],
+        type=str,
+        action="append",
+        help=(
+            "Constrain the selected Python interpreter. Specify with Requirement-style syntax, "
+            'e.g. "CPython>=2.7,<3" (A CPython interpreter with version >=2.7 AND version <3), '
+            '">=2.7,<3" (Any Python interpreter with version >=2.7 AND version <3) or "PyPy" (A '
+            "PyPy interpreter of any version). This argument may be repeated multiple times to OR "
+            "the constraints. Try `{singe_interpreter_info_cmd}` to find the exact interpreter "
+            "constraints of {current_interpreter} and `{all_interpreters_info_cmd}` to find out "
+            "the interpreter constraints of all Python interpreters on the $PATH.".format(
+                current_interpreter=current_interpreter.binary,
+                singe_interpreter_info_cmd=singe_interpreter_info_cmd,
+                all_interpreters_info_cmd=all_interpreters_info_cmd,
+            )
+        ),
+    )
+
+    parser.add_argument(
+        "--platform",
+        dest="platforms",
+        default=[],
+        type=str,
+        action="append",
+        help=(
+            "The platform for which to build the PEX. This option can be passed multiple times "
+            "to create a multi-platform pex. To use the platform corresponding to the current "
+            "interpreter you can pass `current`. To target any other platform you pass a string "
+            "composed of fields: <platform>-<python impl abbr>-<python version>-<abi>. "
+            "These fields stem from wheel name conventions as outlined in "
+            "https://www.python.org/dev/peps/pep-0427#file-name-convention and influenced by "
+            "https://www.python.org/dev/peps/pep-0425. For the current interpreter at "
+            "{current_interpreter} the full platform string is {current_platform}. To find out "
+            "more, try `{all_interpreters_info_cmd}` to print out the platform for all "
+            "interpreters on the $PATH or `{singe_interpreter_info_cmd}` to inspect the single "
+            "interpreter {current_interpreter}.".format(
+                current_interpreter=current_interpreter.binary,
+                current_platform=current_interpreter.platform,
+                singe_interpreter_info_cmd=singe_interpreter_info_cmd,
+                all_interpreters_info_cmd=all_interpreters_info_cmd,
+            )
+        ),
+    )
+
+    default_target_configuration = TargetConfiguration()
+    parser.add_argument(
+        "--manylinux",
+        "--no-manylinux",
+        "--no-use-manylinux",
+        dest="assume_manylinux",
+        type=str,
+        default=default_target_configuration.assume_manylinux,
+        action=_ManylinuxAction,
+        help="Whether to allow resolution of manylinux wheels for linux target platforms.",
+    )
+
+    parser.add_argument(
+        "--resolve-local-platforms",
+        dest="resolve_local_platforms",
+        default=False,
+        action=HandleBoolAction,
+        help=(
+            "When --platforms are specified, attempt to resolve a local interpreter that matches "
+            "each platform specified. If found, use the interpreter to resolve distributions; if "
+            "not (or if this option is not specified), resolve for each platform only allowing "
+            "matching binary distributions and failing if only sdists or non-matching binary "
+            "distributions can be found."
+        ),
+    )
+
+
+class TargetConfigurationError(Exception):
+    """Indicates a problem configuring resolve targets."""
+
+
+class InterpreterNotFound(TargetConfigurationError):
+    """Indicates an explicitly requested interpreter could not be found."""
+
+
+class InterpreterConstraintsNotSatisfied(TargetConfigurationError):
+    """Indicates no interpreter meeting the requested constraints could be found."""
+
+
+def configure(options):
+    # type: (Namespace) -> TargetConfiguration
+    """Creates a target configuration from options registered by `register`.
+
+    :param options: The target configuration options.
+    :raise: :class:`InterpreterNotFound` specific --python interpreters were requested but could
+            not be found.
+    :raise: :class:`InterpreterConstraintsNotSatisfied` if --interpreter-constraint were specified
+            but no conforming interpreters could be found.
+    """
+
+    interpreters = None  # Default to the current interpreter.
+
+    # TODO(#1075): stop looking at PEX_PYTHON_PATH and solely consult the `--python-path` flag.
+    # If None, this will result in using $PATH.
+    pex_python_path = options.python_path or ENV.PEX_PYTHON_PATH
+
+    # NB: options.python and interpreter constraints cannot be used together.
+    if options.python:
+        with TRACER.timed("Resolving interpreters", V=2):
+
+            def to_python_interpreter(full_path_or_basename):
+                if os.path.isfile(full_path_or_basename):
+                    return PythonInterpreter.from_binary(full_path_or_basename)
+                else:
+                    interp = PythonInterpreter.from_env(
+                        full_path_or_basename, paths=parse_path(pex_python_path)
+                    )
+                    if interp is None:
+                        raise InterpreterNotFound(
+                            "Failed to find interpreter: {}".format(full_path_or_basename)
+                        )
+                    return interp
+
+            interpreters = OrderedSet(to_python_interpreter(interp) for interp in options.python)
+    elif options.interpreter_constraint:
+        with TRACER.timed("Resolving interpreters", V=2):
+            constraints = options.interpreter_constraint
+            validate_constraints(constraints)
+            try:
+                interpreters = OrderedSet(
+                    iter_compatible_interpreters(
+                        path=pex_python_path, interpreter_constraints=constraints
+                    )
+                )
+            except UnsatisfiableInterpreterConstraintsError as e:
+                raise InterpreterConstraintsNotSatisfied(
+                    e.create_message("Could not find a compatible interpreter.")
+                )
+
+    try:
+        platforms = OrderedSet(
+            convert_platforms(options.platforms)
+        )  # type: OrderedSet[Optional[Platform]]
+    except Platform.InvalidPlatformError as e:
+        raise ArgumentTypeError(str(e))
+
+    interpreters = interpreters or OrderedSet()
+    if platforms and options.resolve_local_platforms:
+        with TRACER.timed(
+            "Searching for local interpreters matching {}".format(", ".join(map(str, platforms)))
+        ):
+            candidate_interpreters = OrderedSet(iter_compatible_interpreters(path=pex_python_path))
+            candidate_interpreters.add(PythonInterpreter.get())
+            for candidate_interpreter in candidate_interpreters:
+                resolved_platforms = candidate_interpreter.supported_platforms.intersection(
+                    platforms
+                )
+                if resolved_platforms:
+                    for resolved_platform in resolved_platforms:
+                        TRACER.log(
+                            "Resolved {} for platform {}".format(
+                                candidate_interpreter, resolved_platform
+                            )
+                        )
+                        platforms.remove(resolved_platform)
+                    interpreters.add(candidate_interpreter)
+        if platforms:
+            TRACER.log(
+                "Could not resolve a local interpreter for {}, will resolve only binary "
+                "distributions for {}.".format(
+                    ", ".join(map(str, platforms)),
+                    "this platform" if len(platforms) == 1 else "these platforms",
+                )
+            )
+
+    return TargetConfiguration(
+        interpreters=interpreters, platforms=platforms, assume_manylinux=options.assume_manylinux
+    )

--- a/tests/resolve/conftest.py
+++ b/tests/resolve/conftest.py
@@ -1,0 +1,46 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from argparse import ArgumentParser
+
+import pytest
+
+from pex.interpreter import PythonInterpreter
+from pex.platforms import Platform
+from pex.testing import PY27, PY37, PY38, ensure_python_interpreter
+
+
+@pytest.fixture
+def parser():
+    # type: () -> ArgumentParser
+    return ArgumentParser()
+
+
+@pytest.fixture
+def current_interpreter():
+    # type: () -> PythonInterpreter
+    return PythonInterpreter.get()
+
+
+@pytest.fixture
+def current_platform(current_interpreter):
+    # type: (PythonInterpreter) -> Platform
+    return current_interpreter.platform
+
+
+@pytest.fixture
+def py27():
+    # type: () -> PythonInterpreter
+    return PythonInterpreter.from_binary(ensure_python_interpreter(PY27))
+
+
+@pytest.fixture
+def py37():
+    # type: () -> PythonInterpreter
+    return PythonInterpreter.from_binary(ensure_python_interpreter(PY37))
+
+
+@pytest.fixture
+def py38():
+    # type: () -> PythonInterpreter
+    return PythonInterpreter.from_binary(ensure_python_interpreter(PY38))

--- a/tests/resolve/test_target_configuration.py
+++ b/tests/resolve/test_target_configuration.py
@@ -1,0 +1,57 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pex.distribution_target import DistributionTarget
+from pex.interpreter import PythonInterpreter
+from pex.orderedset import OrderedSet
+from pex.platforms import Platform
+from pex.resolve.target_configuration import TargetConfiguration
+
+
+def test_interpreter(
+    py27,  # type: PythonInterpreter
+    current_interpreter,  # type: PythonInterpreter
+):
+    # type: (...) -> None
+    assert TargetConfiguration().interpreter is None
+    assert py27 == TargetConfiguration(interpreters=[py27]).interpreter
+    assert py27 == TargetConfiguration(interpreters=[py27, current_interpreter]).interpreter
+
+
+def test_unique_targets(
+    py27,  # type: PythonInterpreter
+    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
+    current_interpreter,  # type: PythonInterpreter
+    current_platform,  # type: Platform
+):
+    # type: (...) -> None
+    assert (
+        OrderedSet([DistributionTarget.current()]) == TargetConfiguration().unique_targets()
+    ), "Expected the default TargetConfiguration to produce the current interpreter."
+
+    assert (
+        OrderedSet([DistributionTarget.current()])
+        == TargetConfiguration(platforms=[None]).unique_targets()
+    ), (
+        "Expected the 'current' platform - which maps to `None` - to produce the current "
+        "interpreter when no interpreters were configured."
+    )
+
+    assert (
+        OrderedSet([DistributionTarget.for_interpreter(py27)])
+        == TargetConfiguration(interpreters=[py27], platforms=[None]).unique_targets()
+    ), (
+        "Expected the 'current' platform - which maps to `None` - to be ignored when at least one "
+        "concrete interpreter for the current platform is configured."
+    )
+
+    assert (
+        OrderedSet([DistributionTarget.for_platform(current_platform)])
+        == TargetConfiguration(platforms=[current_platform]).unique_targets()
+    )
+
+    assert (
+        OrderedSet(DistributionTarget.for_interpreter(i) for i in (py27, py37, py38))
+        == TargetConfiguration(interpreters=[py27, py37, py38]).unique_targets()
+    )

--- a/tests/resolve/test_target_options.py
+++ b/tests/resolve/test_target_options.py
@@ -1,0 +1,289 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import itertools
+import os
+from argparse import ArgumentParser, ArgumentTypeError
+
+import pytest
+
+from pex.interpreter import PythonInterpreter
+from pex.platforms import Platform
+from pex.resolve import target_options
+from pex.resolve.target_configuration import TargetConfiguration
+from pex.testing import IS_MAC, environment_as
+from pex.typing import TYPE_CHECKING
+from pex.variables import ENV
+
+if TYPE_CHECKING:
+    from typing import Iterable, List, Optional, Tuple
+
+
+def compute_target_configuration(
+    parser,  # type: ArgumentParser
+    args,  # type: List[str]
+):
+    # type: (...) -> TargetConfiguration
+    options = parser.parse_args(args=args)
+    return target_options.configure(options)
+
+
+def test_clp_manylinux(parser):
+    # type: (ArgumentParser) -> None
+    target_options.register(parser)
+
+    target_configuration = compute_target_configuration(parser, args=[])
+    assert (
+        target_configuration.assume_manylinux
+    ), "The --manylinux option should default to some value."
+
+    def assert_manylinux(value):
+        # type: (str) -> None
+        rc = compute_target_configuration(parser, args=["--manylinux", value])
+        assert value == rc.assume_manylinux
+
+    # Legacy manylinux standards should be supported.
+    assert_manylinux("manylinux1_x86_64")
+    assert_manylinux("manylinux2010_x86_64")
+    assert_manylinux("manylinux2014_x86_64")
+
+    # The modern open-ended glibc version based manylinux standards should be supported.
+    assert_manylinux("manylinux_2_5_x86_64")
+    assert_manylinux("manylinux_2_33_x86_64")
+
+    target_configuration = compute_target_configuration(parser, args=["--no-manylinux"])
+    assert target_configuration.assume_manylinux is None
+
+    with pytest.raises(ArgumentTypeError):
+        compute_target_configuration(parser, args=["--manylinux", "foo"])
+
+
+def test_configure_platform(parser):
+    # type: (ArgumentParser) -> None
+    target_options.register(parser)
+
+    def assert_platforms(
+        platforms,  # type: Iterable[str]
+        *expected_platforms  # type: Optional[Platform]
+    ):
+        # type: (...) -> None
+        args = list(itertools.chain.from_iterable(("--platform", p) for p in platforms))
+        target_configuration = compute_target_configuration(parser, args)
+        assert not target_configuration.interpreters
+        assert expected_platforms == target_configuration.platforms
+
+    # The special 'current' platform should map to a `None` platform entry.
+    assert_platforms(["current"], None)
+
+    assert_platforms(["linux-x86_64-cp-37-cp37m"], Platform.create("linux-x86_64-cp-37-cp37m"))
+    assert_platforms(["linux-x86_64-cp-37-m"], Platform.create("linux-x86_64-cp-37-cp37m"))
+    assert_platforms(
+        ["linux-x86_64-cp-37-m", "macosx-10.13-x86_64-cp-36-cp36m"],
+        Platform.create("linux-x86_64-cp-37-cp37m"),
+        Platform.create("macosx-10.13-x86_64-cp-36-m"),
+    )
+
+
+def assert_interpreters_configured(
+    target_configuration,  # type: TargetConfiguration
+    expected_interpreter,  # type: Optional[PythonInterpreter]
+    expected_interpreters=None,  # type: Optional[Tuple[PythonInterpreter, ...]]
+):
+    # type: (...) -> None
+    if expected_interpreter is None:
+        assert target_configuration.interpreter is None
+        assert not expected_interpreters
+        return
+
+    assert expected_interpreter == target_configuration.interpreter
+    if expected_interpreters:
+        assert expected_interpreter in expected_interpreters
+        assert expected_interpreters == target_configuration.interpreters
+    else:
+        assert (expected_interpreter,) == target_configuration.interpreters
+
+
+def assert_interpreter(
+    parser,  # type: ArgumentParser
+    args,  # type: List[str]
+    expected_interpreter,  # type: Optional[PythonInterpreter]
+    *expected_interpreters  # type: PythonInterpreter
+):
+    # type: (...) -> None
+    target_configuration = compute_target_configuration(parser, args=args)
+    assert not target_configuration.platforms
+    assert_interpreters_configured(
+        target_configuration, expected_interpreter, expected_interpreters
+    )
+
+
+def test_configure_interpreter_empty(parser):
+    # type: (ArgumentParser) -> None
+    target_options.register(parser)
+    assert_interpreter(parser, args=[], expected_interpreter=None)
+
+
+def path_for(*interpreters):
+    # type: (*PythonInterpreter) -> str
+    return os.pathsep.join(os.path.dirname(interpreter.binary) for interpreter in interpreters)
+
+
+def test_configure_interpreter_path(
+    parser,  # type: ArgumentParser
+    py27,  # type: PythonInterpreter
+    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
+):
+    # type: (...) -> None
+    target_options.register(parser)
+
+    with environment_as(PATH=path_for(py27, py37, py38)):
+        assert_interpreter(parser, ["--python", "python"], py27)
+        assert_interpreter(parser, ["--python", "python2"], py27)
+        assert_interpreter(parser, ["--python", "python3"], py37)
+        assert_interpreter(parser, ["--python", "python3.8"], py38)
+        with pytest.raises(target_options.InterpreterNotFound):
+            compute_target_configuration(parser, args=["--python", "python3.9"])
+
+
+def test_configure_interpreter_pex_python_path(
+    parser,  # type: ArgumentParser
+    py27,  # type: PythonInterpreter
+    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
+):
+    # type: (...) -> None
+    target_options.register(parser)
+
+    path_env_var = path_for(py27, py37, py38)
+
+    with ENV.patch(PEX_PYTHON_PATH=path_env_var):
+        assert_interpreter(parser, ["--python", "python"], py27)
+        assert_interpreter(parser, ["--python", "python2"], py27)
+        assert_interpreter(parser, ["--python", "python3"], py37)
+        assert_interpreter(parser, ["--python", "python3.8"], py38)
+        with pytest.raises(target_options.InterpreterNotFound):
+            compute_target_configuration(parser, args=["--python", "python3.9"])
+
+    with ENV.patch(PEX_PYTHON_PATH=py27.binary):
+        assert_interpreter(parser, ["--python", "python2.7"], py27)
+
+    assert_interpreter(parser, ["--python-path", path_env_var, "--python", "python3"], py37)
+    assert_interpreter(parser, ["--python-path", py38.binary, "--python", "python3.8"], py38)
+
+
+def test_configure_interpreter_constraints(
+    parser,  # type: ArgumentParser
+    py27,  # type: PythonInterpreter
+    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
+):
+    # type: (...) -> None
+    target_options.register(parser)
+
+    path_env_var = path_for(py38, py27, py37)
+
+    def interpreter_constraint_args(interpreter_constraints):
+        # type: (Iterable[str]) -> List[str]
+        args = ["--python-path", path_env_var]
+        args.extend(
+            itertools.chain.from_iterable(
+                ("--interpreter-constraint", ic) for ic in interpreter_constraints
+            )
+        )
+        return args
+
+    def assert_interpreter_constraint(
+        interpreter_constraints,  # type: Iterable[str]
+        expected_interpreters,  # type: Iterable[PythonInterpreter]
+        expected_interpreter,  # type: PythonInterpreter
+    ):
+        # type: (...) -> None
+        assert_interpreter(
+            parser,
+            interpreter_constraint_args(interpreter_constraints),
+            expected_interpreter,
+            *expected_interpreters
+        )
+
+    assert_interpreter_constraint(["CPython"], [py38, py27, py37], expected_interpreter=py27)
+    assert_interpreter_constraint([">=2"], [py38, py27, py37], expected_interpreter=py27)
+    assert_interpreter_constraint([">=2,!=3.7.*"], [py38, py27], expected_interpreter=py27)
+    assert_interpreter_constraint(["==3.*"], [py38, py37], expected_interpreter=py37)
+    assert_interpreter_constraint(["==3.8.*"], [py38], expected_interpreter=py38)
+    assert_interpreter_constraint([">3"], [py38, py37], expected_interpreter=py37)
+    assert_interpreter_constraint([">=3.7,<3.8"], [py37], expected_interpreter=py37)
+    assert_interpreter_constraint(["==3.8.*", "==2.7.*"], [py38, py27], expected_interpreter=py27)
+
+    def assert_interpreter_constraint_not_satisfied(interpreter_constraints):
+        # type: (List[str]) -> None
+        with pytest.raises(target_options.InterpreterConstraintsNotSatisfied):
+            compute_target_configuration(
+                parser, interpreter_constraint_args(interpreter_constraints)
+            )
+
+    assert_interpreter_constraint_not_satisfied(["==3.9.*"])
+    assert_interpreter_constraint_not_satisfied(["==3.8.*,!=3.8.*"])
+    assert_interpreter_constraint_not_satisfied(["==3.9.*", "==2.6.*"])
+
+
+def test_configure_resolve_local_platforms(
+    parser,  # type: ArgumentParser
+    py27,  # type: PythonInterpreter
+    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
+):
+    # type: (...) -> None
+    target_options.register(parser)
+
+    path_env_var = path_for(py27, py37, py38)
+
+    def assert_local_platforms(
+        platforms,  # type: Iterable[str]
+        expected_platforms,  # type: Iterable[str]
+        expected_interpreter,  # type: PythonInterpreter
+        expected_interpreters=None,  # type: Optional[Tuple[PythonInterpreter, ...]]
+        extra_args=None,  # type: Optional[Iterable[str]]
+    ):
+        # type: (...) -> None
+        args = ["--python-path", path_env_var, "--resolve-local-platforms"]
+        args.extend(itertools.chain.from_iterable(("--platform", p) for p in platforms))
+        args.extend(extra_args or ())
+        target_configuration = compute_target_configuration(parser, args)
+        assert (
+            tuple(Platform.create(ep) for ep in expected_platforms)
+            == target_configuration.platforms
+        )
+        assert_interpreters_configured(
+            target_configuration, expected_interpreter, expected_interpreters
+        )
+
+    assert_local_platforms(
+        platforms=[str(py27.platform)],
+        expected_platforms=(),
+        expected_interpreter=py27,
+    )
+
+    foreign_platform = "linux-x86_64-cp-37-m" if IS_MAC else "macosx-10.13-x86_64-cp-37-m"
+
+    assert_local_platforms(
+        platforms=[foreign_platform, str(py37.platform)],
+        expected_platforms=[foreign_platform],
+        expected_interpreter=py37,
+    )
+
+    assert_local_platforms(
+        platforms=[foreign_platform, str(py37.platform)],
+        extra_args=["--interpreter-constraint", "CPython"],
+        expected_platforms=[foreign_platform],
+        expected_interpreter=py27,
+        expected_interpreters=(py27, py37, py38),
+    )
+
+    assert_local_platforms(
+        platforms=[foreign_platform, str(py27.platform)],
+        extra_args=["--interpreter-constraint", "==3.8.*"],
+        expected_platforms=[foreign_platform],
+        expected_interpreter=py27,
+        expected_interpreters=(py38, py27),
+    )

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -667,7 +667,7 @@ def test_resolve_from_pex(
         requirements=direct_requirements,
         interpreters=[py27, py38],
         platforms=[foreign_platform],
-        manylinux=manylinux,
+        assume_manylinux=manylinux,
     )
 
     distribution_locations_by_key = defaultdict(set)  # type: DefaultDict[str, Set[str]]
@@ -713,7 +713,7 @@ def test_resolve_from_pex_subset(
         pex=pex_repository,
         requirements=["cffi"],
         platforms=[foreign_platform],
-        manylinux=manylinux,
+        assume_manylinux=manylinux,
     )
 
     assert {"cffi", "pycparser"} == {
@@ -769,7 +769,7 @@ def test_resolve_from_pex_intransitive(
         transitive=False,
         interpreters=[py27, py38],
         platforms=[foreign_platform],
-        manylinux=manylinux,
+        assume_manylinux=manylinux,
     ).installed_distributions
     assert 3 == len(
         installed_distributions


### PR DESCRIPTION
This was started in #1455, but many options and substantial target
configuration logic remained tied to `pex.bin.pex`. Lift all options
and configuration logic up to the `pex.resolve` package where the
`pex3` CLI will be able to share the implementation and add test
coverage.

Work towards #1401.