### PR TITLE
Introduce a `qualified_name` utility.

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -96,6 +96,28 @@ def pluralize(
         return noun + "s"
 
 
+def qualified_name(item):
+    # type: (Any) -> str
+    """Attempt to produce the fully qualified name for an item.
+
+    If the item is a type, method, property or function, its fully qualified name is returned as
+    best as can be determined. Otherwise, the fully qualified name of the type of the given item is
+    returned.
+
+    :param item: The item to identify.
+    :return: The fully qualified name of the given item.
+    """
+    if isinstance(item, property):
+        item = item.fget
+    if not hasattr(item, "__name__"):
+        item = type(item)
+    return "{module}.{type}".format(
+        module=getattr(item, "__module__", "<unknown module>"),
+        # There is no __qualname__ in Python 2.7; so we do the best we can.
+        type=getattr(item, "__qualname__", item.__name__),
+    )
+
+
 def safe_copy(source, dest, overwrite=False):
     # type: (str, str, bool) -> None
     def do_copy():

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -18,10 +18,12 @@ from pex.common import (
     is_exe,
     is_script,
     open_zip,
+    qualified_name,
     safe_open,
     temporary_dir,
     touch,
 )
+from pex.compatibility import PY2
 from pex.typing import TYPE_CHECKING
 
 try:
@@ -386,3 +388,43 @@ def test_is_script(tmpdir):
     assert is_script(exe, check_executable=False)
     assert not is_script(exe)
     assert not is_exe(exe)
+
+
+def test_qualified_name():
+    # type: () -> None
+
+    expected_str_type = "{module}.str".format(module="__builtin__" if PY2 else "builtins")
+    assert expected_str_type == qualified_name(str), "Expected builtin types to be handled."
+    assert expected_str_type == qualified_name(
+        "foo"
+    ), "Expected non-callable objects to be identified via their types."
+
+    assert "pex.common.qualified_name" == qualified_name(
+        qualified_name
+    ), "Expected functions to be handled"
+
+    assert "pex.common.AtomicDirectory" == qualified_name(
+        AtomicDirectory
+    ), "Expected custom types to be handled."
+    expected_prefix = "pex.common." if PY2 else "pex.common.AtomicDirectory."
+    assert expected_prefix + "finalize" == qualified_name(
+        AtomicDirectory.finalize
+    ), "Expected methods to be handled."
+    assert expected_prefix + "work_dir" == qualified_name(
+        AtomicDirectory.work_dir
+    ), "Expected @property to be handled."
+
+    expected_prefix = "pex.common." if PY2 else "pex.common.PermPreservingZipFile."
+    assert expected_prefix + "zip_entry_from_file" == qualified_name(
+        PermPreservingZipFile.zip_entry_from_file
+    ), "Expected @classmethod to be handled."
+
+    class Test(object):
+        @staticmethod
+        def static():
+            pass
+
+    expected_prefix = "test_common." if PY2 else "test_common.test_qualified_name.<locals>.Test."
+    assert expected_prefix + "static" == qualified_name(
+        Test.static
+    ), "Expected @staticmethod to be handled."


### PR DESCRIPTION
This will be used for error messages when introducing sortability to
`Enum` and in lock file parsing.

Work towards #1401 and #1414.