### PR TITLE
Make Enums sortable.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -43,7 +43,7 @@ from pex.venv_bin_path import BinPath
 from pex.version import __version__
 
 if TYPE_CHECKING:
-    from typing import Dict, Iterable, List, Optional, Union
+    from typing import Dict, List, Optional, Union
     from argparse import Namespace
 
 
@@ -336,11 +336,6 @@ class Seed(Enum["Seed.Value"]):
     NONE = Value("none")
     ARGS = Value("args")
     VERBOSE = Value("verbose")
-
-    @classmethod
-    def values(cls):
-        # type: () -> Iterable[Seed.Value]
-        return cls.NONE, cls.ARGS, cls.VERBOSE
 
 
 class HandleSeedAction(Action):

--- a/pex/common.py
+++ b/pex/common.py
@@ -96,6 +96,28 @@ def pluralize(
         return noun + "s"
 
 
+def qualified_name(item):
+    # type: (Any) -> str
+    """Attempt to produce the fully qualified name for an item.
+
+    If the item is a type, method, property or function, its fully qualified name is returned as
+    best as can be determined. Otherwise, the fully qualified name of the type of the given item is
+    returned.
+
+    :param item: The item to identify.
+    :return: The fully qualified name of the given item.
+    """
+    if isinstance(item, property):
+        item = item.fget
+    if not hasattr(item, "__name__"):
+        item = type(item)
+    return "{module}.{type}".format(
+        module=getattr(item, "__module__", "<unknown module>"),
+        # There is no __qualname__ in Python 2.7; so we do the best we can.
+        type=getattr(item, "__qualname__", item.__name__),
+    )
+
+
 def safe_copy(source, dest, overwrite=False):
     # type: (str, str, bool) -> None
     def do_copy():

--- a/pex/enum.py
+++ b/pex/enum.py
@@ -3,19 +3,41 @@
 
 from __future__ import absolute_import
 
-from pex.typing import TYPE_CHECKING, Generic
+import weakref
+from collections import defaultdict
+from functools import total_ordering
+
+from _weakref import ReferenceType
+
+from pex.common import qualified_name
+from pex.typing import TYPE_CHECKING, Generic, cast
 
 if TYPE_CHECKING:
-    from typing import Iterable, Type, TypeVar
+    from typing import Any, DefaultDict, List, Optional, Tuple, Type, TypeVar
 
     _V = TypeVar("_V", bound="Enum.Value")
 
 
 class Enum(Generic["_V"]):
+    @total_ordering
     class Value(object):
+        _values_by_type = defaultdict(
+            list
+        )  # type: DefaultDict[Type[Enum.Value], List[ReferenceType[Enum.Value]]]
+
+        @classmethod
+        def _iter_values(cls):
+            for ref in cls._values_by_type[cls]:
+                value = ref()
+                if value:
+                    yield value
+
         def __init__(self, value):
             # type: (str) -> None
+            values = Enum.Value._values_by_type[type(self)]
             self.value = value
+            self.ordinal = len(values)
+            values.append(weakref.ref(self))
 
         def __str__(self):
             # type: () -> str
@@ -25,10 +47,42 @@ class Enum(Generic["_V"]):
             # type: () -> str
             return repr(self.value)
 
+        def __eq__(self, other):
+            # type: (Any) -> bool
+            return self is other
+
+        @classmethod
+        def _create_type_error(cls, other):
+            # type: (Any) -> TypeError
+            return TypeError(
+                "Can only compare values of type {value_type} amongst themselves; given "
+                "{other!r} of type {other_type}.".format(
+                    value_type=qualified_name(cls),
+                    other=other,
+                    other_type=qualified_name(other),
+                )
+            )
+
+        def __lt__(self, other):
+            # type: (Any) -> bool
+            if type(self) != type(other):
+                raise self._create_type_error(other)
+            return self.ordinal < cast(Enum.Value, other).ordinal
+
+        def __le__(self, other):
+            # type: (Any) -> bool
+            if type(self) != type(other):
+                raise self._create_type_error(other)
+            return self is other or self < other
+
+    _values = None  # type: Optional[Tuple[_V, ...]]
+
     @classmethod
     def values(cls):
-        # type: (Type[Enum[_V]]) -> Iterable[_V]
-        raise NotImplementedError()
+        # type: (Type[Enum[_V]]) -> Tuple[_V, ...]
+        if cls._values is None:
+            cls._values = tuple(cls.Value._iter_values())
+        return cls._values
 
     @classmethod
     def for_value(

--- a/pex/inherit_path.py
+++ b/pex/inherit_path.py
@@ -19,10 +19,6 @@ class InheritPath(Enum["InheritPath.Value"]):
     FALLBACK = Value("fallback")
 
     @classmethod
-    def values(cls):
-        return cls.FALSE, cls.PREFER, cls.FALLBACK
-
-    @classmethod
     def for_value(cls, value):
         # type: (Union[str, bool]) -> InheritPath.Value
         if not isinstance(value, bool):

--- a/pex/layout.py
+++ b/pex/layout.py
@@ -15,7 +15,7 @@ from pex.typing import TYPE_CHECKING
 from pex.variables import unzip_dir
 
 if TYPE_CHECKING:
-    from typing import Optional, Iterable, Iterator
+    from typing import Optional, Iterator
 
 BOOTSTRAP_DIR = ".bootstrap"
 DEPS_DIR = ".deps"
@@ -29,11 +29,6 @@ class Layout(Enum["Layout.Value"]):
     ZIPAPP = Value("zipapp")
     PACKED = Value("packed")
     LOOSE = Value("loose")
-
-    @classmethod
-    def values(cls):
-        # type: () -> Iterable[Layout.Value]
-        return cls.ZIPAPP, cls.PACKED, cls.LOOSE
 
 
 class _Layout(object):

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -39,7 +39,7 @@ from pex.typing import TYPE_CHECKING
 from pex.util import CacheHelper, DistributionHelper
 
 if TYPE_CHECKING:
-    from typing import Dict, Iterable, Optional
+    from typing import Dict, Optional
 
 
 class CopyMode(Enum["CopyMode.Value"]):
@@ -49,11 +49,6 @@ class CopyMode(Enum["CopyMode.Value"]):
     COPY = Value("copy")
     LINK = Value("link")
     SYMLINK = Value("symlink")
-
-    @classmethod
-    def values(cls):
-        # type: () -> Iterable[CopyMode.Value]
-        return cls.COPY, cls.LINK, cls.SYMLINK
 
 
 BOOTSTRAP_ENVIRONMENT = """\

--- a/pex/resolve/locked_resolve.py
+++ b/pex/resolve/locked_resolve.py
@@ -16,7 +16,7 @@ from pex.util import CacheHelper
 
 if TYPE_CHECKING:
     import attr  # vendor:skip
-    from typing import BinaryIO, IO, Iterable, Tuple
+    from typing import BinaryIO, IO, Tuple
 else:
     from pex.third_party import attr
 
@@ -27,11 +27,6 @@ class LockStyle(Enum["LockStyle.Value"]):
 
     STRICT = Value("strict")
     SOURCES = Value("sources")
-
-    @classmethod
-    def values(cls):
-        # type: () -> Iterable[LockStyle.Value]
-        return cls.STRICT, cls.SOURCES
 
 
 @attr.s(frozen=True)

--- a/pex/resolve/resolver_configuration.py
+++ b/pex/resolve/resolver_configuration.py
@@ -10,7 +10,7 @@ from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import attr  # vendor:skip
-    from typing import Iterable, Tuple
+    from typing import Tuple
 else:
     from pex.third_party import attr
 
@@ -24,11 +24,6 @@ class ResolverVersion(Enum["ResolverVersion.Value"]):
 
     PIP_LEGACY = Value("pip-legacy-resolver")
     PIP_2020 = Value("pip-2020-resolver")
-
-    @classmethod
-    def values(cls):
-        # type: () -> Iterable[ResolverVersion.Value]
-        return cls.PIP_LEGACY, cls.PIP_2020
 
 
 @attr.s(frozen=True)

--- a/pex/venv_bin_path.py
+++ b/pex/venv_bin_path.py
@@ -4,10 +4,6 @@
 from __future__ import absolute_import
 
 from pex.enum import Enum
-from pex.typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Iterable
 
 
 class BinPath(Enum["BinPath.Value"]):
@@ -17,8 +13,3 @@ class BinPath(Enum["BinPath.Value"]):
     FALSE = Value("false")
     PREPEND = Value("prepend")
     APPEND = Value("append")
-
-    @classmethod
-    def values(cls):
-        # type: () -> Iterable[BinPath.Value]
-        return cls.FALSE, cls.PREPEND, cls.APPEND

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -18,10 +18,12 @@ from pex.common import (
     is_exe,
     is_script,
     open_zip,
+    qualified_name,
     safe_open,
     temporary_dir,
     touch,
 )
+from pex.compatibility import PY2
 from pex.typing import TYPE_CHECKING
 
 try:
@@ -386,3 +388,43 @@ def test_is_script(tmpdir):
     assert is_script(exe, check_executable=False)
     assert not is_script(exe)
     assert not is_exe(exe)
+
+
+def test_qualified_name():
+    # type: () -> None
+
+    expected_str_type = "{module}.str".format(module="__builtin__" if PY2 else "builtins")
+    assert expected_str_type == qualified_name(str), "Expected builtin types to be handled."
+    assert expected_str_type == qualified_name(
+        "foo"
+    ), "Expected non-callable objects to be identified via their types."
+
+    assert "pex.common.qualified_name" == qualified_name(
+        qualified_name
+    ), "Expected functions to be handled"
+
+    assert "pex.common.AtomicDirectory" == qualified_name(
+        AtomicDirectory
+    ), "Expected custom types to be handled."
+    expected_prefix = "pex.common." if PY2 else "pex.common.AtomicDirectory."
+    assert expected_prefix + "finalize" == qualified_name(
+        AtomicDirectory.finalize
+    ), "Expected methods to be handled."
+    assert expected_prefix + "work_dir" == qualified_name(
+        AtomicDirectory.work_dir
+    ), "Expected @property to be handled."
+
+    expected_prefix = "pex.common." if PY2 else "pex.common.PermPreservingZipFile."
+    assert expected_prefix + "zip_entry_from_file" == qualified_name(
+        PermPreservingZipFile.zip_entry_from_file
+    ), "Expected @classmethod to be handled."
+
+    class Test(object):
+        @staticmethod
+        def static():
+            pass
+
+    expected_prefix = "test_common." if PY2 else "test_common.test_qualified_name.<locals>.Test."
+    assert expected_prefix + "static" == qualified_name(
+        Test.static
+    ), "Expected @staticmethod to be handled."

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -29,7 +29,7 @@ from pex.typing import TYPE_CHECKING
 try:
     from unittest import mock
 except ImportError:
-    import mock  # type: ignore[no-redef]
+    import mock  # type: ignore[no-redef,import]
 
 if TYPE_CHECKING:
     from typing import Any, Iterator, Optional, Tuple, Type

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,42 +1,90 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+import re
 
 import pytest
 
+from pex.common import qualified_name
 from pex.enum import Enum
-from pex.typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from typing import Iterable
+
+class Color(Enum["Color.Value"]):
+    class Value(Enum.Value):
+        pass
+
+    RED = Value("red")
+    GREEN = Value("green")
+    BLUE = Value("blue")
 
 
 def test_basics():
     # type: () -> None
 
-    class Colors(Enum["Colors.Value"]):
+    assert Color.RED is Color.for_value("red")
+    assert Color.RED == Color.for_value("red")
+
+    assert Color.GREEN is not Enum.Value("green")
+    assert Color.GREEN != Enum.Value("green")
+
+    assert Color.BLUE is not Color.Value("blue")
+    assert Color.BLUE != Color.Value("blue")
+
+    assert Color.for_value("red") is not Color.for_value("green") is not Color.for_value("blue")
+    assert Color.for_value("red") != Color.for_value("green") != Color.for_value("blue")
+
+    with pytest.raises(ValueError):
+        Color.for_value("yellow")
+
+
+def test_value():
+    # type: () -> None
+
+    assert ["red", "green", "blue"] == [color.value for color in Color.values()]
+
+
+def test_ordinal():
+    # type: () -> None
+
+    assert [0, 1, 2] == [color.ordinal for color in Color.values()]
+
+    class PlaceHolder(Enum["PlaceHolder.Value"]):
         class Value(Enum.Value):
             pass
 
-        RED = Value("red")
-        GREEN = Value("green")
-        BLUE = Value("blue")
+        FOO = Value("foo")
+        BAR = Value("bar")
+        BAZ = Value("baz")
 
-        @classmethod
-        def values(cls):
-            # type: () -> Iterable[Colors.Value]
-            return cls.RED, cls.GREEN, cls.BLUE
+    assert [0, 1, 2] == [place_holder.ordinal for place_holder in PlaceHolder.values()]
 
-    assert Colors.RED is Colors.for_value("red")
-    assert Colors.RED == Colors.for_value("red")
 
-    assert Colors.GREEN is not Enum.Value("green")
-    assert Colors.GREEN != Enum.Value("green")
+def test_comparable():
+    # type: () -> None
 
-    assert Colors.BLUE is not Colors.Value("blue")
-    assert Colors.BLUE != Colors.Value("blue")
+    assert Color.BLUE > Color.RED
+    assert Color.GREEN >= Color.RED
+    assert Color.RED >= Color.RED
+    assert Color.RED <= Color.RED
+    assert Color.RED < Color.GREEN
 
-    assert Colors.for_value("red") is not Colors.for_value("green") is not Colors.for_value("blue")
-    assert Colors.for_value("red") != Colors.for_value("green") != Colors.for_value("blue")
+    assert [Color.RED, Color.GREEN, Color.BLUE] == sorted(Color.values())
+    assert [Color.RED, Color.GREEN, Color.BLUE] == sorted([Color.GREEN, Color.RED, Color.BLUE])
 
-    with pytest.raises(ValueError):
-        Colors.for_value("yellow")
+    class Op(Enum["Op.Value"]):
+        class Value(Enum.Value):
+            pass
+
+        ADD = Value("+")
+        SUB = Value("-")
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Can only compare values of type {op_value_type} amongst themselves; given 'red' of "
+            "type {color_value_type}.".format(
+                op_value_type=qualified_name(Op.Value),
+                color_value_type=qualified_name(Color.Value),
+            )
+        ),
+    ):
+        assert Op.SUB > Color.RED

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -31,9 +31,9 @@ from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
 
 try:
-    from mock import Mock, patch
+    from unittest.mock import Mock, patch  # type: ignore[import]
 except ImportError:
-    from unittest.mock import Mock, patch  # type: ignore[misc,no-redef,import]
+    from mock import Mock, patch  # type: ignore[misc,import]
 
 if TYPE_CHECKING:
     from typing import Any, Iterator, List, Tuple, Optional

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -41,7 +41,7 @@ from pex.util import named_temporary_file
 try:
     from unittest import mock
 except ImportError:
-    import mock  # type: ignore[no-redef]
+    import mock  # type: ignore[no-redef,import]
 
 if TYPE_CHECKING:
     import attr  # vendor:skip

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -16,7 +16,7 @@ from pex.util import CacheHelper, DistributionHelper, iter_pth_paths, named_temp
 try:
     from unittest import mock
 except ImportError:
-    import mock  # type: ignore[no-redef]
+    import mock  # type: ignore[no-redef,import]
 
 if TYPE_CHECKING:
     from typing import Any, Dict, List

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,8 @@ commands =
 [testenv:typecheck]
 deps =
     attrs==21.2.0  # This version should track the version in pex/vendor/__init__.py.
-    mypy==0.800
+    mypy[python2]==0.910
+    types-mock
 commands =
     bash scripts/typecheck.sh
 


### PR DESCRIPTION
Upcoming lock file work will benefit from this. Instead of just sorting
by the string value of an `Enum.Value`, introduce an ordinal to sort by
and take the opportunity to dry up the values method.

Work towards #1401 and #1414.