### PR TITLE
Populate `platform_machine` in --platform resolve.

### DIFF
--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -310,10 +310,29 @@ class Platform(object):
 
         if "linux" in self.platform:
             env["os_name"] = "posix"
+            if self.platform.startswith(
+                ("linux_", "manylinux1_", "manylinux2010_", "manylinux2014_")
+            ):
+                # E.G.:
+                # + linux_x86_64
+                # + manylinux{1,2010,2014}_x86_64
+                # For the manylinux* See:
+                # + manylinux1: https://www.python.org/dev/peps/pep-0513/
+                # + manylinux2010: https://www.python.org/dev/peps/pep-0571/
+                # + manylinux2014: https://www.python.org/dev/peps/pep-0599/
+                env["platform_machine"] = self.platform.split("_", 1)[-1]
+            else:
+                # E.G.: manylinux_<glibc major>_<glibc_minor>_x86_64
+                # See: https://www.python.org/dev/peps/pep-0600/
+                env["platform_machine"] = self.platform.split("_", 3)[-1]
             env["platform_system"] = "Linux"
             env["sys_platform"] = "linux2" if major_version == 2 else "linux"
         elif "mac" in self.platform:
             env["os_name"] = "posix"
+            # E.G:
+            # + macosx_10_15_x86_64
+            # + macosx_11_0_arm64
+            env["platform_machine"] = self.platform.split("_", 3)[-1]
             env["platform_system"] = "Darwin"
             env["sys_platform"] = "darwin"
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -113,6 +113,7 @@ def test_platform_marker_environment():
     assert_known_marker("python_version == '3.7'")
     assert_known_marker("implementation_name == 'cpython'")
     assert_known_marker("platform_system == 'Linux'")
+    assert_known_marker("platform_machine == 'x86_64'")
 
     def assert_unknown_marker(expression):
         # type: (str) -> None
@@ -123,4 +124,23 @@ def test_platform_marker_environment():
     assert_unknown_marker("python_full_version == '3.7.10'")
     assert_unknown_marker("platform_release == '5.12.12-arch1-1'")
     assert_unknown_marker("platform_version == '#1 SMP PREEMPT Fri, 18 Jun 2021 21:59:22 +0000'")
-    assert_unknown_marker("platform_machine == 'x86_64'")
+
+
+def test_platform_marker_environment_issue_1488():
+    # type: () -> None
+
+    def assert_platform_machine(
+        expected,  # type: str
+        platform,  # type: str
+    ):
+        assert expected == Platform.create(platform).marker_environment()["platform_machine"]
+
+    assert_platform_machine("x86_64", "linux-x86_64-cp-37-cp37m")
+    assert_platform_machine("x86_64", "manylinux1-x86_64-cp-37-cp37m")
+    assert_platform_machine("x86_64", "manylinux2010-x86_64-cp-37-cp37m")
+    assert_platform_machine("x86_64", "manylinux2014-x86_64-cp-37-cp37m")
+    assert_platform_machine("x86_64", "manylinux_2_5-x86_64-cp-37-cp37m")
+    assert_platform_machine("aarch64", "manylinux_2_77-aarch64-cp-37-cp37m")
+
+    assert_platform_machine("x86_64", "macosx-10.15-x86_64-cp-38-m")
+    assert_platform_machine("arm64", "macosx-11.0-arm64-cp-39-cp39")


### PR DESCRIPTION
Previously we were not doing this, but all the needed info was present in
the platform tag.

Fixes #1488