### PR TITLE
Add support for setting custom venv prompts.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -746,11 +746,12 @@ def seed_cache(
 
         if options.venv:
             with TRACER.timed("Creating venv from {}".format(pex_path)):
-                venv_pex = ensure_venv(pex)
-                if verbose:
-                    return json.dumps(create_verbose_info(final_pex_path=venv_pex))
-                else:
-                    return venv_pex
+                with ENV.patch(PEX=os.path.realpath(os.path.expanduser(pex_path))):
+                    venv_pex = ensure_venv(pex)
+                    if verbose:
+                        return json.dumps(create_verbose_info(final_pex_path=venv_pex))
+                    else:
+                        return venv_pex
 
         pex_hash = pex_info.pex_hash
         if pex_hash is None:

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -426,6 +426,7 @@ def ensure_venv(pex):
                 venv_dir=venv,
                 interpreter=pex.interpreter,
                 copies=pex_info.venv_copies,
+                prompt=os.path.basename(ENV.PEX) if ENV.PEX else None,
             )
 
             pex_path = os.path.abspath(pex.path())

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -648,3 +648,10 @@ def run_command_with_jitter(
         extra_env=extra_env,
         delay=delay,
     )
+
+
+def pex_project_dir():
+    # type: () -> str
+    return str(
+        subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode("ascii").strip()
+    )

--- a/pex/tools/commands/repository.py
+++ b/pex/tools/commands/repository.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 
 import functools
+import logging
 import os
 import re
 import shutil
@@ -13,7 +14,7 @@ from contextlib import contextmanager
 from textwrap import dedent
 from threading import Thread
 
-from pex import dist_metadata, pex_warnings
+from pex import dist_metadata
 from pex.commands.command import Error, JsonMixin, Ok, OutputMixin, Result
 from pex.common import (
     DETERMINISTIC_DATETIME_TIMESTAMP,
@@ -38,6 +39,9 @@ if TYPE_CHECKING:
     RepositoryFunc = Callable[["Repository", PEX], Result]
 else:
     from pex.third_party import attr
+
+
+logger = logging.getLogger(__name__)
 
 
 @attr.s(frozen=True)
@@ -332,7 +336,7 @@ class Repository(JsonMixin, OutputMixin, PEXCommand):
                 PythonIdentity.parse_requirement(pex_info.interpreter_constraints[0]).specifier
             )
         elif pex_info.interpreter_constraints:
-            pex_warnings.warn(
+            logger.warning(
                 "Omitting `python_requires` for {name} sdist since {pex} has multiple "
                 "interpreter constraints:\n{interpreter_constraints}".format(
                     name=name,

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 
 import errno
+import logging
 import os
 import shutil
 from argparse import ArgumentParser
@@ -23,6 +24,8 @@ from pex.venv_bin_path import BinPath
 
 if TYPE_CHECKING:
     from typing import Iterable, Iterator, Optional, Tuple
+
+logger = logging.getLogger(__name__)
 
 
 # N.B.: We can't use shutil.copytree since we copy from multiple source locations to the same site
@@ -403,6 +406,13 @@ class Venv(PEXCommand):
             copies=self.options.copies,
             prompt=self.options.prompt,
         )
+        if self.options.prompt != venv.custom_prompt:
+            logger.warning(
+                "Unable to apply custom --prompt {prompt!r} in {python} venv; continuing with the "
+                "default prompt.".format(
+                    prompt=self.options.prompt, python=venv.interpreter.identity
+                )
+            )
         populate_venv_with_pex(
             venv,
             pex,

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -386,6 +386,10 @@ class Venv(PEXCommand):
             default=False,
             help="Compile all `.py` files in the venv.",
         )
+        parser.add_argument(
+            "--prompt",
+            help="A custom prompt for the venv activation scripts to use.",
+        )
         cls.register_global_arguments(parser, include_verbosity=False)
 
     def run(self, pex):
@@ -397,6 +401,7 @@ class Venv(PEXCommand):
             interpreter=pex.interpreter,
             force=self.options.force,
             copies=self.options.copies,
+            prompt=self.options.prompt,
         )
         populate_venv_with_pex(
             venv,

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -330,6 +330,19 @@ class Variables(object):
         yield self._environ
         self._environ = old_environ
 
+    @property
+    def PEX(self):
+        # type: () -> Optional[str]
+        """String.
+
+        The absolute path of the PEX that is executing. This will either be the path of the PEX
+        zip for zipapps or else the path of the PEX loose directory for packed or loose PEXes.
+
+        N.B.: The path is not the path of the underlying unzipped PEX or else the PEXes installed
+        venv.
+        """
+        return self._maybe_get_path("PEX")
+
     @defaulted_property(default=False)
     def PEX_ALWAYS_CACHE(self):
         # type: () -> bool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import pytest
+
+from pex import testing
+
+
+@pytest.fixture(scope="session")
+def pex_project_dir():
+    # type: () -> str
+    return testing.pex_project_dir()

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,61 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os
+import subprocess
+
+import pytest
+
+from pex.common import atomic_directory
+from pex.testing import make_env, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+@pytest.fixture(scope="session")
+def is_pytest_xdist(worker_id):
+    # type: (str) -> bool
+    return worker_id != "master"
+
+
+@pytest.fixture(scope="session")
+def shared_integration_test_tmpdir(
+    tmpdir_factory,  # type: Any
+    is_pytest_xdist,  # type: bool
+):
+    # type: (...) -> str
+    tmpdir = str(tmpdir_factory.getbasetemp())
+
+    # We know pytest-xdist creates a subdir under the pytest session tmp dir for each worker; so we
+    # go up a level to lock a directory all workers can use.
+    if is_pytest_xdist:
+        tmpdir = os.path.dirname(tmpdir)
+
+    return os.path.join(tmpdir, "shared_integration_test_tmpdir")
+
+
+@pytest.fixture(scope="session")
+def pex_bdist(
+    pex_project_dir,  # type: str
+    shared_integration_test_tmpdir,  # type: str
+):
+    # type: (...) -> str
+    pex_bdist_chroot = os.path.join(shared_integration_test_tmpdir, "pex_bdist_chroot")
+    with atomic_directory(pex_bdist_chroot, exclusive=True) as chroot:
+        wheels_dir = os.path.join(pex_bdist_chroot, "wheels_dir")
+        if not chroot.is_finalized:
+            pex_pex = os.path.join(pex_bdist_chroot, "pex.pex")
+            run_pex_command(
+                args=[pex_project_dir, "-o", pex_pex, "--include-tools"]
+            ).assert_success()
+            subprocess.check_call(
+                args=[pex_pex, "repository", "extract", "-f", wheels_dir],
+                env=make_env(PEX_TOOLS=True),
+            )
+        wheels = os.listdir(wheels_dir)
+        assert 1 == len(wheels)
+        return os.path.join(wheels_dir, wheels[0])

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -45,8 +45,8 @@ def pex_bdist(
 ):
     # type: (...) -> str
     pex_bdist_chroot = os.path.join(shared_integration_test_tmpdir, "pex_bdist_chroot")
+    wheels_dir = os.path.join(pex_bdist_chroot, "wheels_dir")
     with atomic_directory(pex_bdist_chroot, exclusive=True) as chroot:
-        wheels_dir = os.path.join(pex_bdist_chroot, "wheels_dir")
         if not chroot.is_finalized:
             pex_pex = os.path.join(pex_bdist_chroot, "pex.pex")
             run_pex_command(
@@ -56,6 +56,6 @@ def pex_bdist(
                 args=[pex_pex, "repository", "extract", "-f", wheels_dir],
                 env=make_env(PEX_TOOLS=True),
             )
-        wheels = os.listdir(wheels_dir)
-        assert 1 == len(wheels)
-        return os.path.join(wheels_dir, wheels[0])
+    wheels = os.listdir(wheels_dir)
+    assert 1 == len(wheels)
+    return os.path.join(wheels_dir, wheels[0])

--- a/tests/integration/test_executuon_mode_venv.py
+++ b/tests/integration/test_executuon_mode_venv.py
@@ -1,0 +1,63 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import json
+import os
+import re
+import subprocess
+
+from pex.testing import IS_PYPY, PY_VER, make_env, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_custom_prompt(tmpdir):
+    # type: (Any) -> None
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+
+    venv_pex_name = "venv.pex"
+    venv_pex = os.path.join(str(tmpdir), venv_pex_name)
+
+    result = run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "-o",
+            venv_pex,
+            "--seed",
+            "verbose",
+            "--venv",
+        ]
+    )
+    result.assert_success()
+    venv_dir = os.path.dirname(json.loads(result.output)["pex"])
+
+    if PY_VER == (2, 7) or IS_PYPY:
+        # Neither CPython 2.7 not PyPy interpreters have (functioning) venv modules; so we create
+        # their venvs with an old copy of virtualenv that does not surround the prompt with parens.
+        expected_prompt = r"{venv_pex_name}".format(venv_pex_name=re.escape(venv_pex_name))
+    elif PY_VER == (3, 5):
+        # We can't set the prompt for CPython 3.5 so we expect a venv atomic_directory-style name.
+        expected_prompt = r"^\({venv_dir}\.[0-9a-f]+\)$".format(
+            venv_dir=re.escape(os.path.basename(venv_dir))
+        )
+    else:
+        expected_prompt = r"^\({venv_pex_name}\)$".format(venv_pex_name=re.escape(venv_pex_name))
+
+    output = subprocess.check_output(
+        args=[
+            "/usr/bin/env",
+            "bash",
+            "-c",
+            "source {} && echo $PS1".format(os.path.join(venv_dir, "bin", "activate")),
+        ],
+        env=make_env(TERM="dumb", COLS=80),
+    )
+    assert re.match(expected_prompt, output.decode("utf-8").strip()) is not None

--- a/tests/integration/test_executuon_mode_venv.py
+++ b/tests/integration/test_executuon_mode_venv.py
@@ -42,7 +42,7 @@ def test_custom_prompt(tmpdir):
     if PY_VER == (2, 7) or IS_PYPY:
         # Neither CPython 2.7 not PyPy interpreters have (functioning) venv modules; so we create
         # their venvs with an old copy of virtualenv that does not surround the prompt with parens.
-        expected_prompt = r"{venv_pex_name}".format(venv_pex_name=re.escape(venv_pex_name))
+        expected_prompt = r"^{venv_pex_name}$".format(venv_pex_name=re.escape(venv_pex_name))
     elif PY_VER == (3, 5):
         # We can't set the prompt for CPython 3.5 so we expect a venv atomic_directory-style name.
         expected_prompt = r"^\({venv_dir}\.[0-9a-f]+\)$".format(

--- a/tests/integration/test_variables.py
+++ b/tests/integration/test_variables.py
@@ -1,0 +1,56 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from pex.layout import Layout
+from pex.testing import run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+@pytest.mark.parametrize(
+    "strip_pex_env", [pytest.param(True, id="StripPexEnv"), pytest.param(False, id="NoStripPexEnv")]
+)
+@pytest.mark.parametrize(
+    "layout", [pytest.param(layout, id=layout.value) for layout in Layout.values()]
+)
+@pytest.mark.parametrize("venv", [pytest.param(True, id="VENV"), pytest.param(False, id="UNZIP")])
+def test_pex_variable_always_defined_at_runtime(
+    tmpdir,  # type: Any
+    strip_pex_env,  # type: bool
+    venv,  # type: bool
+    layout,  # type: Layout.Value
+    pex_bdist,  # type: str
+):
+    # type: (...) -> None
+    pex_pex = os.path.join(str(tmpdir), "pex.pex")
+
+    build_pex_args = [
+        pex_bdist,
+        "--layout",
+        layout.value,
+        "--strip-pex-env" if strip_pex_env else "--no-strip-pex-env",
+        "-o",
+        pex_pex,
+    ]
+    if venv:
+        build_pex_args.append("--venv")
+
+    run_pex_command(args=build_pex_args).assert_success()
+
+    run_pex_args = [pex_pex] if Layout.ZIPAPP == layout else [sys.executable, pex_pex]
+    assert (
+        os.path.realpath(pex_pex)
+        == subprocess.check_output(
+            args=run_pex_args + ["-c", "from pex.variables import ENV; print(ENV.PEX)"]
+        )
+        .decode("utf-8")
+        .strip()
+    )

--- a/tests/resolve/__init__.py
+++ b/tests/resolve/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).

--- a/tests/test_bdist_pex.py
+++ b/tests/test_bdist_pex.py
@@ -9,18 +9,11 @@ from textwrap import dedent
 from pex import resolver
 from pex.common import open_zip, temporary_dir
 from pex.interpreter import spawn_python_job
-from pex.testing import WheelBuilder, make_project, temporary_content
+from pex.testing import WheelBuilder, make_project, pex_project_dir, temporary_content
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Dict, List, Iterator, Iterable, Optional, Text, Union
-
-
-def pex_project_dir():
-    # type: () -> str
-    return str(
-        subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode("ascii").strip()
-    )
 
 
 BDIST_PEX_PYTHONPATH = None

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).

--- a/tests/tools/commands/__init__.py
+++ b/tests/tools/commands/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).


### PR DESCRIPTION
The `PEX_TOOLS` `venv` tool gains a `--prompt` option and the underlying
infrastructure that supports this is used to give automatically created
`--venv`s in the `PEX_ROOT` human readable names pointing back to the
original PEX name when possible.