### PR TITLE
Fix `--venv` mode short link creation.

### DIFF
--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -404,8 +404,11 @@ def _bootstrap(entry_point):
     return pex_info
 
 
-def ensure_venv(pex):
-    # type: (PEX) -> str
+def ensure_venv(
+    pex,  # type: PEX
+    collisions_ok=True,  # type: bool
+):
+    # type: (...) -> str
     pex_info = pex.pex_info()
     venv_dir = pex_info.venv_dir(pex_file=pex.path(), interpreter=pex.interpreter)
     if venv_dir is None:
@@ -431,9 +434,6 @@ def ensure_venv(pex):
 
             pex_path = os.path.abspath(pex.path())
 
-            short_venv_dir = os.path.join(pex_info.pex_root, "venvs", "short")
-            safe_mkdir(short_venv_dir)
-
             # A sha1 hash is 160 bits -> 20 bytes -> 40 hex characters. We start with 8 characters
             # (32 bits) of entropy since that is short and _very_ unlikely to collide with another
             # PEX venv on this machine. If we still collide after using the whole sha1 (for a total
@@ -442,57 +442,58 @@ def ensure_venv(pex):
             collisions = []
             for chars in range(8, len(venv_hash) + 1):
                 entropy = venv_hash[:chars]
-                short_venv_path = os.path.join(short_venv_dir, entropy)
-                try:
-                    os.symlink(venv_dir, short_venv_path)
-                    break
-                except OSError as e:
-                    if e.errno != errno.EEXIST:
-                        raise e
-                    collisions.append(short_venv_path)
-                    if entropy == venv_hash:
-                        raise RuntimeError(
-                            "The venv for {pex} at {venv} has hash collisions with {count} other "
-                            "{venvs}!\n{collisions}".format(
+                short_venv_dir = os.path.join(pex_info.pex_root, "venvs", "s", entropy)
+                with atomic_directory(short_venv_dir, exclusive=True) as short_venv:
+                    if short_venv.is_finalized:
+                        collisions.append(short_venv_dir)
+                        if entropy == venv_hash:
+                            raise RuntimeError(
+                                "The venv for {pex} at {venv} has hash collisions with {count} "
+                                "other {venvs}!\n{collisions}".format(
+                                    pex=pex_path,
+                                    venv=venv_dir,
+                                    count=len(collisions),
+                                    venvs=pluralize(collisions, "venv"),
+                                    collisions="\n".join(
+                                        "{index}.) {venv_path}".format(
+                                            index=index, venv_path=os.path.realpath(path)
+                                        )
+                                        for index, path in enumerate(collisions, start=1)
+                                    ),
+                                )
+                            )
+                        continue
+
+                    os.symlink(venv_dir, os.path.join(short_venv.work_dir, "venv"))
+                    shebang = populate_venv_with_pex(
+                        virtualenv,
+                        pex,
+                        bin_path=pex_info.venv_bin_path,
+                        python=os.path.join(
+                            short_venv_dir, "venv", "bin", os.path.basename(pex.interpreter.binary)
+                        ),
+                        collisions_ok=collisions_ok,
+                    )
+
+                    # There are popular Linux distributions with shebang length limits
+                    # (BINPRM_BUF_SIZE in /usr/include/linux/binfmts.h) set at 128 characters, so
+                    # we warn in the _very_ unlikely case that our shortened shebang is longer than
+                    # this.
+                    if len(shebang) > 128:
+                        pex_warnings.warn(
+                            "The venv for {pex} at {venv} has script shebangs of {shebang!r} with "
+                            "{count} characters. On some systems this may be too long and cause "
+                            "problems running the venv scripts. You may be able adjust PEX_ROOT "
+                            "from {pex_root} to a shorter path as a work-around.".format(
                                 pex=pex_path,
                                 venv=venv_dir,
-                                count=len(collisions),
-                                venvs=pluralize(collisions, "venv"),
-                                collisions="\n".join(
-                                    "{index}.) {venv_path}".format(
-                                        index=index, venv_path=os.path.realpath(path)
-                                    )
-                                    for index, path in enumerate(collisions, start=1)
-                                ),
+                                shebang=shebang,
+                                count=len(shebang),
+                                pex_root=pex_info.pex_root,
                             )
                         )
 
-            shenbang = populate_venv_with_pex(
-                virtualenv,
-                pex,
-                bin_path=pex_info.venv_bin_path,
-                python=os.path.join(
-                    short_venv_path, "bin", os.path.basename(pex.interpreter.binary)
-                ),
-                collisions_ok=True,
-            )
-
-            # There are popular Linux distributions with shebang length limits (BINPRM_BUF_SIZE
-            # in /usr/include/linux/binfmts.h) set at 128 characters, so we warn in the _very_
-            # unlikely case that our shortened shebang is longer than this.
-            if len(shenbang) > 128:
-                pex_warnings.warn(
-                    "The venv for {pex} at {venv} has script shebangs of {shebang!r} with {count} "
-                    "characters. On some systems this may be too long and cause problems running "
-                    "the venv scripts. You may be able adjust PEX_ROOT from {pex_root} to a "
-                    "shorter path as a work-around.".format(
-                        pex=pex_path,
-                        venv=venv_dir,
-                        shebang=shenbang,
-                        count=len(shenbang),
-                        pex_root=pex_info.pex_root,
-                    )
-                )
+                    break
 
     return os.path.join(venv_dir, "pex")
 

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -39,7 +39,7 @@ def _copytree(
     # type: (...) -> Iterator[Tuple[str, str]]
     safe_mkdir(dst)
     link = True
-    for root, dirs, files in os.walk(src, topdown=True, followlinks=False):
+    for root, dirs, files in os.walk(src, topdown=True, followlinks=True):
         if src == root:
             dirs[:] = [d for d in dirs if d not in exclude]
             files[:] = [f for f in files if f not in exclude]

--- a/tests/integration/test_pex_bootstrapper.py
+++ b/tests/integration/test_pex_bootstrapper.py
@@ -1,0 +1,79 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+import re
+
+import pytest
+
+from pex.pex import PEX
+from pex.pex_bootstrapper import ensure_venv
+from pex.pex_info import PexInfo
+from pex.testing import run_pex_command
+from pex.tools.commands.venv import CollisionError
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_ensure_venv(
+    pex_src,  # type: str
+    pex_bdist,  # type: str
+    tmpdir,  # type: Any
+):
+    # type: (...) -> None
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    collisions_pex = os.path.join(str(tmpdir), "collisions.pex")
+    run_pex_command(
+        args=[
+            pex_bdist,
+            "-D",
+            pex_src,
+            "-o",
+            collisions_pex,
+            "--runtime-pex-root",
+            pex_root,
+            "--venv",
+        ]
+    ).assert_success()
+
+    with pytest.raises(CollisionError):
+        ensure_venv(PEX(collisions_pex), collisions_ok=False)
+
+    # The directory structure for successfully executed --venv PEXes is:
+    #
+    # PEX_ROOT/
+    #   venvs/
+    #     s/  # shortcuts dir
+    #       <short hash>/
+    #         venv -> <real venv parent dir (see below)>
+    #     <full hash1>/
+    #       <full hash2>/
+    #         <real venv>
+    #
+    # AtomicDirectory locks are used to create both branches of the venvs/ tree; so if there is a
+    # failure creating a venv we expect just:
+    #
+    # PEX_ROOT/
+    #   venvs/
+    #     s/
+    #       .<short hash>.atomic_directory.lck
+    #     <full hash1>/
+    #       .<full hash2>.atomic_directory.lck
+
+    expected_venv_dir = PexInfo.from_pex(collisions_pex).venv_dir(collisions_pex)
+    assert expected_venv_dir is not None
+
+    full_hash1_dir = os.path.basename(os.path.dirname(expected_venv_dir))
+    full_hash2_dir = os.path.basename(expected_venv_dir)
+
+    venvs_dir = os.path.join(pex_root, "venvs")
+    assert {"s", full_hash1_dir} == set(os.listdir(venvs_dir))
+    short_listing = os.listdir(os.path.join(venvs_dir, "s"))
+    assert 1 == len(short_listing)
+    assert re.match(r"^\.[0-9a-f]+\.atomic_directory.lck", short_listing[0])
+    assert [".{full_hash2}.atomic_directory.lck".format(full_hash2=full_hash2_dir)] == os.listdir(
+        os.path.join(venvs_dir, full_hash1_dir)
+    )


### PR DESCRIPTION
Previously this was non-atomic which would lead to artificial short link
creation collisions for venvs that consistently failed to populate.

Fixes #1504