### PR TITLE
Fix more-itertools breaking 2.7 & 3.5.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,9 @@ commands =
     # Ensure pex's main entrypoint can be run externally.
     pex --disable-cache . -e pex.bin.pex:main --version
 deps =
+    # The more-itertools project is an indirect requirement of pytest and its broken for
+    # Python < 3.6 in newer releases so we force low here.
+    more-itertools<=8.10.0
     pytest==4.6.11
     pkginfo==1.7.0
     py{27,py,py2}: mock==3.0.5


### PR DESCRIPTION
The 8.11.0 release today uses f-strings and old pytest floats on this
dep.