### PR TITLE
pex builder dup dist resilience

### DIFF
--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -454,9 +454,7 @@ class PEXBuilder(object):
         dist_name = dist_name or os.path.basename(dist.location)
         self._distributions[dist.location] = dist
         if dist_name in self._pex_info.distributions:
-            TRACER.log(
-                "Skipping adding {} - already added from requirements pex".format(dist), V=9
-            )
+            TRACER.log("Skipping adding {} - already added from requirements pex".format(dist), V=9)
             return
         if os.path.isdir(dist.location):
             dist_hash = self._add_dist_dir(dist.location, dist_name)

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -453,7 +453,11 @@ class PEXBuilder(object):
         self._ensure_unfrozen("Adding a distribution")
         dist_name = dist_name or os.path.basename(dist.location)
         self._distributions[dist.location] = dist
-
+        if dist_name in self._pex_info.distributions:
+            TRACER.log(
+                "Skipping adding {} - already added from requirements pex".format(dist), V=9
+            )
+            return
         if os.path.isdir(dist.location):
             dist_hash = self._add_dist_dir(dist.location, dist_name)
         elif dist.location.endswith(".whl"):

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -280,6 +280,18 @@ def test_pex_builder_from_requirements_pex():
         verify(pb4)
 
 
+def test_pex_builder_dup_requirements():
+    """We may get the same dist from separate sources."""
+    with temporary_dir() as td2:
+        with temporary_dir() as td1, make_bdist("p1") as p1:
+            pb1 = write_pex(td1, dists=[p1])
+            pb2 = PEXBuilder(copy_mode=CopyMode.SYMLINK, path=td2)
+            # Add the same dist with two different methods.
+            pb2.add_from_requirements_pex(pb1.path())
+            pb2.add_distribution(p1)
+            # All is well when we get this far.
+
+
 def test_pex_builder_script_from_pex_path(tmpdir):
     # type: (Any) -> None
 


### PR DESCRIPTION
Avoid a `FileExists` error when using symlink copy mode, in case a dist is present in a pex loaded using the `--requirements-pex` option is loaded again from other sources.

closes pantsbuild/pants#13587.
