### PR TITLE
Improve space efficiency of `--venv` mode.

### DIFF
--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import
 
 import os
+import re
 import sys
 from abc import ABCMeta
 from io import BytesIO
@@ -153,3 +154,16 @@ MODE_READ_UNIVERSAL_NEWLINES = "rU" if PY2 else "r"
 def get_stdout_bytes_buffer():
     # type: () -> BytesIO
     return cast(BytesIO, getattr(sys.stdout, "buffer", sys.stdout))
+
+
+if PY3:
+    is_valid_python_identifier = str.isidentifier
+else:
+
+    def is_valid_python_identifier(text):
+        # type: (str) -> bool
+
+        # N.B.: Python 2.7 only supports ASCII characters so the check is easy and this is probably
+        # why it's nt in the stdlib.
+        # See: https://docs.python.org/2.7/reference/lexical_analysis.html#identifiers
+        return re.match(r"^[_a-zA-Z][_a-zA-Z0-9]*$", text) is not None

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -473,6 +473,7 @@ def ensure_venv(
                             short_venv_dir, "venv", "bin", os.path.basename(pex.interpreter.binary)
                         ),
                         collisions_ok=collisions_ok,
+                        symlink=True,
                     )
 
                     # There are popular Linux distributions with shebang length limits

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -1,21 +1,24 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import errno
+import itertools
 import logging
 import os
 import shutil
 from argparse import ArgumentParser
-from collections import defaultdict
+from collections import Counter, defaultdict
 from textwrap import dedent
 
 from pex import pex_warnings
 from pex.commands.command import Error, Ok, Result
 from pex.common import chmod_plus_x, pluralize, safe_delete, safe_mkdir, safe_rmtree
+from pex.compatibility import is_valid_python_identifier
 from pex.enum import Enum
 from pex.environment import PEXEnvironment
+from pex.orderedset import OrderedSet
 from pex.pex import PEX
 from pex.tools.command import PEXCommand
 from pex.tools.commands.virtualenv import PipUnavailableError, Virtualenv
@@ -24,9 +27,20 @@ from pex.typing import TYPE_CHECKING
 from pex.venv_bin_path import BinPath
 
 if TYPE_CHECKING:
+    import typing
     from typing import Iterable, Iterator, Optional, Tuple
 
 logger = logging.getLogger(__name__)
+
+
+def _relative_symlink(
+    src,  # type: str
+    dst,  # type: str
+):
+    # type: (...) -> None
+    dst_parent = os.path.dirname(dst)
+    rel_src = os.path.relpath(src, dst_parent)
+    os.symlink(rel_src, dst)
 
 
 # N.B.: We can't use shutil.copytree since we copy from multiple source locations to the same site
@@ -36,6 +50,7 @@ def _copytree(
     src,  # type: str
     dst,  # type: str
     exclude=(),  # type: Tuple[str, ...]
+    symlink=False,  # type: bool
 ):
     # type: (...) -> Iterator[Tuple[str, str]]
     safe_mkdir(dst)
@@ -45,33 +60,37 @@ def _copytree(
             dirs[:] = [d for d in dirs if d not in exclude]
             files[:] = [f for f in files if f not in exclude]
 
-        for d in dirs:
+        for path, is_dir in itertools.chain(
+            zip(dirs, itertools.repeat(True)), zip(files, itertools.repeat(False))
+        ):
+            src_entry = os.path.join(root, path)
+            dst_entry = os.path.join(dst, os.path.relpath(src_entry, src))
+            yield src_entry, dst_entry
             try:
-                os.mkdir(os.path.join(dst, os.path.relpath(os.path.join(root, d), src)))
+                if symlink:
+                    _relative_symlink(src_entry, dst_entry)
+                elif is_dir:
+                    os.mkdir(dst_entry)
+                else:
+                    # We only try to link regular files since linking a symlink on Linux can produce
+                    # another symlink, which leaves open the possibility the src_entry target could
+                    # later go missing leaving the dst_entry dangling.
+                    if link and not os.path.islink(src_entry):
+                        try:
+                            os.link(src_entry, dst_entry)
+                            continue
+                        except OSError as e:
+                            if e.errno != errno.EXDEV:
+                                raise e
+                            link = False
+                    shutil.copy(src_entry, dst_entry)
             except OSError as e:
                 if e.errno != errno.EEXIST:
                     raise e
 
-        for f in files:
-            src_entry = os.path.join(root, f)
-            dst_entry = os.path.join(dst, os.path.relpath(src_entry, src))
-            yield src_entry, dst_entry
-            try:
-                # We only try to link regular files since linking a symlink on Linux can produce
-                # another symlink, which leaves open the possibility the src_entry target could
-                # later go missing leaving the dst_entry dangling.
-                if link and not os.path.islink(src_entry):
-                    try:
-                        os.link(src_entry, dst_entry)
-                        continue
-                    except OSError as e:
-                        if e.errno != errno.EXDEV:
-                            raise e
-                        link = False
-                shutil.copy(src_entry, dst_entry)
-            except OSError as e:
-                if e.errno != errno.EEXIST:
-                    raise e
+        if symlink:
+            # Once we've symlinked the top-level directories and files, we've "copied" everything.
+            return
 
 
 class CollisionError(Exception):
@@ -84,6 +103,7 @@ def populate_venv_with_pex(
     bin_path=BinPath.FALSE,  # type: BinPath.Value
     python=None,  # type: Optional[str]
     collisions_ok=True,  # type: bool
+    symlink=False,  # type: bool
 ):
     # type: (...) -> str
 
@@ -99,25 +119,83 @@ def populate_venv_with_pex(
         for src, dst in src_to_dst:
             provenance[dst].append(src)
 
+    # Since the pex.path() is ~always outside our control (outside ~/.pex), we copy all PEX user
+    # sources into the venv.
     pex_info = pex.pex_info()
     record_provenance(
         _copytree(
             src=PEXEnvironment.mount(pex.path()).path,
             dst=venv.site_packages_dir,
             exclude=(pex_info.internal_cache, pex_info.bootstrap, "__main__.py", pex_info.PATH),
+            symlink=False,
         )
     )
 
     with open(os.path.join(venv.venv_dir, pex_info.PATH), "w") as fp:
         fp.write(pex_info.dump())
 
+    # Since the pex distributions are all materialized to ~/.pex/installed_wheels, which we control,
+    # we can optionally symlink to take advantage of sharing generated *.pyc files for auto-venvs
+    # created in ~/.pex/venvs.
+    top_level_packages = Counter()  # type: typing.Counter[str]
+    rel_extra_paths = OrderedSet()  # type: OrderedSet[str]
     for dist in pex.resolve():
+        # In the symlink case, in order to share all generated *.pyc files for a given distribution,
+        # we need to be able to have each contribution to a namespace package get its own top-level
+        # symlink. This requires adjoining extra sys.path entries beyond site-packages. We create
+        # the minimal number of extra such paths to satisfy all namespace package contributing dists
+        # for a given namespace package using a .pth file (See:
+        # https://docs.python.org/3/library/site.html).
+        #
+        # For example, given a PEX that depends on 3 different distributions contributing to the foo
+        # namespace package, we generate a layout like:
+        #   site-packages/
+        #     foo -> ../../../../../../installed_wheels/<hash>/foo-1.0-py3-none-any.why/foo
+        #     foo-1.0.dist-info -> ../../../../../../installed_wheels/<hash>/foo1/foo-1.0.dist-info
+        #     pex-ns-pkgs/
+        #       1/
+        #           foo -> ../../../../../../../../installed_wheels/<hash>/foo2-3.0-py3-none-any.whl/foo
+        #           foo2-3.0.dist-info -> ../../../../../../../../installed_wheels/<hash>/foo2-3.0-py3-none-any.whl/foo2-3.0.dist-info
+        #       2/
+        #           foo -> ../../../../../../../../installed_wheels/<hash>/foo3-2.5-py3-none-any.whl/foo
+        #           foo3-2.5.dist-info -> ../../../../../../../../installed_wheels/<hash>/foo3-2.5-py3-none-any.whl/foo2-2.5.dist-info
+        #     pex-ns-pkgs.pth
+        #
+        # Here site-packages/pex-ns-pkgs.pth contains:
+        #   pex-ns-pkgs/1
+        #   pex-ns-pkgs/2
+        #
+        # Although we don't need to do this for the link/copy case since directories (and
+        # subdirectories) then naturally merge, we do so anyhow to keep the code simpler and
+        # arguably provide a more transparently debuggable venv.
+        packages = [
+            name
+            for name in os.listdir(dist.location)
+            if name not in ("bin", "__pycache__")
+            and is_valid_python_identifier(name)
+            and os.path.isdir(os.path.join(dist.location, name))
+        ]
+        count = max(top_level_packages[package] for package in packages) if packages else 0
+        if count > 0:
+            rel_extra_path = os.path.join("pex-ns-pkgs", str(count))
+            dst = os.path.join(venv.site_packages_dir, rel_extra_path)
+            rel_extra_paths.add(rel_extra_path)
+        else:
+            dst = venv.site_packages_dir
+        top_level_packages.update(packages)
+
+        # N.B.: We do not include the top_level __pycache__ for a dist since there may be multiple
+        # dists with top-level modules. In that case, one dists top-level __pycache__ would be
+        # symlinked and all dists with top-level modules would have the .pyc files for those modules
+        # be mixed in. For sanity sake, and since ~no dist provides more than just 1 top-level
+        # module, we keep .pyc anchored to their associated dists when shared and accept the cost
+        # of re-compiling top-level modules in each venv that uses them.
         record_provenance(
-            _copytree(src=dist.location, dst=venv.site_packages_dir, exclude=("bin",))
+            _copytree(src=dist.location, dst=dst, exclude=("bin", "__pycache__"), symlink=symlink)
         )
         dist_bin_dir = os.path.join(dist.location, "bin")
         if os.path.isdir(dist_bin_dir):
-            record_provenance(_copytree(dist_bin_dir, venv.bin_dir))
+            record_provenance(_copytree(src=dist_bin_dir, dst=venv.bin_dir, symlink=symlink))
 
     collisions = {dst: srcs for dst, srcs in provenance.items() if len(srcs) > 1}
     if collisions:
@@ -136,6 +214,11 @@ def populate_venv_with_pex(
         if not collisions_ok:
             raise CollisionError(message)
         pex_warnings.warn(message)
+
+    if rel_extra_paths:
+        with open(os.path.join(venv.site_packages_dir, "pex-ns-pkgs.pth"), "w") as fp:
+            for rel_extra_path in rel_extra_paths:
+                print(rel_extra_path, file=fp)
 
     # 2. Add a __main__ to the root of the venv for running the venv dir like a loose PEX dir
     # and a main.py for running as a script.
@@ -442,6 +525,7 @@ class Venv(PEXCommand):
             pex,
             bin_path=self.options.bin_path,
             collisions_ok=self.options.collisions_ok,
+            symlink=False,
         )
         if self.options.pip:
             try:

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import, print_function
 
 import errno
-import glob
 import itertools
 import logging
 import os
@@ -15,7 +14,7 @@ from textwrap import dedent
 
 from pex import pex_warnings
 from pex.commands.command import Error, Ok, Result
-from pex.common import chmod_plus_x, pluralize, safe_copy, safe_delete, safe_mkdir, safe_rmtree
+from pex.common import chmod_plus_x, pluralize, safe_delete, safe_mkdir, safe_rmtree
 from pex.compatibility import is_valid_python_identifier
 from pex.enum import Enum
 from pex.environment import PEXEnvironment

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -60,21 +60,3 @@ def pex_bdist(
     wheels = os.listdir(wheels_dir)
     assert 1 == len(wheels)
     return os.path.join(wheels_dir, wheels[0])
-
-
-@pytest.fixture(scope="session")
-def pex_src(
-    pex_project_dir,  # type: str
-    shared_integration_test_tmpdir,  # type: str
-):
-    # type: (...) -> str
-    src = os.path.join(shared_integration_test_tmpdir, "pex_src")
-    for root, dirs, files in os.walk(os.path.join(pex_project_dir, "pex")):
-        root_relpath = os.path.relpath(root, pex_project_dir)
-        dirs[:] = [d for d in dirs if d != "__pycache__"]
-        for d in dirs:
-            safe_mkdir(os.path.join(src, root_relpath, d))
-        for f in files:
-            if not f.endswith(".pyc"):
-                shutil.copy(os.path.join(root, f), os.path.join(src, root_relpath, f))
-    return src

--- a/tests/integration/test_pex_bootstrapper.py
+++ b/tests/integration/test_pex_bootstrapper.py
@@ -3,34 +3,68 @@
 
 import os.path
 import re
+import subprocess
+from textwrap import dedent
 
 import pytest
 
+from pex.common import safe_open
 from pex.pex import PEX
 from pex.pex_bootstrapper import ensure_venv
 from pex.pex_info import PexInfo
-from pex.testing import run_pex_command
+from pex.testing import make_env, run_pex_command
 from pex.tools.commands.venv import CollisionError
+from pex.tools.commands.virtualenv import Virtualenv
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any
 
 
-def test_ensure_venv(
-    pex_src,  # type: str
+def test_ensure_venv_short_link(
     pex_bdist,  # type: str
     tmpdir,  # type: Any
 ):
     # type: (...) -> None
 
     pex_root = os.path.join(str(tmpdir), "pex_root")
+
+    collision_src = os.path.join(str(tmpdir), "src")
+    with safe_open(os.path.join(collision_src, "will_not_collide_module.py"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                def verb():
+                  return 42
+                """
+            )
+        )
+    with safe_open(os.path.join(collision_src, "setup.cfg"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                [metadata]
+                name = collision
+                version = 0.0.1
+
+                [options]
+                py_modules =
+                    will_not_collide_module
+                
+                [options.entry_points]
+                console_scripts =
+                    pex = will_not_collide_module:verb
+                """
+            )
+        )
+    with safe_open(os.path.join(collision_src, "setup.py"), "w") as fp:
+        fp.write("from setuptools import setup; setup()")
+
     collisions_pex = os.path.join(str(tmpdir), "collisions.pex")
     run_pex_command(
         args=[
             pex_bdist,
-            "-D",
-            pex_src,
+            collision_src,
             "-o",
             collisions_pex,
             "--runtime-pex-root",
@@ -77,3 +111,103 @@ def test_ensure_venv(
     assert [".{full_hash2}.atomic_directory.lck".format(full_hash2=full_hash2_dir)] == os.listdir(
         os.path.join(venvs_dir, full_hash1_dir)
     )
+
+    venv_pex = ensure_venv(PEX(collisions_pex), collisions_ok=True)
+    # We happen to know built distributions are always ordered before downloaded wheels in PEXes
+    # as a detail of how `pex/resolver.py` works.
+    assert 42 == subprocess.Popen(args=[venv_pex], env=make_env(PEX_SCRIPT="pex")).wait()
+
+
+def test_ensure_venv_namespace_packages(tmpdir):
+    # type: (Any) -> None
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    nspkgs_pex = os.path.join(str(tmpdir), "ns-pkgs.pex")
+
+    # We know the twitter.common.metrics distributions depends on 4 other distributions contributing
+    # to the twitter.common namespace package:
+    # + twitter.common.exceptions
+    # + twitter.common.decorators
+    # + twitter.common.lang
+    # + twitter.common.quantity
+    run_pex_command(
+        args=[
+            "twitter.common.metrics==0.3.11",
+            "-o",
+            nspkgs_pex,
+            "--runtime-pex-root",
+            pex_root,
+            "--venv",
+        ]
+    ).assert_success()
+    nspkgs_venv_pex = ensure_venv(PEX(nspkgs_pex), collisions_ok=False)
+
+    pex_info = PexInfo.from_pex(nspkgs_pex)
+    venv_dir = pex_info.venv_dir(nspkgs_pex)
+    assert venv_dir is not None
+    venv = Virtualenv(venv_dir=venv_dir)
+
+    pex_ns_pkgs_pth = os.path.join(venv.site_packages_dir, "pex-ns-pkgs.pth")
+    assert os.path.isfile(pex_ns_pkgs_pth)
+    with open(pex_ns_pkgs_pth) as fp:
+        assert (
+            dedent(
+                """\
+                pex-ns-pkgs/1
+                pex-ns-pkgs/2
+                pex-ns-pkgs/3
+                pex-ns-pkgs/4
+                """
+            )
+            == fp.read()
+        )
+
+    expected_path_entries = [
+        os.path.join(venv.site_packages_dir, d)
+        for d in ("", "pex-ns-pkgs/1", "pex-ns-pkgs/2", "pex-ns-pkgs/3", "pex-ns-pkgs/4")
+    ]
+    for d in expected_path_entries:
+        assert os.path.islink(os.path.join(venv.site_packages_dir, d, "twitter"))
+        assert os.path.isdir(os.path.join(venv.site_packages_dir, d, "twitter", "common"))
+
+    package_file_paths = set(
+        subprocess.check_output(
+            args=[
+                nspkgs_venv_pex,
+                "-c",
+                dedent(
+                    """\
+                    from __future__ import print_function
+                    import os
+
+                    from twitter.common import decorators, exceptions, lang, metrics, quantity
+    
+                    
+                    for pkg in decorators, exceptions, lang, metrics, quantity:
+                        print(os.path.realpath(pkg.__file__))
+                    """
+                ),
+            ]
+        )
+        .decode("utf-8")
+        .splitlines()
+    )
+    assert 5 == len(package_file_paths), "Expected 5 unique __init__.pyc files"
+
+    # We expect package paths like:
+    #   .../twitter.common.foo-0.3.11.*.whl/twitter/common/foo/__init__.pyc
+    package_file_installed_wheel_dirs = {
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(p))))
+        for p in package_file_paths
+    }
+    assert os.path.realpath(pex_info.install_cache) == os.path.realpath(
+        os.path.commonprefix(list(package_file_installed_wheel_dirs))
+    ), "Expected contributing wheel content to be symlinked from the installed wheel cache."
+    assert {
+        "twitter.common.{package}-0.3.11-py{py_major}-none-any.whl".format(
+            package=p, py_major=venv.interpreter.version[0]
+        )
+        for p in ("decorators", "exceptions", "lang", "metrics", "quantity")
+    } == {
+        os.path.basename(d) for d in package_file_installed_wheel_dirs
+    }, "Expected 5 unique contributing wheels."

--- a/tests/integration/test_pex_bootstrapper.py
+++ b/tests/integration/test_pex_bootstrapper.py
@@ -150,17 +150,7 @@ def test_ensure_venv_namespace_packages(tmpdir):
     pex_ns_pkgs_pth = os.path.join(venv.site_packages_dir, "pex-ns-pkgs.pth")
     assert os.path.isfile(pex_ns_pkgs_pth)
     with open(pex_ns_pkgs_pth) as fp:
-        assert (
-            dedent(
-                """\
-                pex-ns-pkgs/1
-                pex-ns-pkgs/2
-                pex-ns-pkgs/3
-                pex-ns-pkgs/4
-                """
-            )
-            == fp.read()
-        )
+        assert 4 == len(fp.readlines())
 
     expected_path_entries = [
         os.path.join(venv.site_packages_dir, d)


### PR DESCRIPTION
Previously `--venv` mode auto-venvs were constructed just like PEX_TOOLS
venvs - using hard links (or copies if needed). Although this is
required for robust PEX_TOOLS venvs that don't collapse when you delete
the PEX_ROOT, it is not required for `--venv` mode auto-venvs which are
themselves stored in the PEX_ROOT. Now we symlink all `--venv` mode
auto-venv 3rdparty distributions to save a minor amount of space over
hard linking individual `.py` files, but a significant amount of space
in the shared `.pyc` files generated when the venv is later executed in
the case where many venvs share 3rdparty distribution dependencies and
interpreter major/minor versions.