### PR TITLE
Do not re-hash installed wheels.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -597,7 +597,9 @@ def build_pex(
                     )
 
             for installed_dist in result.installed_distributions:
-                pex_builder.add_distribution(installed_dist.distribution)
+                pex_builder.add_distribution(
+                    installed_dist.distribution, fingerprint=installed_dist.fingerprint
+                )
                 if installed_dist.direct_requirement:
                     pex_builder.add_requirement(installed_dist.direct_requirement)
         except Unsatisfiable as e:


### PR DESCRIPTION
Previously, installed wheels were re-hashed when adding them to a PEX.
This was wasted time and effort that showed up particularly strongly
when building a large PEX that used a fast --pex-repository resolve.

Fixes #1533