### PR TITLE
Add knob for `--venv` site-packages symlinking.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -184,7 +184,21 @@ def configure_clp_pex_options(parser):
         action=HandleBoolAction,
         help=(
             "If --venv is specified, create the venv using copies of base interpreter files "
-            "instead of symlinks."
+            "instead of symlinks. This allows --venv mode PEXes to work across interpreter "
+            "upgrades without being forced to remove the PEX_ROOT to allow the venv to re-build "
+            "using the upgraded interpreter."
+        ),
+    )
+    group.add_argument(
+        "--venv-site-packages-copies",
+        "--no-venv-site-packages-copies",
+        dest="venv_site_packages_copies",
+        default=False,
+        action=HandleBoolAction,
+        help=(
+            "If --venv is specified, populate the venv site packages using hard links or copies of "
+            "resolved PEX dependencies instead of symlinks. This can be used to work around "
+            "problems with tools or libraries that are confused by symlinked source files."
         ),
     )
 
@@ -529,6 +543,7 @@ def build_pex(
     pex_info.venv = bool(options.venv)
     pex_info.venv_bin_path = options.venv or BinPath.FALSE
     pex_info.venv_copies = options.venv_copies
+    pex_info.venv_site_packages_copies = options.venv_site_packages_copies
     pex_info.includes_tools = options.include_tools or options.venv
     pex_info.pex_path = options.pex_path
     pex_info.ignore_errors = options.ignore_errors

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -473,7 +473,7 @@ def ensure_venv(
                             short_venv_dir, "venv", "bin", os.path.basename(pex.interpreter.binary)
                         ),
                         collisions_ok=collisions_ok,
-                        symlink=True,
+                        symlink=not pex_info.venv_site_packages_copies,
                     )
 
                     # There are popular Linux distributions with shebang length limits

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -200,6 +200,16 @@ class PexInfo(object):
         # type: (bool) -> None
         self._pex_info["venv_copies"] = value
 
+    @property
+    def venv_site_packages_copies(self):
+        # type: () -> bool
+        return self._pex_info.get("venv_site_packages_copies", False)
+
+    @venv_site_packages_copies.setter
+    def venv_site_packages_copies(self, value):
+        # type: (bool) -> None
+        self._pex_info["venv_site_packages_copies"] = value
+
     def venv_dir(
         self,
         pex_file,  # type: str


### PR DESCRIPTION
Previously, `--venv` mode PEXes always used symlinks for site-packages
dependencies; now there is a `--venv-site-packages-copies` option to
allow the choice of hard links / copies when symlinks are not understood
by projects installed in site-packages.

Fixes #1542