### PR TITLE
Work around setuptools 60 release in test.

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1566,6 +1566,7 @@ def test_requirement_file_from_url(tmpdir):
     with open(constraints, "w") as fp:
         print("translate>=3.2.1,<3.6.0", file=fp)
         print("protobuf<=3.17.3", file=fp)
+        print("setuptools<60", file=fp)
 
     pex_file = os.path.join(str(tmpdir), "pex")
 


### PR DESCRIPTION
The release added a warning that trips up a test. Pin low to avoid this
since setuptools version is incidental to the test.

See: https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6000