### PR TITLE
Fix Pex to be duplicate requirement agnostic.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -615,8 +615,8 @@ def build_pex(
                 pex_builder.add_distribution(
                     installed_dist.distribution, fingerprint=installed_dist.fingerprint
                 )
-                if installed_dist.direct_requirement:
-                    pex_builder.add_requirement(installed_dist.direct_requirement)
+                for direct_req in installed_dist.direct_requirements:
+                    pex_builder.add_requirement(direct_req)
         except Unsatisfiable as e:
             die(str(e))
 

--- a/tests/integration/test_issue_1550.py
+++ b/tests/integration/test_issue_1550.py
@@ -1,0 +1,39 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import json
+import os.path
+import subprocess
+
+from pex import dist_metadata
+from pex.dist_metadata import ProjectNameAndVersion
+from pex.orderedset import OrderedSet
+from pex.pex_info import PexInfo
+from pex.testing import make_env, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_duplicate_requirements_issues_1550(tmpdir):
+    # type: (Any) -> None
+
+    pex_file = os.path.join(str(tmpdir), "pex")
+    run_pex_command(
+        args=[
+            "PyJWT",
+            "PyJWT==1.7.1",
+            "--resolver-version",
+            "pip-2020-resolver",
+            "-o",
+            pex_file,
+        ]
+    ).assert_success()
+
+    subprocess.check_call(args=[pex_file, "-c", "import jwt"])
+    pex_info = PexInfo.from_pex(pex_file)
+    assert 1 == len(pex_info.distributions)
+    assert ProjectNameAndVersion("PyJWT", "1.7.1") == dist_metadata.project_name_and_version(
+        next(iter(pex_info.distributions.keys()))
+    )
+    assert OrderedSet(("PyJWT", "PyJWT==1.7.1")) == pex_info.requirements

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -140,8 +140,8 @@ def assert_force_local_implicit_ns_packages_issues_598(
             requirements, cache=cache, interpreters=[builder.interpreter]
         ).installed_distributions:
             builder.add_distribution(installed_dist.distribution)
-            if installed_dist.direct_requirement:
-                builder.add_requirement(installed_dist.direct_requirement)
+            for direct_req in installed_dist.direct_requirements:
+                builder.add_requirement(direct_req)
 
     def add_wheel(builder, content):
         # type: (PEXBuilder, Dict[str, str]) -> None
@@ -314,8 +314,8 @@ def test_activate_extras_issue_615():
         for installed_dist in resolver.resolve(
             ["pex[requests]==1.6.3"], interpreters=[pb.interpreter]
         ).installed_distributions:
-            if installed_dist.direct_requirement:
-                pb.add_requirement(installed_dist.direct_requirement)
+            for direct_req in installed_dist.direct_requirements:
+                pb.add_requirement(direct_req)
             pb.add_dist_location(installed_dist.distribution.location)
         pb.set_script("pex")
         pb.freeze()


### PR DESCRIPTION
The only place Pex cares about this is at runtime when ranking
requirements to pick distributions to add to the `sys.path`. Since Pip
will have already resolved one unique distribution per requirement
family per relevant marker environment, we will be safe just picking the
highest ranked distribution.

Fixes #1550