### PR TITLE
Allow using `pex3` CLI with the PEX from GitHub Releases

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -653,6 +653,12 @@ def _compatible_with_current_platform(interpreter, platforms):
 
 
 def main(args=None):
+    if "PEX3_CLI" in os.environ:
+        import pex.cli.pex
+
+        pex.cli.pex.main()
+        return
+
     args = args[:] if args else sys.argv[1:]
     args = [transform_legacy_arg(arg) for arg in args]
     parser = configure_clp()


### PR DESCRIPTION
For Pants lockfile generation, we need to be able to run the `pex3` console script. To do that, users simply set `PEX3_CLI`.

## Alternatives considered

Releasing a `pex3` binary. It would be inefficient to download both `pex` and `pex3`.