### PR TITLE
Introduce iter_compatible_versions.

### DIFF
--- a/pex/interpreter_constraints.py
+++ b/pex/interpreter_constraints.py
@@ -157,6 +157,15 @@ class Lifecycle(Enum):
     EOL = Value("eol")
 
 
+# This value is based off of:
+# 1. Past releases: https://www.python.org/downloads/ where the max patch level was achieved by
+#    2.7.18.
+# 2. The 3.9+ annual release cycle formalization: https://www.python.org/dev/peps/pep-0602/ where
+#    the last bugfix release will be at a patch level of ~10 and then 3.5 years of security fixes
+#    as needed before going to EOL at the 5-year mark.
+DEFAULT_MAX_PATCH = 30
+
+
 @attr.s(frozen=True)
 class PythonVersion(object):
     lifecycle = attr.ib()  # type: Lifecycle.Value
@@ -164,15 +173,14 @@ class PythonVersion(object):
     minor = attr.ib()  # type: int
     patch = attr.ib()  # type: int
 
-    def pad(self, padding):
-        # type: (int) -> PythonVersion
-        if self.lifecycle == Lifecycle.EOL:
-            return self
-        return attr.evolve(self, patch=self.patch + padding)
-
-    def iter_compatible_versions(self, specifier_sets):
-        # type: (Iterable[SpecifierSet]) -> Iterator[Tuple[int, int, int]]
-        for patch in range(self.patch + 1):
+    def iter_compatible_versions(
+        self,
+        specifier_sets,  # type: Iterable[SpecifierSet]
+        max_patch=DEFAULT_MAX_PATCH,  # type: int
+    ):
+        # type: (...) -> Iterator[Tuple[int, int, int]]
+        last_patch = self.patch if self.lifecycle == Lifecycle.EOL else max_patch
+        for patch in range(last_patch + 1):
             version = (self.major, self.minor, patch)
             version_string = ".".join(map(str, version))
             if not specifier_sets:
@@ -188,29 +196,27 @@ class PythonVersion(object):
 # use that emits the current max patch for these versions so we automatically stay up to date
 # mod dormancy in the project.
 
-COMPATIBLE_PYTHON_VERSIONS = tuple(
-    # Each 5 units of padding costs `iter_compatible_versions` ~2 extra ms and a padding of 10 gets
-    # us through most of a brand new stable release's likely active lifecycle.
-    version.pad(10)
-    for version in (
-        PythonVersion(Lifecycle.EOL, 2, 7, 18),
-        # N.B.: Pex does not support the missing 3.x versions here.
-        PythonVersion(Lifecycle.EOL, 3, 5, 10),
-        PythonVersion(Lifecycle.EOL, 3, 6, 15),
-        PythonVersion(Lifecycle.STABLE, 3, 7, 12),
-        PythonVersion(Lifecycle.STABLE, 3, 8, 11),
-        PythonVersion(Lifecycle.STABLE, 3, 9, 10),
-        PythonVersion(Lifecycle.STABLE, 3, 10, 2),
-        PythonVersion(Lifecycle.DEV, 3, 11, 0),
-    )
+COMPATIBLE_PYTHON_VERSIONS = (
+    PythonVersion(Lifecycle.EOL, 2, 7, 18),
+    # N.B.: Pex does not support the missing 3.x versions here.
+    PythonVersion(Lifecycle.EOL, 3, 5, 10),
+    PythonVersion(Lifecycle.EOL, 3, 6, 15),
+    PythonVersion(Lifecycle.STABLE, 3, 7, 12),
+    PythonVersion(Lifecycle.STABLE, 3, 8, 11),
+    PythonVersion(Lifecycle.STABLE, 3, 9, 10),
+    PythonVersion(Lifecycle.STABLE, 3, 10, 2),
+    PythonVersion(Lifecycle.DEV, 3, 11, 0),
 )
 
 
-def iter_compatible_versions(requires_python):
-    # type: (Iterable[str]) -> Iterator[Tuple[int, int, int]]
+def iter_compatible_versions(
+    requires_python,  # type: Iterable[str]
+    max_patch=DEFAULT_MAX_PATCH,  # type: int
+):
+    # type: (...) -> Iterator[Tuple[int, int, int]]
 
     specifier_sets = OrderedSet(SpecifierSet(req) for req in requires_python)
     return itertools.chain.from_iterable(
-        python_version.iter_compatible_versions(specifier_sets)
+        python_version.iter_compatible_versions(specifier_sets, max_patch=max_patch)
         for python_version in COMPATIBLE_PYTHON_VERSIONS
     )

--- a/tests/test_interpreter_constraints.py
+++ b/tests/test_interpreter_constraints.py
@@ -1,0 +1,83 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import itertools
+import sys
+
+from pex import interpreter_constraints
+from pex.interpreter_constraints import Lifecycle, PythonVersion
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import List, Tuple
+
+
+def test_python_version_pad():
+    # type: () -> None
+
+    assert PythonVersion(Lifecycle.EOL, 1, 2, 3) == PythonVersion(Lifecycle.EOL, 1, 2, 3).pad(5)
+    assert PythonVersion(Lifecycle.STABLE, 1, 2, 8) == PythonVersion(Lifecycle.STABLE, 1, 2, 3).pad(
+        5
+    )
+    assert PythonVersion(Lifecycle.DEV, 3, 2, 6) == PythonVersion(Lifecycle.DEV, 3, 2, 1).pad(5)
+
+
+def iter_compatible_versions(*requires_python):
+    # type: (*str) -> List[Tuple[int, int, int]]
+    return list(interpreter_constraints.iter_compatible_versions(list(requires_python)))
+
+
+def test_iter_compatible_versions_none():
+    # type: () -> None
+
+    assert [] == iter_compatible_versions(">3.6,<3.6")
+    assert [] == iter_compatible_versions("<2")
+    assert [] == iter_compatible_versions(">4")
+    assert [] == iter_compatible_versions("<2", ">4")
+
+
+def test_iter_compatible_versions_basic():
+    # type: () -> None
+
+    # N.B.: 2.7.18 is EOL.
+    assert [(2, 7, patch) for patch in range(19)] == iter_compatible_versions("==2.7.*")
+    assert [(2, 7, patch) for patch in range(19)] == iter_compatible_versions("~=2.7")
+    assert [(2, 7, patch) for patch in range(1, 19)] == iter_compatible_versions("==2.7.*,!=2.7.0")
+
+
+def test_iter_compatible_versions_or():
+    # type: () -> None
+
+    # N.B.: 2.7.18 is EOL as is 3.5.10.
+    assert (
+        list(
+            itertools.chain(
+                [(2, 7, patch) for patch in range(19)],
+                [(3, 5, patch) for patch in range(1, 11)],
+            )
+        )
+        == iter_compatible_versions("==2.7.*", ">3.5,<3.6")
+    )
+
+
+def test_iter_compatible_versions_sorted():
+    # type: () -> None
+
+    # N.B.: 2.7.18 is EOL as is 3.5.10.
+    assert list(
+        itertools.chain(
+            [(2, 7, patch) for patch in range(19)],
+            [(3, 5, patch) for patch in range(1, 11)],
+        )
+    ) == iter_compatible_versions(
+        ">3.5,<3.6",
+        "==2.7.*",
+    )
+
+
+def test_iter_compatible_versions_current():
+    # type: () -> None
+
+    assert sys.version_info[:3] in set(
+        iter_compatible_versions()
+    ), "Expected every interpreter we test on to always be compatible"


### PR DESCRIPTION
This will be used to filter distributions in platform agnostic resolves
when interpreter constraints are specified.

Work towards #1402.