### PR TITLE
Add debug tox envs for vendored tools.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -158,3 +158,33 @@ deps =
 commands =
     flit publish
 
+[testenv:pip]
+description = Run Pex's vendored pip.
+skip_install = true
+setenv   =
+    __PEX_UNVENDORED__ = 1
+    PYTHONPATH = {env:PYTHONPATH:}{:}{toxinidir}/pex/vendor/_vendored/pip
+    PYTHONPATH = {env:PYTHONPATH:}{:}{toxinidir}/pex/vendor/_vendored/setuptools
+    PYTHONPATH = {env:PYTHONPATH:}{:}{toxinidir}/pex/vendor/_vendored/wheel
+    SETUPTOOLS_USE_DISTUTILS = stdlib
+commands =
+    python -s -mpip {posargs}
+
+[testenv:setuptools]
+description = Run Python with Pex's vendored setuptools on the sys.path.
+skip_install = true
+setenv   =
+  __PEX_UNVENDORED__ = 1
+  PYTHONPATH = {env:PYTHONPATH:}{:}{toxinidir}/pex/vendor/_vendored/setuptools
+  SETUPTOOLS_USE_DISTUTILS = stdlib
+commands =
+  python {posargs}
+
+[testenv:wheel]
+description = Run Pex's vendored wheel
+skip_install = true
+setenv   =
+  PYTHONPATH = {env:PYTHONPATH:}{:}{toxinidir}/pex/vendor/_vendored/wheel
+commands =
+  python -s -mwheel {posargs}
+


### PR DESCRIPTION
It's handy to be able to easily execute Pex's vendored versions of
tools when experimenting.