### PR TITLE
Update vendored Pip to 386a54f0.

### DIFF
--- a/pex/vendor/__init__.py
+++ b/pex/vendor/__init__.py
@@ -139,13 +139,20 @@ def iter_vendor_specs():
 
     # We shell out to pip at buildtime to resolve and install dependencies.
     # N.B.: We're currently using a patched version of Pip 20.3.4 housed at
-    # https://github.com/pantsbuild/pip/tree/pex/patches/generation-2. The patch works around a bug
-    # in `pip download --constraint...` tracked at https://github.com/pypa/pip/issues/9283 and fixed
-    # by https://github.com/pypa/pip/pull/9301 there and https://github.com/pantsbuild/pip/pull/8 in
-    # our fork.
+    # https://github.com/pantsbuild/pip/tree/pex/patches/generation-2.
+    # It has 2 patches:
+    # 1.) https://github.com/pantsbuild/pip/commit/06f462537c981116c763c1ba40cf40e9dd461bcf
+    #     The patch works around a bug in `pip download --constraint...` tracked at
+    #     https://github.com/pypa/pip/issues/9283 and fixed by https://github.com/pypa/pip/pull/9301
+    #     there and https://github.com/pantsbuild/pip/pull/8 in our fork.
+    # 2.) https://github.com/pantsbuild/pip/commit/386a54f097ece66775d0c7f34fd29bb596c6b0be
+    #     This is a cherry-pick of
+    #     https://github.com/pantsbuild/pip/commit/00fb5a0b224cde08e3e5ca034247baadfb646468
+    #     (https://github.com/pypa/pip/pull/9533) from upstream that upgrades Pip's vendored
+    #     packaging to 20.9 to pick up support for mac universal2 wheels.
     yield VendorSpec.git(
         repo="https://github.com/pantsbuild/pip",
-        commit="de1c91261f2b54d60fdf2a17fba756ef0decb146",
+        commit="386a54f097ece66775d0c7f34fd29bb596c6b0be",
         project_name="pip",
         rewrite=False,
     )

--- a/pex/vendor/_vendored/pip/pip/_vendor/packaging/__about__.py
+++ b/pex/vendor/_vendored/pip/pip/_vendor/packaging/__about__.py
@@ -18,7 +18,7 @@ __title__ = "packaging"
 __summary__ = "Core utilities for Python packages"
 __uri__ = "https://github.com/pypa/packaging"
 
-__version__ = "20.8"
+__version__ = "20.9"
 
 __author__ = "Donald Stufft and individual contributors"
 __email__ = "donald@stufft.io"

--- a/pex/vendor/_vendored/pip/pip/_vendor/packaging/markers.py
+++ b/pex/vendor/_vendored/pip/pip/_vendor/packaging/markers.py
@@ -8,13 +8,21 @@ import os
 import platform
 import sys
 
-from pip._vendor.pyparsing import ParseException, ParseResults, stringStart, stringEnd
-from pip._vendor.pyparsing import ZeroOrMore, Group, Forward, QuotedString
-from pip._vendor.pyparsing import Literal as L  # noqa
+from pip._vendor.pyparsing import (  # noqa: N817
+    Forward,
+    Group,
+    Literal as L,
+    ParseException,
+    ParseResults,
+    QuotedString,
+    ZeroOrMore,
+    stringEnd,
+    stringStart,
+)
 
 from ._compat import string_types
 from ._typing import TYPE_CHECKING
-from .specifiers import Specifier, InvalidSpecifier
+from .specifiers import InvalidSpecifier, Specifier
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Callable, Dict, List, Optional, Tuple, Union

--- a/pex/vendor/_vendored/pip/pip/_vendor/packaging/requirements.py
+++ b/pex/vendor/_vendored/pip/pip/_vendor/packaging/requirements.py
@@ -3,13 +3,22 @@
 # for complete details.
 from __future__ import absolute_import, division, print_function
 
-import string
 import re
+import string
 import sys
 
-from pip._vendor.pyparsing import stringStart, stringEnd, originalTextFor, ParseException
-from pip._vendor.pyparsing import ZeroOrMore, Word, Optional, Regex, Combine
-from pip._vendor.pyparsing import Literal as L  # noqa
+from pip._vendor.pyparsing import (  # noqa: N817
+    Combine,
+    Literal as L,
+    Optional,
+    ParseException,
+    Regex,
+    Word,
+    ZeroOrMore,
+    originalTextFor,
+    stringEnd,
+    stringStart,
+)
 
 from ._typing import TYPE_CHECKING
 from .markers import MARKER_EXPR, Marker

--- a/pex/vendor/_vendored/pip/pip/_vendor/packaging/specifiers.py
+++ b/pex/vendor/_vendored/pip/pip/_vendor/packaging/specifiers.py
@@ -12,10 +12,10 @@ import warnings
 from ._compat import string_types, with_metaclass
 from ._typing import TYPE_CHECKING
 from .utils import canonicalize_version
-from .version import Version, LegacyVersion, parse
+from .version import LegacyVersion, Version, parse
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import List, Dict, Union, Iterable, Iterator, Optional, Callable, Tuple
+    from typing import Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
     ParsedVersion = Union[Version, LegacyVersion]
     UnparsedVersion = Union[Version, LegacyVersion, str]

--- a/pex/vendor/_vendored/pip/pip/_vendor/packaging/tags.py
+++ b/pex/vendor/_vendored/pip/pip/_vendor/packaging/tags.py
@@ -27,9 +27,9 @@ from ._typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import (
+        IO,
         Dict,
         FrozenSet,
-        IO,
         Iterable,
         Iterator,
         List,
@@ -458,14 +458,28 @@ def mac_platforms(version=None, arch=None):
                     major=major_version, minor=0, binary_format=binary_format
                 )
 
-    if version >= (11, 0) and arch == "x86_64":
+    if version >= (11, 0):
         # Mac OS 11 on x86_64 is compatible with binaries from previous releases.
         # Arm64 support was introduced in 11.0, so no Arm binaries from previous
         # releases exist.
-        for minor_version in range(16, 3, -1):
-            compat_version = 10, minor_version
-            binary_formats = _mac_binary_formats(compat_version, arch)
-            for binary_format in binary_formats:
+        #
+        # However, the "universal2" binary format can have a
+        # macOS version earlier than 11.0 when the x86_64 part of the binary supports
+        # that version of macOS.
+        if arch == "x86_64":
+            for minor_version in range(16, 3, -1):
+                compat_version = 10, minor_version
+                binary_formats = _mac_binary_formats(compat_version, arch)
+                for binary_format in binary_formats:
+                    yield "macosx_{major}_{minor}_{binary_format}".format(
+                        major=compat_version[0],
+                        minor=compat_version[1],
+                        binary_format=binary_format,
+                    )
+        else:
+            for minor_version in range(16, 3, -1):
+                compat_version = 10, minor_version
+                binary_format = "universal2"
                 yield "macosx_{major}_{minor}_{binary_format}".format(
                     major=compat_version[0],
                     minor=compat_version[1],

--- a/pex/vendor/_vendored/pip/pip/_vendor/packaging/utils.py
+++ b/pex/vendor/_vendored/pip/pip/_vendor/packaging/utils.py
@@ -6,23 +6,41 @@ from __future__ import absolute_import, division, print_function
 import re
 
 from ._typing import TYPE_CHECKING, cast
+from .tags import Tag, parse_tag
 from .version import InvalidVersion, Version
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import NewType, Union
+    from typing import FrozenSet, NewType, Tuple, Union
 
+    BuildTag = Union[Tuple[()], Tuple[int, str]]
     NormalizedName = NewType("NormalizedName", str)
 else:
+    BuildTag = tuple
     NormalizedName = str
 
+
+class InvalidWheelFilename(ValueError):
+    """
+    An invalid wheel filename was found, users should refer to PEP 427.
+    """
+
+
+class InvalidSdistFilename(ValueError):
+    """
+    An invalid sdist filename was found, users should refer to the packaging user guide.
+    """
+
+
 _canonicalize_regex = re.compile(r"[-_.]+")
+# PEP 427: The build number must start with a digit.
+_build_tag_regex = re.compile(r"(\d+)(.*)")
 
 
 def canonicalize_name(name):
     # type: (str) -> NormalizedName
     # This is taken from PEP 503.
     value = _canonicalize_regex.sub("-", name).lower()
-    return cast("NormalizedName", value)
+    return cast(NormalizedName, value)
 
 
 def canonicalize_version(version):
@@ -65,3 +83,56 @@ def canonicalize_version(version):
         parts.append("+{0}".format(version.local))
 
     return "".join(parts)
+
+
+def parse_wheel_filename(filename):
+    # type: (str) -> Tuple[NormalizedName, Version, BuildTag, FrozenSet[Tag]]
+    if not filename.endswith(".whl"):
+        raise InvalidWheelFilename(
+            "Invalid wheel filename (extension must be '.whl'): {0}".format(filename)
+        )
+
+    filename = filename[:-4]
+    dashes = filename.count("-")
+    if dashes not in (4, 5):
+        raise InvalidWheelFilename(
+            "Invalid wheel filename (wrong number of parts): {0}".format(filename)
+        )
+
+    parts = filename.split("-", dashes - 2)
+    name_part = parts[0]
+    # See PEP 427 for the rules on escaping the project name
+    if "__" in name_part or re.match(r"^[\w\d._]*$", name_part, re.UNICODE) is None:
+        raise InvalidWheelFilename("Invalid project name: {0}".format(filename))
+    name = canonicalize_name(name_part)
+    version = Version(parts[1])
+    if dashes == 5:
+        build_part = parts[2]
+        build_match = _build_tag_regex.match(build_part)
+        if build_match is None:
+            raise InvalidWheelFilename(
+                "Invalid build number: {0} in '{1}'".format(build_part, filename)
+            )
+        build = cast(BuildTag, (int(build_match.group(1)), build_match.group(2)))
+    else:
+        build = ()
+    tags = parse_tag(parts[-1])
+    return (name, version, build, tags)
+
+
+def parse_sdist_filename(filename):
+    # type: (str) -> Tuple[NormalizedName, Version]
+    if not filename.endswith(".tar.gz"):
+        raise InvalidSdistFilename(
+            "Invalid sdist filename (extension must be '.tar.gz'): {0}".format(filename)
+        )
+
+    # We are requiring a PEP 440 version, which cannot contain dashes,
+    # so we split on the last dash.
+    name_part, sep, version_part = filename[:-7].rpartition("-")
+    if not sep:
+        raise InvalidSdistFilename("Invalid sdist filename: {0}".format(filename))
+
+    name = canonicalize_name(name_part)
+    version = Version(version_part)
+    return (name, version)

--- a/pex/vendor/_vendored/pip/pip/_vendor/vendor.txt
+++ b/pex/vendor/_vendored/pip/pip/_vendor/vendor.txt
@@ -7,7 +7,7 @@ distro==1.5.0
 html5lib==1.1
 ipaddress==1.0.23  # Only needed on 2.6 and 2.7
 msgpack==1.0.0
-packaging==20.8
+packaging==20.9
 pep517==0.9.1
 progress==1.5
 pyparsing==2.4.7


### PR DESCRIPTION
This picks up upstream support for mac universal2 wheels.

Fixes #1587