### PR TITLE
Prepare the 2.1.65 release.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+2.1.65
+------
+
+This release really brings support for mac universal2 wheels. The fix
+provided by 2.1.64 was partial; universal2 wheels could be resolved at
+build time, but not at runtime.
+
+* Upgrade vendored packaging to 20.9. (#1591)
+  `PR #1591 <https://github.com/pantsbuild/pex/pull/1591>`_
+
 2.1.64
 ------
 

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.1.64"
+__version__ = "2.1.65"


### PR DESCRIPTION
Closes #1588