### PR TITLE
Docs: Clarify that 'python_full_version' is not available if '--platform' is used.

### DIFF
--- a/docs/buildingpex.rst
+++ b/docs/buildingpex.rst
@@ -402,6 +402,12 @@ like ``PLATFORM-IMPL-PYVER-ABI``, where ``PLATFORM`` is the platform (e.g. ``lin
 is a two-digit string representing the python version (e.g., ``36``) and ``ABI`` is the ABI tag (e.g., ``cp36m``,
 ``cp27mu``, ``abi3``, ``none``). A complete example: ``linux_x86_64-cp-36-cp36m``.
 
+**Constraints**: when ``--platform`` is used the `environment marker <https://www.python.org/dev/peps/pep-0508/#environment-markers>`_
+``python_full_version`` is not available, because its value cannot be determined from a platform where only a two-digit string
+representing the python version can be specified (e.g., ``38``), while ``python_full_version`` is meant to have 3 digits (e.g., ``3.8.10``).
+If ``python_full_version`` is found an ``UndefinedEnvironmentName`` exception will be raised.
+
+
 Tailoring PEX execution at runtime
 ----------------------------------
 


### PR DESCRIPTION
Hello, I was playing with the `--platform` option while I've got this error:
```
root@f38a03ba9139:/# cat req.txt
fastapi==0.73.0; python_full_version >= "3.6.1"

root@f38a03ba9139:/# pex --requirement=./req.txt --platform manylinux1_x86_64-cp-38-cp38 -o /tmp/deletemelater.pex
ERROR: Exception:
Traceback (most recent call last):
  File "/root/.pex/venvs/s/83c98751/venv/lib/python3.8/site-packages/pip/_internal/cli/base_command.py", line 223, in _main
    status = self.run(options, args)
  File "/root/.pex/venvs/s/83c98751/venv/lib/python3.8/site-packages/pip/_internal/cli/req_command.py", line 180, in wrapper
    return func(self, options, args)
  File "/root/.pex/venvs/s/83c98751/venv/lib/python3.8/site-packages/pip/_internal/commands/download.py", line 130, in run
    requirement_set = resolver.resolve(
  File "/root/.pex/venvs/s/83c98751/venv/lib/python3.8/site-packages/pip/_internal/resolution/legacy/resolver.py", line 170, in resolve
    requirement_set.add_requirement(req)
  File "/root/.pex/venvs/s/83c98751/venv/lib/python3.8/site-packages/pip/_internal/req/req_set.py", line 90, in add_requirement
    if not install_req.match_markers(extras_requested):
  File "/root/.pex/venvs/s/83c98751/venv/lib/python3.8/site-packages/pip/_internal/req/req_install.py", line 290, in match_markers
    return any(
  File "/root/.pex/venvs/s/83c98751/venv/lib/python3.8/site-packages/pip/_internal/req/req_install.py", line 291, in <genexpr>
    self.markers.evaluate({'extra': extra})
  File "/root/.pex/venvs/s/83c98751/venv/lib/python3.8/site-packages/pip/_vendor/packaging/markers.py", line 336, in evaluate
    return _evaluate_markers(self._markers, current_environment)
  File "/root/.pex/venvs/s/83c98751/venv/lib/python3.8/site-packages/pip/_vendor/packaging/markers.py", line 252, in _evaluate_markers
    lhs_value = _get_env(environment, lhs.value)
  File "/root/.pex/venvs/s/83c98751/venv/lib/python3.8/site-packages/pip/_vendor/packaging/markers.py", line 232, in _get_env
    raise UndefinedEnvironmentName(
pip._vendor.packaging.markers.UndefinedEnvironmentName: 'python_full_version' does not exist in evaluation environment.
pid 343 -> /root/.pex/venvs/f26e8dfffec05b830126670629aca03e0b9fccd8/5fd7049af63e03f347278c89401424cd9731df9a/pex --disable-pip-version-check --no-python-version-warning --exists-action a --use-deprecated legacy-resolver --isolated -q --cache-dir /root/.pex --log /tmp/tmpmlknkrjc/pip.log download --dest /tmp/tmpg15zkknn/manylinux1_x86_64-cp-38-cp38 --platform manylinux1_x86_64 --implementation cp --python-version 38 --abi cp38 --only-binary :all: --requirement ./req.txt --index-url https://pypi.org/simple --retries 5 --timeout 15 exited with 2 and STDERR:
Failed to resolve for platform manylinux1_x86_64-cp-38-cp38. Resolve requires evaluation of unknown environment marker: 'python_full_version' does not exist in evaluation environment.
```
which I solved just by adding the missing env variable, finally my build works!
