### PR TITLE
Respect `PEX_ROOT` in `PEXEnvironment.mount`.

### DIFF
--- a/pex/environment.py
+++ b/pex/environment.py
@@ -216,16 +216,18 @@ class PEXEnvironment(object):
         target=None,  # type: Optional[DistributionTarget]
     ):
         # type: (...) -> PEXEnvironment
-        pi = pex_info or PexInfo.from_pex(pex)
-        pex_hash = pi.pex_hash
+        if not pex_info:
+            pex_info = PexInfo.from_pex(pex)
+            pex_info.update(PexInfo.from_env())
+        pex_hash = pex_info.pex_hash
         if pex_hash is None:
             raise AssertionError(
                 "There was no pex_hash stored in {} for {}.".format(PexInfo.PATH, pex)
             )
-        pex_root = pi.pex_root
+        pex_root = pex_info.pex_root
         pex = maybe_install(pex=pex, pex_root=pex_root, pex_hash=pex_hash) or pex
         target = target or DistributionTarget.current()
-        return cls(pex=pex, pex_info=pi, target=target)
+        return cls(pex=pex, pex_info=pex_info, target=target)
 
     def __init__(
         self,

--- a/tests/integration/test_issue_1598.py
+++ b/tests/integration/test_issue_1598.py
@@ -17,11 +17,11 @@ def test_mount_respects_env(
     # type: (...) -> None
 
     home = os.path.join(str(tmpdir), "home")
-    os.mkdir(home)
 
     pex_root = os.path.join(home, ".pex")
-    os.mkdir(pex_root)
+    os.makedirs(pex_root)
     os.chmod(pex_root, 0o555)
+    unwritable_pex_root_warning = "PEXWarning: PEX_ROOT is configured as {}".format(pex_root)
 
     pex_file = os.path.join(str(tmpdir), "pex.pex")
 
@@ -29,7 +29,8 @@ def test_mount_respects_env(
         args=[pex_project_dir, "-o", pex_file], env=make_env(HOME=home), quiet=True
     )
     result.assert_success()
-    assert "PEXWarning: PEX_ROOT is configured as {}".format(pex_root) in result.error
+
+    assert unwritable_pex_root_warning in result.error
 
     pex_root_override = os.path.join(str(tmpdir), "pex_root_override")
     result = run_pex_command(
@@ -38,4 +39,4 @@ def test_mount_respects_env(
         quiet=True,
     )
     result.assert_success()
-    assert "" == result.error
+    assert unwritable_pex_root_warning not in result.error

--- a/tests/integration/test_issue_1598.py
+++ b/tests/integration/test_issue_1598.py
@@ -1,0 +1,41 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+
+from pex.testing import make_env, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_mount_respects_env(
+    pex_project_dir,  # type: str
+    tmpdir,  # type: Any
+):
+    # type: (...) -> None
+
+    home = os.path.join(str(tmpdir), "home")
+    os.mkdir(home)
+
+    pex_root = os.path.join(home, ".pex")
+    os.mkdir(pex_root)
+    os.chmod(pex_root, 0o555)
+
+    pex_file = os.path.join(str(tmpdir), "pex.pex")
+
+    result = run_pex_command(
+        args=[pex_project_dir, "-o", pex_file], env=make_env(HOME=home), quiet=True
+    )
+    result.assert_success()
+    assert "PEXWarning: PEX_ROOT is configured as {}".format(pex_root) in result.error
+
+    pex_root_override = os.path.join(str(tmpdir), "pex_root_override")
+    result = run_pex_command(
+        args=[pex_project_dir, "-o", pex_file],
+        env=make_env(HOME=home, PEX_ROOT=pex_root_override),
+        quiet=True,
+    )
+    result.assert_success()
+    assert "" == result.error


### PR DESCRIPTION
There was a narrow case of loose layout PEXes that would not mount in
the `PEX_ROOT` (when set in the environment) that this fixes. That
narrow case was exercised by the `pip.pex` PEX that Pex itself creates
to perform resolves with.

Fixes #1598