### PR TITLE
Upgrade isort and black to latest possible.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -45,8 +45,8 @@ from pex.venv_bin_path import BinPath
 from pex.version import __version__
 
 if TYPE_CHECKING:
-    from typing import Dict, List, Optional, Union
     from argparse import Namespace
+    from typing import Dict, List, Optional, Union
 
 
 CANNOT_SETUP_INTERPRETER = 102

--- a/pex/cli/commands/lock.py
+++ b/pex/cli/commands/lock.py
@@ -26,8 +26,9 @@ from pex.typing import TYPE_CHECKING
 from pex.version import __version__
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import DefaultDict, List, Union
+
+    import attr  # vendor:skip
 else:
     from pex.third_party import attr
 

--- a/pex/cli/commands/lockfile/__init__.py
+++ b/pex/cli/commands/lockfile/__init__.py
@@ -70,6 +70,7 @@ def store(
     :param path: The path to store the lock file at.
     """
     import json
+
     from pex.cli.commands.lockfile import json_codec
 
     with safe_open(path, "w") as fp:

--- a/pex/cli/commands/lockfile/json_codec.py
+++ b/pex/cli/commands/lockfile/json_codec.py
@@ -26,17 +26,7 @@ from pex.third_party.pkg_resources import Requirement, RequirementParseError
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from typing import (
-        Any,
-        Dict,
-        List,
-        Mapping,
-        Text,
-        Tuple,
-        Type,
-        TypeVar,
-        Union,
-    )
+    from typing import Any, Dict, List, Mapping, Text, Tuple, Type, TypeVar, Union
 
     _V = TypeVar("_V", bound=Enum.Value)
 

--- a/pex/cli/commands/lockfile/lockfile.py
+++ b/pex/cli/commands/lockfile/lockfile.py
@@ -16,15 +16,9 @@ from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Iterable, Iterator, List, Mapping, Optional, Tuple
+
     import attr  # vendor:skip
-    from typing import (
-        Iterable,
-        Iterator,
-        List,
-        Mapping,
-        Optional,
-        Tuple,
-    )
 else:
     from pex.third_party import attr
 

--- a/pex/cli/commands/lockfile/updater.py
+++ b/pex/cli/commands/lockfile/updater.py
@@ -25,8 +25,9 @@ from pex.typing import TYPE_CHECKING
 from pex.util import named_temporary_file
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import Dict, Iterable, Iterator, Mapping, Optional, Union
+
+    import attr  # vendor:skip
 else:
     from pex.third_party import attr
 

--- a/pex/commands/command.py
+++ b/pex/commands/command.py
@@ -27,14 +27,13 @@ from pex.variables import ENV, Variables
 from pex.version import __version__
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import (
+        IO,
         Any,
         Callable,
         Dict,
         Iterable,
         Iterator,
-        IO,
         NoReturn,
         Optional,
         Sequence,
@@ -42,6 +41,8 @@ if TYPE_CHECKING:
         TypeVar,
         Union,
     )
+
+    import attr  # vendor:skip
 else:
     from pex.third_party import attr
 

--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -16,7 +16,7 @@ from sys import version_info as sys_version_info
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from typing import Optional, AnyStr, Text, Tuple, Type
+    from typing import AnyStr, Optional, Text, Tuple, Type
 
 
 try:
@@ -60,7 +60,6 @@ if PY2:
         else:
             raise ValueError("Cannot convert %s to a unicode string" % type(st))
 
-
 else:
 
     def to_bytes(st, encoding="utf-8"):
@@ -96,7 +95,6 @@ if PY3:
         exec (ast, globals_map, locals_map)
         return locals_map
 
-
 else:
 
     def exec_function(ast, globals_map):
@@ -108,22 +106,20 @@ else:
 
 if PY3:
     from urllib import parse as urlparse
-
     from urllib.error import HTTPError as HTTPError
-    from urllib.request import build_opener as build_opener
     from urllib.request import FileHandler as FileHandler
     from urllib.request import HTTPSHandler as HTTPSHandler
     from urllib.request import ProxyHandler as ProxyHandler
     from urllib.request import Request as Request
+    from urllib.request import build_opener as build_opener
 else:
     import urlparse as urlparse
-
-    from urllib2 import build_opener as build_opener
     from urllib2 import FileHandler as FileHandler
     from urllib2 import HTTPError as HTTPError
     from urllib2 import HTTPSHandler as HTTPSHandler
     from urllib2 import ProxyHandler as ProxyHandler
     from urllib2 import Request as Request
+    from urllib2 import build_opener as build_opener
 
 if PY3:
     from queue import Queue as Queue
@@ -139,10 +135,10 @@ if PY3:
             cpu_set = os.sched_getaffinity(0)
             return len(cpu_set)
 
-
 else:
-    from Queue import Queue as Queue
     from multiprocessing import cpu_count as cpu_count
+
+    from Queue import Queue as Queue
 
 WINDOWS = os.name == "nt"
 

--- a/pex/compiler.py
+++ b/pex/compiler.py
@@ -10,7 +10,7 @@ from pex.typing import TYPE_CHECKING, cast
 from pex.util import named_temporary_file
 
 if TYPE_CHECKING:
-    from typing import Iterable, Text, List
+    from typing import Iterable, List, Text
 
 
 _COMPILER_MAIN = """

--- a/pex/dist_metadata.py
+++ b/pex/dist_metadata.py
@@ -24,8 +24,9 @@ from pex.third_party.pkg_resources import DistInfoDistribution, Distribution, Re
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import Dict, Iterable, Iterator, List, Optional, Tuple, Union
+
+    import attr  # vendor:skip
 
     DistributionLike = Union[Distribution, str]
 else:

--- a/pex/distribution_target.py
+++ b/pex/distribution_target.py
@@ -14,8 +14,9 @@ from pex.third_party.pkg_resources import Requirement
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
+    from typing import Any, Iterator, Optional, Tuple
+
     import attr  # vendor:skip
-    from typing import Any, Optional, Tuple, Iterator
 else:
     from pex.third_party import attr
 

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -24,7 +24,6 @@ from pex.typing import TYPE_CHECKING, cast
 from pex.util import DistributionHelper
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import (
         DefaultDict,
         FrozenSet,
@@ -36,6 +35,8 @@ if TYPE_CHECKING:
         Tuple,
         Union,
     )
+
+    import attr  # vendor:skip
 else:
     from pex.third_party import attr
 

--- a/pex/finders.py
+++ b/pex/finders.py
@@ -11,8 +11,9 @@ from pex.third_party.pkg_resources import Distribution
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import Optional
+
+    import attr  # vendor:skip
 else:
     from pex.third_party import attr
 

--- a/pex/interpreter_constraints.py
+++ b/pex/interpreter_constraints.py
@@ -14,8 +14,9 @@ from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import Iterable, Iterator, Optional, Tuple
+
+    import attr  # vendor:skip
 
     from pex.interpreter import InterpreterIdentificationError
 else:

--- a/pex/jobs.py
+++ b/pex/jobs.py
@@ -13,8 +13,9 @@ from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING, Generic
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import Any, Callable, Iterable, Optional, Text, Tuple, TypeVar
+
+    import attr  # vendor:skip
 
     _T = TypeVar("_T")
 else:

--- a/pex/layout.py
+++ b/pex/layout.py
@@ -15,7 +15,7 @@ from pex.typing import TYPE_CHECKING
 from pex.variables import unzip_dir
 
 if TYPE_CHECKING:
-    from typing import Optional, Iterator
+    from typing import Iterator, Optional
 
 BOOTSTRAP_DIR = ".bootstrap"
 DEPS_DIR = ".deps"

--- a/pex/network_configuration.py
+++ b/pex/network_configuration.py
@@ -7,8 +7,9 @@ from __future__ import absolute_import
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import Optional
+
+    import attr  # vendor:skip
 else:
     from pex.third_party import attr
 

--- a/pex/orderedset.py
+++ b/pex/orderedset.py
@@ -118,6 +118,5 @@ if TYPE_CHECKING:
             # type: (bool) -> _I
             return cast("_I", super(OrderedSet, self).pop(last=last))
 
-
 else:
     OrderedSet = _OrderedSet

--- a/pex/pep_503.py
+++ b/pex/pep_503.py
@@ -8,8 +8,9 @@ from pex.third_party.pkg_resources import Distribution, Requirement
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import Union
+
+    import attr  # vendor:skip
 else:
     from pex.third_party import attr
 

--- a/pex/pep_508.py
+++ b/pex/pep_508.py
@@ -8,8 +8,9 @@ from pex.third_party.packaging import markers
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Dict, Optional
+
     import attr  # vendor:skip
-    from typing import Optional, Dict
 else:
     from pex.third_party import attr
 

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -19,16 +19,7 @@ from pex.typing import TYPE_CHECKING, cast
 from pex.variables import ENV
 
 if TYPE_CHECKING:
-    from typing import (
-        Iterable,
-        Iterator,
-        List,
-        NoReturn,
-        Optional,
-        Set,
-        Tuple,
-        Union,
-    )
+    from typing import Iterable, Iterator, List, NoReturn, Optional, Set, Tuple, Union
 
     from pex.interpreter import InterpreterIdentificationError, InterpreterOrError, PathFilter
     from pex.pex import PEX

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -19,9 +19,9 @@ from pex.venv_bin_path import BinPath
 from pex.version import __version__ as pex_version
 
 if TYPE_CHECKING:
-    from pex.interpreter import PythonInterpreter
-
     from typing import Any, Dict, Mapping, Optional, Text, Union
+
+    from pex.interpreter import PythonInterpreter
 
 
 # TODO(wickman) Split this into a PexInfoBuilder/PexInfo to ensure immutability.

--- a/pex/pex_warnings.py
+++ b/pex/pex_warnings.py
@@ -9,9 +9,10 @@ import warnings
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Optional
+
     from pex.pex_info import PexInfo
     from pex.variables import Variables
-    from typing import Optional
 
 
 class PEXWarning(Warning):

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -53,8 +53,6 @@ from pex.util import CacheHelper, named_temporary_file
 from pex.variables import ENV
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
-
     from typing import (
         Any,
         Callable,
@@ -73,11 +71,12 @@ if TYPE_CHECKING:
         Union,
     )
 
+    import attr  # vendor:skip
+
     class CSVWriter(Protocol):
         def writerow(self, row):
             # type: (Iterable[Union[str, int]]) -> None
             pass
-
 
 else:
     from pex.third_party import attr

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -16,8 +16,9 @@ from pex.typing import TYPE_CHECKING, cast
 from pex.variables import ENV
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+
+    import attr  # vendor:skip
 else:
     from pex.third_party import attr
 

--- a/pex/pyenv.py
+++ b/pex/pyenv.py
@@ -12,8 +12,9 @@ from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Iterable, Iterator, Optional, Tuple
+
     import attr  # vendor:skip
-    from typing import Iterable, Iterator, Optional, Tuple, Iterable
 else:
     from pex.third_party import attr
 

--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -19,16 +19,9 @@ from pex.third_party.pkg_resources import Requirement, RequirementParseError
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
+    from typing import Iterable, Iterator, Match, Optional, Text, Tuple, Union
+
     import attr  # vendor:skip
-    from typing import (
-        Iterable,
-        Iterator,
-        Match,
-        Optional,
-        Text,
-        Tuple,
-        Union,
-    )
 else:
     from pex.third_party import attr
 

--- a/pex/resolve/locked_resolve.py
+++ b/pex/resolve/locked_resolve.py
@@ -18,8 +18,9 @@ from pex.typing import TYPE_CHECKING
 from pex.util import CacheHelper
 
 if TYPE_CHECKING:
+    from typing import IO, Any, BinaryIO, Iterable, Iterator, Optional, Tuple
+
     import attr  # vendor:skip
-    from typing import Any, BinaryIO, IO, Iterable, Iterator, Optional, Tuple
 else:
     from pex.third_party import attr
 

--- a/pex/resolve/requirement_configuration.py
+++ b/pex/resolve/requirement_configuration.py
@@ -9,8 +9,10 @@ from pex.requirements import Constraint, parse_requirement_file, parse_requireme
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Iterable, List, Optional
+
     import attr  # vendor:skip
-    from typing import Optional, Iterable, List
+
     from pex.requirements import ParsedRequirement
 else:
     from pex.third_party import attr

--- a/pex/resolve/resolver_configuration.py
+++ b/pex/resolve/resolver_configuration.py
@@ -9,8 +9,9 @@ from pex.network_configuration import NetworkConfiguration
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import Optional, Tuple
+
+    import attr  # vendor:skip
 else:
     from pex.third_party import attr
 

--- a/pex/resolve/resolvers.py
+++ b/pex/resolve/resolvers.py
@@ -11,8 +11,9 @@ from pex.third_party.pkg_resources import Distribution, Requirement
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import Iterable, Optional, Tuple
+
+    import attr  # vendor:skip
 else:
     from pex.third_party import attr
 

--- a/pex/resolve/target_configuration.py
+++ b/pex/resolve/target_configuration.py
@@ -17,8 +17,9 @@ from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import Optional, Tuple
+
+    import attr  # vendor:skip
 else:
     from pex.third_party import attr
 

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -31,7 +31,6 @@ from pex.typing import TYPE_CHECKING
 from pex.util import CacheHelper, DistributionHelper
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import (
         DefaultDict,
         Dict,
@@ -43,6 +42,8 @@ if TYPE_CHECKING:
         Sequence,
         Tuple,
     )
+
+    import attr  # vendor:skip
 
     from pex.requirements import ParsedRequirement
 else:

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -35,7 +35,6 @@ from pex.typing import TYPE_CHECKING
 from pex.util import DistributionHelper, named_temporary_file
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import (
         Any,
         Callable,
@@ -50,6 +49,8 @@ if TYPE_CHECKING:
         Tuple,
         Union,
     )
+
+    import attr  # vendor:skip
 else:
     from pex.third_party import attr
 

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -347,9 +347,9 @@ def isolated():
     if _ISOLATED is None:
         from pex import vendor
         from pex.common import atomic_directory, is_pyc_temporary_file
+        from pex.third_party.pkg_resources import resource_isdir, resource_listdir, resource_stream
         from pex.util import CacheHelper
         from pex.variables import ENV
-        from pex.third_party.pkg_resources import resource_isdir, resource_listdir, resource_stream
 
         module = "pex"
 

--- a/pex/tools/commands/digraph.py
+++ b/pex/tools/commands/digraph.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Dict, IO, List, Mapping, Optional, Tuple
+    from typing import IO, Dict, List, Mapping, Optional, Tuple
 
     Value = Optional[str]
     Attributes = Mapping[str, Value]

--- a/pex/tools/commands/graph.py
+++ b/pex/tools/commands/graph.py
@@ -20,7 +20,7 @@ from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
 
 if TYPE_CHECKING:
-    from typing import Iterator, IO, Tuple
+    from typing import IO, Iterator, Tuple
 
 logger = logging.getLogger(__name__)
 

--- a/pex/tools/commands/repository.py
+++ b/pex/tools/commands/repository.py
@@ -33,8 +33,9 @@ from pex.tools.command import PEXCommand
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
+    from typing import IO, Callable, Iterable, Iterator, Text, Tuple
+
     import attr  # vendor:skip
-    from typing import Callable, IO, Iterable, Iterator, Text, Tuple
 
     RepositoryFunc = Callable[["Repository", PEX], Result]
 else:

--- a/pex/tools/commands/virtualenv.py
+++ b/pex/tools/commands/virtualenv.py
@@ -22,8 +22,9 @@ from pex.typing import TYPE_CHECKING, cast
 from pex.util import named_temporary_file
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import Iterator, Optional, Union
+
+    import attr  # vendor:skip
 else:
     from pex.third_party import attr
 

--- a/pex/tools/commands/virtualenv_16.7.12_py
+++ b/pex/tools/commands/virtualenv_16.7.12_py
@@ -1048,6 +1048,7 @@ def _install_wheel_with_search_dir(download, project_names, py_executable, searc
     # with spaces in them. Convert any of those to local file:// URL form.
     try:
         from urllib import pathname2url
+
         from urlparse import urljoin
     except ImportError:
         from urllib.parse import urljoin

--- a/pex/tools/commands/virtualenv_16.7.12_py
+++ b/pex/tools/commands/virtualenv_16.7.12_py
@@ -1048,7 +1048,6 @@ def _install_wheel_with_search_dir(download, project_names, py_executable, searc
     # with spaces in them. Convert any of those to local file:// URL form.
     try:
         from urllib import pathname2url
-
         from urlparse import urljoin
     except ImportError:
         from urllib.parse import urljoin

--- a/pex/tracer.py
+++ b/pex/tracer.py
@@ -14,7 +14,7 @@ from pex.variables import ENV
 __all__ = ("TRACER", "TraceLogger")
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, IO, Iterator, List, Optional
+    from typing import IO, Any, Callable, Iterator, List, Optional
 
 
 class Trace(object):

--- a/pex/typing.py
+++ b/pex/typing.py
@@ -37,9 +37,10 @@ TYPE_CHECKING = False
 # Unlike most type-hints, `cast` and `overload` get used at runtime. We define no-op versions for
 # runtime use.
 if TYPE_CHECKING:
-    from typing import cast as cast, Any
-    from typing import overload as overload
+    from typing import Any
     from typing import Generic as Generic
+    from typing import cast as cast
+    from typing import overload as overload
 else:
 
     def cast(_type, value):

--- a/pex/util.py
+++ b/pex/util.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
         from hashlib import _hash as _Hash
     else:
         from hashlib import _Hash
-    from typing import Any, BinaryIO, Callable, IO, Iterable, Iterator, Optional, Text
+    from typing import IO, Any, BinaryIO, Callable, Iterable, Iterator, Optional, Text
 
 
 class DistributionHelper(object):

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -21,17 +21,7 @@ from pex.typing import TYPE_CHECKING, Generic, overload
 from pex.venv_bin_path import BinPath
 
 if TYPE_CHECKING:
-    from typing import (
-        Callable,
-        Dict,
-        Iterator,
-        Optional,
-        Tuple,
-        TypeVar,
-        Type,
-        Union,
-        Any,
-    )
+    from typing import Any, Callable, Dict, Iterator, Optional, Tuple, Type, TypeVar, Union
 
     _O = TypeVar("_O")
     _P = TypeVar("_P")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,10 @@ Documentation = "https://pex.readthedocs.io/en/latest/"
 [tool.black]
 line-length = 100
 target-version = ["py27"]
-exclude = '''
+extend-exclude = '''
 /(
   | \.git
-  | \pex/vendor/_vendored
+  | pex/vendor/_vendored
   | \.pyenv_test
 )/
 '''
@@ -73,3 +73,4 @@ use_parentheses = true
 line_length = 100
 default_section = "THIRDPARTY"
 known_first_party = "pex"
+skip_glob = ["pex/vendor/_vendored/**"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,9 @@ line-length = 100
 target-version = ["py27"]
 extend-exclude = '''
 /(
-  | \.git
-  | pex/vendor/_vendored
-  | \.pyenv_test
-)/
+  | pex/tools/commands/virtualenv_16.7.12_py
+  | pex/vendor/_vendored/
+)
 '''
 
 [tool.isort]
@@ -73,4 +72,7 @@ use_parentheses = true
 line_length = 100
 default_section = "THIRDPARTY"
 known_first_party = "pex"
-skip_glob = ["pex/vendor/_vendored/**"]
+skip_glob = [
+  "pex/tools/commands/virtualenv_16.7.12_py",
+  "pex/vendor/_vendored/**"
+]

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function run_black {
+  black "$@" pex scripts tests 2>&1 | \
+    grep -v "DEPRECATION: Python 2 support will be removed in the first stable release" || true
+}
+
+function run_isort {
+  isort "$@" pex scripts tests
+}
+
+if [[ "--check" == "${1:-}" ]]; then
+  run_black --check
+  run_isort --check-only
+else
+  run_black
+  run_isort
+fi

--- a/tests/cli/commands/lockfile/test_json_codec.py
+++ b/tests/cli/commands/lockfile/test_json_codec.py
@@ -28,8 +28,9 @@ from pex.third_party.pkg_resources import Requirement
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import Any
+
+    import attr  # vendor:skip
 else:
     if "__PEX_UNVENDORED__" in __import__("os").environ:
         import attr  # vendor:skip

--- a/tests/integration/cli/commands/test_lock.py
+++ b/tests/integration/cli/commands/test_lock.py
@@ -25,8 +25,9 @@ from pex.typing import TYPE_CHECKING
 from pex.version import __version__
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import Any, Optional
+
+    import attr  # vendor:skip
 else:
     from pex.third_party import attr
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -49,15 +49,7 @@ from pex.util import DistributionHelper, named_temporary_file
 from pex.variables import ENV, unzip_dir, venv_dir
 
 if TYPE_CHECKING:
-    from typing import (
-        Any,
-        Callable,
-        ContextManager,
-        Iterator,
-        List,
-        Optional,
-        Tuple,
-    )
+    from typing import Any, Callable, ContextManager, Iterator, List, Optional, Tuple
 
 
 def test_pex_execute():

--- a/tests/integration/test_issue_1018.py
+++ b/tests/integration/test_issue_1018.py
@@ -13,9 +13,9 @@ from pex.testing import run_pex_command
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
-
     from typing import Any, Iterable, List, Optional
+
+    import attr  # vendor:skip
 else:
     from pex.third_party import attr
 

--- a/tests/integration/test_locked_resolve.py
+++ b/tests/integration/test_locked_resolve.py
@@ -15,8 +15,9 @@ from pex.typing import TYPE_CHECKING
 from pex.util import CacheHelper
 
 if TYPE_CHECKING:
+    from typing import Any, Dict, Iterable
+
     import attr  # vendor:skip
-    from typing import Any, Iterable, Dict
 else:
     from pex.third_party import attr
 

--- a/tests/integration/test_reexec.py
+++ b/tests/integration/test_reexec.py
@@ -22,7 +22,7 @@ from pex.testing import (
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Iterable, Optional, List
+    from typing import Iterable, List, Optional
 
 
 def _assert_exec_chain(

--- a/tests/integration/test_reproducible.py
+++ b/tests/integration/test_reproducible.py
@@ -22,7 +22,7 @@ from pex.testing import (
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Iterable, Optional, List
+    from typing import Iterable, List, Optional
 
 
 def assert_reproducible_build(

--- a/tests/resolve/test_pex_repository_resolver.py
+++ b/tests/resolve/test_pex_repository_resolver.py
@@ -20,7 +20,7 @@ from pex.third_party.pkg_resources import Requirement
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from typing import Optional, Iterable, DefaultDict, Set
+    from typing import DefaultDict, Iterable, Optional, Set
 
 
 def create_pex_repository(

--- a/tests/test_bdist_pex.py
+++ b/tests/test_bdist_pex.py
@@ -12,7 +12,7 @@ from pex.tools.commands.virtualenv import Virtualenv
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Dict, List, Iterator, Iterable, Optional, Union
+    from typing import Dict, Iterable, Iterator, List, Optional, Union
 
 
 BDIST_PEX_VENV = None  # type: Optional[Virtualenv]

--- a/tests/test_dist_metadata.py
+++ b/tests/test_dist_metadata.py
@@ -29,7 +29,7 @@ from pex.util import DistributionHelper
 from pex.variables import ENV
 
 if TYPE_CHECKING:
-    from typing import Tuple, Iterator, Any
+    from typing import Any, Iterator, Tuple
 
 
 @contextmanager

--- a/tests/test_execution_mode.py
+++ b/tests/test_execution_mode.py
@@ -15,8 +15,9 @@ from pex.testing import run_pex_command
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import Any, Callable, Dict, Iterable, Tuple
+
+    import attr  # vendor:skip
 
     CreateColorsPex = Callable[[Iterable[str]], str]
     ExecuteColorsPex = Callable[[str, Dict[str, str]], Tuple[str, str]]

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -44,8 +44,9 @@ except ImportError:
     import mock  # type: ignore[no-redef,import]
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import Dict, Iterable, Iterator, Union
+
+    import attr  # vendor:skip
 else:
     from pex.third_party import attr
 

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -31,8 +31,9 @@ from pex.third_party.pkg_resources import Requirement
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import attr  # vendor:skip
     from typing import Any, Iterable, Iterator, List, Optional, Union
+
+    import attr  # vendor:skip
 
     from pex.requirements import ParsedRequirement
 

--- a/tests/tools/commands/test_interpreter_command.py
+++ b/tests/tools/commands/test_interpreter_command.py
@@ -16,8 +16,9 @@ from pex.tools.commands.virtualenv import Virtualenv
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Any, Dict, Iterable
+
     import attr  # vendor:skip
-    from typing import Iterable, Dict, Any
 else:
     from pex.third_party import attr
 

--- a/tox.ini
+++ b/tox.ini
@@ -51,27 +51,17 @@ commands =
 [testenv:format-run]
 skip_install = true
 deps =
-    black==20.8b1
-    isort==4.3.21
+    black==21.12b0
+    isort==5.10.1
 commands =
-    black .
-    isort \
-        --apply \
-        --dont-skip __init__.py \
-        --skip-glob pex/vendor/_vendored/** \
-        --skip-glob .pyenv_test/**
+    bash scripts/format.sh
 
 [testenv:format-check]
 skip_install = true
 deps =
     {[testenv:format-run]deps}
 commands =
-    black --check .
-    isort \
-        --check-only \
-        --dont-skip __init__.py \
-        --skip-glob pex/vendor/_vendored/** \
-        --skip-glob .pyenv_test/**
+    bash scripts/format.sh --check
 
 [testenv:typecheck]
 deps =


### PR DESCRIPTION
For isort this is latest stable but for black we have to hang back
pre-stable since stable drops support for Python 2.7.