### PR TITLE
Use setproctitle to sanitize `ps` info.

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -3,6 +3,36 @@
 PEX Recipes and Notes
 =====================
 
+Long running PEX applications and daemons
+-----------------------------------------
+
+If your PEXed application will run a long time, at some point you'll likely need to debug or
+otherwise inspect it using operating system tools. Unless you built your application as a
+non-``--venv`` ``--layout loose`` PEX, its final process information will be inscrutable in ``ps``
+output since all other PEX forms re-execute themselves against an installed version of themselves in
+the configured ``PEX_ROOT``.
+
+You'll see something like this as a result:
+
+.. code-block:: bash
+
+    $ ./my.pex --foo bar &
+    $ ps -o command | grep pex
+    /home/jsirois/.pyenv/versions/3.10.2/bin/python3.10 /home/jsirois/.pex/unzipped_pexes/94790b07dc3768a9926dab999b41a87e399e0aa9 --foo bar
+
+The original PEX file is not mentioned anywhere in the ``ps`` output. Worse, if you have many PEX
+processes it will be unclear which process corresponds to which PEX.
+
+To remedy this, simply add `setproctitle <https://pypi.org/project/setproctitle/>`_ as a dependency
+for your PEX. The PEX runtime will then detect the presence of ``setproctitle`` and alter the
+process title so you see both the Python being used to run your PEX and the PEX file being run:
+
+.. code-block:: bash
+
+    $ ./my.pex --foo bar &
+    $ ps -o command | grep pex
+    /home/jsirois/.pyenv/versions/3.10.2/bin/python3.10 /home/jsirois/dev/pantsbuild/jsirois-pex/my.pex --foo bar
+
 PEX app in a container
 ----------------------
 

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -473,6 +473,26 @@ class PEX(object):  # noqa: T000
                 exit_value = tools.main(pex=PEX(sys.argv[0]))
             else:
                 self.activate()
+
+                pex_file = os.environ.get("PEX", None)
+                if pex_file:
+                    try:
+                        from setproctitle import setproctitle  # type: ignore[import]
+
+                        setproctitle(
+                            "{python} {pex_file} {args}".format(
+                                python=sys.executable,
+                                pex_file=pex_file,
+                                args=" ".join(sys.argv[1:]),
+                            )
+                        )
+                    except ImportError:
+                        TRACER.log(
+                            "Not setting process title since setproctitle is not available in "
+                            "{pex_file}".format(pex_file=pex_file),
+                            V=3,
+                        )
+
                 exit_value = self._wrap_coverage(self._wrap_profiling, self._execute)
             sys.exit(exit_value)
         except Exception:

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -282,6 +282,17 @@ def populate_venv_with_pex(
                 os.environ[current_interpreter_blessed_env_var] = "1"
                 os.execv(python, [python, "-sE"] + sys.argv)
 
+            pex_file = os.environ.get("PEX", None)
+            if pex_file:
+                try:
+                    from setproctitle import setproctitle
+
+                    setproctitle("{{python}} {{pex_file}} {{args}}".format(
+                        python=sys.executable, pex_file=pex_file, args=" ".join(sys.argv[1:]))
+                    )
+                except ImportError:
+                    pass
+
             ignored_pex_env_vars = [
                 "{{}}={{}}".format(name, value)
                 for name, value in os.environ.items()

--- a/tests/integration/test_setproctitle.py
+++ b/tests/integration/test_setproctitle.py
@@ -1,0 +1,136 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import os.path
+import subprocess
+import sys
+from textwrap import dedent
+from typing import Text
+
+import pytest
+
+from pex import variables
+from pex.common import safe_open
+from pex.interpreter import PythonInterpreter
+from pex.layout import Layout
+from pex.pex_info import PexInfo
+from pex.testing import run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Tuple
+
+
+@pytest.mark.parametrize("venv", [pytest.param(True, id="VENV"), pytest.param(False, id="UNZIP")])
+@pytest.mark.parametrize(
+    "layout", [pytest.param(layout, id=layout.value) for layout in Layout.values()]
+)
+def test_setproctitle(
+    tmpdir,  # type: Any
+    venv,  # type: bool
+    layout,  # type: Layout.Value
+):
+    # type: (...) -> None
+
+    pid_file = os.path.join(str(tmpdir), "pid")
+    os.mkfifo(pid_file)
+
+    src = os.path.join(str(tmpdir), "src")
+    with safe_open(os.path.join(src, "app.py"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                from __future__ import print_function
+
+                import os
+                import threading
+
+                # Indicate PEX boot is complete and we've reached user code.
+                with open({pid_file!r}, "w") as fp:
+                    print(str(os.getpid()), file=fp)
+
+                # Run forever to ensure there is time to read out our `ps` info.
+                cv = threading.Condition()
+                with cv:
+                    cv.wait()
+                """.format(
+                    pid_file=pid_file
+                )
+            )
+        )
+
+    build_pex_args = ["-D", src, "-m", "app", "--layout", layout.value]
+    if venv:
+        build_pex_args.append("--venv")
+
+    def grab_ps(
+        pex,  # type: str
+        *extra_pex_args  # type: str
+    ):
+        # type: (...) -> Tuple[Text, Text]
+        run_pex_command(args=build_pex_args + ["-o", pex] + list(extra_pex_args)).assert_success()
+
+        process = subprocess.Popen(args=[sys.executable, pex, "--some", "arguments", "here"])
+        try:
+            # N.B.: We need to block on receiving the pid via fifo to prove that the PEX runtime has
+            # finished booting and completed any and all re-execs and landed in user code.
+            with open(pid_file) as fp:
+                assert process.pid == int(fp.read().strip())
+
+            exe, args = (
+                subprocess.check_output(
+                    args=["ps", "-p", str(process.pid), "-o", "command=", "-ww"]
+                )
+                .decode("utf-8")
+                .strip()
+                .split(" ", 1)
+            )
+            return exe, args
+        finally:
+            process.kill()
+
+    def assert_expected_python(exe):
+        # type: (Text) -> None
+        assert (
+            PythonInterpreter.get().resolve_base_interpreter()
+            == PythonInterpreter.from_binary(str(exe)).resolve_base_interpreter()
+        )
+
+    pex_file = os.path.join(str(tmpdir), "pex.file")
+    exe, args = grab_ps(pex_file)
+    assert_expected_python(exe)
+
+    pex_info = PexInfo.from_pex(pex_file)
+    assert pex_info.pex_hash is not None
+
+    if Layout.LOOSE == layout and not venv:
+        # N.B.: A non-venv loose PEX runs from where it is and presents a nice ps without help.
+        assert "{pex_file} --some arguments here".format(pex_file=pex_file) == args
+    elif venv:
+        # A `--venv` mode PEX boot terminates in a final process of:
+        # ~/.pex/venvs/<venv short dir>/bin/python -sE ~/.pex/venvs/<venv long dir>/pex <args...>
+        python_args, installed_location, rest = args.split(" ", 2)
+        assert "-sE" == python_args
+        assert (
+            os.path.join(
+                variables.venv_dir(
+                    pex_file,
+                    pex_info.pex_root,
+                    pex_info.pex_hash,
+                    has_interpreter_constraints=False,
+                ),
+                "pex",
+            )
+            == installed_location
+        )
+        assert "--some arguments here" == rest
+    else:
+        # All other PEX boots terminate in an unzipped execution that looks like:
+        # <python> ~/.pex/unzipped_pexes/<unzipped pex dir> <args...>
+        installed_location, rest = args.split(" ", 1)
+        assert variables.unzip_dir(pex_info.pex_root, pex_info.pex_hash) == installed_location
+        assert "--some arguments here" == rest
+
+    setproctitle_pex_file = os.path.join(str(tmpdir), "pex.file.titled")
+    exe, args = grab_ps(setproctitle_pex_file, "setproctitle")
+    assert_expected_python(exe)
+    assert "{pex_file} --some arguments here".format(pex_file=setproctitle_pex_file) == args


### PR DESCRIPTION
When the setproctitle distribution is part of a PEX's activated
distributions, use it to set the process title to include the PEX file
used to launch the application instead of the final unzipped or venv
directory in the PEX_ROOT.

Fixes #1604