### PR TITLE
Fix black exclude.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,9 @@ line-length = 100
 target-version = ["py27"]
 extend-exclude = '''
 /(
-  | pex/tools/commands/virtualenv_16.7.12_py
-  | pex/vendor/_vendored/
-)
+  | pex/tools/commands/virtualenv_.*_py
+  | pex/vendor/_vendored
+)/
 '''
 
 [tool.isort]


### PR DESCRIPTION
The prior setup was skipping all files:
```
$ tox -qq -eformat-run
No Python files are present to be formatted. Nothing to do 😴
Skipped 8 files
```

Now we get them all looked at:
```
$ tox -qq -eformat-run
All done! ✨ 🍰 ✨
182 files left unchanged.
Skipped 8 files
```