### PR TITLE
Introduce `pex3 interpreter inspect`.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -287,8 +287,11 @@ def configure_clp_pex_options(parser):
 def configure_clp_pex_environment(parser):
     # type: (ArgumentParser) -> None
     group = parser.add_argument_group(
-        "PEX environment options",
-        "Tailor the interpreter and platform targets for the PEX environment.",
+        "PEX target environment options",
+        "Specify which target environments the PEX should run on. If more than one interpreter or "
+        "platform is specified a multi-platform PEX will be created that can run on all specified "
+        "targets. N.B.: You may need to adjust the `--python-shebang` so that it works in all "
+        "the specified target environments.",
     )
 
     target_options.register(group)

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -289,7 +289,7 @@ def configure_clp_pex_environment(parser):
     group = parser.add_argument_group(
         "PEX target environment options",
         "Specify which target environments the PEX should run on. If more than one interpreter or "
-        "platform is specified a multi-platform PEX will be created that can run on all specified "
+        "platform is specified, a multi-platform PEX will be created that can run on all specified "
         "targets. N.B.: You may need to adjust the `--python-shebang` so that it works in all "
         "the specified target environments.",
     )

--- a/pex/cli/command.py
+++ b/pex/cli/command.py
@@ -11,7 +11,7 @@ from pex.commands.command import Command, Result
 from pex.typing import TYPE_CHECKING, Generic, cast
 
 if TYPE_CHECKING:
-    from typing import Callable, Iterator, Optional, Type, TypeVar
+    from typing import Callable, ClassVar, Iterator, Optional, Type, TypeVar
 
     _C = TypeVar("_C", bound="BuildTimeCommand")
 
@@ -21,9 +21,11 @@ class BuildTimeCommand(Command):
         def __init__(
             self,
             subparsers,  # type: _SubParsersAction
+            include_verbosity,  # type: bool
         ):
             # type: (...) -> None
             self._subparsers = subparsers
+            self._include_verbosity = include_verbosity
 
         @contextmanager
         def parser(
@@ -31,20 +33,30 @@ class BuildTimeCommand(Command):
             name,  # type: str
             help,  # type: str
             func=None,  # type: Optional[Callable[[_C], Result]]
+            include_verbosity=None,  # type: Optional[bool]
         ):
             # type: (...) -> Iterator[ArgumentParser]
             subcommand_parser = self._subparsers.add_parser(name=name, help=help)
             yield subcommand_parser
             if func:
                 subcommand_parser.set_defaults(subcommand_func=func)
-                Command.register_global_arguments(subcommand_parser)
+                Command.register_global_arguments(
+                    subcommand_parser,
+                    include_verbosity=include_verbosity
+                    if include_verbosity is not None
+                    else self._include_verbosity,
+                )
+
+    include_global_verbosity_option = True  # type: ClassVar[bool]
 
     @classmethod
     def add_arguments(cls, parser):
         # type: (ArgumentParser) -> None
         cls.add_extra_arguments(parser)
         if not parser.get_default("subcommand_func"):
-            cls.register_global_arguments(parser)
+            cls.register_global_arguments(
+                parser, include_verbosity=cls.include_global_verbosity_option
+            )
 
     @classmethod
     def add_extra_arguments(cls, parser):
@@ -60,7 +72,7 @@ class BuildTimeCommand(Command):
         # type: (...) -> Subcommands[_C]
         parser.set_defaults(subcommand_func=functools.partial(cls.show_help, parser))
         subparsers = parser.add_subparsers(description=description)
-        return cls.Subcommands(subparsers)
+        return cls.Subcommands(subparsers, include_verbosity=cls.include_global_verbosity_option)
 
     def run(self):
         # type: (_C) -> Result

--- a/pex/cli/commands/__init__.py
+++ b/pex/cli/commands/__init__.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pex.cli.command import BuildTimeCommand
+from pex.cli.commands.interpreter import Interpreter
 from pex.cli.commands.lock import Lock
 from pex.typing import TYPE_CHECKING
 
@@ -11,4 +12,4 @@ if TYPE_CHECKING:
 
 def all_commands():
     # type: () -> Iterable[Type[BuildTimeCommand]]
-    return [Lock]
+    return Interpreter, Lock

--- a/pex/cli/commands/interpreter.py
+++ b/pex/cli/commands/interpreter.py
@@ -1,0 +1,150 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import logging
+from argparse import ArgumentParser, _ActionsContainer
+
+from pex.cli.command import BuildTimeCommand
+from pex.commands.command import Error, JsonMixin, Ok, OutputMixin, Result
+from pex.interpreter import PythonInterpreter
+from pex.interpreter_constraints import UnsatisfiableInterpreterConstraintsError
+from pex.resolve import target_options
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Dict
+
+
+logger = logging.getLogger(__name__)
+
+
+class Interpreter(OutputMixin, JsonMixin, BuildTimeCommand):
+    @classmethod
+    def _add_inspect_arguments(cls, parser):
+        # type: (_ActionsContainer) -> None
+        cls.add_output_option(parser, entity="Python interpreter path")
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            action="store_true",
+            help=(
+                "Provide more information about the interpreter in JSON format. Use --tags and "
+                "--markers to include even more information. The 'path' key is guaranteed to be "
+                "present at a minimum and will contain the path to the interpreter."
+            ),
+        )
+        parser.add_argument(
+            "-t",
+            "--tags",
+            "--compatible-tags",
+            action="store_true",
+            help=(
+                "Include the interpreter's compatible tags in the verbose JSON output under the "
+                "'compatible_tags' key with more preferable (more specific) tags ordered earlier. "
+                "The 'path' key is guaranteed to be present and will contain the path to the "
+                "interpreter."
+            ),
+        )
+        parser.add_argument(
+            "-m",
+            "--markers",
+            "--marker-env",
+            "--marker-environment",
+            action="store_true",
+            help=(
+                "Include the interpreter's PEP-508 marker environment in the verbose JSON output "
+                "under the 'marker_environment' key. The 'path' key is guaranteed to be present "
+                "and will contain the path to the interpreter."
+            ),
+        )
+        cls.add_json_options(parser, entity="verbose output")
+
+        interpreter_options_parser = parser.add_argument_group(
+            title="Interpreter options",
+            description=(
+                "Specify which interpreters to inspect. The current interpreter is inspected "
+                "by default."
+            ),
+        )
+        interpreter_options_parser.add_argument(
+            "-a",
+            "--all",
+            action="store_true",
+            help="Print all compatible interpreters, preferred first.",
+        )
+        target_options.register(interpreter_options_parser, include_platforms=False)
+
+    @classmethod
+    def add_extra_arguments(
+        cls,
+        parser,  # type: ArgumentParser
+    ):
+        # type: (...) -> None
+        subcommands = cls.create_subcommands(
+            parser,
+            description="Interact with local interpreters via the following subcommands.",
+        )
+        with subcommands.parser(
+            name="inspect",
+            help="Inspect local interpreters",
+            func=cls._inspect,
+            include_verbosity=False,
+        ) as inspect_parser:
+            cls._add_inspect_arguments(inspect_parser)
+
+    def _inspect(self):
+        # type: () -> Result
+
+        interpreter_configuration = target_options.configure_interpreters(self.options)
+        interpreters = interpreter_configuration.resolve_interpreters()
+        if self.options.all:
+            python_path = (
+                interpreter_configuration.python_path.split(":")
+                if interpreter_configuration.python_path
+                else None
+            )
+            interpreters.update(PythonInterpreter.all(paths=python_path))
+        if not interpreters:
+            interpreters.add(PythonInterpreter.get())
+
+        verbose = self.options.verbose or self.options.tags or self.options.markers
+        if self.options.indent and not verbose:
+            logger.warning(
+                "Ignoring --indent={} since --verbose mode is not enabled.".format(
+                    self.options.indent
+                )
+            )
+        with self.output(self.options) as out:
+            try:
+                for interpreter in interpreters:
+                    if verbose:
+                        interpreter_info = {"path": interpreter.binary}  # type: Dict[str, Any]
+                        if self.options.verbose:
+                            interpreter_info.update(
+                                version=interpreter.identity.version_str,
+                                requirement=str(interpreter.identity.requirement),
+                                platform=str(interpreter.platform),
+                                venv=interpreter.is_venv,
+                            )
+                            if interpreter.is_venv:
+                                interpreter_info[
+                                    "base_interpreter"
+                                ] = interpreter.resolve_base_interpreter().binary
+                        if self.options.tags:
+                            interpreter_info["compatible_tags"] = [
+                                str(tag) for tag in interpreter.identity.supported_tags
+                            ]
+                        if self.options.markers:
+                            interpreter_info[
+                                "marker_environment"
+                            ] = interpreter.identity.env_markers.as_dict()
+                        self.dump_json(self.options, interpreter_info, out)
+                    else:
+                        out.write(interpreter.binary)
+                    out.write("\n")
+            except UnsatisfiableInterpreterConstraintsError as e:
+                return Error(str(e))
+
+        return Ok()

--- a/pex/cli/testing.py
+++ b/pex/cli/testing.py
@@ -1,0 +1,27 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import subprocess
+import sys
+from typing import Any
+
+from pex.testing import IntegResults
+
+
+def run_pex3(
+    *args,  # type: str
+    **popen_kwargs  # type: Any
+):
+    # type: (...) -> IntegResults
+    process = subprocess.Popen(
+        args=[sys.executable, "-mpex.cli"] + list(args),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        **popen_kwargs
+    )
+    stdout, stderr = process.communicate()
+    return IntegResults(
+        output=stdout.decode("utf-8"), error=stderr.decode("utf-8"), return_code=process.returncode
+    )

--- a/tests/integration/cli/commands/test_interpreter_inspect.py
+++ b/tests/integration/cli/commands/test_interpreter_inspect.py
@@ -1,0 +1,127 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import itertools
+import json
+import os
+
+from pex.cli.testing import run_pex3
+from pex.interpreter import PythonInterpreter
+from pex.pep_508 import MarkerEnvironment
+from pex.testing import IntegResults
+from pex.third_party.packaging import tags
+from pex.typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Text
+
+
+def inspect(
+    *args,  # type: str
+    **popen_kwargs  # type: str
+):
+    # type: (...) -> IntegResults
+    return run_pex3("interpreter", "inspect", *args, **popen_kwargs)
+
+
+def assert_inspect(
+    *args,  # type: str
+    **popen_kwargs  # type: str
+):
+    # type: (...) -> Text
+
+    result = inspect(*args, **popen_kwargs)
+    result.assert_success()
+    return result.output
+
+
+def test_inspect_default(current_interpreter):
+    # type: (PythonInterpreter) -> None
+    assert current_interpreter.binary == assert_inspect().strip()
+
+
+def assert_default_verbose_data(
+    *args,  # type: str
+    **popen_kwargs  # type: str
+):
+    # type: (...) -> Dict[str, Any]
+
+    data = json.loads(assert_inspect(*args, **popen_kwargs))
+    assert PythonInterpreter.get().binary == data.pop("path")
+    return cast("Dict[str, Any]", data)
+
+
+def test_inspect_default_verbose():
+    # type: () -> None
+
+    data = assert_default_verbose_data("-v")
+    assert data, "There should be additional verbose details beyond just 'path'."
+
+
+def assert_marker_environment(data):
+    # type: (Dict[str, Any]) -> None
+    assert PythonInterpreter.get().identity.env_markers == MarkerEnvironment(
+        **data.pop("marker_environment")
+    )
+
+
+def test_inspect_default_markers():
+    # type: () -> None
+
+    data = assert_default_verbose_data("-m")
+    assert_marker_environment(data)
+    assert not data
+
+
+def assert_compatible_tags(data):
+    assert PythonInterpreter.get().identity.supported_tags == tuple(
+        itertools.chain.from_iterable(tags.parse_tag(tag) for tag in data.pop("compatible_tags"))
+    )
+
+
+def test_inspect_default_tags():
+    # type: () -> None
+
+    data = assert_default_verbose_data("-t")
+    assert_compatible_tags(data)
+    assert not data
+
+
+def test_inspect_default_combined():
+    # type: () -> None
+
+    data = assert_default_verbose_data("-vmt")
+    assert_marker_environment(data)
+    assert_compatible_tags(data)
+    assert data, (
+        "There should be additional verbose details beyond just 'path', 'marker_environment' and "
+        "'compatible_tags'."
+    )
+
+
+def test_inspect_all():
+    # type: () -> None
+    assert [pi.binary for pi in PythonInterpreter.all()] == assert_inspect("--all").splitlines()
+
+
+def test_inspect_interpreter_selection(
+    py27,  # type: PythonInterpreter
+    py37,  # type: PythonInterpreter
+    py310,  # type: PythonInterpreter
+):
+    # type: (...) -> None
+
+    assert [py27.binary, py310.binary] == assert_inspect(
+        "--python", py27.binary, "--python", py310.binary
+    ).splitlines()
+
+    assert [py37.binary, py310.binary] == assert_inspect(
+        "--all", "--python-path", ":".join([os.path.dirname(py37.binary), py310.binary])
+    ).splitlines()
+
+    assert [py37.binary] == assert_inspect(
+        "--interpreter-constraint",
+        "<3.10",
+        "--python-path",
+        ":".join([os.path.dirname(py37.binary), py310.binary]),
+    ).splitlines()

--- a/tests/integration/cli/commands/test_lock.py
+++ b/tests/integration/cli/commands/test_lock.py
@@ -3,14 +3,13 @@
 
 import os
 import re
-import subprocess
-import sys
 from textwrap import dedent
 
 import pytest
 
 from pex.cli.commands import lockfile
 from pex.cli.commands.lockfile import Lockfile
+from pex.cli.testing import run_pex3
 from pex.distribution_target import DistributionTarget
 from pex.interpreter import PythonInterpreter
 from pex.pep_440 import Version
@@ -30,23 +29,6 @@ if TYPE_CHECKING:
     import attr  # vendor:skip
 else:
     from pex.third_party import attr
-
-
-def run_pex3(
-    *args,  # type: str
-    **popen_kwargs  # type: Any
-):
-    # type: (...) -> IntegResults
-    process = subprocess.Popen(
-        args=[sys.executable, "-mpex.cli"] + list(args),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        **popen_kwargs
-    )
-    stdout, stderr = process.communicate()
-    return IntegResults(
-        output=stdout.decode("utf-8"), error=stderr.decode("utf-8"), return_code=process.returncode
-    )
 
 
 def normalize_lockfile(


### PR DESCRIPTION
This command can be used to get a full marker environment to
support #1597 complete remote platform specification. Its similar
to the `interpreter` PEX tool but works without having to point
at a PEX which will be what a user of #1597 will want.