### PR TITLE
Expand `--platform` syntax: support full versions.

### DIFF
--- a/docs/buildingpex.rst
+++ b/docs/buildingpex.rst
@@ -398,17 +398,19 @@ platform.
 
 The abbreviated platform is described by a string of the form ``PLATFORM-IMPL-PYVER-ABI``, where
 ``PLATFORM`` is the platform (e.g. ``linux-x86_64``, ``macosx-10.4-x86_64``), ``IMPL`` is the python
-implementation abbreviation (``cp`` or ``pp``), ``PYVER`` is a two-digit string representing the
-python version (e.g., ``36``) and ``ABI`` is the ABI tag (e.g., ``cp36m``, ``cp27mu``, ``abi3``,
-``none``). A complete example: ``linux_x86_64-cp-36-cp36m``.
+implementation abbreviation (``cp`` or ``pp``), ``PYVER`` is either a two or more digit string
+representing the python version (e.g., ``36`` or ``310``) or else a component dotted version
+string (e.g., ``3.6`` or ``3.10.1``) and ``ABI`` is the ABI tag (e.g., ``cp36m``, ``cp27mu``,
+``abi3``, ``none``). A complete example: ``linux_x86_64-cp-36-cp36m``.
 
 **Constraints**: when ``--platform`` is used the
 `environment marker <https://www.python.org/dev/peps/pep-0508/#environment-markers>`_
-``python_full_version`` is not available, because its value cannot be determined from a platform
-where only a two-digit string representing the python version can be specified (e.g., ``38``), while
-``python_full_version`` is meant to have 3 digits (e.g., ``3.8.10``). If ``python_full_version`` is
-found an ``UndefinedEnvironmentName`` exception will be raised. To remedy this, use
-``--complete-platform`` instead.
+``python_full_version`` will not be available if ``PYVER`` is not given as a three component dotted
+version since ``python_full_version`` is meant to have 3 digits (e.g., ``3.8.10``). If a
+``python_full_version`` environment marker is encountered during a resolve, an
+``UndefinedEnvironmentName`` exception will be raised. To remedy this, either specify the full
+version in the platform (e.g, ``linux_x86_64-cp-3.8.10-cp38``) or use ``--complete-platform``
+instead.
 
 ``--complete-platform``
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -294,6 +294,13 @@ class PythonIdentity(object):
         # type: () -> Iterator[Platform]
         """All platforms supported by the associated interpreter ordered from most specific to
         least."""
+        yield Platform(
+            platform=self._platform_tag,
+            impl=self.python_tag[:2],
+            version=self.version_str,
+            version_info=self.version,
+            abi=self.abi_tag,
+        )
         for tag in self._supported_tags:
             yield Platform.from_tag(tag)
 

--- a/pex/pep_508.py
+++ b/pex/pep_508.py
@@ -41,7 +41,7 @@ class MarkerEnvironment(object):
         wild. For those we can't, we leave the markers unset (`None`).
         """
 
-        major_version = int(platform.version[0])
+        major_version = platform.version_info[0]
 
         implementation_name = None
         implementation_version = None
@@ -97,7 +97,11 @@ class MarkerEnvironment(object):
         elif platform.impl == "pp":
             platform_python_implementation = "PyPy"
 
-        python_version = ".".join(platform.version)
+        python_version = ".".join(map(str, platform.version_info[:2]))
+
+        python_full_version = None
+        if len(platform.version_info) == 3:
+            python_full_version = ".".join(map(str, platform.version_info))
 
         return cls(
             implementation_name=implementation_name,
@@ -108,7 +112,7 @@ class MarkerEnvironment(object):
             platform_release=None,
             platform_system=platform_system,
             platform_version=None,
-            python_full_version=None,
+            python_full_version=python_full_version,
             python_version=python_version,
             sys_platform=sys_platform,
         )

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
     from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
     import attr  # vendor:skip
+
+    VersionInfo = Union[Tuple[int], Tuple[int, int], Tuple[int, int, int]]
 else:
     from pex.third_party import attr
 
@@ -37,6 +39,55 @@ class Platform(object):
     class InvalidPlatformError(Exception):
         """Indicates an invalid platform string."""
 
+        @classmethod
+        def create(cls, platform, cause=None):
+            message_parts = ["Not a valid platform specifier: {platform}".format(platform=platform)]
+            if cause:
+                message_parts.append(cause)
+            message_parts.append(
+                dedent(
+                    """\
+                    Platform strings must be in one of two forms:
+                    1. Canonical: <platform>-<python impl abbr>-<python version>-<abi>
+                    2. Abbreviated: <platform>-<python impl abbr>-<python version>-<abbr abi>
+
+                    These fields stem from wheel name conventions as outlined in
+                    https://www.python.org/dev/peps/pep-0427#file-name-convention and influenced by
+                    https://www.python.org/dev/peps/pep-0425 except as otherwise noted below.
+
+                    Given a canonical platform string for CPython 3.7.5 running on 64 bit Linux of:
+                      linux-x86_64-cp-37-cp37m
+
+                    Where the fields above are:
+                    + <platform>: linux-x86_64
+                    + <python impl abbr>: cp (e.g.: cp for CPython or pp for PyPY)
+                    + <python version>: 37 (a 2 or more digit major/minor version or a component 
+                                            dotted version)
+                    + <abi>: cp37m
+
+                    The abbreviated platform string is:
+                      linux-x86_64-cp-37-m
+
+                    Some other canonical platform string examples:
+                    + OSX CPython: macosx-10.13-x86_64-cp-36-cp36m
+                    + Linux PyPy: linux-x86_64-pp-273-pypy_73.
+
+                    Unlike in the conventions set forth in PEP-425 and PEP-427, the python version 
+                    field can take on a component dotted value. So, for the example of CPython 3.7.5
+                    running on 64 bit Linux, you could also specify:
+                    + canonical: linux-x86_64-cp-3.7.5-cp37m
+                    + abbreviated: linux-x86_64-cp-3.7.5-m
+
+                    You may be forced to specify this form when resolves encounter environment
+                    markers that use `python_full_version`. See the `--complete-platform` help as
+                    well as:
+                    + https://pex.readthedocs.io/en/v2.1.66/buildingpex.html#complete-platform
+                    + https://www.python.org/dev/peps/pep-0508/#environment-markers
+                    """
+                )
+            )
+            return cls("\n\n".join(message_parts))
+
     SEP = "-"
 
     @classmethod
@@ -45,44 +96,45 @@ class Platform(object):
         if isinstance(platform, Platform):
             return platform
 
-        platform = platform.lower()
+        platform_components = platform.rsplit(cls.SEP, 3)
         try:
-            platform, impl, version, abi = platform.rsplit(cls.SEP, 3)
-            return cls(platform, impl, version, abi)
+            plat, impl, version, abi = platform_components
         except ValueError:
-            raise cls.InvalidPlatformError(
-                dedent(
-                    """\
-                    Not a valid platform specifier: {}
-                    
-                    Platform strings must be in one of two forms:
-                    1. Canonical: <platform>-<python impl abbr>-<python version>-<abi>
-                    2. Abbreviated: <platform>-<python impl abbr>-<python version>-<abbr abi>
-                    
-                    Given a canonical platform string for CPython 3.7.5 running on 64 bit linux of:
-                      linux-x86_64-cp-37-cp37m
-                    
-                    Where the fields above are:
-                    + <platform>: linux-x86_64 
-                    + <python impl abbr>: cp
-                    + <python version>: 37
-                    + <abi>: cp37m
-                    
-                    The abbreviated platform string is:
-                      linux-x86_64-cp-37-m
-                    
-                    Some other canonical platform string examples:
-                    + OSX CPython: macosx-10.13-x86_64-cp-36-cp36m
-                    + Linux PyPy: linux-x86_64-pp-273-pypy_73.
-                    
-                    These fields stem from wheel name conventions as outlined in
-                    https://www.python.org/dev/peps/pep-0427#file-name-convention and influenced by
-                    https://www.python.org/dev/peps/pep-0425.
-                    """.format(
-                        platform
-                    )
-                )
+            raise cls.InvalidPlatformError.create(
+                platform,
+                cause="There are missing platform fields. Expected 4 but given {count}.".format(
+                    count=len(platform_components)
+                ),
             )
+
+        version_components = version.split(".")
+        if len(version_components) == 1:
+            component = version_components[0]
+            if len(component) < 2:
+                raise cls.InvalidPlatformError.create(
+                    platform,
+                    cause=(
+                        "The version field must either be a 2 or more digit digit major/minor "
+                        "version or else a component dotted version. "
+                        "Given: {version!r}".format(version=version)
+                    ),
+                )
+
+            # Here version is py_version_nodot (e.g.: "37" or "310") as outlined in
+            # https://www.python.org/dev/peps/pep-0425/#python-tag
+            version_components = [component[0], component[1:]]
+
+        try:
+            version_info = cast("VersionInfo", tuple(map(int, version_components)))
+        except ValueError:
+            raise cls.InvalidPlatformError.create(
+                platform,
+                cause="The version specified had non-integer components. Given: {version!r}".format(
+                    version=version
+                ),
+            )
+
+        return cls(platform=plat, impl=impl, version=version, version_info=version_info, abi=abi)
 
     @classmethod
     def from_tag(cls, tag):
@@ -92,11 +144,32 @@ class Platform(object):
         See: https://www.python.org/dev/peps/pep-0425/#details
         """
         impl, version = tag.interpreter[:2], tag.interpreter[2:]
-        return cls(platform=tag.platform, impl=impl, version=version, abi=tag.abi)
+
+        major, minor = version[0], version[1:]
+        components = [major] if not minor else [major, minor]
+        try:
+            version_info = cast("VersionInfo", tuple(map(int, components)))
+        except ValueError:
+            raise cls.InvalidPlatformError.create(
+                tag,
+                cause=(
+                    "The tag's interpreter field has an non-integer version suffix following the "
+                    "impl {impl!r} of {version!r}.".format(impl=impl, version=version)
+                ),
+            )
+
+        return cls(
+            platform=tag.platform,
+            impl=impl,
+            version=version,
+            version_info=version_info,
+            abi=tag.abi,
+        )
 
     platform = attr.ib(converter=_normalize_platform)  # type: str
     impl = attr.ib()  # type: str
     version = attr.ib()  # type: str
+    version_info = attr.ib()  # type: VersionInfo
     abi = attr.ib()  # type: str
 
     @platform.validator
@@ -105,10 +178,13 @@ class Platform(object):
     @abi.validator
     def _non_blank(self, attribute, value):
         if not value:
-            raise self.InvalidPlatformError(
-                "Platform specifiers cannot have blank fields. Given {field}={value!r}".format(
-                    field=attribute.name, value=value
-                )
+            raise self.InvalidPlatformError.create(
+                platform=str(self),
+                cause=(
+                    "Platform specifiers cannot have blank fields. Given a blank {field}.".format(
+                        field=attribute.name
+                    )
+                ),
             )
 
     def __attrs_post_init__(self):
@@ -121,7 +197,9 @@ class Platform(object):
     @property
     def interpreter(self):
         # type: () -> str
-        return self.impl + self.version
+        return "{impl}{version}".format(
+            impl=self.impl, version="".join(map(str, self.version_info[:2]))
+        )
 
     @property
     def tag(self):
@@ -187,7 +265,7 @@ class Platform(object):
             return supported_tags
 
         # Read level 2.
-        components = list(attr.astuple(self))
+        components = [str(self)]
         if manylinux:
             components.append(manylinux)
         disk_cache_key = os.path.join(ENV.PEX_ROOT, "platforms", self.SEP.join(components))
@@ -267,4 +345,4 @@ class Platform(object):
 
     def __str__(self):
         # type: () -> str
-        return cast(str, self.SEP.join(attr.astuple(self)))
+        return cast(str, self.SEP.join((self.platform, self.impl, self.version, self.abi)))

--- a/pex/resolve/target_options.py
+++ b/pex/resolve/target_options.py
@@ -112,10 +112,10 @@ def _register_platform_options(
         type=str,
         action="append",
         help=(
-            "The platform for which to build the PEX. This option can be passed multiple times "
-            "to create a multi-platform pex. To use the platform corresponding to the current "
-            "interpreter you can pass `current`. To target any other platform you pass a string "
-            "composed of fields: <platform>-<python impl abbr>-<python version>-<abi>. "
+            "The (abbreviated) platform to build the PEX for. This option can be passed multiple "
+            "times to create a multi-platform pex. To use the platform corresponding to the "
+            "current interpreter you can pass `current`. To target any other platform you pass a "
+            "string composed of fields: <platform>-<python impl abbr>-<python version>-<abi>. "
             "These fields stem from wheel name conventions as outlined in "
             "https://www.python.org/dev/peps/pep-0427#file-name-convention and influenced by "
             "https://www.python.org/dev/peps/pep-0425. For the current interpreter at "

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -167,7 +167,7 @@ def make_project(
         "extras_require": extras_require or {},
         "entry_points": entry_points or {},
         "python_requires": python_requires,
-        "universal": universal
+        "universal": universal,
     }
 
     with temporary_content(project_content, interp=interp) as td:

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -125,6 +125,7 @@ def make_project(
     extras_require=None,  # type: Optional[Dict[str, List[str]]]
     entry_points=None,  # type: Optional[Union[str, Dict[str, List[str]]]]
     python_requires=None,  # type: Optional[str]
+    universal=False,  # type: bool
 ):
     # type: (...) -> Iterator[str]
     project_content = {
@@ -146,6 +147,7 @@ def make_project(
             extras_require=%(extras_require)r,
             entry_points=%(entry_points)r,
             python_requires=%(python_requires)r,
+            options={'bdist_wheel': {'universal': %(universal)r}},
             )
             """
         ),
@@ -165,6 +167,7 @@ def make_project(
         "extras_require": extras_require or {},
         "entry_points": entry_points or {},
         "python_requires": python_requires,
+        "universal": universal
     }
 
     with temporary_content(project_content, interp=interp) as td:
@@ -217,6 +220,7 @@ def built_wheel(
     entry_points=None,  # type: Optional[Union[str, Dict[str, List[str]]]]
     interpreter=None,  # type: Optional[PythonInterpreter]
     python_requires=None,  # type: Optional[str]
+    universal=False,  # type: bool
     **kwargs  # type: Any
 ):
     # type: (...) -> Iterator[str]
@@ -228,6 +232,7 @@ def built_wheel(
         extras_require=extras_require,
         entry_points=entry_points,
         python_requires=python_requires,
+        universal=universal,
     ) as td:
         builder = WheelBuilder(td, interpreter=interpreter, **kwargs)
         yield builder.bdist()

--- a/tests/integration/test_issue_1597.py
+++ b/tests/integration/test_issue_1597.py
@@ -3,6 +3,7 @@
 
 import json
 import os.path
+import platform
 
 from pex.cli.testing import run_pex3
 from pex.interpreter import PythonInterpreter
@@ -14,7 +15,33 @@ from pex.testing import IntegResults, built_wheel, run_pex_command
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
+    from typing import Any, List
+
+
+def build_pex(
+    args,  # type: List[str]
+    marker='python_full_version == "{python_full_version}"'.format(
+        python_full_version=platform.python_version()
+    ),  # type: str
+):
+    # type: (...) -> IntegResults
+
+    with built_wheel(
+        name="project_has_python_full_version_marker",
+        version="0.1.0",
+        install_reqs=["ansicolors==1.1.8; {marker}".format(marker=marker)],
+    ) as wheel:
+        return run_pex_command(
+            args=["-f", os.path.dirname(wheel), "project_has_python_full_version_marker"] + args,
+        )
+
+
+def assert_expected_dists(pex_file):
+    # type: (str) -> None
+    assert {
+        ProjectName("project_has_python_full_version_marker"): Version("0.1.0"),
+        ProjectName("ansicolors"): Version("1.1.8"),
+    } == {ProjectName(dist.project_name): Version(dist.version) for dist in PEX(pex_file).resolve()}
 
 
 def test_platform_complete(
@@ -23,54 +50,34 @@ def test_platform_complete(
 ):
     # type: (...) -> None
 
-    def build_pex(*pex_args):
-        # type: (*str) -> IntegResults
-
-        with built_wheel(
-            name="project_has_python_full_version_marker",
-            version="0.1.0",
-            install_reqs=[
-                'ansicolors==1.1.8; python_full_version == "{python_full_version}"'.format(
-                    python_full_version=current_interpreter.identity.env_markers.python_full_version
-                )
-            ],
-            interpreter=current_interpreter,
-        ) as wheel:
-            return run_pex_command(
-                args=["-f", os.path.dirname(wheel), "project_has_python_full_version_marker"]
-                + list(pex_args),
-            )
-
-    def assert_expected_dists(pex_file):
-        # type: (str) -> None
-        assert {
-            ProjectName("project_has_python_full_version_marker"): Version("0.1.0"),
-            ProjectName("ansicolors"): Version("1.1.8"),
-        } == {
-            ProjectName(dist.project_name): Version(dist.version)
-            for dist in PEX(pex_file).resolve()
-        }
-
     local_interpreter_pex = os.path.join(str(tmpdir), "local_interpreter.pex")
-    build_pex("-o", local_interpreter_pex, "--python", current_interpreter.binary).assert_success()
+    build_pex(
+        args=["-o", local_interpreter_pex, "--python", current_interpreter.binary]
+    ).assert_success()
     assert_expected_dists(local_interpreter_pex)
 
-    result = build_pex("-o", local_interpreter_pex, "--platform", str(current_interpreter.platform))
+    # An abbreviated platform does not have the Python interpreter patch version needed to form a
+    # `python_full_version` marker environment entry.
+    result = build_pex(
+        args=["-o", local_interpreter_pex, "--platform", "manylinux_2_35_x86_64-cp-310-cp310"]
+    )
     result.assert_failure()
     assert "'python_full_version' does not exist in evaluation environment." in result.error
 
     complete_platform_pex = os.path.join(str(tmpdir), "complete_platform.pex")
     complete_platform = CompletePlatform.from_interpreter(current_interpreter)
     build_pex(
-        "-o",
-        complete_platform_pex,
-        "--complete-platform",
-        json.dumps(
-            dict(
-                marker_environment=complete_platform.marker_environment.as_dict(),
-                compatible_tags=complete_platform.get_supported_tags().to_string_list(),
-            )
-        ),
+        args=[
+            "-o",
+            complete_platform_pex,
+            "--complete-platform",
+            json.dumps(
+                dict(
+                    marker_environment=complete_platform.marker_environment.as_dict(),
+                    compatible_tags=complete_platform.get_supported_tags().to_string_list(),
+                )
+            ),
+        ]
     ).assert_success()
     assert_expected_dists(complete_platform_pex)
 
@@ -87,6 +94,39 @@ def test_platform_complete(
         platform_file,
     ).assert_success()
     build_pex(
-        "-o", complete_platform_from_file_pex, "--complete-platform", platform_file
+        args=["-o", complete_platform_from_file_pex, "--complete-platform", platform_file]
     ).assert_success()
     assert_expected_dists(complete_platform_from_file_pex)
+
+
+def test_platform_abbreviated(
+    current_interpreter,  # type: PythonInterpreter
+    tmpdir,  # type: Any
+):
+    # type: (...) -> None
+
+    pex_file = os.path.join(str(tmpdir), "a.pex")
+
+    # An abbreviated platform does not have the Python interpreter patch version needed to form a
+    # `python_full_version` marker environment entry.
+    result = build_pex(args=["-o", pex_file, "--platform", "manylinux_2_35_x86_64-cp-310-cp310"])
+    result.assert_failure()
+    assert "'python_full_version' does not exist in evaluation environment." in result.error
+
+    # However, the Platform supplied by a PythonInterpreter (e.g:
+    # manylinux_2_35_x86_64-cp-3.10.2-cp310) includes a full version; so it should work.
+    current_interpreter_platform = current_interpreter.platform
+    assert 3 == len(current_interpreter_platform.version_info)
+    build_pex(
+        args=["-o", pex_file, "--platform", str(current_interpreter_platform)]
+    ).assert_success()
+    assert_expected_dists(pex_file)
+
+    # But the Platform supplied by a PythonInterpreter does not keep enough information from the
+    # source interpreter to fill in marker environment fields like `platform_version`.
+    result = build_pex(
+        args=["-o", pex_file, "--platform", str(current_interpreter_platform)],
+        marker='platform_version == "#1 SMP PREEMPT Wed, 16 Feb 2022 19:35:18 +0000"',
+    )
+    result.assert_failure()
+    assert "'platform_version' does not exist in evaluation environment." in result.error

--- a/tests/integration/test_issue_1597.py
+++ b/tests/integration/test_issue_1597.py
@@ -30,6 +30,7 @@ def build_pex(
         name="project_has_python_full_version_marker",
         version="0.1.0",
         install_reqs=["ansicolors==1.1.8; {marker}".format(marker=marker)],
+        universal=True,
     ) as wheel:
         return run_pex_command(
             args=["-f", os.path.dirname(wheel), "project_has_python_full_version_marker"] + args,

--- a/tests/resolve/test_target_options.py
+++ b/tests/resolve/test_target_options.py
@@ -153,10 +153,10 @@ def test_configure_complete_platform(
     )
 
     assert_complete_platforms(
-        ['{"marker_environment": {}, "compatible_tags": ["this-is.a-tag"], "ignored": 42}'],
+        ['{"marker_environment": {}, "compatible_tags": ["py2.py3-none-any"], "ignored": 42}'],
         CompletePlatform.create(
             marker_environment=MarkerEnvironment(),
-            supported_tags=CompatibilityTags.from_strings(["this-is.a-tag"]),
+            supported_tags=CompatibilityTags.from_strings(["py2.py3-none-any"]),
         ),
     )
 
@@ -178,12 +178,12 @@ def test_configure_complete_platform(
 
     assert_argument_type_error(
         "The complete platform JSON object did not have the required 'marker_environment' " "key:",
-        '{"compatible_tags": ["this-is.a-tag"]}',
+        '{"compatible_tags": ["py2.py3-none-any"]}',
     )
 
     assert_argument_type_error(
         "Invalid environment entry provided:",
-        '{"marker_environment": {"bad_key": "42"}, "compatible_tags": ["this-is.a-tag"]}',
+        '{"marker_environment": {"bad_key": "42"}, "compatible_tags": ["py2.py3-none-any"]}',
     )
 
 

--- a/tests/test_pep_508.py
+++ b/tests/test_pep_508.py
@@ -12,6 +12,15 @@ if TYPE_CHECKING:
     from typing import Dict
 
 
+def evaluate_marker(
+    expression,  # type: str
+    environment,  # type: Dict[str, str]
+):
+    # type: (...) -> bool
+    markers.default_environment = environment.copy
+    return cast(bool, markers.Marker(expression).evaluate())
+
+
 def test_platform_marker_environment():
     # type: () -> None
     platform = Platform.create("linux-x86_64-cp-37-cp37m")
@@ -20,14 +29,6 @@ def test_platform_marker_environment():
     env_sparse = marker_environment.as_dict(default_unknown=False)
 
     assert set(env_sparse.items()).issubset(set(env_defaulted.items()))
-
-    def evaluate_marker(
-        expression,  # type: str
-        environment,  # type: Dict[str, str]
-    ):
-        # type: (...) -> bool
-        markers.default_environment = environment.copy
-        return cast(bool, markers.Marker(expression).evaluate())
 
     def assert_known_marker(expression):
         # type: (str) -> None
@@ -46,6 +47,34 @@ def test_platform_marker_environment():
             evaluate_marker(expression, env_sparse)
 
     assert_unknown_marker("python_full_version == '3.7.10'")
+    assert_unknown_marker("platform_release == '5.12.12-arch1-1'")
+    assert_unknown_marker("platform_version == '#1 SMP PREEMPT Fri, 18 Jun 2021 21:59:22 +0000'")
+
+
+def test_extended_platform_marker_environment():
+    # type: () -> None
+    platform = Platform.create("linux-x86_64-cp-3.10.1-cp310")
+    marker_environment = MarkerEnvironment.from_platform(platform)
+    env_defaulted = marker_environment.as_dict(default_unknown=True)
+    env_sparse = marker_environment.as_dict(default_unknown=False)
+
+    def assert_known_marker(expression):
+        # type: (str) -> None
+        assert evaluate_marker(expression, env_defaulted)
+        assert evaluate_marker(expression, env_sparse)
+
+    assert_known_marker("python_full_version == '3.10.1'")
+    assert_known_marker("python_version == '3.10'")
+    assert_known_marker("implementation_name == 'cpython'")
+    assert_known_marker("platform_system == 'Linux'")
+    assert_known_marker("platform_machine == 'x86_64'")
+
+    def assert_unknown_marker(expression):
+        # type: (str) -> None
+        assert not evaluate_marker(expression, env_defaulted)
+        with pytest.raises(markers.UndefinedEnvironmentName):
+            evaluate_marker(expression, env_sparse)
+
     assert_unknown_marker("platform_release == '5.12.12-arch1-1'")
     assert_unknown_marker("platform_version == '#1 SMP PREEMPT Fri, 18 Jun 2021 21:59:22 +0000'")
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -3,6 +3,8 @@
 
 import itertools
 import pkgutil
+import re
+from textwrap import dedent
 
 import pytest
 
@@ -15,38 +17,105 @@ EXPECTED_BASE = [("py27", "none", "any"), ("py2", "none", "any")]
 
 def test_platform():
     # type: () -> None
-    assert Platform("linux-x86_64", "cp", "27", "mu") == Platform(
-        "linux_x86_64", "cp", "27", "cp27mu"
+    assert Platform("linux-x86_64", "cp", "27", (2, 7), "mu") == Platform(
+        "linux_x86_64", "cp", "27", (2, 7), "cp27mu"
     )
-    assert str(Platform("linux-x86_64", "cp", "27", "m")) == "linux_x86_64-cp-27-cp27m"
+    assert Platform("linux-x86_64", "cp", "2.7", (2, 7), "mu") == Platform(
+        "linux_x86_64", "cp", "2.7", (2, 7), "cp27mu"
+    )
+
+    assert str(Platform("linux-x86_64", "cp", "27", (2, 7), "m")) == "linux_x86_64-cp-27-cp27m"
+    assert (
+        str(Platform("linux-x86_64", "cp", "310", (3, 10), "cp310")) == "linux_x86_64-cp-310-cp310"
+    )
+
+    assert (
+        str(Platform("linux-x86_64", "cp", "3.10", (3, 10), "cp310"))
+        == "linux_x86_64-cp-3.10-cp310"
+    )
+    assert (
+        str(Platform("linux-x86_64", "cp", "3.10.1", (3, 10, 1), "cp310"))
+        == "linux_x86_64-cp-3.10.1-cp310"
+    )
 
 
 def test_platform_create():
     # type: () -> None
     assert Platform.create("linux-x86_64-cp-27-cp27mu") == Platform(
-        "linux_x86_64", "cp", "27", "cp27mu"
+        "linux_x86_64", "cp", "27", (2, 7), "cp27mu"
     )
     assert Platform.create("linux-x86_64-cp-27-mu") == Platform(
-        "linux_x86_64", "cp", "27", "cp27mu"
+        "linux_x86_64", "cp", "27", (2, 7), "cp27mu"
     )
     assert Platform.create("macosx-10.4-x86_64-cp-27-m") == Platform(
         "macosx_10_4_x86_64",
         "cp",
         "27",
+        (2, 7),
         "cp27m",
     )
 
 
+def assert_raises(platform, expected_cause):
+    with pytest.raises(
+        Platform.InvalidPlatformError,
+        match=(
+            r".*{literal}.*".format(
+                literal=re.escape(
+                    dedent(
+                        """\
+                        Not a valid platform specifier: {platform}
+                        
+                        {expected_cause}
+                        """
+                    ).format(platform=platform, expected_cause=expected_cause)
+                )
+            )
+        ),
+    ):
+        Platform.create(platform)
+
+
 def test_platform_create_bad_platform_missing_fields():
     # type: () -> None
-    with pytest.raises(Platform.InvalidPlatformError):
-        Platform.create("linux-x86_64")
+    assert_raises(
+        platform="linux_x86_64",
+        expected_cause="There are missing platform fields. Expected 4 but given 1.",
+    )
 
 
 def test_platform_create_bad_platform_empty_fields():
     # type: () -> None
-    with pytest.raises(Platform.InvalidPlatformError):
-        Platform.create("linux-x86_64-cp--cp27mu")
+    assert_raises(
+        platform="linux_x86_64--27-cp27mu",
+        expected_cause="Platform specifiers cannot have blank fields. Given a blank impl.",
+    )
+
+
+def test_platform_create_bad_platform_bad_version():
+    # type: () -> None
+    assert_raises(
+        platform="linux_x86_64-cp-2-cp27mu",
+        expected_cause=(
+            "The version field must either be a 2 or more digit digit major/minor version or else "
+            "a component dotted version. Given: '2'"
+        ),
+    )
+
+    assert_raises(
+        platform="linux_x86_64-cp-XY-cp27mu",
+        expected_cause="The version specified had non-integer components. Given: 'XY'",
+    )
+
+    assert_raises(
+        platform="linux_x86_64-cp-2.-cp27mu",
+        expected_cause="The version specified had non-integer components. Given: '2.'",
+    )
+
+    assert_raises(
+        platform="linux_x86_64-cp-2.Y-cp27mu",
+        expected_cause="The version specified had non-integer components. Given: '2.Y'",
+    )
 
 
 def test_platform_create_noop():


### PR DESCRIPTION
Although `--complete-platform` allows every foreign platform resolve with
available wheels to succeed, often `--platform` would be enough if the
`python_full_version` marker environment entry could be derived from it.
Expand the syntax accepted for the PYVER field to support dotted
versions and, when 3-component dotted version is supplied, create a
`python_full_version` marker environment entry.

This should prove to be a more workable corrective than creating and
consuming a `--complete-platform` as introduced in #1609 for most users 
affected by #1597.