### PR TITLE
Never default marker environment entries.

### DIFF
--- a/pex/pep_508.py
+++ b/pex/pep_508.py
@@ -125,34 +125,11 @@ class MarkerEnvironment(object):
     python_version = attr.ib(default=None)  # type: Optional[str]
     sys_platform = attr.ib(default=None)  # type: Optional[str]
 
-    def as_dict(self, default_unknown=True):
-        # type: (bool) -> Dict[str, str]
+    def as_dict(self):
+        # type: () -> Dict[str, str]
         """Render this marker environment as a dictionary.
 
-        For any environment markers that are unset (`None`), the value is either defaulted as
-        specified in PEP 508 or else omitted entirely as per `default_unknown`. Defaulting will
-        cause tests against those environment markers to always fail (return `False`); thus marking
-        the requirement as not applying. Leaving the marker out will cause the same test to error;
-        thus failing the resolve outright.
+        For any environment markers that are unset (`None`), the entry is omitted from the
+        environment so that any attempt to evaluate a marker needing the entry's value will fail.
         """
-        env = (
-            # N.B.: The PEP-508 defaulting scheme is "0" for versions and the empty string for
-            # everything else.
-            {
-                "implementation_name": "",
-                "implementation_version": "0",
-                "os_name": "",
-                "platform_machine": "",
-                "platform_python_implementation": "",
-                "platform_release": "",
-                "platform_system": "",
-                "platform_version": "0",
-                "python_full_version": "0",
-                "python_version": "0",
-                "sys_platform": "",
-            }
-            if default_unknown
-            else {}
-        )
-        env.update(attr.asdict(self, filter=lambda _attribute, value: value is not None))
-        return env
+        return attr.asdict(self, filter=lambda _attribute, value: value is not None)

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -1143,11 +1143,7 @@ class Pip(object):
             # failing when encountering them, ignoring them or doing what we do here: evaluate those
             # environment markers we know but fail for those we don't.
             patches_dir = safe_mkdtemp()
-            patched_environment = target.marker_environment.as_dict(
-                # We want to fail a resolve when it needs to evaluate environment markers we don't
-                # know.
-                default_unknown=False
-            )
+            patched_environment = target.marker_environment.as_dict()
             with open(os.path.join(patches_dir, "markers.json"), "w") as markers_fp:
                 json.dump(patched_environment, markers_fp)
             extra_env[self._PATCHED_MARKERS_FILE_ENV_VAR_NAME] = markers_fp.name

--- a/tests/test_pep_508.py
+++ b/tests/test_pep_508.py
@@ -16,10 +16,7 @@ def test_platform_marker_environment():
     # type: () -> None
     platform = Platform.create("linux-x86_64-cp-37-cp37m")
     marker_environment = MarkerEnvironment.from_platform(platform)
-    env_defaulted = marker_environment.as_dict(default_unknown=True)
-    env_sparse = marker_environment.as_dict(default_unknown=False)
-
-    assert set(env_sparse.items()).issubset(set(env_defaulted.items()))
+    env = marker_environment.as_dict()
 
     def evaluate_marker(
         expression,  # type: str
@@ -31,8 +28,7 @@ def test_platform_marker_environment():
 
     def assert_known_marker(expression):
         # type: (str) -> None
-        assert evaluate_marker(expression, env_defaulted)
-        assert evaluate_marker(expression, env_sparse)
+        assert evaluate_marker(expression, env)
 
     assert_known_marker("python_version == '3.7'")
     assert_known_marker("implementation_name == 'cpython'")
@@ -41,9 +37,8 @@ def test_platform_marker_environment():
 
     def assert_unknown_marker(expression):
         # type: (str) -> None
-        assert not evaluate_marker(expression, env_defaulted)
         with pytest.raises(markers.UndefinedEnvironmentName):
-            evaluate_marker(expression, env_sparse)
+            evaluate_marker(expression, env)
 
     assert_unknown_marker("python_full_version == '3.7.10'")
     assert_unknown_marker("platform_release == '5.12.12-arch1-1'")


### PR DESCRIPTION
We fail resolves that require unknown environment markers when building
a PEX via Pip and we should do the same when resolving from a PEX.
Although this case has not been knowingly exercised yet (Pants only
subsets for local interpreters and not foreign platforms), it is a both
inconsistent and incorrect behavior.

We'll have a similar need to resolve using platforms against lock files
shortly and all three forms of resolve should behave the same.