### PR TITLE
Lift `Requires-Python` evaluation to Target.

### DIFF
--- a/pex/environment.py
+++ b/pex/environment.py
@@ -157,7 +157,7 @@ class _PythonRequiresMismatch(_UnrankedDistribution):
             "The distribution has a python requirement of {python_requires} which does not match "
             "the python version of {python_version} for {target}.".format(
                 python_requires=self.python_requires,
-                python_version=target.get_python_version_str(),
+                python_version=target.python_version_str,
                 target=target,
             )
         )
@@ -250,7 +250,6 @@ class PEXEnvironment(object):
         self._activated_dists = None  # type: Optional[Iterable[Distribution]]
 
         self._target = target or targets.current()
-        self._interpreter_version = self._target.get_python_version_str()
 
         # The supported_tags come ordered most specific (platform specific) to least specific
         # (universal). We want to rank most specific highest; so we need to reverse iteration order
@@ -310,10 +309,11 @@ class PEXEnvironment(object):
         if rank == -1:
             return _TagMismatch(fingerprinted_dist, wheel_tags)
 
-        if self._interpreter_version:
-            python_requires = dist_metadata.requires_python(fingerprinted_dist.distribution)
-            if python_requires and self._interpreter_version not in python_requires:
-                return _PythonRequiresMismatch(fingerprinted_dist, python_requires)
+        python_requires = dist_metadata.requires_python(fingerprinted_dist.distribution)
+        if python_requires and not self._target.requires_python_applies(
+            python_requires, source=fingerprinted_dist.distribution.as_requirement()
+        ):
+            return _PythonRequiresMismatch(fingerprinted_dist, python_requires)
 
         return _RankedDistribution(rank, fingerprinted_dist)
 

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -3,13 +3,30 @@
 
 from __future__ import absolute_import
 
+import re
+
 import pytest
 
 from pex import targets
 from pex.interpreter import PythonInterpreter
 from pex.orderedset import OrderedSet
+from pex.pep_425 import CompatibilityTags
+from pex.pep_508 import MarkerEnvironment
 from pex.platforms import Platform
-from pex.targets import AbbreviatedPlatform, CompletePlatform, LocalInterpreter, Targets
+from pex.targets import (
+    AbbreviatedPlatform,
+    CompletePlatform,
+    LocalInterpreter,
+    RequiresPythonError,
+    Target,
+    Targets,
+)
+from pex.third_party.packaging.specifiers import SpecifierSet
+from pex.third_party.pkg_resources import Requirement
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Optional
 
 
 @pytest.fixture
@@ -77,3 +94,143 @@ def test_unique_targets(
             complete_platforms=(complete_platform_current, complete_platform_py27)
         ).unique_targets()
     )
+
+
+def assert_python_requirement_applies(
+    expected_result,  # type: bool
+    target,  # type: Target
+    python_requirement,  # type: str
+    source=None,  # type: Optional[Requirement]
+):
+    # type: (...) -> None
+    assert expected_result == target.requires_python_applies(
+        SpecifierSet(python_requirement), source=source or Requirement.parse("foo")
+    )
+
+
+def test_requires_python_current():
+    # type: () -> None
+
+    current_target = targets.current()
+    major, minor, patch = current_target.interpreter.version
+
+    def requires_python(template):
+        # type: (str) -> str
+        return template.format(major=major, minor=minor, patch=patch)
+
+    def assert_requires_python(
+        expected_result,  # type: bool
+        template,  # type: str
+    ):
+        # type: (...) -> None
+        assert_python_requirement_applies(
+            expected_result=expected_result,
+            target=current_target,
+            python_requirement=requires_python(template),
+        )
+
+    assert_requires_python(True, "~={major}.{minor}")
+
+    assert_requires_python(True, "=={major}.{minor}.*")
+    assert_requires_python(False, "=={major}.{minor}")
+    assert_requires_python(True, "=={major}.{minor}.{patch}")
+
+    assert_requires_python(True, "!={major}")
+    assert_requires_python(False, "!={major}.*")
+    assert_requires_python(True, "!={major}.{minor}")
+    assert_requires_python(False, "!={major}.{minor}.*")
+    assert_requires_python(False, "!={major}.{minor}.{patch}")
+
+    assert_requires_python(False, "<{major}")
+    assert_requires_python(False, "<={major}")
+    assert_requires_python(False, "<{major}.{minor}")
+    assert_requires_python(False, "<={major}.{minor}")
+    assert_requires_python(False, "<{major}.{minor}.{patch}")
+    assert_requires_python(True, "<={major}.{minor}.{patch}")
+
+    assert_requires_python(True, ">{major}")
+    assert_requires_python(True, ">={major}")
+    assert_requires_python(True, ">{major}.{minor}")
+    assert_requires_python(True, ">={major}.{minor}")
+    assert_requires_python(False, ">{major}.{minor}.{patch}")
+    assert_requires_python(True, ">={major}.{minor}.{patch}")
+
+    assert_requires_python(False, "==={major}.{minor}")
+    assert_requires_python(True, "==={major}.{minor}.{patch}")
+
+
+def test_requires_python_abbreviated_platform():
+    abbreviated_platform = AbbreviatedPlatform.create(Platform.create("linux-x86_64-cp-37-m"))
+
+    def assert_requires_python(
+        expected_result,  # type: bool
+        requires_python,  # type: str
+    ):
+        # type: (...) -> None
+        assert_python_requirement_applies(
+            expected_result=expected_result,
+            target=abbreviated_platform,
+            python_requirement=requires_python,
+        )
+
+    assert_requires_python(True, "~=3.7")
+
+    assert_requires_python(True, "==3.7.*")
+    assert_requires_python(True, "==3.7")
+    assert_requires_python(True, "==3.7.0")
+    assert_requires_python(False, "==3.7.1")
+
+    assert_requires_python(True, "!=3")
+    assert_requires_python(False, "!=3.*")
+    assert_requires_python(False, "!=3.7")
+    assert_requires_python(False, "!=3.7.*")
+    assert_requires_python(False, "!=3.7.0")
+    assert_requires_python(True, "!=3.7.1")
+
+    assert_requires_python(False, "<3")
+    assert_requires_python(False, "<=3")
+    assert_requires_python(False, "<3.7")
+    assert_requires_python(True, "<=3.7")
+    assert_requires_python(False, "<3.7.0")
+    assert_requires_python(True, "<3.7.1")
+    assert_requires_python(True, "<=3.7.0")
+
+    assert_requires_python(True, ">3")
+    assert_requires_python(True, ">=3")
+    assert_requires_python(False, ">3.7")
+    assert_requires_python(True, ">=3.7")
+    assert_requires_python(False, ">3.7.0")
+    assert_requires_python(True, ">=3.7.0")
+
+    assert_requires_python(True, "===3.7")
+
+    # There is no zeo-padding for the `===` operator:
+    # https://www.python.org/dev/peps/pep-0440/#arbitrary-equality
+    assert_requires_python(False, "===3.7.0")
+
+    assert_requires_python(False, "===3.7.1")
+
+
+def test_requires_python_invalid_target():
+    # type: () -> None
+
+    # This target has an empty marker environment; so no `python_version` and no
+    # `python_full_version`.
+    invalid_target = CompletePlatform.create(
+        marker_environment=MarkerEnvironment(),
+        supported_tags=CompatibilityTags.from_strings(["cp37-cp37m-linux_x86_64"]),
+    )
+
+    requires_python = SpecifierSet(">=2.7")
+    source = Requirement.parse("foo==1.2.3")
+    with pytest.raises(
+        RequiresPythonError,
+        match=r".*{}.*".format(
+            re.escape(
+                "Encountered `Requires-Python: >=2.7` when evaluating foo==1.2.3 for applicability "
+                "but the Python version information needed to evaluate this requirement is not "
+                "contained in the target being evaluated for: cp37-cp37m-linux_x86_64"
+            )
+        ),
+    ):
+        invalid_target.requires_python_applies(requires_python=requires_python, source=source)


### PR DESCRIPTION
This will be needed to resolve from lock files.