### PR TITLE
Introduce Rank and use it unify resolve ranking.

### DIFF
--- a/pex/pep_425.py
+++ b/pex/pep_425.py
@@ -6,11 +6,12 @@ from __future__ import absolute_import
 import itertools
 
 from pex.orderedset import OrderedSet
+from pex.rank import Rank
 from pex.third_party.packaging.tags import Tag, parse_tag
-from pex.typing import TYPE_CHECKING
+from pex.typing import TYPE_CHECKING, cast, overload
 
 if TYPE_CHECKING:
-    from typing import Iterable, Iterator, List, Tuple
+    from typing import Iterable, Iterator, List, Mapping, MutableMapping, Optional, Tuple, Union
 
     import attr  # vendor:skip
 else:
@@ -22,9 +23,31 @@ def _prepare_tags(tags):
     return tags if isinstance(tags, tuple) else tuple(OrderedSet(tags))
 
 
+class TagRank(Rank["TagRank"]):
+    """A Rank new-type to single out the ranking scheme for tags from other ranking schemes.
+
+    The highest rank tag is the most specific tag.
+    """
+
+
+@attr.s(frozen=True)
+class RankedTag(object):
+    tag = attr.ib(order=False)  # type: Tag
+    rank = attr.ib()  # type: TagRank
+
+    def select_higher_rank(self, other):
+        # type: (RankedTag) -> RankedTag
+        return Rank.select_highest_rank(
+            self, other, extract_rank=lambda ranked_tag: ranked_tag.rank
+        )
+
+
 @attr.s(frozen=True)
 class CompatibilityTags(object):
-    """An ordered set of PEP-425 compatibility tags.
+    """A ranked set of PEP-425 compatibility tags.
+
+    Tags are ordered most specific 1st to most generic last. The more specific a tag, the lower its
+    rank value, with the most specific tag (best match) being ranked 0.
 
     See: https://www.python.org/dev/peps/pep-0425/#use
     """
@@ -32,9 +55,23 @@ class CompatibilityTags(object):
     @classmethod
     def from_strings(cls, tags):
         # type: (Iterable[str]) -> CompatibilityTags
-        return cls(tags=itertools.chain.from_iterable(parse_tag(tag) for tag in tags))
+        return cls(tags=tuple(itertools.chain.from_iterable(parse_tag(tag) for tag in tags)))
 
     _tags = attr.ib(converter=_prepare_tags)  # type: Tuple[Tag, ...]
+    __rankings = attr.ib(eq=False, factory=dict)  # type: MutableMapping[Tag, TagRank]
+
+    @_tags.validator
+    def _validate_tags(
+        self,
+        attribute,  # type: attr.Attribute
+        value,  # type: Tuple[Tag, ...]
+    ):
+        if not value:
+            raise ValueError(
+                "The {name} parameter should contain at least one tag; given an empty set.".format(
+                    name=attribute.name
+                )
+            )
 
     def compatible_tags(self, tags):
         # type: (Iterable[Tag]) -> OrderedSet[Tag]
@@ -52,13 +89,59 @@ class CompatibilityTags(object):
         # type: () -> List[str]
         return [str(tag) for tag in self._tags]
 
+    @property
+    def _rankings(self):
+        # type: () -> Mapping[Tag, TagRank]
+        if not self.__rankings:
+            self.__rankings.update(TagRank.ranked(self._tags))
+        return self.__rankings
+
+    @property
+    def lowest_rank(self):
+        # type: () -> TagRank
+        return cast(TagRank, self.rank(self[-1]))
+
+    def rank(self, tag):
+        # type: (Tag) -> Optional[TagRank]
+        return self._rankings.get(tag)
+
+    def best_match(self, tags):
+        # type: (Iterable[Tag]) -> Optional[RankedTag]
+        best_match = None  # type: Optional[RankedTag]
+        for tag in tags:
+            rank = self.rank(tag)
+            if rank is None:
+                continue
+            ranked_tag = RankedTag(tag=tag, rank=rank)
+            if best_match is None or ranked_tag is best_match.select_higher_rank(ranked_tag):
+                best_match = ranked_tag
+        return best_match
+
     def __iter__(self):
         # type: () -> Iterator[Tag]
         return iter(self._tags)
 
-    def __reversed__(self):
-        return CompatibilityTags(tags=reversed(self._tags))
+    def __len__(self):
+        # type: () -> int
+        return len(self._tags)
 
+    @overload
     def __getitem__(self, index):
         # type: (int) -> Tag
-        return self._tags[index]
+        pass
+
+    @overload
+    def __getitem__(self, tag):
+        # type: (Tag) -> TagRank
+        pass
+
+    def __getitem__(self, index_or_tag):
+        # type: (Union[int, Tag]) -> Union[Tag, TagRank]
+        """Retrieve tag by its rank or a tags rank.
+
+        Ranks are 0-based with the 0-rank tag being the most specific (best match).
+        """
+        if isinstance(index_or_tag, Tag):
+            return self._rankings[index_or_tag]
+        else:
+            return self._tags[index_or_tag]

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -1039,7 +1039,7 @@ class Pip(object):
                     )
                 )
             elif isinstance(target, CompletePlatform):
-                compatible_tags = target.get_supported_tags()
+                compatible_tags = target.supported_tags
                 if compatible_tags:
                     with open(os.path.join(patches_dir, "tags.json"), "w") as tags_fp:
                         json.dump(compatible_tags.to_string_list(), tags_fp)

--- a/pex/rank.py
+++ b/pex/rank.py
@@ -1,0 +1,125 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from pex.typing import TYPE_CHECKING, Generic, cast, overload
+
+if TYPE_CHECKING:
+    from typing import Any, Callable, ClassVar, Iterable, Iterator, Optional, Tuple, Type, TypeVar
+
+    _I = TypeVar("_I")
+    _R = TypeVar("_R", bound="Rank")
+
+
+class Rank(Generic["_R"]):
+    """Represents a ranking where lower values represent higher ranks.
+
+    Ranks naturally sort from highest rank (lowest value) to lowest rank (highest value).
+
+    Rank is intended to be sub-classed to define a ranking for a given set of subjects. Subclasses
+    can adjust the value of the highest rank by over-riding the `HIGHEST_NATURAL_VALUE` class
+    variable.
+    """
+
+    HIGHEST_NATURAL_VALUE = 1  # type: ClassVar[int]
+
+    @classmethod
+    def highest_natural(cls):
+        # type: (Type[_R]) -> _R
+        return cls(cls.HIGHEST_NATURAL_VALUE)
+
+    @classmethod
+    def ranked(
+        cls,  # type: Type[_R]
+        items,  # type: Iterable[_I]
+    ):
+        # type: (...) -> Iterator[Tuple[_I, _R]]
+        for rank, item in enumerate(items, start=cls.HIGHEST_NATURAL_VALUE):
+            yield item, cls(rank)
+
+    @classmethod
+    @overload
+    def select_highest_rank(
+        cls,
+        item1,  # type: Rank
+        item2,  # type: Rank
+    ):
+        # type: (...) -> Rank
+        pass
+
+    @classmethod
+    @overload
+    def select_highest_rank(
+        cls,
+        item1,  # type: _I
+        item2,  # type: _I
+        extract_rank,  # type: Callable[[_I], Rank]
+    ):
+        # type: (...) -> _I
+        pass
+
+    @classmethod
+    def select_highest_rank(
+        cls,
+        item1,  # type: _I
+        item2,  # type: _I
+        extract_rank=None,  # type: Optional[Callable[[_I], Rank]]
+    ):
+        # type: (...) -> _I
+        if extract_rank is not None:
+            return item1 if extract_rank(item1) < extract_rank(item2) else item2
+
+        if not isinstance(item1, Rank):
+            raise TypeError(
+                "Can only select from amongst the same rank type; item1 is a `{item1_type}` "
+                "and not a `Rank`. You may need to supply an `extract_rank` function.".format(
+                    item1_type=type(item1).__name__
+                )
+            )
+        if type(item1) != type(item2):
+            raise TypeError(
+                "Can only select from amongst the same rank type; item1 is a `{item1_type}` "
+                "but item2 is a `{item2_type}`.".format(
+                    item1_type=item1.__class__.__name__, item2_type=type(item2).__name__
+                )
+            )
+        return cast("_I", item1 if item1 < item2 else item2)
+
+    def __init__(self, value):
+        # type: (int) -> None
+        self._value = value
+
+    @property
+    def value(self):
+        # type: () -> int
+        return self._value
+
+    def higher(self):
+        # type: (_R) -> _R
+        return self.__class__(self._value - 1)
+
+    def lower(self):
+        # type: (_R) -> _R
+        return self.__class__(self._value + 1)
+
+    def __repr__(self):
+        # type: () -> str
+        return "{class_name}({value})".format(class_name=self.__class__.__name__, value=self._value)
+
+    def __eq__(self, other):
+        # type: (Any) -> bool
+        return type(self) == type(other) and self._value == other._value
+
+    def __ne__(self, other):
+        # type: (Any) -> bool
+        return not self == other
+
+    def __lt__(self, other):
+        # type: (Any) -> bool
+        if type(self) != type(other):
+            return NotImplemented
+        # The need for this ignore appears to be tied to `return NotImplemented` but it seems that
+        # MyPy doesn't understand `NotImplemented` as either a `Literal` value or as a type in
+        # `Union`.
+        return self._value < other.value  # type: ignore[no-any-return]

--- a/pex/targets.py
+++ b/pex/targets.py
@@ -32,7 +32,8 @@ class Target(object):
     platform = attr.ib()  # type: Platform
     marker_environment = attr.ib()  # type: MarkerEnvironment
 
-    def get_supported_tags(self):
+    @property
+    def supported_tags(self):
         # type: () -> CompatibilityTags
         raise NotImplementedError()
 
@@ -165,7 +166,8 @@ class LocalInterpreter(Target):
         # type: () -> PythonInterpreter
         return self.interpreter
 
-    def get_supported_tags(self):
+    @property
+    def supported_tags(self):
         return self.interpreter.identity.supported_tags
 
     def __str__(self):
@@ -191,7 +193,8 @@ class AbbreviatedPlatform(Target):
 
     manylinux = attr.ib()  # type: Optional[str]
 
-    def get_supported_tags(self):
+    @property
+    def supported_tags(self):
         # type: () -> CompatibilityTags
         return self.platform.supported_tags(manylinux=self.manylinux)
 
@@ -229,7 +232,8 @@ class CompletePlatform(Target):
 
     _supported_tags = attr.ib()  # type: CompatibilityTags
 
-    def get_supported_tags(self):
+    @property
+    def supported_tags(self):
         # type: () -> CompatibilityTags
         return self._supported_tags
 

--- a/tests/integration/test_issue_1597.py
+++ b/tests/integration/test_issue_1597.py
@@ -75,7 +75,7 @@ def test_platform_complete(
             json.dumps(
                 dict(
                     marker_environment=complete_platform.marker_environment.as_dict(),
-                    compatible_tags=complete_platform.get_supported_tags().to_string_list(),
+                    compatible_tags=complete_platform.supported_tags.to_string_list(),
                 )
             ),
         ]

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -19,6 +19,7 @@ from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
+from pex.rank import Rank
 from pex.targets import LocalInterpreter, Targets
 from pex.testing import (
     IS_LINUX,
@@ -448,7 +449,7 @@ def test_can_add_ranking_platform_tag_more_specific(assert_cpython_37_environmen
     ranked_universal = assert_cpython_37_environment_can_add(
         create_dist("foo-2.0.0-py2.py3-none-any.whl", "2.0.0")
     )
-    assert ranked_specific > ranked_universal
+    assert ranked_specific < ranked_universal
 
     ranked_almost_py3universal = assert_cpython_37_environment_can_add(
         create_dist("foo-2.0.0-py3-none-any.whl", "2.0.0")
@@ -467,19 +468,4 @@ def test_can_add_ranking_version_newer_tie_break(assert_cpython_37_environment_c
     ranked_v2 = assert_cpython_37_environment_can_add(
         create_dist("foo-2.0.0-cp37-cp37m-macosx_10_9_x86_64.linux_x86_64.whl", "2.0.0")
     )
-    assert ranked_v2 > ranked_v1
-
-
-def test_ranking_platform_tag_maximum(cpython_37_environment):
-    # type: (PEXEnvironment) -> None
-    dist = create_dist("foo-1.0.0-cp37-cp37m-macosx_10_9_x86_64.linux_x86_64.whl", "1.0.0")
-
-    minimum_tag_rank = min(cpython_37_environment._supported_tags_to_rank.values())
-    maximum_tag_rank = max(cpython_37_environment._supported_tags_to_rank.values())
-    assert maximum_tag_rank > minimum_tag_rank
-
-    maximum_rank = _RankedDistribution.maximum(dist)
-    bigger_than_naturally_possible_rank = _RankedDistribution(
-        rank=maximum_tag_rank + 1, fingerprinted_distribution=dist
-    )
-    assert maximum_rank > bigger_than_naturally_possible_rank
+    assert ranked_v2 < ranked_v1


### PR DESCRIPTION
Previously some parts of the codebase used larger ints to denote better
fits and others used smaller ints for this. This resulted in a
mix of sorts of ranked things in the codebase which could be confusing.

Push the ordering, choosing and sorting into Rank to help make sense of
all this and ensure subset rwsolve ranking works the same as lockfile
resolve ranking.