### PR TITLE
Work around a Flit bug.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -113,6 +113,9 @@ commands =
 basepython = python3
 deps =
     flit
+    # This is only here to pin the transitive dependency low to work around
+    # https://github.com/pypa/flit/issues/530
+    flit_core<3.7.0
     pygments
 
 [_package]


### PR DESCRIPTION
There was a Flit release yesterday that broke `tox -epackage`.

See: https://github.com/pypa/flit/issues/530