### PR TITLE
Plumb a lock source to resolve error messages.

### DIFF
--- a/pex/resolve/locked_resolve.py
+++ b/pex/resolve/locked_resolve.py
@@ -424,6 +424,7 @@ class LockedResolve(object):
         self,
         target,  # type: Target
         requirements,  # type: Iterable[Requirement]
+        source=None,  # type: Optional[str]
         transitive=True,  # type: bool
         build=True,  # type: bool
         use_wheel=True,  # type: bool
@@ -599,17 +600,19 @@ class LockedResolve(object):
             resolved_artifacts.append(best_match)
 
         if errors:
+            from_source = " from {source}".format(source=source) if source else ""
             return Error(
-                "Failed to resolve all requirements for {target}:\n"
+                "Failed to resolve all requirements for {target}{from_source}:\n"
                 "\n"
                 "Configured with:\n"
                 "    build: {build}\n"
                 "    use_wheel: {use_wheel}\n"
                 "\n"
                 "{errors}".format(
+                    target=target.render_description(),
+                    from_source=from_source,
                     build=build,
                     use_wheel=use_wheel,
-                    target=target.render_description(),
                     errors="\n\n".join("{error}".format(error=error) for error in errors),
                 )
             )

--- a/tests/resolve/test_locked_resolve.py
+++ b/tests/resolve/test_locked_resolve.py
@@ -296,6 +296,27 @@ def test_not_found(
     )
 
 
+def test_source(
+    current_target,  # type: Target
+    ansicolors_exotic,  # type: LockedResolve
+):
+    # type: (...) -> None
+    assert_error(
+        ansicolors_exotic.resolve(current_target, [req("requests>1")], source="lock.json"),
+        dedent(
+            """\
+            Failed to resolve all requirements for {target_description} from lock.json:
+
+            Configured with:
+                build: True
+                use_wheel: True
+
+            Dependency on requests (via: requests>1) not satisfied, no candidates found.
+            """
+        ).format(target_description=current_target.render_description()),
+    )
+
+
 def test_version_mismatch(
     current_target,  # type: Target
     ansicolors_exotic,  # type: LockedResolve


### PR DESCRIPTION
The Lockfile class already has a source field that callers of
`LockedResolve.resolve` will be able to pass in.