### PR TITLE
Force stderr to be unbuffered in tests.

### DIFF
--- a/tests/integration/venv_ITs/test_issue_1637.py
+++ b/tests/integration/venv_ITs/test_issue_1637.py
@@ -127,7 +127,6 @@ def test_pex_path_collision_non_conflicting(
     execute_app(app, PEX_PATH=os.pathsep.join((deps, srcs)))
 
 
-@pytest.mark.skipif(IS_PYPY3, reason="Warnings are not always flushed to stderr under PyPy3.")
 def test_pex_path_collision_conflicting(tmpdir):
     # Test a conflicting duplicate dep top-level module collision.
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,13 @@ passenv =
     CPPFLAGS
     LDFLAGS
     PEX_VERBOSE
+setenv =
+    # Python 3 (until a fix here in 3.9: https://bugs.python.org/issue13601) switched from stderr
+    # being unbuffered to stderr being buffered by default. This can lead to tests checking stderr
+    # failing to see what they expect if the stderr buffer block has not been flushed. Force stderr
+    # line buffering (which is what setting PYTHONUNBUFFERED nets you) so that tests can rely on
+    # stderr lines being observable.
+    py{py3,35,36,37,38}: PYTHONUNBUFFERED=1
 whitelist_externals =
     open
     bash
@@ -48,6 +55,13 @@ deps =
     {[testenv]deps}
 commands =
     pytest -n auto tests/integration {posargs:-vvs}
+setenv =
+    # Python 3 (until a fix here in 3.9: https://bugs.python.org/issue13601) switched from stderr
+    # being unbuffered to stderr being buffered by default. This can lead to tests checking stderr
+    # failing to see what they expect if the stderr buffer block has not been flushed. Force stderr
+    # line buffering (which is what setting PYTHONUNBUFFERED nets you) so that tests can rely on
+    # stderr lines being observable.
+    py{py3,35,36,37,38}-integration: PYTHONUNBUFFERED=1
 
 [testenv:format-run]
 skip_install = true


### PR DESCRIPTION
Python 3 (Until a fix here in 3.9: https://bugs.python.org/issue13601)
switched from stderr being unbuffered to stderr being buffered by
default (See more here: https://bugs.python.org/issue13597). This can
lead to tests checking stderr failing to see what they expect if the
stderr buffer block has not been flushed. Force stderr line buffering
(which is what setting PYTHONUNBUFFERED nets you) so that tests can
rely on stderr lines being observable.