### PR TITLE
Introduce `--lock` resolves.

### DIFF
--- a/pex/cli/commands/lock.py
+++ b/pex/cli/commands/lock.py
@@ -77,6 +77,7 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
         resolver_options.register(
             cls._create_resolver_options_group(parser),
             include_pex_repository=False,
+            include_lock=False,
         )
 
     @classmethod

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -302,13 +302,6 @@ class _Issue10050Analyzer(_ErrorAnalyzer):
 
 
 class Locker(_LogAnalyzer):
-    class StateError(Exception):
-        """Indicates the Locker lifecycle was violated.
-
-        A Locker 1st should be used to collect data from a Pip debug log and only then can a `lock`
-        be requested.
-        """
-
     def __init__(self, lock_request):
         # type: (LockRequest) -> None
         self._lock_request = lock_request

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -1,0 +1,289 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import functools
+import hashlib
+from collections import OrderedDict
+from multiprocessing.pool import ThreadPool
+
+from pex.common import pluralize
+from pex.compatibility import cpu_count
+from pex.fetcher import URLFetcher
+from pex.network_configuration import NetworkConfiguration
+from pex.orderedset import OrderedSet
+from pex.pip import PackageIndexConfiguration
+from pex.resolve import lockfile
+from pex.resolve.locked_resolve import Artifact, DownloadableArtifact, Resolved
+from pex.resolve.lockfile import parse_lockable_requirements
+from pex.resolve.lockfile.download_manager import DownloadedArtifact, DownloadManager
+from pex.resolve.requirement_configuration import RequirementConfiguration
+from pex.resolve.resolver_configuration import ResolverVersion
+from pex.resolve.resolvers import Installed
+from pex.resolver import BuildAndInstallRequest, BuildRequest, InstallRequest
+from pex.result import Error, ResultError, catch, try_
+from pex.targets import Target, Targets
+from pex.tracer import TRACER
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Dict, Iterable, Optional, Sequence, Union
+
+
+class URLFetcherDownloadManager(DownloadManager):
+    _BUFFER_SIZE = 65536
+
+    def __init__(
+        self,
+        url_fetcher,  # type: URLFetcher
+        pex_root=None,  # type: Optional[str]
+    ):
+        super(URLFetcherDownloadManager, self).__init__(pex_root=pex_root)
+        self._url_fetcher = url_fetcher
+
+    def store_downloadable_artifact(self, downloadable_artifact):
+        return self.store(artifact=downloadable_artifact.artifact)
+
+    def save(
+        self,
+        artifact,  # type: Artifact
+        path,  # type: str
+    ):
+        # type: (...) -> str
+        digest_check = hashlib.new(artifact.fingerprint.algorithm)
+        digest_internal = hashlib.sha1()
+        url = artifact.url
+        try:
+            with open(path, "wb") as fp, self._url_fetcher.get_body_stream(url) as stream:
+                for chunk in iter(lambda: stream.read(self._BUFFER_SIZE), b""):
+                    fp.write(chunk)
+                    digest_check.update(chunk)
+                    digest_internal.update(chunk)
+        except IOError as e:
+            raise ResultError(Error(str(e)))
+
+        actual_hash = digest_check.hexdigest()
+        if artifact.fingerprint.hash != actual_hash:
+            raise ResultError(
+                Error(
+                    "Expected {algorithm} hash of {expected_hash} but hashed to "
+                    "{actual_hash}.".format(
+                        algorithm=artifact.fingerprint.algorithm,
+                        expected_hash=artifact.fingerprint.hash,
+                        actual_hash=actual_hash,
+                    )
+                )
+            )
+        return digest_internal.hexdigest()
+
+
+# Derived from notes in the bandersnatch PyPI mirroring tool:
+# https://github.com/pypa/bandersnatch/blob/1485712d6aa77fba54bbf5a2df0d7314124ad097/src/bandersnatch/default.conf#L30-L35
+MAX_PARALLEL_DOWNLOADS = 10
+
+
+def resolve_from_lock(
+    targets,  # type: Targets
+    lockfile_path,  # type: str
+    requirements=None,  # type: Optional[Iterable[str]]
+    requirement_files=None,  # type: Optional[Iterable[str]]
+    constraint_files=None,  # type: Optional[Iterable[str]]
+    indexes=None,  # type: Optional[Sequence[str]]
+    find_links=None,  # type: Optional[Sequence[str]]
+    resolver_version=None,  # type: Optional[ResolverVersion.Value]
+    network_configuration=None,  # type: Optional[NetworkConfiguration]
+    cache=None,  # type: Optional[str]
+    build=True,  # type: bool
+    use_wheel=True,  # type: bool
+    prefer_older_binary=False,  # type: bool
+    use_pep517=None,  # type: Optional[bool]
+    build_isolation=True,  # type: bool
+    compile=False,  # type: bool
+    transitive=True,  # type: bool
+    verify_wheels=True,  # type: bool
+    max_parallel_jobs=None,  # type: Optional[int]
+):
+    # type: (...) -> Union[Installed, Error]
+
+    with TRACER.timed("Parsing lock {lockfile}".format(lockfile=lockfile_path)):
+        lock = lockfile.load(lockfile_path)
+
+    with TRACER.timed("Parsing requirements"):
+        requirement_configuration = RequirementConfiguration(
+            requirements=requirements,
+            requirement_files=requirement_files,
+            constraint_files=constraint_files,
+        )
+        parsed_requirements = try_(
+            parse_lockable_requirements(
+                requirement_configuration, network_configuration=network_configuration
+            )
+        )
+
+    errors_by_target = {}  # type: Dict[Target, Iterable[Error]]
+    downloadable_artifacts = OrderedSet()  # type: OrderedSet[DownloadableArtifact]
+    downloadable_artifacts_by_target = {}  # type: Dict[Target, Iterable[DownloadableArtifact]]
+
+    with TRACER.timed(
+        "Resolving urls to fetch for {count} requirements from lock {lockfile}".format(
+            count=len(parsed_requirements.requirements), lockfile=lockfile_path
+        )
+    ):
+        for target in targets.unique_targets():
+            resolveds = []
+            errors = []
+            for locked_resolve in lock.locked_resolves:
+                resolve_result = locked_resolve.resolve(
+                    target,
+                    parsed_requirements.requirements,
+                    constraints=parsed_requirements.constraints,
+                    source=lockfile_path,
+                    transitive=transitive,
+                    build=build,
+                    use_wheel=use_wheel,
+                    prefer_older_binary=prefer_older_binary,
+                    # TODO(John Sirois): Plumb `--ignore-errors` to support desired but technically
+                    #  invalid `pip-legacy-resolver` locks:
+                    #  https://github.com/pantsbuild/pex/issues/1652
+                )
+                if isinstance(resolve_result, Resolved):
+                    resolveds.append(resolve_result)
+                else:
+                    errors.append(resolve_result)
+
+            if resolveds:
+                resolved = sorted(resolveds, key=lambda res: res.target_specificity)[-1]
+                downloadable_artifacts_by_target[target] = resolved.downloadable_artifacts
+                downloadable_artifacts.update(resolved.downloadable_artifacts)
+            else:
+                errors_by_target[target] = tuple(errors)
+
+    if errors_by_target:
+        return Error(
+            "Failed to resolve compatible artifacts from lock {lock} for {count} {targets}:\n"
+            "{errors}".format(
+                lock=lock.source,
+                count=len(errors_by_target),
+                targets=pluralize(errors_by_target, "target"),
+                errors="\n".join(
+                    "{index}. {target}:\n    {errors}".format(
+                        index=index, target=target, errors="\n    ".join(map(str, errors))
+                    )
+                    for index, (target, errors) in enumerate(errors_by_target.items(), start=1)
+                ),
+            )
+        )
+
+    download_manager = URLFetcherDownloadManager(
+        url_fetcher=URLFetcher(network_configuration=network_configuration, handle_file_urls=True)
+    )
+    max_threads = min(
+        len(downloadable_artifacts),
+        min(MAX_PARALLEL_DOWNLOADS, 4 * (max_parallel_jobs or cpu_count() or 1)),
+    )
+    with TRACER.timed(
+        "Downloading {url_count} distributions to satisfy {requirement_count} requirements".format(
+            url_count=len(downloadable_artifacts),
+            requirement_count=len(parsed_requirements.requirements),
+        )
+    ):
+        pool = ThreadPool(processes=max_threads)
+        try:
+            download_results = tuple(
+                zip(
+                    downloadable_artifacts,
+                    pool.map(
+                        functools.partial(catch, download_manager.store_downloadable_artifact),
+                        downloadable_artifacts,
+                    ),
+                )
+            )
+        finally:
+            pool.close()
+            pool.join()
+
+    with TRACER.timed("Categorizing {} downloaded artifacts".format(len(download_results))):
+        downloaded_artifacts = {}
+        download_errors = OrderedDict()
+        for downloadable_artifact, download_result in download_results:
+            if isinstance(download_result, DownloadedArtifact):
+                downloaded_artifacts[downloadable_artifact] = download_result
+            else:
+                download_errors[downloadable_artifact] = download_result
+
+        if download_errors:
+            error_count = len(download_errors)
+            return Error(
+                "There {were} {count} {errors} downloading required artifacts:\n"
+                "{error_details}".format(
+                    were="was" if error_count == 1 else "were",
+                    count=error_count,
+                    errors=pluralize(download_errors, "error"),
+                    error_details="\n".join(
+                        "{index}. {pin} from {url}\n    {error}".format(
+                            index=index,
+                            pin=downloadable_artifact.pin,
+                            url=downloadable_artifact.artifact.url,
+                            error=error,
+                        )
+                        for index, (downloadable_artifact, error) in enumerate(
+                            download_errors.items(), start=1
+                        )
+                    ),
+                )
+            )
+
+        build_requests = []
+        install_requests = []
+        for target, artifacts in downloadable_artifacts_by_target.items():
+            for downloadable_artifact in artifacts:
+                downloaded_artifact = downloaded_artifacts[downloadable_artifact]
+                if downloaded_artifact.path.endswith(".whl"):
+                    install_requests.append(
+                        InstallRequest(
+                            target=target,
+                            wheel_path=downloaded_artifact.path,
+                            fingerprint=downloaded_artifact.fingerprint(),
+                        )
+                    )
+                else:
+                    build_requests.append(
+                        BuildRequest(
+                            target=target,
+                            source_path=downloaded_artifact.path,
+                            fingerprint=downloaded_artifact.fingerprint(),
+                        )
+                    )
+
+    with TRACER.timed(
+        "Building {} artifacts and installing {}".format(
+            len(build_requests), len(build_requests) + len(install_requests)
+        )
+    ):
+        build_and_install_request = BuildAndInstallRequest(
+            build_requests=build_requests,
+            install_requests=install_requests,
+            direct_requirements=parsed_requirements.parsed_requirements,
+            package_index_configuration=PackageIndexConfiguration.create(
+                resolver_version=resolver_version,
+                indexes=indexes,
+                find_links=find_links,
+                network_configuration=network_configuration,
+            ),
+            cache=cache,
+            compile=compile,
+            prefer_older_binary=prefer_older_binary,
+            use_pep517=use_pep517,
+            build_isolation=build_isolation,
+            verify_wheels=verify_wheels,
+        )
+        installed_distributions = build_and_install_request.install_distributions(
+            # This otherwise checks that resolved distributions all meet internal requirement
+            # constraints (This allows pip-legacy-resolver resolves with invalid solutions to be
+            # failed post-facto by Pex at PEX build time). We've already done this via
+            # `LockedResolve.resolve` above and need not waste time (~O(100ms)) doing this again.
+            ignore_errors=True,
+            max_parallel_jobs=max_parallel_jobs,
+        )
+    return Installed(installed_distributions=tuple(installed_distributions))

--- a/pex/resolve/lockfile/download_manager.py
+++ b/pex/resolve/lockfile/download_manager.py
@@ -1,0 +1,56 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os
+
+from pex.common import atomic_directory
+from pex.resolve.locked_resolve import Artifact
+from pex.typing import TYPE_CHECKING
+from pex.variables import ENV
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class DownloadedArtifact(object):
+    path = attr.ib()  # type: str
+
+    def fingerprint(self):
+        # type: () -> str
+        with open(os.path.join(os.path.dirname(self.path), "sha1"), "rb") as fp:
+            return str(fp.read().decode("ascii"))
+
+
+class DownloadManager(object):
+    def __init__(self, pex_root=None):
+        # type: (Optional[str]) -> None
+        self._download_dir = os.path.join(pex_root or ENV.PEX_ROOT, "downloads")
+
+    def store(self, artifact):
+        # type: (Artifact) -> DownloadedArtifact
+
+        download_dir = os.path.join(self._download_dir, artifact.fingerprint.hash)
+        with atomic_directory(download_dir, exclusive=True) as atomic_dir:
+            if not atomic_dir.is_finalized():
+                dest = os.path.join(atomic_dir.work_dir, artifact.filename)
+                internal_fingerprint = self.save(artifact, dest)
+                with open(os.path.join(atomic_dir.work_dir, "sha1"), "wb") as fp:
+                    fp.write(internal_fingerprint.encode("ascii"))
+
+        return DownloadedArtifact(path=os.path.join(download_dir, artifact.filename))
+
+    def save(
+        self,
+        artifact,  # type: Artifact
+        path,  # type: str
+    ):
+        # type: (...) -> str
+        """Save the given `artifact` at `path` and return its sha1 hex digest."""
+        raise NotImplementedError()

--- a/pex/resolve/resolver_configuration.py
+++ b/pex/resolve/resolver_configuration.py
@@ -53,3 +53,9 @@ class PexRepositoryConfiguration(object):
     pex_repository = attr.ib()  # type: str
     network_configuration = attr.ib(default=NetworkConfiguration())  # type: NetworkConfiguration
     transitive = attr.ib(default=True)  # type: bool
+
+
+@attr.s(frozen=True)
+class LockRepositoryConfiguration(object):
+    lock_file = attr.ib()  # type: str
+    pip_configuration = attr.ib()  # type: PipConfiguration

--- a/pex/resolve/resolver_options.py
+++ b/pex/resolve/resolver_options.py
@@ -96,7 +96,9 @@ def register(
         help="Deprecated: No longer used.",
     )
 
-    repository_choice = parser.add_mutually_exclusive_group()
+    repository_choice = (
+        parser.add_mutually_exclusive_group() if include_pex_repository and include_lock else parser
+    )
     if include_pex_repository:
         repository_choice.add_argument(
             "--pex-repository",

--- a/pex/resolve/resolver_options.py
+++ b/pex/resolve/resolver_options.py
@@ -11,6 +11,7 @@ from pex.network_configuration import NetworkConfiguration
 from pex.orderedset import OrderedSet
 from pex.resolve.resolver_configuration import (
     PYPI,
+    LockRepositoryConfiguration,
     PexRepositoryConfiguration,
     PipConfiguration,
     ReposConfiguration,
@@ -51,12 +52,14 @@ class _HandleTransitiveAction(Action):
 def register(
     parser,  # type: _ActionsContainer
     include_pex_repository=False,  # type: bool
+    include_lock=False,  # type: bool
 ):
     # type: (...) -> None
     """Register resolver configuration options with the given parser.
 
     :param parser: The parser to register resolver configuration options with.
     :param include_pex_repository: Whether to include the `--pex-repository` option.
+    :param include_lock: Whether to include the `--lock` option.
     """
 
     default_resolver_configuration = PipConfiguration()
@@ -93,16 +96,29 @@ def register(
         help="Deprecated: No longer used.",
     )
 
+    repository_choice = parser.add_mutually_exclusive_group()
     if include_pex_repository:
-        parser.add_argument(
+        repository_choice.add_argument(
             "--pex-repository",
             dest="pex_repository",
             metavar="FILE",
             default=None,
             type=str,
             help=(
-                "Resolve requirements from the given PEX file instead of from --index servers or "
-                "--find-links repos."
+                "Resolve requirements from the given PEX file instead of from --index servers, "
+                "--find-links repos or a --lock file."
+            ),
+        )
+    if include_lock:
+        repository_choice.add_argument(
+            "--lock",
+            dest="lock",
+            metavar="FILE",
+            default=None,
+            type=str,
+            help=(
+                "Resolve requirements from the given lock file instead of from --index servers, "
+                "--find-links repos or a --pex-repository."
             ),
         )
 
@@ -300,8 +316,14 @@ class InvalidConfigurationError(Exception):
     """Indicates an invalid resolver configuration."""
 
 
+if TYPE_CHECKING:
+    ResolverConfiguration = Union[
+        LockRepositoryConfiguration, PexRepositoryConfiguration, PipConfiguration
+    ]
+
+
 def configure(options):
-    # type: (Namespace) -> Union[PipConfiguration, PexRepositoryConfiguration]
+    # type: (Namespace) -> ResolverConfiguration
     """Creates a resolver configuration from options registered by `register`.
 
     :param options: The resolver configuration options.
@@ -309,9 +331,15 @@ def configure(options):
     """
 
     pex_repository = getattr(options, "pex_repository", None)
+    lock = getattr(options, "lock", None)
     if pex_repository and (options.indexes or options.find_links):
         raise InvalidConfigurationError(
             'The "--pex-repository" option cannot be used together with the "--index" or '
+            '"--find-links" options.'
+        )
+    if lock and (options.indexes or options.find_links):
+        raise InvalidConfigurationError(
+            'The "--lock" option cannot be used together with the "--index" or '
             '"--find-links" options.'
         )
 
@@ -321,7 +349,13 @@ def configure(options):
             network_configuration=create_network_configuration(options),
             transitive=options.transitive,
         )
-    return create_pip_configuration(options)
+    pip_configuration = create_pip_configuration(options)
+    if lock:
+        return LockRepositoryConfiguration(
+            lock_file=options.lock,
+            pip_configuration=pip_configuration,
+        )
+    return pip_configuration
 
 
 def create_pip_configuration(options):

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -645,14 +645,16 @@ class BuildAndInstallRequest(object):
                 TRACER.log(
                     "Installing {} in {}".format(
                         install_request.wheel_path, install_result.install_chroot
-                    )
+                    ),
+                    V=2,
                 )
                 unsatisfied_install_requests.append(install_request)
             else:
                 TRACER.log(
                     "Using cached installation of {} at {}".format(
                         install_request.wheel_file, install_result.install_chroot
-                    )
+                    ),
+                    V=2,
                 )
                 install_results.append(install_result)
         return unsatisfied_install_requests, install_results
@@ -765,7 +767,7 @@ class BuildAndInstallRequest(object):
             installations.extend(install_result.finalize_install(install_requests))
 
         with TRACER.timed(
-            "Installing:" "\n  {}".format("\n  ".join(map(str, representative_install_requests)))
+            "Installing {} distributions".format(len(representative_install_requests))
         ):
             install_requests, install_results = self._categorize_install_requests(
                 install_requests=representative_install_requests,
@@ -783,7 +785,8 @@ class BuildAndInstallRequest(object):
                 add_installation(install_result)
 
         if not ignore_errors:
-            self._check_install(installations)
+            with TRACER.timed("Checking install"):
+                self._check_install(installations)
 
         installed_distributions = OrderedSet()  # type: OrderedSet[InstalledDistribution]
         for installed_distribution in installations:

--- a/pex/result.py
+++ b/pex/result.py
@@ -62,6 +62,10 @@ class ResultError(Exception):
 
     error = attr.ib()  # type: Error
 
+    def __str__(self):
+        # type: () -> str
+        return str(self.error)
+
 
 def try_(result):
     # type: (Union[_T, Error]) -> _T

--- a/tests/integration/test_lock_resolver.py
+++ b/tests/integration/test_lock_resolver.py
@@ -1,0 +1,308 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import glob
+import hashlib
+import os
+import re
+import subprocess
+
+import pytest
+
+from pex import dist_metadata
+from pex.cli.testing import run_pex3
+from pex.interpreter import PythonInterpreter
+from pex.pep_440 import Version
+from pex.pep_503 import ProjectName
+from pex.pex_info import PexInfo
+from pex.resolve import lockfile
+from pex.resolve.locked_resolve import LockedRequirement, LockedResolve
+from pex.testing import make_env, run_pex_command
+from pex.typing import TYPE_CHECKING
+from pex.util import CacheHelper
+
+if TYPE_CHECKING:
+    from typing import Any, Mapping, Tuple
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+def project_name_and_version(path):
+    # type: (str) -> Tuple[ProjectName, Version]
+
+    name_and_version = dist_metadata.project_name_and_version(path)
+    assert name_and_version is not None
+    return ProjectName(name_and_version.project_name), Version(name_and_version.version)
+
+
+def index_pex_distributions(pex_file):
+    # type: (str) -> Mapping[ProjectName, Version]
+
+    return dict(
+        project_name_and_version(location) for location in PexInfo.from_pex(pex_file).distributions
+    )
+
+
+def index_lock_artifacts(lock_file):
+    # type: (str) -> Mapping[ProjectName, LockedRequirement]
+
+    lock = lockfile.load(lock_file)
+    assert 1 == len(lock.locked_resolves)
+    locked_resolve = lock.locked_resolves[0]
+    return {
+        locked_requirement.pin.project_name: locked_requirement
+        for locked_requirement in locked_resolve.locked_requirements
+    }
+
+
+@pytest.fixture(scope="module")
+def requests_lock_strict(tmpdir_factory):
+    # type: (Any) -> str
+
+    lock = os.path.join(str(tmpdir_factory.mktemp("locks")), "requests.lock")
+    # N.B.: requests 2.25.1 is known to work with all versions of Python Pex supports.
+    run_pex3("lock", "create", "--style", "strict", "requests==2.25.1", "-o", lock).assert_success()
+    return lock
+
+
+def test_strict_basic(
+    tmpdir,  # type: Any
+    requests_lock_strict,  # type: str
+):
+    # type: (...) -> None
+
+    requests_pex = os.path.join(str(tmpdir), "requests.pex")
+    run_pex_command(
+        args=[
+            "--lock",
+            requests_lock_strict,
+            "requests",
+            "-o",
+            requests_pex,
+            "--",
+            "-c",
+            "import requests",
+        ]
+    ).assert_success()
+
+    pex_distributions = index_pex_distributions(requests_pex)
+    requests_version = pex_distributions.get(ProjectName("requests"))
+    assert (
+        requests_version is not None
+    ), "Expected the requests pex to contain the requests distribution."
+
+    assert (
+        dict(
+            (project_name, locked_requirement.pin.version)
+            for project_name, locked_requirement in index_lock_artifacts(
+                requests_lock_strict
+            ).items()
+        )
+        == pex_distributions
+    )
+
+
+def test_subset(
+    tmpdir,  # type: Any
+    requests_lock_strict,  # type: str
+):
+    # type: (...) -> None
+
+    urllib3_pex = os.path.join(str(tmpdir), "urllib3.pex")
+    run_pex_command(
+        args=[
+            "--lock",
+            requests_lock_strict,
+            "urllib3",
+            "-o",
+            urllib3_pex,
+            "--",
+            "-c",
+            "import urllib3",
+        ]
+    ).assert_success()
+    pex_distributions = index_pex_distributions(urllib3_pex)
+    assert ProjectName("requests") not in pex_distributions
+    assert ProjectName("urllib3") in pex_distributions
+
+
+@attr.s(frozen=True)
+class LockAndRepo(object):
+    lock_file = attr.ib()  # type: str
+    find_links_repo = attr.ib()  # type: str
+
+
+@pytest.fixture(scope="module")
+def requests_tool_pex(
+    tmpdir_factory,  # type: Any
+    requests_lock_strict,  # type: str
+):
+    # type: (...) -> str
+
+    requests_pex = os.path.join(str(tmpdir_factory.mktemp("tool")), "requests.pex")
+    run_pex_command(
+        args=["--lock", requests_lock_strict, "--include-tools", "requests", "-o", requests_pex]
+    ).assert_success()
+    return requests_pex
+
+
+@pytest.fixture
+def requests_lock_findlinks(
+    tmpdir_factory,  # type: Any
+    requests_tool_pex,  # type: str
+):
+    # type: (...) -> LockAndRepo
+
+    find_links_repo = str(tmpdir_factory.mktemp("repo"))
+    subprocess.check_call(
+        args=[requests_tool_pex, "repository", "extract", "-f", find_links_repo],
+        env=make_env(PEX_TOOLS=1),
+    )
+    lock = os.path.join(str(tmpdir_factory.mktemp("locks")), "requests-find-links.lock")
+    run_pex3(
+        "lock",
+        "create",
+        "--style",
+        "strict",
+        "--no-pypi",
+        "-f",
+        find_links_repo,
+        "requests",
+        "-o",
+        lock,
+    ).assert_success()
+    return LockAndRepo(lock_file=lock, find_links_repo=find_links_repo)
+
+
+def test_corrupt_artifact(
+    tmpdir,  # type: Any
+    requests_lock_findlinks,  # type: LockAndRepo
+):
+    # type: (...) -> None
+
+    listing = glob.glob(os.path.join(requests_lock_findlinks.find_links_repo, "requests-*"))
+    assert 1 == len(listing)
+    requests_distribution = listing[0]
+    with open(requests_distribution, "ab") as fp:
+        fp.write(b"corrupted")
+
+    locked_requirement = index_lock_artifacts(requests_lock_findlinks.lock_file)[
+        ProjectName("requests")
+    ]
+    algorithm = locked_requirement.artifact.fingerprint.algorithm
+    expected_hash = locked_requirement.artifact.fingerprint.hash
+    actual_hash = CacheHelper.hash(requests_distribution, digest=hashlib.new(algorithm))
+
+    pex_file = os.path.join(str(tmpdir), "pex.file")
+    # The Pex cache should save us from downloading the corrupt artifact.
+    run_pex_command(
+        args=["--lock", requests_lock_findlinks.lock_file, "requests", "-o", pex_file]
+    ).assert_success()
+
+    # With the cache cleared (disabled), we're forced to download the artifact and should find it
+    # corrupted.
+    result = run_pex_command(
+        args=[
+            "--lock",
+            requests_lock_findlinks.lock_file,
+            "--disable-cache",
+            "requests",
+            "-o",
+            pex_file,
+        ]
+    )
+    result.assert_failure()
+
+    assert (
+        "There was 1 error downloading required artifacts:\n"
+        "1. requests 2.25.1 from file://{requests_distribution}\n"
+        "    Expected {algorithm} hash of {expected_hash} but hashed to {actual_hash}.".format(
+            requests_distribution=requests_distribution,
+            algorithm=algorithm,
+            expected_hash=expected_hash,
+            actual_hash=actual_hash,
+        )
+    ) in result.error, result.error
+
+
+def test_unavailable_artifacts(
+    tmpdir,  # type: Any
+    requests_lock_findlinks,  # type: LockAndRepo
+):
+    # type: (...) -> None
+
+    listing = glob.glob(os.path.join(requests_lock_findlinks.find_links_repo, "requests-*"))
+    assert 1 == len(listing)
+    requests_distribution = listing[0]
+    os.unlink(requests_distribution)
+
+    pex_file = os.path.join(str(tmpdir), "pex.file")
+    # The Pex cache should save us from downloading the unavailable artifact.
+    run_pex_command(
+        args=["--lock", requests_lock_findlinks.lock_file, "requests", "-o", pex_file]
+    ).assert_success()
+
+    # With the cache cleared (disabled), we're forced to download the artifact and should find it
+    # missing.
+    result = run_pex_command(
+        args=[
+            "--lock",
+            requests_lock_findlinks.lock_file,
+            "--disable-cache",
+            "requests",
+            "-o",
+            pex_file,
+        ]
+    )
+    result.assert_failure()
+
+    assert re.search(
+        r"There was 1 error downloading required artifacts:\n"
+        r"1\. requests 2\.25\.1 from file://{requests_distribution}\n"
+        r"    .* No such file or directory: .*'{requests_distribution}'>".format(
+            requests_distribution=re.escape(requests_distribution)
+        ),
+        result.error,
+        re.MULTILINE,
+    )
+
+
+@pytest.fixture(scope="module")
+def requests_lock_universal(tmpdir_factory):
+    # type: (Any) -> str
+
+    lock = os.path.join(str(tmpdir_factory.mktemp("locks")), "requests-universal.lock")
+    run_pex3(
+        "lock", "create", "--style", "universal", "requests[security]==2.25.1", "-o", lock
+    ).assert_success()
+    return lock
+
+
+def test_multiplatform(
+    tmpdir,  # type: Any
+    requests_lock_universal,  # type: str
+    py37,  # type: PythonInterpreter
+    py310,  # type: PythonInterpreter
+):
+    # type: (...) -> None
+
+    pex_file = os.path.join(str(tmpdir), "pex.file")
+    run_pex_command(
+        args=[
+            "--python",
+            py37.binary,
+            "--python",
+            py310.binary,
+            "--lock",
+            requests_lock_universal,
+            "requests[security]",
+            "-o",
+            pex_file,
+        ]
+    ).assert_success()
+
+    check_command = [pex_file, "-c", "import requests"]
+    py37.execute(check_command)
+    py310.execute(check_command)

--- a/tests/resolve/test_resolver_options.py
+++ b/tests/resolve/test_resolver_options.py
@@ -14,14 +14,16 @@ from pex.resolve.resolver_configuration import (
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import List, Union
+    from typing import List
+
+    from pex.resolve.resolver_options import ResolverConfiguration
 
 
 def compute_resolver_configuration(
     parser,  # type: ArgumentParser
     args,  # type: List[str]
 ):
-    # type: (...) -> Union[PipConfiguration, PexRepositoryConfiguration]
+    # type: (...) -> ResolverConfiguration
     options = parser.parse_args(args=args)
     return resolver_options.configure(options)
 


### PR DESCRIPTION
The Pex CLI can now resolve from a lock file created via
`pex3 lock create` when creating PEX files.

Closes #1583