### PR TITLE
`--lock` without requirements installs the entire lock.

### DIFF
--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -119,7 +119,7 @@ def resolve_from_lock(
             parse_lockable_requirements(
                 requirement_configuration,
                 network_configuration=network_configuration,
-                fallback_requirements=lock.requirements,
+                fallback_requirements=(str(req) for req in lock.requirements),
             )
         )
 

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -119,9 +119,18 @@ def resolve_from_lock(
             parse_lockable_requirements(
                 requirement_configuration,
                 network_configuration=network_configuration,
-                fallback_requirements=(str(req) for req in lock.requirements),
+                fallback_requirements=lock.requirements,
             )
         )
+        if not parsed_requirements:
+            raise ResultError(
+                Error(
+                    "No requirements requested. This should not be possible: either users will "
+                    "have specified requirements on the command line, or we will fall back to "
+                    "resolving the entire lockfile. Please file a bug at "
+                    "https://github.com/pantsbuild/pex/issues/new."
+                )
+            )
 
     errors_by_target = {}  # type: Dict[Target, Iterable[Error]]
     downloadable_artifacts = OrderedSet()  # type: OrderedSet[DownloadableArtifact]

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -122,15 +122,6 @@ def resolve_from_lock(
                 fallback_requirements=lock.requirements,
             )
         )
-        if not parsed_requirements:
-            raise ResultError(
-                Error(
-                    "No requirements requested. This should not be possible: either users will "
-                    "have specified requirements on the command line, or we will fall back to "
-                    "resolving the entire lockfile. Please file a bug at "
-                    "https://github.com/pantsbuild/pex/issues/new."
-                )
-            )
 
     errors_by_target = {}  # type: Dict[Target, Iterable[Error]]
     downloadable_artifacts = OrderedSet()  # type: OrderedSet[DownloadableArtifact]

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -117,7 +117,9 @@ def resolve_from_lock(
         )
         parsed_requirements = try_(
             parse_lockable_requirements(
-                requirement_configuration, network_configuration=network_configuration
+                requirement_configuration,
+                network_configuration=network_configuration,
+                fallback_requirements=(str(req) for req in lock.requirements),
             )
         )
 

--- a/pex/resolve/lockfile/__init__.py
+++ b/pex/resolve/lockfile/__init__.py
@@ -125,15 +125,13 @@ class Requirements(object):
 def parse_lockable_requirements(
     requirement_configuration,  # type: RequirementConfiguration
     network_configuration=None,  # type: Optional[NetworkConfiguration]
-    fallback_requirements=None,  # type: Optional[Iterable[Requirement]]
+    fallback_requirements=None,  # type: Optional[Iterable[str]]
 ):
     # type: (...) -> Union[Requirements, Error]
 
     all_parsed_requirements = requirement_configuration.parse_requirements(network_configuration)
     if not all_parsed_requirements and fallback_requirements:
-        all_parsed_requirements = parse_requirement_strings(
-            str(req) for req in fallback_requirements
-        )
+        all_parsed_requirements = parse_requirement_strings(fallback_requirements)
 
     parsed_requirements = []  # type: List[Union[PyPIRequirement, URLRequirement]]
     projects = []  # type: List[str]

--- a/pex/resolve/requirement_configuration.py
+++ b/pex/resolve/requirement_configuration.py
@@ -24,8 +24,12 @@ class RequirementConfiguration(object):
     requirement_files = attr.ib(default=None)  # type: Optional[Iterable[str]]
     constraint_files = attr.ib(default=None)  # type: Optional[Iterable[str]]
 
-    def parse_requirements(self, network_configuration=None):
-        # type: (Optional[NetworkConfiguration]) -> Iterable[ParsedRequirement]
+    def parse_requirements(
+        self,
+        network_configuration=None,  # type: Optional[NetworkConfiguration]
+        fallback_requirements=None,  # type: Optional[Iterable[str]]
+    ):
+        # type: (...) -> Iterable[ParsedRequirement]
         parsed_requirements = []  # type: List[ParsedRequirement]
         if self.requirements:
             parsed_requirements.extend(parse_requirement_strings(self.requirements))
@@ -39,6 +43,8 @@ class RequirementConfiguration(object):
                     )
                     if not isinstance(requirement_or_constraint, Constraint)
                 )
+        if not parsed_requirements:
+            parsed_requirements.extend(parse_requirement_strings(fallback_requirements))
         return parsed_requirements
 
     def parse_constraints(self, network_configuration=None):

--- a/pex/resolve/requirement_configuration.py
+++ b/pex/resolve/requirement_configuration.py
@@ -43,7 +43,7 @@ class RequirementConfiguration(object):
                     )
                     if not isinstance(requirement_or_constraint, Constraint)
                 )
-        if not parsed_requirements:
+        if not parsed_requirements and fallback_requirements:
             parsed_requirements.extend(parse_requirement_strings(fallback_requirements))
         return parsed_requirements
 

--- a/pex/resolve/requirement_configuration.py
+++ b/pex/resolve/requirement_configuration.py
@@ -24,12 +24,8 @@ class RequirementConfiguration(object):
     requirement_files = attr.ib(default=None)  # type: Optional[Iterable[str]]
     constraint_files = attr.ib(default=None)  # type: Optional[Iterable[str]]
 
-    def parse_requirements(
-        self,
-        network_configuration=None,  # type: Optional[NetworkConfiguration]
-        fallback_requirements=None,  # type: Optional[Iterable[str]]
-    ):
-        # type: (...) -> Iterable[ParsedRequirement]
+    def parse_requirements(self, network_configuration=None):
+        # type: (Optional[NetworkConfiguration]) -> Iterable[ParsedRequirement]
         parsed_requirements = []  # type: List[ParsedRequirement]
         if self.requirements:
             parsed_requirements.extend(parse_requirement_strings(self.requirements))
@@ -43,8 +39,6 @@ class RequirementConfiguration(object):
                     )
                     if not isinstance(requirement_or_constraint, Constraint)
                 )
-        if not parsed_requirements and fallback_requirements:
-            parsed_requirements.extend(parse_requirement_strings(fallback_requirements))
         return parsed_requirements
 
     def parse_constraints(self, network_configuration=None):

--- a/pex/resolve/resolver_options.py
+++ b/pex/resolve/resolver_options.py
@@ -108,8 +108,7 @@ def register(
             type=str,
             help=(
                 "Resolve requirements from the given PEX file instead of from --index servers, "
-                "--find-links repos or a --lock file. If no requirements are specified, will "
-                "install the entire PEX."
+                "--find-links repos or a --lock file."
             ),
         )
     if include_lock:
@@ -120,8 +119,8 @@ def register(
             default=None,
             type=str,
             help=(
-                "Resolve requirements from the given PEX lock file instead of from --index "
-                "servers, --find-links repos or a --pex-repository. If no requirements are "
+                "Resolve requirements from the given lock file crated by Pex instead of from "
+                "--index servers, --find-links repos or a --pex-repository. If no requirements are "
                 "specified, will install the entire lock."
             ),
         )

--- a/pex/resolve/resolver_options.py
+++ b/pex/resolve/resolver_options.py
@@ -108,7 +108,8 @@ def register(
             type=str,
             help=(
                 "Resolve requirements from the given PEX file instead of from --index servers, "
-                "--find-links repos or a --lock file."
+                "--find-links repos or a --lock file. If no requirements are specified, will "
+                "install the entire PEX."
             ),
         )
     if include_lock:
@@ -119,8 +120,9 @@ def register(
             default=None,
             type=str,
             help=(
-                "Resolve requirements from the given lock file instead of from --index servers, "
-                "--find-links repos or a --pex-repository."
+                "Resolve requirements from the given PEX lock file instead of from --index "
+                "servers, --find-links repos or a --pex-repository. If no requirements are "
+                "specified, will install the entire lock."
             ),
         )
 

--- a/tests/integration/test_lock_resolver.py
+++ b/tests/integration/test_lock_resolver.py
@@ -111,25 +111,27 @@ def test_subset(
     # type: (...) -> None
 
     urllib3_pex = os.path.join(str(tmpdir), "urllib3.pex")
-    args = [
-        "--lock",
-        requests_lock_strict,
-        "urllib3",
-        "-o",
-        urllib3_pex,
-        "--",
-        "-c",
-        "import urllib3",
-    ]
-    run_pex_command(args).assert_success()
+
+    def args(*requirements):
+        return [
+            "--lock",
+            requests_lock_strict,
+            *requirements,
+            "-o",
+            urllib3_pex,
+            "--",
+            "-c",
+            "import urllib3",
+        ]
+
+    run_pex_command(args("urllib3")).assert_success()
     pex_distributions = index_pex_distributions(urllib3_pex)
     assert ProjectName("urllib3") in pex_distributions
     for project in ("requests", "idna", "chardet", "certifi"):
         assert ProjectName(project) not in pex_distributions
 
     # However, if no requirements are specified, resolve the entire lock.
-    args.pop(2)
-    run_pex_command(args).assert_success()
+    run_pex_command(args()).assert_success()
     pex_distributions = index_pex_distributions(urllib3_pex)
     for project in ("requests", "urllib3", "idna", "chardet", "certifi"):
         assert ProjectName(project) in pex_distributions

--- a/tests/integration/test_lock_resolver.py
+++ b/tests/integration/test_lock_resolver.py
@@ -111,21 +111,28 @@ def test_subset(
     # type: (...) -> None
 
     urllib3_pex = os.path.join(str(tmpdir), "urllib3.pex")
-    run_pex_command(
-        args=[
-            "--lock",
-            requests_lock_strict,
-            "urllib3",
-            "-o",
-            urllib3_pex,
-            "--",
-            "-c",
-            "import urllib3",
-        ]
-    ).assert_success()
+    args = [
+        "--lock",
+        requests_lock_strict,
+        "urllib3",
+        "-o",
+        urllib3_pex,
+        "--",
+        "-c",
+        "import urllib3",
+    ]
+    run_pex_command(args).assert_success()
     pex_distributions = index_pex_distributions(urllib3_pex)
-    assert ProjectName("requests") not in pex_distributions
     assert ProjectName("urllib3") in pex_distributions
+    for project in ("requests", "idna", "chardet", "certifi"):
+        assert ProjectName(project) not in pex_distributions
+
+    # However, if no requirements are specified, resolve the entire lock.
+    args.pop(2)
+    run_pex_command(args).assert_success()
+    pex_distributions = index_pex_distributions(urllib3_pex)
+    for project in ("requests", "urllib3", "idna", "chardet", "certifi"):
+        assert ProjectName(project) in pex_distributions
 
 
 @attr.s(frozen=True)

--- a/tests/integration/test_lock_resolver.py
+++ b/tests/integration/test_lock_resolver.py
@@ -113,16 +113,11 @@ def test_subset(
     urllib3_pex = os.path.join(str(tmpdir), "urllib3.pex")
 
     def args(*requirements):
-        return [
-            "--lock",
-            requests_lock_strict,
-            *requirements,
-            "-o",
-            urllib3_pex,
-            "--",
-            "-c",
-            "import urllib3",
-        ]
+        return (
+            ["--lock", requests_lock_strict, "-o", urllib3_pex]
+            + list(requirements)
+            + ["--", "-c", "import urllib3"]
+        )
 
     run_pex_command(args("urllib3")).assert_success()
     pex_distributions = index_pex_distributions(urllib3_pex)


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pex/issues/1657.

A followup will make sure that we can support `pex --lock` when the lock is empty.