### PR TITLE
Fix venv creation to ignore ambient PEX env vars.

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -79,11 +79,12 @@ class PEX(object):  # noqa: T000
         if verify_entry_point:
             self._do_entry_point_verification()
 
-    def pex_info(self):
-        # type: () -> PexInfo
+    def pex_info(self, include_env_overrides=True):
+        # type: (bool) -> PexInfo
         pex_info = self._pex_info.copy()
-        pex_info.update(self._pex_info_overrides)
-        pex_info.merge_pex_path(self._vars.PEX_PATH)
+        if include_env_overrides:
+            pex_info.update(self._pex_info_overrides)
+            pex_info.merge_pex_path(self._vars.PEX_PATH)
         return pex_info
 
     @property

--- a/pex/venv/pex.py
+++ b/pex/venv/pex.py
@@ -286,9 +286,14 @@ def _populate_sources(
 ):
     # type: (...) -> Iterator[Tuple[str, str]]
 
+    # We want the venv at rest to reflect the PEX it was created from at rest; as such we use the
+    # PEX's at-rest PEX-INFO to perform the layout. The venv can then be executed with various PEX
+    # environment variables in-play that it respects (e.g.: PEX_EXTRA_SYS_PATH, PEX_INTERPRETER,
+    # PEX_MODULE, etc.).
+    pex_info = pex.pex_info(include_env_overrides=False)
+
     # Since the pex.path() is ~always outside our control (outside ~/.pex), we copy all PEX user
     # sources into the venv.
-    pex_info = pex.pex_info()
     for src, dst in _copytree(
         src=PEXEnvironment.mount(pex.path()).path,
         dst=venv.site_packages_dir,

--- a/tests/integration/venv_ITs/test_issue_1668.py
+++ b/tests/integration/venv_ITs/test_issue_1668.py
@@ -1,0 +1,74 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+import subprocess
+
+from pex.testing import PY37, ensure_python_interpreter, make_env, pex_project_dir, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def assert_venv_runtime_env_vars_ignored_during_create(
+    tmpdir,  # type: Any
+    pex_venv,  # type: bool
+):
+    # type: (...) -> None
+
+    pex_pex = os.path.join(str(tmpdir), "pex.pex")
+    args = [pex_project_dir(), "-c", "pex", "-o", pex_pex, "--no-strip-pex-env", "--disable-cache"]
+    if pex_venv:
+        args.append("--venv")
+    run_pex_command(args=args).assert_success()
+
+    py37 = ensure_python_interpreter(PY37)
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    lock = os.path.join(str(tmpdir), "lock.json")
+    subprocess.check_call(
+        args=[
+            py37,
+            pex_pex,
+            "lock",
+            "create",
+            "ansicolors==1.1.8",
+            "-o",
+            lock,
+            "--pex-root",
+            pex_root,
+        ],
+        env=make_env(PEX_SCRIPT="pex3"),
+    )
+    ansicolors_path = (
+        subprocess.check_output(
+            args=[
+                py37,
+                pex_pex,
+                "--pex-root",
+                pex_root,
+                "--runtime-pex-root",
+                pex_root,
+                "--lock",
+                lock,
+                "--",
+                "-c",
+                "import colors; print(colors.__file__)",
+            ]
+        )
+        .decode("utf-8")
+        .strip()
+    )
+    assert ansicolors_path.startswith(pex_root)
+
+
+def test_venv_runtime_env_vars_ignored_during_create_nested(tmpdir):
+    # type: (Any) -> None
+
+    # N.B.: The venv being created here is the internal Pip venv Pex uses to execute Pip. It's that
+    # venv that used to get PEX env vars like PEX_MODULE and PEX_SCRIPT sealed in at creation time.
+    assert_venv_runtime_env_vars_ignored_during_create(tmpdir, pex_venv=False)
+
+
+def test_venv_runtime_env_vars_ignored_during_create_top_level(tmpdir):
+    assert_venv_runtime_env_vars_ignored_during_create(tmpdir, pex_venv=True)


### PR DESCRIPTION
Previously any ambient PEX env vars infected the `pex` venv script that
was written out, fouling its defaults.

Fixes #1668