### PR TITLE
Extract Pip runtime patches.

### DIFF
--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -31,7 +31,7 @@ from pex.layout import Layout
 from pex.orderedset import OrderedSet
 from pex.pex import PEX
 from pex.pex_info import PexInfo
-from pex.pip import get_pip
+from pex.pip.tool import get_pip
 from pex.targets import LocalInterpreter
 from pex.third_party.pkg_resources import DefaultProvider, Distribution, ZipProvider, get_provider
 from pex.tracer import TRACER

--- a/pex/pip/__init__.py
+++ b/pex/pip/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).

--- a/pex/pip/runtime_patches.py
+++ b/pex/pip/runtime_patches.py
@@ -1,0 +1,193 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# Various runtime patches applied to Pip to work around issues or else bend Pip to Pex's needs.
+
+import os
+import runpy
+
+# N.B.: The following environment variables are used by the Pex runtime to control Pip and must be
+# kept in-sync with `tool.py`.
+skip_markers = os.environ.pop("_PEX_SKIP_MARKERS", None)
+patched_markers_file = os.environ.pop("_PEX_PATCHED_MARKERS_FILE", None)
+patched_tags_file = os.environ.pop("_PEX_PATCHED_TAGS_FILE", None)
+python_versions_file = os.environ.pop("_PEX_PYTHON_VERSIONS_FILE", None)
+
+if skip_markers is not None and patched_markers_file is not None:
+    raise AssertionError(
+        "Pex should never both set both {skip_markers_env_var_name} "
+        "and {patched_markers_env_var_name} environment variables."
+    )
+if skip_markers is not None and patched_tags_file is not None:
+    raise AssertionError(
+        "Pex should never both set both {skip_markers_env_var_name} "
+        "and {patched_tags_env_var_name} environment variables."
+    )
+
+if skip_markers:
+    python_full_versions = []
+    python_versions = []
+    python_majors = []
+
+    if python_versions_file:
+        import json
+
+        with open(python_versions_file) as fp:
+            python_full_versions = json.load(fp)
+        python_versions = sorted(set((version[0], version[1]) for version in python_full_versions))
+        python_majors = sorted(set(version[0] for version in python_full_versions))
+
+    # 1.) Universal dependency environment marker applicability.
+    #
+    # Allows all dependencies in metadata to be followed regardless
+    # of whether they apply to this system. For example, if this is
+    # Python 3.10 but a marker says a dependency is only for
+    # 'python_version < "3.6"' we still want to lock that dependency
+    # subgraph too.
+    def patch_marker_evaluate():
+        from pip._vendor.packaging import markers  # type: ignore[import]
+
+        original_get_env = markers._get_env
+        original_eval_op = markers._eval_op
+
+        skip = object()
+
+        def versions_to_string(versions):
+            return [".".join(map(str, version)) for version in versions]
+
+        python_versions_strings = versions_to_string(python_versions) or skip
+
+        python_full_versions_strings = versions_to_string(python_full_versions) or skip
+
+        def _get_env(environment, name):
+            if name == "extra":
+                return original_get_env(environment, name)
+            if name == "python_version":
+                return python_versions_strings
+            if name == "python_full_version":
+                return python_full_versions_strings
+            return skip
+
+        def _eval_op(lhs, op, rhs):
+            if lhs is skip or rhs is skip:
+                return True
+            return any(
+                original_eval_op(left, op, right)
+                for left in (lhs if isinstance(lhs, list) else [lhs])
+                for right in (rhs if isinstance(rhs, list) else [rhs])
+            )
+
+        markers._get_env = _get_env
+        markers._eval_op = _eval_op
+
+    patch_marker_evaluate()
+    del patch_marker_evaluate
+
+    # 2.) Universal wheel tag applicability.
+    #
+    # Allows all wheel URLs to be checked even when the wheel does not
+    # match system tags.
+    def patch_wheel_model():
+        from pip._internal.models.wheel import Wheel  # type: ignore[import]
+
+        Wheel.support_index_min = lambda *args, **kwargs: 0
+
+        if python_versions:
+            import re
+
+            def supported(self, *_args, **_kwargs):
+                if not hasattr(self, "_versions"):
+                    versions = set()
+                    is_abi3 = ["abi3"] == list(self.abis)
+                    for pyversion in self.pyversions:
+                        if pyversion[:2] in ("cp", "pp", "py"):
+                            version_str = pyversion[2:]
+                            # N.B.: This overblown seeming use of an re
+                            # is necessitated by distributions like
+                            # pydantic 0.18.* which incorrectly use
+                            # `py36+`.
+                            match = re.search(r"^(?P<major>\d)(?P<minor>\d+)?", version_str)
+                            major = int(match.group("major"))
+                            minor = match.group("minor")
+                            if is_abi3 and major == 3:
+                                versions.add(major)
+                            elif minor:
+                                versions.add((major, int(minor)))
+                            else:
+                                versions.add(major)
+
+                    self._versions = versions
+
+                return any(
+                    (version in python_majors) or (version in python_versions)
+                    for version in self._versions
+                )
+
+            Wheel.supported = supported
+        else:
+            Wheel.supported = lambda *args, **kwargs: True
+
+    patch_wheel_model()
+    del patch_wheel_model
+
+    # 3.) Universal Python version applicability.
+    #
+    # Much like 2 (wheel applicability), we want to gather distributions
+    # even when they require different Pythons than the system Python.
+    def patch_requires_python():
+        from pip._internal.utils import packaging  # type: ignore[import]
+
+        if python_full_versions:
+            orig_check_requires_python = packaging.check_requires_python
+
+            def check_requires_python(requires_python, *_args, **_kw):
+                return any(
+                    orig_check_requires_python(requires_python, python_full_version)
+                    for python_full_version in python_full_versions
+                )
+
+            packaging.check_requires_python = check_requires_python
+        else:
+            packaging.check_requires_python = lambda *_args, **_kw: True
+
+    patch_requires_python()
+    del patch_requires_python
+else:
+    if patched_markers_file:
+
+        def patch_markers_default_environment():
+            import json
+
+            from pip._vendor.packaging import markers  # type: ignore[import]
+
+            with open(patched_markers_file) as fp:
+                patched_markers = json.load(fp)
+
+            markers.default_environment = patched_markers.copy
+
+        patch_markers_default_environment()
+        del patch_markers_default_environment
+
+    if patched_tags_file:
+
+        def patch_compatibility_tags():
+            import itertools
+            import json
+
+            from pip._internal.utils import compatibility_tags  # type: ignore[import]
+            from pip._vendor.packaging import tags  # type: ignore[import]
+
+            with open(patched_tags_file) as fp:
+                tags = tuple(
+                    itertools.chain.from_iterable(tags.parse_tag(tag) for tag in json.load(fp))
+                )
+
+            def get_supported(*args, **kwargs):
+                return list(tags)
+
+            compatibility_tags.get_supported = get_supported
+
+        patch_compatibility_tags()
+        del patch_compatibility_tags
+
+runpy.run_module(mod_name="pip", run_name="__main__", alter_sys=True)

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -212,7 +212,7 @@ class Platform(object):
     ):
         # type: (...) -> Iterator[tags.Tag]
         from pex.jobs import SpawnedJob
-        from pex.pip import get_pip
+        from pex.pip.tool import get_pip
 
         def parse_tags(output):
             # type: (bytes) -> Iterator[tags.Tag]

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -13,7 +13,7 @@ from pex.compatibility import cpu_count
 from pex.fetcher import URLFetcher
 from pex.network_configuration import NetworkConfiguration
 from pex.orderedset import OrderedSet
-from pex.pip import PackageIndexConfiguration
+from pex.pip.tool import PackageIndexConfiguration
 from pex.resolve import lockfile
 from pex.resolve.locked_resolve import Artifact, DownloadableArtifact, Resolved
 from pex.resolve.lockfile import parse_lockable_requirements

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -21,7 +21,7 @@ from pex.network_configuration import NetworkConfiguration
 from pex.orderedset import OrderedSet
 from pex.pep_503 import ProjectName, distribution_satisfies_requirement
 from pex.pex_info import PexInfo
-from pex.pip import PackageIndexConfiguration, get_pip
+from pex.pip.tool import PackageIndexConfiguration, get_pip
 from pex.requirements import LocalProjectRequirement
 from pex.resolve.locked_resolve import LockConfiguration, LockedResolve, LockRequest
 from pex.resolve.requirement_configuration import RequirementConfiguration

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -28,7 +28,7 @@ from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
-from pex.pip import get_pip
+from pex.pip.tool import get_pip
 from pex.targets import LocalInterpreter
 from pex.third_party.pkg_resources import Distribution
 from pex.typing import TYPE_CHECKING

--- a/tests/integration/test_issue_539.py
+++ b/tests/integration/test_issue_539.py
@@ -8,7 +8,7 @@ import subprocess
 import pytest
 
 from pex.common import temporary_dir
-from pex.pip import get_pip
+from pex.pip.tool import get_pip
 from pex.testing import IS_PYPY, run_pex_command
 
 

--- a/tests/test_dist_metadata.py
+++ b/tests/test_dist_metadata.py
@@ -21,7 +21,7 @@ from pex.dist_metadata import (
     requires_python,
 )
 from pex.pex_warnings import PEXWarning
-from pex.pip import get_pip
+from pex.pip.tool import get_pip
 from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.third_party.pkg_resources import Distribution, Requirement
 from pex.typing import TYPE_CHECKING

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -7,7 +7,7 @@ import pytest
 
 from pex.finders import get_entry_point_from_console_script, get_script_from_distributions
 from pex.pep_376 import InstalledWheel
-from pex.pip import get_pip
+from pex.pip.tool import get_pip
 from pex.typing import TYPE_CHECKING
 from pex.util import DistributionHelper
 

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -13,7 +13,7 @@ from pex import targets
 from pex.common import safe_rmtree
 from pex.interpreter import PythonInterpreter
 from pex.jobs import Job
-from pex.pip import PackageIndexConfiguration, Pip
+from pex.pip.tool import PackageIndexConfiguration, Pip
 from pex.platforms import Platform
 from pex.targets import AbbreviatedPlatform, LocalInterpreter, Target
 from pex.testing import PY310, ensure_python_interpreter, environment_as

--- a/tox.ini
+++ b/tox.ini
@@ -82,6 +82,7 @@ commands =
 deps =
     attrs==21.2.0  # This version should track the version in pex/vendor/__init__.py.
     packaging==20.9  # This version should track the version in pex/vendor/__init__.py.
+    pip==20.3.4  # This version should track the version in pex/vendor/__init__.py.
     setuptools==44.0.0  # This version should track the version in pex/vendor/__init__.py.
     mypy[python2]==0.931
     typing-extensions


### PR DESCRIPTION
This moves the Pip tool into its own package and extracts the Pip runtime
patching code into a sibling resource that can be type-checked and linted.

Fixes #1581