### PR TITLE
Ensure universal locks cover IC range.

### DIFF
--- a/pex/interpreter_constraints.py
+++ b/pex/interpreter_constraints.py
@@ -190,7 +190,7 @@ COMPATIBLE_PYTHON_VERSIONS = (
     PythonVersion(Lifecycle.EOL, 3, 5, 10),
     PythonVersion(Lifecycle.EOL, 3, 6, 15),
     PythonVersion(Lifecycle.STABLE, 3, 7, 12),
-    PythonVersion(Lifecycle.STABLE, 3, 8, 11),
+    PythonVersion(Lifecycle.STABLE, 3, 8, 12),
     PythonVersion(Lifecycle.STABLE, 3, 9, 10),
     PythonVersion(Lifecycle.STABLE, 3, 10, 2),
     PythonVersion(Lifecycle.DEV, 3, 11, 0),

--- a/pex/pip/runtime_patches.py
+++ b/pex/pip/runtime_patches.py
@@ -141,7 +141,11 @@ if skip_markers:
             orig_check_requires_python = packaging.check_requires_python
 
             def check_requires_python(requires_python, *_args, **_kw):
-                return any(
+                # Ensure any dependency we lock is compatible with the full interpreter range
+                # specified since we have no way to force Pip to backtrack and follow paths for any
+                # divergences. Most (all?) true divergences should be covered by forked environment
+                # markers.
+                return all(
                     orig_check_requires_python(requires_python, python_full_version)
                     for python_full_version in python_full_versions
                 )

--- a/pex/pip/tool.py
+++ b/pex/pip/tool.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 from abc import abstractmethod
 from collections import defaultdict, deque
-from textwrap import dedent
 
 from pex import dist_metadata, targets, third_party
 from pex.common import atomic_directory, safe_mkdtemp

--- a/tests/integration/cli/commands/test_issue_1667.py
+++ b/tests/integration/cli/commands/test_issue_1667.py
@@ -66,10 +66,17 @@ def test_interpreter_constraints_range_coverage(
         ],
     ).assert_success()
 
-    run_ipython_args = [ipython_pex, "-c", "import IPython; print(IPython.__file__)"]
-    output = subprocess.check_output(args=[py37.binary] + run_ipython_args)
-    assert output.decode("utf-8").strip().startswith(pex_root)
+    def assert_pex_works(python):
+        # type: (str) -> None
+        assert (
+            subprocess.check_output(
+                args=[python, ipython_pex, "-c", "import IPython; print(IPython.__file__)"]
+            )
+            .decode("utf-8")
+            .strip()
+            .startswith(pex_root)
+        )
 
+    assert_pex_works(py37.binary)
     if (3, 7) <= sys.version_info[:2] < (3, 11):
-        output = subprocess.check_output(args=[sys.executable] + run_ipython_args)
-        assert output.decode("utf-8").strip().startswith(pex_root)
+        assert_pex_works(sys.executable)

--- a/tests/integration/cli/commands/test_issue_1667.py
+++ b/tests/integration/cli/commands/test_issue_1667.py
@@ -1,0 +1,63 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+import subprocess
+import sys
+
+import pytest
+
+from pex.cli.testing import run_pex3
+from pex.testing import run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+@pytest.mark.skipif(
+    sys.version_info[:2] < (3, 7) or sys.version_info[:2] >= (3, 11),
+    reason="The lock under test requires an interpreter satisfying >=3.7,<3.11 to test against.",
+)
+def test_interpreter_constraints_range_coverage(tmpdir):
+    # type: (Any) -> None
+
+    # We lock with an unconstrained IPython requirement and we know IPython latest does not support
+    # Python 3.7. If locking respects ICs it should not pick latest, but a version that supports at
+    # least 3.7
+    lock = os.path.join(str(tmpdir), "lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--style",
+        "universal",
+        "--resolver-version",
+        "pip-2020-resolver",
+        "--interpreter-constraint",
+        ">=3.7,<3.11",
+        "ipython",
+        "-o",
+        lock,
+    ).assert_success()
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    ipython_pex = os.path.join(str(tmpdir), "ipython.pex")
+    run_pex_command(
+        args=[
+            "--interpreter-constraint",
+            ">=3.7,<3.11",
+            "--lock",
+            lock,
+            "-c",
+            "ipython",
+            "-o",
+            ipython_pex,
+            "--runtime-pex-root",
+            pex_root,
+        ],
+    ).assert_success()
+
+    output = subprocess.check_output(
+        args=[ipython_pex, "-c", "import IPython; print(IPython.__file__)"]
+    )
+    assert output.decode("utf-8").strip().startswith(pex_root)


### PR DESCRIPTION
Previously any dependency that satisfied just one interpreter version
in an IC range would be picked which was problematic if that dependency
version did not satisfy all interpreters in the range. Force a universal
resolve with an IC range to satisfy every Python version in that range.

Fixes #1667