### PR TITLE
Fix `--lock` resolve wheel tag parsing.

### DIFF
--- a/pex/resolve/locked_resolve.py
+++ b/pex/resolve/locked_resolve.py
@@ -12,7 +12,7 @@ from pex.compatibility import urlparse
 from pex.dist_metadata import DistMetadata
 from pex.enum import Enum
 from pex.fetcher import URLFetcher
-from pex.pep_425 import TagRank
+from pex.pep_425 import CompatibilityTags, TagRank
 from pex.pep_503 import ProjectName
 from pex.rank import Rank
 from pex.resolve.resolved_requirement import Fingerprint, PartialArtifact, Pin, ResolvedRequirement
@@ -107,8 +107,7 @@ class Artifact(object):
     def parse_tags(self):
         # type: () -> Iterator[tags.Tag]
         if self.filename.endswith(".whl"):
-            artifact_stem, _ = os.path.splitext(self.filename)
-            for tag in tags.parse_tag(artifact_stem.split("-", 2)[-1]):
+            for tag in CompatibilityTags.from_wheel(self.filename):
                 yield tag
 
 

--- a/tests/resolve/test_locked_resolve.py
+++ b/tests/resolve/test_locked_resolve.py
@@ -92,7 +92,7 @@ def ansicolors_simple():
             LockedRequirement.create(
                 pin=pin("ansicolors", "1.1.7"),
                 artifact=artifact(
-                    url="https://example.org/ansicolors-1.1.7-py2.py3-none-any.whl",
+                    url="https://example.org/ansicolors-1.1.7-1buildtag-py2.py3-none-any.whl",
                     algorithm="blake256",
                     hash="cafebabe",
                 ),
@@ -146,7 +146,7 @@ def test_build(
         DownloadableArtifact.create(
             pin=pin("ansicolors", "1.1.7"),
             artifact=artifact(
-                url="https://example.org/ansicolors-1.1.7-py2.py3-none-any.whl",
+                url="https://example.org/ansicolors-1.1.7-1buildtag-py2.py3-none-any.whl",
                 algorithm="blake256",
                 hash="cafebabe",
             ),
@@ -165,7 +165,7 @@ def test_use_wheel(
         DownloadableArtifact.create(
             pin=pin("ansicolors", "1.1.7"),
             artifact=artifact(
-                url="https://example.org/ansicolors-1.1.7-py2.py3-none-any.whl",
+                url="https://example.org/ansicolors-1.1.7-1buildtag-py2.py3-none-any.whl",
                 algorithm="blake256",
                 hash="cafebabe",
             ),
@@ -210,7 +210,7 @@ def test_constraints(
         DownloadableArtifact.create(
             pin=pin("ansicolors", "1.1.7"),
             artifact=artifact(
-                url="https://example.org/ansicolors-1.1.7-py2.py3-none-any.whl",
+                url="https://example.org/ansicolors-1.1.7-1buildtag-py2.py3-none-any.whl",
                 algorithm="blake256",
                 hash="cafebabe",
             ),
@@ -448,7 +448,7 @@ def test_requires_python_mismatch(
             LockedRequirement.create(
                 pin=pin("ansicolors", "1.1.7"),
                 artifact=artifact(
-                    url="https://example.org/ansicolors-1.1.7-py2.py3-none-any.whl",
+                    url="https://example.org/ansicolors-1.1.7-1buildtag-py2.py3-none-any.whl",
                     algorithm="blake256",
                     hash="cafebabe",
                 ),
@@ -478,7 +478,7 @@ def test_requires_python_mismatch(
         DownloadableArtifact.create(
             pin=pin("ansicolors", "1.1.7"),
             artifact=artifact(
-                url="https://example.org/ansicolors-1.1.7-py2.py3-none-any.whl",
+                url="https://example.org/ansicolors-1.1.7-1buildtag-py2.py3-none-any.whl",
                 algorithm="blake256",
                 hash="cafebabe",
             ),
@@ -498,7 +498,7 @@ def test_constraint_mismatch(
             LockedRequirement.create(
                 pin=pin("ansicolors", "1.1.7"),
                 artifact=artifact(
-                    url="https://example.org/ansicolors-1.1.7-py2.py3-none-any.whl",
+                    url="https://example.org/ansicolors-1.1.7-1buildtag-py2.py3-none-any.whl",
                     algorithm="blake256",
                     hash="cafebabe",
                 ),
@@ -532,7 +532,7 @@ def test_constraint_mismatch(
         DownloadableArtifact.create(
             pin=pin("ansicolors", "1.1.7"),
             artifact=artifact(
-                url="https://example.org/ansicolors-1.1.7-py2.py3-none-any.whl",
+                url="https://example.org/ansicolors-1.1.7-1buildtag-py2.py3-none-any.whl",
                 algorithm="blake256",
                 hash="cafebabe",
             ),
@@ -550,7 +550,7 @@ def test_prefer_older_binary(current_target):
             LockedRequirement.create(
                 pin=pin("ansicolors", "1.1.7"),
                 artifact=artifact(
-                    url="https://example.org/ansicolors-1.1.7-py2.py3-none-any.whl",
+                    url="https://example.org/ansicolors-1.1.7-1buildtag-py2.py3-none-any.whl",
                     algorithm="blake256",
                     hash="cafebabe",
                 ),
@@ -584,7 +584,7 @@ def test_prefer_older_binary(current_target):
         DownloadableArtifact.create(
             pin=pin("ansicolors", "1.1.7"),
             artifact=artifact(
-                url="https://example.org/ansicolors-1.1.7-py2.py3-none-any.whl",
+                url="https://example.org/ansicolors-1.1.7-1buildtag-py2.py3-none-any.whl",
                 algorithm="blake256",
                 hash="cafebabe",
             ),

--- a/tests/tools/commands/test_venv.py
+++ b/tests/tools/commands/test_venv.py
@@ -48,11 +48,20 @@ def pex():
         touch(os.path.join(src_dir, "user/__init__.py"))
         touch(os.path.join(src_dir, "user/package/__init__.py"))
 
+        # Fabric dips into Invoke vendored code. It depends on "invoke<2.0,>=1.3", but in version
+        # 1.7.0, the vendored `decorator` module Fabric depends on inside Invoke no longer is
+        # importable under Python 2.7; so we pin low.
+        constraints = os.path.join(tmpdir, "constraints.txt")
+        with open(constraints, "w") as fp:
+            fp.write("Invoke==1.6.0")
+
         # N.B.: --unzip just speeds up runs 2+ of the pex file and is otherwise not relevant to
         # these tests.
         run_pex_command(
             args=[
                 "fabric=={}".format(FABRIC_VERSION),
+                "--constraints",
+                constraints,
                 "-c",
                 "fab",
                 "--sources-directory",


### PR DESCRIPTION
We had a robust utility for this, but it was the evolution of copy-pasta
and not all the instances of copy-pasta were cleaned up. Now they are.

Fixes #1676