### PR TITLE
Fix `--requirements-pex`.

### DIFF
--- a/pex/environment.py
+++ b/pex/environment.py
@@ -254,7 +254,7 @@ class PEXEnvironment(object):
         # type: () -> str
         return self._pex
 
-    def _load_internal_cache(self):
+    def iter_distributions(self):
         # type: () -> Iterator[FingerprintedDistribution]
         internal_cache = os.path.join(self._pex, self._pex_info.internal_cache)
         with TRACER.timed("Searching dependency cache: %s" % internal_cache, V=2):
@@ -499,7 +499,7 @@ class PEXEnvironment(object):
     def resolve_dists(self, reqs):
         # type: (Iterable[Requirement]) -> Iterable[FingerprintedDistribution]
 
-        self._update_candidate_distributions(self._load_internal_cache())
+        self._update_candidate_distributions(self.iter_distributions())
 
         unresolved_reqs = OrderedDict()  # type: OrderedDict[Requirement, OrderedSet]
 

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -14,7 +14,6 @@ from pex.common import (
     atomic_directory,
     chmod_plus_x,
     is_pyc_temporary_file,
-    open_zip,
     safe_copy,
     safe_mkdir,
     safe_mkdtemp,
@@ -25,6 +24,7 @@ from pex.common import (
 from pex.compatibility import to_bytes
 from pex.compiler import Compiler
 from pex.enum import Enum
+from pex.environment import PEXEnvironment
 from pex.finders import get_entry_point_from_console_script, get_script_from_distributions
 from pex.interpreter import PythonInterpreter
 from pex.layout import Layout
@@ -297,30 +297,10 @@ class PEXBuilder(object):
         :param pex: The path to an existing .pex file or unzipped pex directory.
         """
         self._ensure_unfrozen("Adding from pex")
-        pex_info = PexInfo.from_pex(pex)
-
-        def add(location, dname, expected_dhash):
-            dhash = self._add_dist_dir(location, dname)
-            if dhash != expected_dhash:
-                raise self.InvalidDistribution(
-                    "Distribution {} at {} had hash {}, expected {}".format(
-                        dname, location, dhash, expected_dhash
-                    )
-                )
-            self._pex_info.add_distribution(dname, dhash)
-
-        if os.path.isfile(pex):
-            with open_zip(pex) as zf:
-                for dist_name, dist_hash in pex_info.distributions.items():
-                    internal_dist_path = "/".join([pex_info.internal_cache, dist_name])
-                    cached_location = os.path.join(pex_info.install_cache, dist_hash, dist_name)
-                    CacheHelper.cache_distribution(zf, internal_dist_path, cached_location)
-                    add(cached_location, dist_name, dist_hash)
-        else:
-            for dist_name, dist_hash in pex_info.distributions.items():
-                add(os.path.join(pex, pex_info.internal_cache, dist_name), dist_name, dist_hash)
-        for req in pex_info.requirements:
-            self._pex_info.add_requirement(req)
+        pex_environment = PEXEnvironment.mount(pex)
+        for dist in pex_environment.resolve():
+            self.add_distribution(dist)
+            self.add_requirement(dist.as_requirement())
 
     def set_executable(self, filename, env_filename=None):
         """Set the executable for this environment.

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -297,10 +297,14 @@ class PEXBuilder(object):
         :param pex: The path to an existing .pex file or unzipped pex directory.
         """
         self._ensure_unfrozen("Adding from pex")
-        pex_environment = PEXEnvironment.mount(pex)
-        for dist in pex_environment.resolve():
-            self.add_distribution(dist)
-            self.add_requirement(dist.as_requirement())
+        pex_info = PexInfo.from_pex(pex)
+        pex_environment = PEXEnvironment.mount(pex, pex_info=pex_info)
+        for fingerprinted_dist in pex_environment.iter_distributions():
+            self.add_distribution(
+                dist=fingerprinted_dist.distribution, fingerprint=fingerprinted_dist.fingerprint
+            )
+        for requirement in pex_info.requirements:
+            self.add_requirement(requirement)
 
     def set_executable(self, filename, env_filename=None):
         """Set the executable for this environment.

--- a/tests/integration/test_issue_1683.py
+++ b/tests/integration/test_issue_1683.py
@@ -1,0 +1,66 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+import subprocess
+from textwrap import dedent
+
+from colors import crossed, red
+
+from pex.common import safe_open
+from pex.testing import run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_requirements_pex(tmpdir):
+    # type: (Any) -> None
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    requirements_pex = os.path.join(str(tmpdir), "requirements.pex")
+    run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "ansicolors==1.1.8",
+            "-o",
+            requirements_pex,
+        ]
+    ).assert_success()
+
+    src_dir = os.path.join(str(tmpdir), "src")
+    with safe_open(os.path.join(src_dir, "exe.py"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                from colors import crossed, red
+
+
+                print(red(crossed("Broken")))
+                """
+            )
+        )
+
+    app_pex = os.path.join(str(tmpdir), "app.pex")
+    run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--requirements-pex",
+            requirements_pex,
+            "-D",
+            src_dir,
+            "-m",
+            "exe",
+            "-o",
+            app_pex,
+        ]
+    ).assert_success()
+
+    assert red(crossed("Broken")) == subprocess.check_output(args=[app_pex]).decode("utf-8").strip()


### PR DESCRIPTION
The switch from sha1 to sha256 hashes in #1661 did not cover this
feature. Simplify and use the existing machinery to get at a PEX's
distributions.

Fixes #1683