### PR TITLE
Add support for locking VCS requirements.

### DIFF
--- a/pex/hashing.py
+++ b/pex/hashing.py
@@ -1,0 +1,208 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import hashlib
+import os
+
+from pex.typing import TYPE_CHECKING, Generic
+
+if TYPE_CHECKING:
+    from typing import IO, Callable, Iterable, Iterator, Optional, Protocol, Type, TypeVar
+
+    class HintedDigest(Protocol):
+        @property
+        def block_size(self):
+            # type: () -> int
+            pass
+
+        def update(self, data):
+            # type: (bytes) -> None
+            pass
+
+    class Hasher(HintedDigest, Protocol):
+        @property
+        def name(self):
+            # type: () -> str
+            pass
+
+        def digest(self):
+            # type: () -> bytes
+            pass
+
+        def hexdigest(self):
+            # type: () -> str
+            pass
+
+
+class Fingerprint(str):
+    class Algorithm(object):
+        def __get__(
+            self,
+            _instance,  # type: Optional[Fingerprint]
+            owner,  # type: Type[Fingerprint]
+        ):
+            # type: (...) -> str
+
+            alg = getattr(owner, "_alg", None)
+            if alg is None:
+                alg = owner.__name__[: -len(Fingerprint.__name__)].lower()
+                setattr(owner, "_alg", alg)
+            return alg
+
+    algorithm = Algorithm()
+
+    @classmethod
+    def new_hasher(cls, data=b""):
+        # type: (bytes) -> HashlibHasher
+        return HashlibHasher(cls, data=data)
+
+    def __eq__(self, other):
+        if isinstance(other, Fingerprint) and type(self) != type(other):
+            return False
+        return super(Fingerprint, self).__eq__(other)
+
+    def __ne__(self, other):
+        return not self == other
+
+
+def new_fingerprint(
+    algorithm,  # type: str
+    hexdigest,  # type: str
+):
+    # type: (...) -> Fingerprint
+
+    for subclass in Fingerprint.__subclasses__():
+        if subclass.algorithm == algorithm:
+            return subclass(hexdigest)
+
+    raise ValueError(
+        "There is no fingerprint type registered for hash algorithm {algorithm}. The supported "
+        "algorithms are: {algorithms}".format(
+            algorithm=algorithm,
+            algorithms=", ".join(fp.algorithm for fp in Fingerprint.__subclasses__()),
+        )
+    )
+
+
+class Sha1Fingerprint(Fingerprint):
+    pass
+
+
+class Sha256Fingerprint(Fingerprint):
+    pass
+
+
+if TYPE_CHECKING:
+    _F = TypeVar("_F", bound=Fingerprint)
+
+
+class HashlibHasher(Generic["_F"]):
+    def __init__(
+        self,
+        hexdigest_type,  # type: Type[_F]
+        data=b"",  # type: bytes
+    ):
+        # type: (...) -> None
+        self._hexdigest_type = hexdigest_type
+        self._hasher = hashlib.new(hexdigest_type.algorithm, data)
+
+    @property
+    def name(self):
+        # type: () -> str
+        return self._hasher.name
+
+    @property
+    def block_size(self):
+        # type: () -> int
+        return self._hasher.block_size
+
+    def update(self, data):
+        # type: (bytes) -> None
+        self._hasher.update(data)
+
+    def digest(self):
+        # type: () -> bytes
+        return self._hasher.digest()
+
+    def hexdigest(self):
+        # type: () -> _F
+        return self._hexdigest_type(self._hasher.hexdigest())
+
+
+class Sha1(HashlibHasher[Sha1Fingerprint]):
+    def __init__(self, data=b""):
+        # type: (bytes) -> None
+        super(Sha1, self).__init__(hexdigest_type=Sha1Fingerprint, data=data)
+
+
+class Sha256(HashlibHasher[Sha256Fingerprint]):
+    def __init__(self, data=b""):
+        # type: (bytes) -> None
+        super(Sha256, self).__init__(hexdigest_type=Sha256Fingerprint, data=data)
+
+
+class MultiDigest(object):
+    def __init__(self, digests):
+        # type: (Iterable[HintedDigest]) -> None
+        self._digests = digests
+        self._block_size = max(digest.block_size for digest in digests)
+
+    @property
+    def block_size(self):
+        # type: () -> int
+        return self._block_size
+
+    def update(self, data):
+        # type: (bytes) -> None
+        for digest in self._digests:
+            digest.update(data)
+
+
+def update_hash(
+    filelike,  # type: IO[bytes]
+    digest,  # type: HintedDigest
+):
+    # type: (...) -> None
+    """Update the digest of a single file in a memory-efficient manner."""
+    block_size = digest.block_size * 1024
+    for chunk in iter(lambda: filelike.read(block_size), b""):
+        digest.update(chunk)
+
+
+def file_hash(
+    path,  # type: str
+    digest,  # type: HintedDigest
+):
+    # type: (...) -> None
+    """Digest of a single file in a memory-efficient manner."""
+    with open(path, "rb") as fp:
+        update_hash(filelike=fp, digest=digest)
+
+
+def dir_hash(
+    directory,  # type: str
+    digest,  # type: HintedDigest
+    dir_filter=lambda dirs: dirs,  # type: Callable[[Iterable[str]], Iterable[str]]
+    file_filter=lambda files: files,  # type: Callable[[Iterable[str]], Iterable[str]]
+):
+    # type: (...) -> None
+    """Digest the contents of a directory in a reproducible manner."""
+
+    def iter_files():
+        # type: () -> Iterator[str]
+        normpath = os.path.realpath(os.path.normpath(directory))
+        for root, dirs, files in os.walk(normpath):
+            dirs[:] = list(dir_filter(dirs))
+            for f in file_filter(files):
+                yield os.path.relpath(os.path.join(root, f), normpath)
+
+    names = sorted(iter_files())
+
+    # Always use / as the path separator, since that's what zip uses.
+    hashed_names = [n.replace(os.sep, "/") for n in names]
+    digest.update("".join(hashed_names).encode("utf-8"))
+
+    for name in names:
+        file_hash(os.path.join(directory, name), digest)

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -78,10 +78,10 @@ class PexInfo(object):
             with open_zip(pex) as zf:
                 pex_info = zf.read(cls.PATH)
         elif os.path.isfile(pex):  # Venv PEX
-            with open(os.path.join(os.path.dirname(pex), cls.PATH)) as fp:
+            with open(os.path.join(os.path.dirname(pex), cls.PATH), "rb") as fp:
                 pex_info = fp.read()
         else:  # Directory (Either loose or installed) PEX
-            with open(os.path.join(pex, cls.PATH)) as fp:
+            with open(os.path.join(pex, cls.PATH), "rb") as fp:
                 pex_info = fp.read()
         return cls.from_json(pex_info)
 

--- a/pex/pip/vcs.py
+++ b/pex/pip/vcs.py
@@ -1,0 +1,73 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import hashlib
+import os
+
+from pex import hashing
+from pex.common import filter_pyc_dirs, filter_pyc_files, open_zip, temporary_dir
+from pex.requirements import VCS
+from pex.resolve.resolved_requirement import Fingerprint
+from pex.tracer import TRACER
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pex.hashing import HintedDigest
+
+
+def fingerprint_downloaded_vcs_archive(
+    download_dir,  # type: str
+    project_name,  # type: str
+    version,  # type: str
+    vcs,  # type: VCS.Value
+):
+    # type: (...) -> Fingerprint
+
+    # All VCS requirements are prepared as zip archives with this naming scheme as
+    # encoded in: `pip._internal.req.req_install.InstallRequirement.archive`.
+    archive_path = os.path.join(
+        download_dir,
+        "{project_name}-{version}.zip".format(
+            project_name=project_name,
+            version=version,
+        ),
+    )
+    digest = hashlib.sha256()
+    digest_vcs_archive(archive_path=archive_path, vcs=vcs, digest=digest)
+    return Fingerprint(algorithm=digest.name, hash=digest.hexdigest())
+
+
+def digest_vcs_archive(
+    archive_path,  # type: str
+    vcs,  # type: VCS.Value
+    digest,  # type: HintedDigest
+):
+    # type: (...) -> None
+
+    # All VCS requirements are prepared as zip archives as encoded in:
+    # `pip._internal.req.req_install.InstallRequirement.archive`.
+    with TRACER.timed(
+        "Digesting {archive} {vcs} archive".format(archive=os.path.basename(archive_path), vcs=vcs)
+    ), temporary_dir(cleanup=False) as chroot, open_zip(archive_path) as archive:
+        archive.extractall(chroot)
+
+        # Ignore VCS control directories for the purposes of fingerprinting the version controlled
+        # source tree. VCS control directories can contain non-reproducible content (Git at least
+        # has files that contain timestamps).
+        #
+        # We cannot prune these directories from the source archive directly unfortunately since
+        # some build processes use VCS version information to derive their version numbers (C.F.:
+        # https://pypi.org/project/setuptools-scm/). As such, we'll get a stable fingerprint, but be
+        # forced to re-build a wheel each time the VCS requirement is re-locked later, even when it
+        # hashes the same.
+        vcs_control_dir = ".{vcs}".format(vcs=vcs)
+
+        # TODO(John Sirois): Consider implementing zip_hash to avoid the extractall.
+        hashing.dir_hash(
+            directory=chroot,
+            digest=digest,
+            dir_filter=lambda dirs: [d for d in filter_pyc_dirs(dirs) if d != vcs_control_dir],
+            file_filter=filter_pyc_files,
+        )

--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -275,8 +275,8 @@ class VCSScheme(object):
     scheme = attr.ib()  # type: str
 
 
-def _parse_non_local_scheme(scheme):
-    # type: (str) -> Optional[Union[ArchiveScheme.Value, VCSScheme]]
+def parse_scheme(scheme):
+    # type: (str) -> Optional[Union[str, ArchiveScheme.Value, VCSScheme]]
     match = re.match(
         r"""
         ^
@@ -301,7 +301,7 @@ def _parse_non_local_scheme(scheme):
         re.VERBOSE,
     )
     if not match:
-        return None
+        return scheme
 
     archive_scheme = match.group("archive_scheme")
     if archive_scheme:
@@ -323,18 +323,15 @@ class ProjectNameExtrasAndMarker(object):
 
 def _try_parse_fragment_project_name_and_marker(fragment):
     # type: (Text) -> Optional[ProjectNameExtrasAndMarker]
-    project_requirement = None
-    for part in fragment.split("&"):
-        if part.startswith("egg="):
-            _, project_requirement = part.split("=", 1)
-            break
-    if project_requirement is None:
+    fragment_parameters = urlparse.parse_qs(fragment)
+    project_requirements = fragment_parameters.get("egg")
+    if not project_requirements:
         return None
     try:
-        req = Requirement.parse(project_requirement)
+        req = Requirement.parse(project_requirements[-1])
         return ProjectNameExtrasAndMarker(req.name, extras=req.extras, marker=req.marker)
     except (RequirementParseError, ValueError):
-        return ProjectNameExtrasAndMarker(project_requirement)
+        return ProjectNameExtrasAndMarker(project_requirements[-1])
 
 
 @attr.s(frozen=True)
@@ -458,9 +455,9 @@ def _parse_requirement_line(
     project_name, direct_reference_url = _split_direct_references(processed_text)
     parsed_url = urlparse.urlparse(direct_reference_url or processed_text)
 
+    parsed_scheme = parse_scheme(parsed_url.scheme)
     # Handle non local URLs.
-    non_local_scheme = _parse_non_local_scheme(parsed_url.scheme)
-    if non_local_scheme:
+    if isinstance(parsed_scheme, (ArchiveScheme.Value, VCSScheme)):
         project_name_extras_and_marker = _try_parse_fragment_project_name_and_marker(
             parsed_url.fragment
         )
@@ -497,9 +494,9 @@ def _parse_requirement_line(
             specifier=specifier,
             marker=marker,
         )
-        if isinstance(non_local_scheme, VCSScheme):
-            url = urlparse.urlparse(url)._replace(scheme=non_local_scheme.scheme).geturl()
-            return VCSRequirement(line, non_local_scheme.vcs, url, requirement, editable=editable)
+        if isinstance(parsed_scheme, VCSScheme):
+            url = urlparse.urlparse(url)._replace(scheme=parsed_scheme.scheme).geturl()
+            return VCSRequirement(line, parsed_scheme.vcs, url, requirement, editable=editable)
         return URLRequirement(line, url, requirement, editable=editable)
 
     # Handle local archives and project directories via path or file URL (Pip proprietary).

--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -323,15 +323,18 @@ class ProjectNameExtrasAndMarker(object):
 
 def _try_parse_fragment_project_name_and_marker(fragment):
     # type: (Text) -> Optional[ProjectNameExtrasAndMarker]
-    fragment_parameters = urlparse.parse_qs(fragment)
-    project_requirements = fragment_parameters.get("egg")
-    if not project_requirements:
+    project_requirement = None
+    for part in fragment.split("&"):
+        if part.startswith("egg="):
+            _, project_requirement = part.split("=", 1)
+            break
+    if project_requirement is None:
         return None
     try:
-        req = Requirement.parse(project_requirements[-1])
+        req = Requirement.parse(project_requirement)
         return ProjectNameExtrasAndMarker(req.name, extras=req.extras, marker=req.marker)
     except (RequirementParseError, ValueError):
-        return ProjectNameExtrasAndMarker(project_requirements[-1])
+        return ProjectNameExtrasAndMarker(project_requirement)
 
 
 @attr.s(frozen=True)

--- a/pex/resolve/lockfile/download_manager.py
+++ b/pex/resolve/lockfile/download_manager.py
@@ -3,54 +3,195 @@
 
 from __future__ import absolute_import
 
+import hashlib
+import json
 import os
 
-from pex.common import atomic_directory
+from pex import hashing
+from pex.common import atomic_directory, safe_rmtree
+from pex.pep_503 import ProjectName
 from pex.resolve.locked_resolve import Artifact
-from pex.typing import TYPE_CHECKING
+from pex.result import Error, ResultError, try_
+from pex.tracer import TRACER
+from pex.typing import TYPE_CHECKING, Generic
 from pex.variables import ENV
 
 if TYPE_CHECKING:
-    from typing import Optional
+    from typing import List, Optional, TypeVar, Union
 
     import attr  # vendor:skip
+
+    from pex.hashing import HintedDigest
+
+    _A = TypeVar("_A", bound=Artifact)
 else:
     from pex.third_party import attr
 
 
 @attr.s(frozen=True)
 class DownloadedArtifact(object):
+    _METADATA_VERSION = 1
+
+    class LoadError(Exception):
+        pass
+
+    @staticmethod
+    def metadata_filename(artifact_dir):
+        # type: (str) -> str
+        return os.path.join(artifact_dir, "metadata.json")
+
+    @classmethod
+    def store(
+        cls,
+        artifact_dir,  # type str
+        filename,  # type: str
+        legacy_fingerprint,  # type: hashing.Sha1Fingerprint
+        fingerprint,  # type: hashing.Fingerprint
+    ):
+        # type: (...) -> None
+
+        # We store v0 metadata so that Pex downgrades work. The v0 metadata mechanism had no
+        # remove & retry upgrade (downgrade) mechanism like v1+ does.
+        with open(os.path.join(artifact_dir, "sha1"), "w") as fp:
+            fp.write(legacy_fingerprint)
+
+        with open(cls.metadata_filename(artifact_dir), "w") as fp:
+            json.dump(
+                dict(
+                    algorithm=fingerprint.algorithm,
+                    hexdigest=fingerprint,
+                    filename=filename,
+                    version=cls._METADATA_VERSION,
+                ),
+                fp,
+            )
+
+    @classmethod
+    def load(cls, artifact_dir):
+        # type: (str) -> DownloadedArtifact
+        metadata_filename = cls.metadata_filename(artifact_dir)
+        try:
+            with open(metadata_filename, "r") as fp:
+                try:
+                    metadata = json.load(fp)
+                except ValueError as e:
+                    raise cls.LoadError(
+                        "Failed to decode download artifact JSON metadata in {path}: {err}".format(
+                            path=metadata_filename, err=e
+                        )
+                    )
+                if not isinstance(metadata, dict) or cls._METADATA_VERSION != metadata.get(
+                    "version"
+                ):
+                    raise cls.LoadError(
+                        "Unexpected downloaded artifact metadata object. Expected JSON metadata "
+                        "version {version} but found {metadata}".format(
+                            version=cls._METADATA_VERSION, metadata=metadata
+                        )
+                    )
+                return DownloadedArtifact(
+                    path=os.path.join(artifact_dir, metadata["filename"]),
+                    fingerprint=hashing.new_fingerprint(
+                        algorithm=str(metadata["algorithm"]), hexdigest=str(metadata["hexdigest"])
+                    ),
+                )
+        except (OSError, IOError) as e:
+            raise cls.LoadError(
+                "Failed to read a downloaded artifact metadata file at {path}: {err}".format(
+                    path=metadata_filename, err=e
+                )
+            )
+
     path = attr.ib()  # type: str
-
-    def fingerprint(self):
-        # type: () -> str
-        with open(os.path.join(os.path.dirname(self.path), "sha1"), "rb") as fp:
-            return str(fp.read().decode("ascii"))
+    fingerprint = attr.ib()  # type: hashing.Fingerprint
 
 
-class DownloadManager(object):
+class DownloadManager(Generic["_A"]):
     def __init__(self, pex_root=None):
         # type: (Optional[str]) -> None
         self._download_dir = os.path.join(pex_root or ENV.PEX_ROOT, "downloads")
 
-    def store(self, artifact):
-        # type: (Artifact) -> DownloadedArtifact
+    def store(
+        self,
+        artifact,  # type: _A
+        project_name,  # type: ProjectName
+        retry=True,  # type: bool
+    ):
+        # type: (...) -> DownloadedArtifact
 
         download_dir = os.path.join(self._download_dir, artifact.fingerprint.hash)
         with atomic_directory(download_dir, exclusive=True) as atomic_dir:
-            if not atomic_dir.is_finalized():
-                dest = os.path.join(atomic_dir.work_dir, artifact.filename)
-                internal_fingerprint = self.save(artifact, dest)
-                with open(os.path.join(atomic_dir.work_dir, "sha1"), "wb") as fp:
-                    fp.write(internal_fingerprint.encode("ascii"))
+            if atomic_dir.is_finalized():
+                TRACER.log("Using cached artifact at {} for {}".format(download_dir, artifact))
+            else:
+                legacy_internal_fingerprint = hashing.Sha1()  # Legacy internal
+                internal_fingerprint = hashing.Sha256()  # Internal
+                digests = [
+                    legacy_internal_fingerprint,
+                    internal_fingerprint,
+                ]  # type: List[HintedDigest]
 
-        return DownloadedArtifact(path=os.path.join(download_dir, artifact.filename))
+                # The locking process will have pre-calculated some artifact fingerprints ahead of
+                # time; these will be marked as verified and can be trusted.
+                if not artifact.verified:
+                    # For the rest (E.G.: PyPI URLs with embedded fingerprints), we distrust and
+                    # establish our own fingerprint. This will mostly be wasted effort since we
+                    # share the same hash algorithm as PyPI currently, but it will serve to upgrade
+                    # the fingerprint on other cheeseshops that use a lower-grade hash algorithm (
+                    # See: https://peps.python.org/pep-0503/#specification).
+                    check = hashlib.new(artifact.fingerprint.algorithm)  # External
+                    digests.append(check)
+
+                with TRACER.timed("Downloading {artifact}".format(artifact=artifact)):
+                    filename = try_(
+                        self.save(
+                            artifact=artifact,
+                            project_name=project_name,
+                            dest_dir=atomic_dir.work_dir,
+                            digest=hashing.MultiDigest(digests),
+                        )
+                    )
+
+                if not artifact.verified:
+                    actual_hash = check.hexdigest()
+                    if artifact.fingerprint.hash != actual_hash:
+                        raise ResultError(
+                            Error(
+                                "Expected {algorithm} hash of {expected_hash} when downloading "
+                                "{project_name} but hashed to {actual_hash}.".format(
+                                    algorithm=artifact.fingerprint.algorithm,
+                                    expected_hash=artifact.fingerprint.hash,
+                                    project_name=project_name,
+                                    actual_hash=actual_hash,
+                                )
+                            )
+                        )
+
+                DownloadedArtifact.store(
+                    artifact_dir=atomic_dir.work_dir,
+                    filename=filename,
+                    legacy_fingerprint=legacy_internal_fingerprint.hexdigest(),
+                    fingerprint=internal_fingerprint.hexdigest(),
+                )
+        try:
+            return DownloadedArtifact.load(download_dir)
+        except DownloadedArtifact.LoadError as e:
+            if not retry:
+                raise ResultError(Error(str(e)))
+
+            TRACER.log(
+                "Found outdated downloaded artifact metadata, upgrading: {err}".format(err=e)
+            )
+            safe_rmtree(download_dir)
+            return self.store(artifact, project_name, retry=False)
 
     def save(
         self,
-        artifact,  # type: Artifact
-        path,  # type: str
+        artifact,  # type: _A
+        project_name,  # type: ProjectName
+        dest_dir,  # type: str
+        digest,  # type: HintedDigest
     ):
-        # type: (...) -> str
-        """Save the given `artifact` at `path` and return its sha1 hex digest."""
+        # type: (...) -> Union[str, Error]
+        """Save and digest the given `artifact` under `dest_dir` and return the saved file name."""
         raise NotImplementedError()

--- a/pex/resolve/lockfile/json_codec.py
+++ b/pex/resolve/lockfile/json_codec.py
@@ -173,7 +173,7 @@ def loads(
             for i, artifact in enumerate(get("artifacts", list, data=req, path=req_path)):
                 ap = '{path}["artifacts"][{index}]'.format(path=req_path, index=i)
                 artifacts.append(
-                    Artifact(
+                    Artifact.from_url(
                         url=get("url", data=artifact, path=ap),
                         fingerprint=Fingerprint(
                             algorithm=get("algorithm", data=artifact, path=ap),

--- a/pex/resolve/resolved_requirement.py
+++ b/pex/resolve/resolved_requirement.py
@@ -67,6 +67,7 @@ class Fingerprint(object):
 class PartialArtifact(object):
     url = attr.ib()  # type: str
     fingerprint = attr.ib(default=None)  # type: Optional[Fingerprint]
+    verified = attr.ib(default=False)  # type: bool
 
 
 @attr.s(frozen=True)

--- a/pex/resolve/resolved_requirement.py
+++ b/pex/resolve/resolved_requirement.py
@@ -77,10 +77,14 @@ class ResolvedRequirement(object):
     additional_artifacts = attr.ib(default=())  # type: Tuple[PartialArtifact, ...]
     via = attr.ib(default=())  # type: Tuple[str, ...]
 
-    def _iter_urls_to_fingerprint(self):
-        # type: () -> Iterator[str]
-        if not self.artifact.fingerprint:
-            yield self.artifact.url
+    def iter_artifacts(self):
+        # type: () -> Iterator[PartialArtifact]
+        yield self.artifact
         for artifact in self.additional_artifacts:
+            yield artifact
+
+    def iter_urls_to_fingerprint(self):
+        # type: () -> Iterator[str]
+        for artifact in self.iter_artifacts():
             if not artifact.fingerprint:
                 yield artifact.url

--- a/pex/resolve/resolved_requirement.py
+++ b/pex/resolve/resolved_requirement.py
@@ -5,12 +5,12 @@ from __future__ import absolute_import
 
 import hashlib
 
+from pex import hashing
 from pex.dist_metadata import ProjectNameAndVersion
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.third_party.pkg_resources import Requirement
 from pex.typing import TYPE_CHECKING
-from pex.util import CacheHelper
 
 if TYPE_CHECKING:
     from typing import BinaryIO, Iterator, Optional, Tuple
@@ -56,7 +56,7 @@ class Fingerprint(object):
     ):
         # type: (...) -> Fingerprint
         digest = hashlib.new(algorithm)
-        CacheHelper.update_hash(filelike=stream, digest=digest)
+        hashing.update_hash(filelike=stream, digest=digest)
         return cls(algorithm=algorithm, hash=digest.hexdigest())
 
     algorithm = attr.ib()  # type: str

--- a/pex/resolve/resolver_options.py
+++ b/pex/resolve/resolver_options.py
@@ -119,7 +119,7 @@ def register(
             default=None,
             type=str,
             help=(
-                "Resolve requirements from the given lock file crated by Pex instead of from "
+                "Resolve requirements from the given lock file created by Pex instead of from "
                 "--index servers, --find-links repos or a --pex-repository. If no requirements are "
                 "specified, will install the entire lock."
             ),

--- a/pex/resolve/testing.py
+++ b/pex/resolve/testing.py
@@ -3,37 +3,48 @@
 
 from __future__ import absolute_import
 
-from pex.resolve.locked_resolve import Artifact, LockedRequirement, LockedResolve
+from pex.resolve.locked_resolve import FileArtifact, LockedRequirement, LockedResolve, VCSArtifact
 from pex.sorted_tuple import SortedTuple
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Union
+
     import attr  # vendor:skip
 else:
     from pex.third_party import attr
 
 
 def normalize_artifact(
-    artifact,  # type: Artifact
+    artifact,  # type: Union[FileArtifact, VCSArtifact]
     skip_urls=False,  # type: bool
+    skip_verified=False,  # type: bool
 ):
-    # type: (...) -> Artifact
-    return attr.evolve(artifact, url="") if skip_urls else artifact
+    # type: (...) -> Union[FileArtifact, VCSArtifact]
+    return attr.evolve(
+        artifact,
+        url="" if skip_urls else artifact.url,
+        verified=False if skip_verified else artifact.verified,
+    )
 
 
 def normalize_locked_requirement(
     locked_req,  # type: LockedRequirement
     skip_additional_artifacts=False,  # type: bool
     skip_urls=False,  # type: bool
+    skip_verified=False,  # type: bool
 ):
     # type: (...) -> LockedRequirement
     return attr.evolve(
         locked_req,
-        artifact=normalize_artifact(locked_req.artifact, skip_urls=skip_urls),
+        artifact=normalize_artifact(
+            locked_req.artifact, skip_urls=skip_urls, skip_verified=skip_verified
+        ),
         additional_artifacts=()
         if skip_additional_artifacts
         else SortedTuple(
-            normalize_artifact(a, skip_urls=skip_urls) for a in locked_req.additional_artifacts
+            normalize_artifact(a, skip_urls=skip_urls, skip_verified=skip_verified)
+            for a in locked_req.additional_artifacts
         ),
     )
 
@@ -42,6 +53,7 @@ def normalize_locked_resolve(
     lock,  # type: LockedResolve
     skip_additional_artifacts=False,  # type: bool
     skip_urls=False,  # type: bool
+    skip_verified=False,  # type: bool
 ):
     # type: (...) -> LockedResolve
     return attr.evolve(
@@ -51,6 +63,7 @@ def normalize_locked_resolve(
                 locked_req,
                 skip_additional_artifacts=skip_additional_artifacts,
                 skip_urls=skip_urls,
+                skip_verified=skip_verified,
             )
             for locked_req in lock.locked_requirements
         ),

--- a/tests/integration/cli/commands/test_vcs_lock.py
+++ b/tests/integration/cli/commands/test_vcs_lock.py
@@ -1,0 +1,242 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import filecmp
+import os.path
+import shutil
+import subprocess
+import sys
+import tempfile
+from textwrap import dedent
+
+import colors
+import pytest
+
+from pex.cli.testing import run_pex3
+from pex.common import safe_open
+from pex.compatibility import PY2, urlparse
+from pex.resolve import lockfile
+from pex.resolve.locked_resolve import VCSArtifact
+from pex.testing import run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class TestTool(object):
+    tmpdir = attr.ib()  # type: str
+
+    @property
+    def pex_root(self):
+        # type: () -> str
+        return os.path.join(self.tmpdir, "pex_root")
+
+    def create_lock(self, *args):
+        # type: (*str) -> str
+        lock = tempfile.mktemp(prefix="lock.", dir=self.tmpdir)
+        run_pex3("lock", "create", "--pex-root", self.pex_root, "-o", lock, *args).assert_success()
+        return lock
+
+    def create_pex(
+        self,
+        lock,  # type: str
+        *args  # type: str
+    ):
+        # type: (...) -> str
+        pex = tempfile.mktemp(suffix=".pex", dir=self.tmpdir)
+        run_pex_command(
+            args=[
+                "--pex-root",
+                self.pex_root,
+                "--runtime-pex-root",
+                self.pex_root,
+                "--lock",
+                lock,
+                "-o",
+                pex,
+            ]
+            + list(args)
+        ).assert_success()
+        return pex
+
+    def create_locked_pex(self, *lock_args):
+        # type: (*str) -> str
+        return self.create_pex(self.create_lock(*lock_args))
+
+
+@pytest.fixture
+def test_tool(tmpdir):
+    # type: (Any) -> TestTool
+    return TestTool(str(tmpdir))
+
+
+def test_vcs_direct_reference(test_tool):
+    # type: (TestTool) -> None
+
+    pex = test_tool.create_locked_pex(
+        "ansicolors @ git+https://github.com/jonathaneunice/colors.git@c965f5b9"
+    )
+
+    assert (
+        colors.cyan("Miles Davis")
+        == subprocess.check_output(
+            args=[pex, "-c", "import colors; print(colors.cyan('Miles Davis'))"]
+        )
+        .decode("utf-8")
+        .strip()
+    )
+
+
+def test_vcs_pip_proprietary(test_tool):
+    # type: (TestTool) -> None
+
+    pex = test_tool.create_locked_pex(
+        "git+https://github.com/jonathaneunice/colors.git@c965f5b9#egg=ansicolors"
+    )
+
+    assert (
+        colors.magenta("Alecia Beth Moore")
+        == subprocess.check_output(
+            args=[pex, "-c", "import colors; print(colors.magenta('Alecia Beth Moore'))"]
+        )
+        .decode("utf-8")
+        .strip()
+    )
+
+
+def test_vcs_equivalence(test_tool):
+    # type: (TestTool) -> None
+
+    lock1 = test_tool.create_lock(
+        "ansicolors @ git+https://github.com/jonathaneunice/colors.git@c965f5b9"
+    )
+    lock2 = test_tool.create_lock(
+        "git+https://github.com/jonathaneunice/colors.git@c965f5b9#egg=ansicolors"
+    )
+
+    assert lock1 != lock2, "Expected two different lock files."
+
+    def extract_single_vcs_artifact(lock):
+        # type: (str) -> VCSArtifact
+        lock_file = lockfile.load(lock)
+
+        assert 1 == len(lock_file.locked_resolves)
+        locked_resolve = lock_file.locked_resolves[0]
+
+        assert 1 == len(locked_resolve.locked_requirements)
+        locked_requirement = locked_resolve.locked_requirements[0]
+
+        assert 0 == len(locked_requirement.additional_artifacts)
+        assert isinstance(locked_requirement.artifact, VCSArtifact)
+        return locked_requirement.artifact
+
+    vcs_artifact1 = extract_single_vcs_artifact(lock1)
+    vcs_artifact2 = extract_single_vcs_artifact(lock2)
+
+    assert vcs_artifact1.fingerprint == vcs_artifact2.fingerprint, (
+        "We expect locking using a direct reference requirement or a Pip proprietary VCS "
+        "requirement for the same VCS revision will produce the same locked VCS archive"
+    )
+    assert vcs_artifact1.url != vcs_artifact2.url, "Expected two different lock URLs."
+    assert "" == urlparse.urlparse(vcs_artifact1.url).fragment
+    assert {"egg": ["ansicolors"]} == urlparse.parse_qs(
+        urlparse.urlparse(vcs_artifact2.url).fragment
+    )
+
+
+@pytest.mark.skipif(sys.version_info[:2] < (3, 6), reason="The library under test uses f-strings.")
+def test_subdir(test_tool):
+    # type: (TestTool) -> None
+
+    # This is a trick you cannot do with a direct reference VCS URL.
+    pex = test_tool.create_locked_pex(
+        "git+https://github.com/SerialDev/sdev_py_utils.git@bd4d36a0"
+        "#egg=sdev_logging_utils&subdirectory=sdev_logging_utils"
+    )
+    assert (
+        subprocess.check_output(
+            args=[pex, "-c", "import sdev_logging_utils; print(sdev_logging_utils.__file__)"]
+        )
+        .decode("utf-8")
+        .startswith(os.path.join(test_tool.pex_root, "installed_wheels"))
+    )
+
+
+def test_vcs_fingerprint_stability(test_tool):
+    # type: (TestTool) -> None
+
+    lock1 = test_tool.create_lock(
+        "git+https://github.com/VaasuDevanS/cowsay-python@v3.0#egg=cowsay"
+    )
+    shutil.rmtree(test_tool.pex_root)
+    lock2 = test_tool.create_lock(
+        "git+https://github.com/VaasuDevanS/cowsay-python@v3.0#egg=cowsay"
+    )
+
+    assert lock1 != lock2, "Expected two different lock files."
+    assert filecmp.cmp(
+        lock1, lock2, shallow=False
+    ), "Expected the same lockfile contents; i.e.: a stable VCS archive hash."
+
+
+def test_vcs_transitive(
+    tmpdir,  # type: Any
+    test_tool,  # type: TestTool
+):
+    # type: (...) -> None
+
+    src = os.path.join(str(tmpdir), "src")
+    with safe_open(os.path.join(src, "poetry.py"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                import colors
+
+
+                def third_worst():
+                    print(colors.green("Prostetnic Vogon Jeltz"))
+                """
+            )
+        )
+    with safe_open(os.path.join(src, "setup.cfg"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                [metadata]
+                name = poetry
+                version = 0.0.1
+
+                [options]
+                py_modules =
+                    poetry
+
+                install_requires =
+                    ansicolors @ git+https://github.com/jonathaneunice/colors.git@c965f5b9
+
+                [options.entry_points]
+                console_scripts =
+                    recite = poetry:third_worst
+                """
+            )
+        )
+    with safe_open(os.path.join(src, "setup.py"), "w") as fp:
+        fp.write("from setuptools import setup; setup()")
+
+    subprocess.check_call(args=["git", "init", "-b", "Golgafrincham", src])
+    subprocess.check_call(args=["git", "config", "user.email", "forty@two.com"], cwd=src)
+    subprocess.check_call(args=["git", "config", "user.name", "Douglas Adams"], cwd=src)
+    subprocess.check_call(args=["git", "add", "."], cwd=src)
+    subprocess.check_call(args=["git", "commit", "-m", "Only commit."], cwd=src)
+
+    lock = test_tool.create_lock("git+file://{src}#egg=poetry".format(src=src))
+    pex = test_tool.create_pex(lock, "-c", "recite")
+    assert (
+        colors.green("Prostetnic Vogon Jeltz")
+        == subprocess.check_output(args=[pex]).decode("utf-8").strip()
+    )

--- a/tests/integration/test_lock_resolver.py
+++ b/tests/integration/test_lock_resolver.py
@@ -16,7 +16,7 @@ from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.pex_info import PexInfo
 from pex.resolve import lockfile
-from pex.resolve.locked_resolve import LockedRequirement, LockedResolve
+from pex.resolve.locked_resolve import LockedRequirement
 from pex.testing import make_env, run_pex_command
 from pex.typing import TYPE_CHECKING
 from pex.util import CacheHelper
@@ -229,7 +229,8 @@ def test_corrupt_artifact(
     assert (
         "There was 1 error downloading required artifacts:\n"
         "1. requests 2.25.1 from file://{requests_distribution}\n"
-        "    Expected {algorithm} hash of {expected_hash} but hashed to {actual_hash}.".format(
+        "    Expected {algorithm} hash of {expected_hash} when downloading requests but hashed to "
+        "{actual_hash}.".format(
             requests_distribution=requests_distribution,
             algorithm=algorithm,
             expected_hash=expected_hash,

--- a/tests/integration/test_locked_resolve.py
+++ b/tests/integration/test_locked_resolve.py
@@ -33,6 +33,7 @@ def normalize(
     downloaded,  # type: Downloaded
     skip_additional_artifacts=False,  # type: bool
     skip_urls=False,  # type: bool
+    skip_verified=False,  # type: bool
 ):
     # type: (...) -> Downloaded
     return attr.evolve(
@@ -45,7 +46,10 @@ def normalize(
         locked_resolves=tuple(
             sorted(
                 normalize_locked_resolve(
-                    lock, skip_additional_artifacts=skip_additional_artifacts, skip_urls=skip_urls
+                    lock,
+                    skip_additional_artifacts=skip_additional_artifacts,
+                    skip_urls=skip_urls,
+                    skip_verified=skip_verified,
                 )
                 for lock in downloaded.locked_resolves
             )
@@ -116,7 +120,9 @@ def test_lock_single_target(
         os.symlink(
             local_dist.path, os.path.join(find_links_repo, os.path.basename(local_dist.path))
         )
-    assert normalize(downloaded, skip_additional_artifacts=True, skip_urls=True) == normalize(
+    assert normalize(
+        downloaded, skip_additional_artifacts=True, skip_urls=True, skip_verified=True
+    ) == normalize(
         resolver.download(
             requirements=requirements,
             lock_configuration=lock_configuration,
@@ -125,10 +131,11 @@ def test_lock_single_target(
         ),
         skip_additional_artifacts=True,
         skip_urls=True,
+        skip_verified=True,
     ), (
         "Expected a find-links lock to match an equivalent PyPI lock except for the primary "
-        "artifact urls and lack of additional artifacts (since these are never downloaded; but "
-        "instead, just recorded)."
+        "artifact urls and their verification status and lack of additional artifacts (since these "
+        "are never downloaded; but instead, just recorded)."
     )
 
     lock_file = os.path.join(str(tmpdir), "requirements.txt")

--- a/tests/resolve/lockfile/test_download_manager.py
+++ b/tests/resolve/lockfile/test_download_manager.py
@@ -26,14 +26,14 @@ else:
     from pex.third_party import attr
 
 
-class TestDownloadManager(DownloadManager[FileArtifact]):
+class FakeDownloadManager(DownloadManager[FileArtifact]):
     def __init__(
         self,
         content,  # type: bytes
         pex_root=None,  # type: Optional[str]
     ):
         # type: (...) -> None
-        super(TestDownloadManager, self).__init__(pex_root=pex_root)
+        super(FakeDownloadManager, self).__init__(pex_root=pex_root)
         self._content = content
         self._calls = []  # type: List[str]
 
@@ -89,14 +89,14 @@ def download_manager(
     expected_content,  # type: bytes
     pex_root,  # type: Any
 ):
-    # type: (...) -> TestDownloadManager
-    return TestDownloadManager(content=expected_content, pex_root=pex_root)
+    # type: (...) -> FakeDownloadManager
+    return FakeDownloadManager(content=expected_content, pex_root=pex_root)
 
 
 def test_storage_cache(
     artifact,  # type: FileArtifact
     project_name,  # type: ProjectName
-    download_manager,  # type: TestDownloadManager
+    download_manager,  # type: FakeDownloadManager
 ):
     # type: (...) -> None
 
@@ -109,7 +109,7 @@ def test_storage_cache(
 def test_storage_version_upgrade(
     artifact,  # type: FileArtifact
     project_name,  # type: ProjectName
-    download_manager,  # type: TestDownloadManager
+    download_manager,  # type: FakeDownloadManager
 ):
     # type: (...) -> None
 
@@ -164,7 +164,7 @@ def test_fingerprint_checking(
     # We expect un-verified artifacts to have their hashes checked against the expected (locked)
     # values.
     actual_content = b"unexpected content"
-    download_manager = TestDownloadManager(content=actual_content, pex_root=pex_root)
+    download_manager = FakeDownloadManager(content=actual_content, pex_root=pex_root)
     expected_sha1_hash = hashing.Sha1(expected_content).hexdigest()
     assert Error(
         "Expected sha1 hash of {expected_hash} when downloading foo but hashed to "

--- a/tests/resolve/lockfile/test_download_manager.py
+++ b/tests/resolve/lockfile/test_download_manager.py
@@ -1,0 +1,187 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import json
+import os.path
+from io import BytesIO
+
+import pytest
+
+from pex import hashing
+from pex.hashing import Sha1Fingerprint, Sha256Fingerprint
+from pex.pep_503 import ProjectName
+from pex.resolve.locked_resolve import FileArtifact
+from pex.resolve.lockfile.download_manager import DownloadedArtifact, DownloadManager
+from pex.resolve.resolved_requirement import Fingerprint
+from pex.result import Error, catch
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, List, Optional, Union
+
+    import attr  # vendor:skip
+
+    from pex.hashing import HintedDigest
+else:
+    from pex.third_party import attr
+
+
+class TestDownloadManager(DownloadManager[FileArtifact]):
+    def __init__(
+        self,
+        content,  # type: bytes
+        pex_root=None,  # type: Optional[str]
+    ):
+        # type: (...) -> None
+        super(TestDownloadManager, self).__init__(pex_root=pex_root)
+        self._content = content
+        self._calls = []  # type: List[str]
+
+    @property
+    def save_calls(self):
+        # type: () -> List[str]
+        return self._calls
+
+    def save(
+        self,
+        artifact,  # type: FileArtifact
+        project_name,  # type: ProjectName
+        dest_dir,  # type: str
+        digest,  # type: HintedDigest
+    ):
+        # type: (...) -> Union[str, Error]
+        self.save_calls.append(dest_dir)
+        digest.update(self._content)
+        return artifact.filename
+
+
+@pytest.fixture
+def expected_content():
+    # type: () -> bytes
+    return b"expected content"
+
+
+@pytest.fixture
+def project_name():
+    # type: () -> ProjectName
+    return ProjectName("foo")
+
+
+@pytest.fixture
+def artifact(expected_content):
+    # type: (bytes) -> FileArtifact
+    return FileArtifact(
+        url="file:///foo-1.0.tar.gz",
+        fingerprint=Fingerprint.from_stream(BytesIO(expected_content), algorithm="sha1"),
+        filename="foo-1.0.tar.gz",
+        verified=False,
+    )
+
+
+@pytest.fixture
+def pex_root(tmpdir):
+    # type: (Any) -> str
+    return os.path.join(str(tmpdir), "pex_root")
+
+
+@pytest.fixture
+def download_manager(
+    expected_content,  # type: bytes
+    pex_root,  # type: Any
+):
+    # type: (...) -> TestDownloadManager
+    return TestDownloadManager(content=expected_content, pex_root=pex_root)
+
+
+def test_storage_cache(
+    artifact,  # type: FileArtifact
+    project_name,  # type: ProjectName
+    download_manager,  # type: TestDownloadManager
+):
+    # type: (...) -> None
+
+    downloaded_artifact1 = download_manager.store(artifact, project_name)
+    downloaded_artifact2 = download_manager.store(artifact, project_name)
+    assert downloaded_artifact1 == downloaded_artifact2
+    assert 1 == len(download_manager.save_calls)
+
+
+def test_storage_version_upgrade(
+    artifact,  # type: FileArtifact
+    project_name,  # type: ProjectName
+    download_manager,  # type: TestDownloadManager
+):
+    # type: (...) -> None
+
+    downloaded_artifact1 = download_manager.store(artifact, project_name)
+
+    # If the storage metadata is not of the expected version, filename or just not present, we
+    # expect the artifact to be re-stored afresh.
+    files = tuple(
+        os.path.join(root, f)
+        for root, _, files in os.walk(os.path.dirname(downloaded_artifact1.path))
+        for f in files
+    )
+    assert len(files) > 0, "We expect at least one metadata file."
+    for f in files:
+        os.unlink(f)
+
+    downloaded_artifact2 = download_manager.store(artifact, project_name)
+    assert downloaded_artifact1 == downloaded_artifact2
+    assert 2 == len(set(download_manager.save_calls)), (
+        "Expected two save calls, each with a different atomic directory work dir signalling a "
+        "re-build of the artifact storage"
+    )
+
+
+def test_storage_version_downgrade_v0(tmpdir):
+    # type: (Any) -> None
+
+    DownloadedArtifact.store(
+        artifact_dir=str(tmpdir),
+        filename="foo",
+        legacy_fingerprint=Sha1Fingerprint("bar"),
+        fingerprint=Sha256Fingerprint("baz"),
+    )
+
+    # We should always be emitting v0 metadata since versions of Pex that emitted that format did
+    # not have an upgrade (downgrade) mechanism.
+    with open(os.path.join(str(tmpdir), "sha1")) as fp:
+        assert "bar" == fp.read()
+
+    with open(DownloadedArtifact.metadata_filename(str(tmpdir))) as fp:
+        assert dict(algorithm="sha256", hexdigest="baz", filename="foo", version=1) == json.load(fp)
+
+
+def test_fingerprint_checking(
+    expected_content,  # type: bytes
+    artifact,  # type: FileArtifact
+    project_name,  # type: ProjectName
+    pex_root,  # type: str
+):
+    # type: (...) -> None
+
+    # We expect un-verified artifacts to have their hashes checked against the expected (locked)
+    # values.
+    actual_content = b"unexpected content"
+    download_manager = TestDownloadManager(content=actual_content, pex_root=pex_root)
+    expected_sha1_hash = hashing.Sha1(expected_content).hexdigest()
+    assert Error(
+        "Expected sha1 hash of {expected_hash} when downloading foo but hashed to "
+        "{actual_hash}.".format(
+            expected_hash=expected_sha1_hash, actual_hash=hashing.Sha1(actual_content).hexdigest()
+        )
+    ) == catch(download_manager.store, artifact, project_name)
+
+    # But when the artifact hash is marked verified, no hash checking should occur.
+    verified_artifact = attr.evolve(artifact, verified=True)
+    expected_artifact_dir = os.path.join(pex_root, "downloads", expected_sha1_hash)
+    downloaded_artifact = download_manager.store(verified_artifact, project_name)
+    assert (
+        DownloadedArtifact(
+            path=os.path.join(expected_artifact_dir, "foo-1.0.tar.gz"),
+            fingerprint=hashing.Sha256(actual_content).hexdigest(),
+        )
+        == downloaded_artifact
+    )
+    assert downloaded_artifact == DownloadedArtifact.load(artifact_dir=expected_artifact_dir)

--- a/tests/resolve/lockfile/test_json_codec.py
+++ b/tests/resolve/lockfile/test_json_codec.py
@@ -62,7 +62,7 @@ def test_roundtrip(tmpdir):
                             pin=Pin(
                                 project_name=ProjectName("ansicolors"), version=Version("1.1.8")
                             ),
-                            artifact=Artifact(
+                            artifact=Artifact.from_url(
                                 url="https://example.org/colors-1.1.8-cp36-cp36m-macosx_10_6_x86_64.whl",
                                 fingerprint=Fingerprint(algorithm="blake256", hash="cafebabe"),
                             ),
@@ -70,12 +70,12 @@ def test_roundtrip(tmpdir):
                         ),
                         LockedRequirement.create(
                             pin=Pin(project_name=ProjectName("requests"), version=Version("2.0.0")),
-                            artifact=Artifact(
+                            artifact=Artifact.from_url(
                                 url="https://example.org/requests-2.0.0-py2.py3-none-any.whl",
                                 fingerprint=Fingerprint(algorithm="sha256", hash="456"),
                             ),
                             additional_artifacts=(
-                                Artifact(
+                                Artifact.from_url(
                                     url="file://find-links/requests-2.0.0.tar.gz",
                                     fingerprint=Fingerprint(algorithm="sha512", hash="123"),
                                 ),
@@ -92,7 +92,7 @@ def test_roundtrip(tmpdir):
                             pin=Pin(
                                 project_name=ProjectName("ansicolors"), version=Version("1.1.8")
                             ),
-                            artifact=Artifact(
+                            artifact=Artifact.from_url(
                                 url="https://example.org/colors-1.1.8-cp37-cp37m-manylinux1_x86_64.whl",
                                 fingerprint=Fingerprint(algorithm="md5", hash="hackme"),
                             ),

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -1,0 +1,71 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import hashlib
+
+import pytest
+
+from pex.hashing import (
+    HashlibHasher,
+    MultiDigest,
+    Sha1Fingerprint,
+    Sha256Fingerprint,
+    new_fingerprint,
+)
+
+
+def test_fingerprint_equality():
+    # type: () -> None
+
+    assert Sha1Fingerprint("foo") == Sha1Fingerprint("foo")
+    assert Sha1Fingerprint("foo") != Sha1Fingerprint("bar")
+
+    assert "foo" == Sha1Fingerprint("foo"), (
+        "Expected a digest str object to see itself as equal to a Sha256Fingerprint "
+        "object with the same digest value"
+    )
+    assert Sha1Fingerprint("foo") != Sha256Fingerprint(
+        "foo"
+    ), "Expected fingerprint objects to require types (algorithms) match exactly"
+
+
+def test_fingerprint_new_hasher():
+    # type: () -> None
+
+    assert hashlib.sha1().hexdigest() == Sha1Fingerprint.new_hasher().hexdigest()
+    assert hashlib.sha256().hexdigest() == Sha256Fingerprint.new_hasher().hexdigest()
+
+
+def test_new_fingerprint():
+    # type: () -> None
+
+    assert Sha1Fingerprint("foo") == new_fingerprint(algorithm="sha1", hexdigest="foo")
+    assert Sha256Fingerprint("foo") == new_fingerprint(algorithm="sha256", hexdigest="foo")
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"There is no fingerprint type registered for hash algorithm md5. The supported "
+            r"algorithms are: "
+        ),
+    ):
+        new_fingerprint(algorithm="md5", hexdigest="foo")
+
+
+def test_hasher():
+    # type: () -> None
+
+    hasher = Sha1Fingerprint.new_hasher()
+    assert isinstance(hasher, HashlibHasher)
+
+    sha1 = hashlib.sha1()
+    assert sha1.name == hasher.name
+    assert sha1.block_size == hasher.block_size
+
+    multi_digest = MultiDigest((sha1, hasher))
+    multi_digest.update(b"foo")
+    assert sha1.digest() == hasher.digest()
+
+    fingerprint = hasher.hexdigest()
+    assert isinstance(fingerprint, Sha1Fingerprint)
+    assert fingerprint == Sha1Fingerprint(sha1.hexdigest())

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -12,6 +12,7 @@ from pex.common import safe_open, temporary_dir, touch
 from pex.fetcher import URLFetcher
 from pex.requirements import (
     VCS,
+    ArchiveScheme,
     Constraint,
     LocalProjectRequirement,
     LogicalLine,
@@ -24,6 +25,7 @@ from pex.requirements import (
     parse_requirement_file,
     parse_requirement_from_project_name_and_specifier,
     parse_requirements,
+    parse_scheme,
 )
 from pex.testing import environment_as
 from pex.third_party.packaging.markers import Marker
@@ -525,3 +527,21 @@ def test_parse_requirements_from_url_no_fetcher():
         "Problem resolving requirements file: The source is a url but no fetcher was supplied to "
         "resolve its contents with.".format(EXAMPLE_PYTHON_REQUIREMENTS_URL)
     ) == str(exec_info.value)
+
+
+def test_parse_scheme():
+    # type: () -> None
+
+    assert "not a scheme" == parse_scheme("not a scheme")
+    assert "gopher" == parse_scheme("gopher")
+
+    assert ArchiveScheme.FTP == parse_scheme("ftp")
+    assert ArchiveScheme.HTTP == parse_scheme("http")
+    assert ArchiveScheme.HTTPS == parse_scheme("https")
+
+    assert VCSScheme(VCS.Bazaar, "nfs") == parse_scheme("bzr+nfs")
+    assert VCSScheme(VCS.Git, "file") == parse_scheme("git+file")
+    assert VCSScheme(VCS.Mercurial, "http") == parse_scheme("hg+http")
+    assert VCSScheme(VCS.Subversion, "https") == parse_scheme("svn+https")
+
+    assert "cvs+https" == parse_scheme("cvs+https")


### PR DESCRIPTION
This supports all forms of VCS requirements Pip supports as direct or 
transitive requirements. VCS source archives fetched by Pip are sha256
hashed by Pex providing a stable & secure fingerprint even for VCS
requirements pointing to possibly mutable tags or branches or even
insecure commit ids.

Fixes #1556