### PR TITLE
Fix #1693

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -470,7 +470,7 @@ def atomic_directory(target_dir, exclusive, source=None):
             # staleness.
             fcntl.lockf(lock_fd, fcntl.LOCK_EX)  # A blocking write lock.
         except OSError as e:
-            if e.errno == 35:  # Resource deadlock avoided
+            if e.errno == errno.EDEADLK:  # Resource deadlock avoided
                 # Another thread/process is doing the work. They get the exclusivity.
                 # N.B.: This can happen if the process running this code forks, this is the same
                 # behavior as described in https://bugs.python.org/issue6721, but instead of logging


### PR DESCRIPTION
The comments added should explain the case and solution.

This has been tested using the same setup/commands as previously used to reliably demonstrate the bug.
Additionally, I modified the code as follows
```
        assert_is_finalized = False
        while True:
            try:
                fcntl.lockf(lock_fd, fcntl.LOCK_EX)  # A blocking write lock.
            except OSError as e:
                if e.errno == errno.EDEADLK:  # Resource deadlock avoided
                    assert_is_finalized = True
                    time.sleep(1)
                    continue
                raise

            is_finalized = atomic_dir.is_finalized()
            if assert_is_finalized:
                assert is_finalized
```
and never saw the `assert`. That tells me that our assumption that in this case we don't have exclusivity and something else does is true.
