### PR TITLE
Prepare the 2.1.75 release.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+2.1.75
+------
+
+This release fixes a deadlock when building PEXes in parallel
+via the new ``--lock`` flag.
+
+* Avoid deadlock error when run in parallel. (#1694)
+  `PR #1694 <https://github.com/pantsbuild/pex/pull/1694>`_
+
 2.1.74
 ------
 

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.1.74"
+__version__ = "2.1.75"


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pex/issues/1691.