### PR TITLE
Fix lock_resolver to use BSD file locks.

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -106,28 +106,6 @@ def pluralize(
         return noun + "s"
 
 
-def qualified_name(item):
-    # type: (Any) -> str
-    """Attempt to produce the fully qualified name for an item.
-
-    If the item is a type, method, property or function, its fully qualified name is returned as
-    best as can be determined. Otherwise, the fully qualified name of the type of the given item is
-    returned.
-
-    :param item: The item to identify.
-    :return: The fully qualified name of the given item.
-    """
-    if isinstance(item, property):
-        item = item.fget
-    if not hasattr(item, "__name__"):
-        item = type(item)
-    return "{module}.{type}".format(
-        module=getattr(item, "__module__", "<unknown module>"),
-        # There is no __qualname__ in Python 2.7; so we do the best we can.
-        type=getattr(item, "__qualname__", item.__name__),
-    )
-
-
 def safe_copy(source, dest, overwrite=False):
     # type: (str, str, bool) -> None
     def do_copy():
@@ -415,8 +393,12 @@ class AtomicDirectory(object):
 
 
 @contextmanager
-def atomic_directory(target_dir, exclusive, source=None):
-    # type: (str, bool, Optional[str]) -> Iterator[AtomicDirectory]
+def atomic_directory(
+    target_dir,  # type: str
+    exclusive,  # type: bool
+    source=None,  # type: Optional[str]
+):
+    # type: (...) -> Iterator[AtomicDirectory]
     """A context manager that yields a potentially exclusively locked AtomicDirectory.
 
     :param target_dir: The target directory to atomically update.

--- a/pex/enum.py
+++ b/pex/enum.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import weakref
 from collections import defaultdict
@@ -9,7 +9,6 @@ from functools import total_ordering
 
 from _weakref import ReferenceType
 
-from pex.common import qualified_name
 from pex.typing import TYPE_CHECKING, Generic, cast
 
 if TYPE_CHECKING:
@@ -102,3 +101,25 @@ class Enum(Generic["_V"]):
                 value, type(value), ", ".join(map(repr, cls.values()))
             )
         )
+
+
+def qualified_name(item):
+    # type: (Any) -> str
+    """Attempt to produce the fully qualified name for an item.
+
+    If the item is a type, method, property or function, its fully qualified name is returned as
+    best as can be determined. Otherwise, the fully qualified name of the type of the given item is
+    returned.
+
+    :param item: The item to identify.
+    :return: The fully qualified name of the given item.
+    """
+    if isinstance(item, property):
+        item = item.fget
+    if not hasattr(item, "__name__"):
+        item = type(item)
+    return "{module}.{type}".format(
+        module=getattr(item, "__module__", "<unknown module>"),
+        # There is no __qualname__ in Python 2.7; so we do the best we can.
+        type=getattr(item, "__qualname__", item.__name__),
+    )

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -20,13 +20,11 @@ from pex.common import (
     is_exe,
     is_script,
     open_zip,
-    qualified_name,
     safe_mkdir,
     safe_open,
     temporary_dir,
     touch,
 )
-from pex.compatibility import PY2
 from pex.typing import TYPE_CHECKING
 
 try:
@@ -416,46 +414,6 @@ def test_is_script(tmpdir):
     assert is_script(exe, check_executable=False)
     assert not is_script(exe)
     assert not is_exe(exe)
-
-
-def test_qualified_name():
-    # type: () -> None
-
-    expected_str_type = "{module}.str".format(module="__builtin__" if PY2 else "builtins")
-    assert expected_str_type == qualified_name(str), "Expected builtin types to be handled."
-    assert expected_str_type == qualified_name(
-        "foo"
-    ), "Expected non-callable objects to be identified via their types."
-
-    assert "pex.common.qualified_name" == qualified_name(
-        qualified_name
-    ), "Expected functions to be handled"
-
-    assert "pex.common.AtomicDirectory" == qualified_name(
-        AtomicDirectory
-    ), "Expected custom types to be handled."
-    expected_prefix = "pex.common." if PY2 else "pex.common.AtomicDirectory."
-    assert expected_prefix + "finalize" == qualified_name(
-        AtomicDirectory.finalize
-    ), "Expected methods to be handled."
-    assert expected_prefix + "work_dir" == qualified_name(
-        AtomicDirectory.work_dir
-    ), "Expected @property to be handled."
-
-    expected_prefix = "pex.common." if PY2 else "pex.common.PermPreservingZipFile."
-    assert expected_prefix + "zip_entry_from_file" == qualified_name(
-        PermPreservingZipFile.zip_entry_from_file
-    ), "Expected @classmethod to be handled."
-
-    class Test(object):
-        @staticmethod
-        def static():
-            pass
-
-    expected_prefix = "test_common." if PY2 else "test_common.test_qualified_name.<locals>.Test."
-    assert expected_prefix + "static" == qualified_name(
-        Test.static
-    ), "Expected @staticmethod to be handled."
 
 
 def test_find_site_packages(tmpdir):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3,7 +3,6 @@
 
 import contextlib
 import errno
-import fcntl
 import os
 from contextlib import contextmanager
 
@@ -120,31 +119,6 @@ def test_atomic_directory_empty_workdir_finalized():
             assert (
                 work_dir.is_finalized()
             ), "When the target_dir exists no work_dir should be created."
-
-
-def test_atomic_directory_deadlock():
-    # type: () -> None
-
-    def mock_lockf(fd, cmd):  # type: (int, int) -> None
-        if cmd == fcntl.LOCK_EX:
-            mock_lockf.lock_call_counter += 1  # type: ignore[attr-defined]
-            if mock_lockf.lock_call_counter < 5:  # type: ignore[attr-defined]
-                raise OSError(
-                    errno.EDEADLK,  # type: ignore[attr-defined] # See https://github.com/python/typeshed/issues/7551
-                    "Resource deadlock avoided",
-                )
-
-    # N.B. Workaround Python 2.7's lack of `nonlocal` support
-    mock_lockf.lock_call_counter = 0  # type: ignore[attr-defined]
-
-    with temporary_dir() as sandbox:
-        target_dir = os.path.join(sandbox, "target_dir")
-        with mock.patch("time.sleep", lambda i: None), mock.patch.object(
-            fcntl, "lockf", mock_lockf
-        ):
-            with atomic_directory(target_dir, exclusive=True) as work_dir:
-                assert not work_dir.is_finalized()
-            assert work_dir.is_finalized()
 
 
 def extract_perms(path):


### PR DESCRIPTION
This avoids spurious deadlock detection errors under Linux.

Fixes #1693