### PR TITLE
Support canonicalizing absolute paths in locks.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -599,16 +599,17 @@ def build_pex(
     ):
         try:
             if isinstance(resolver_configuration, LockRepositoryConfiguration):
+                lock = try_(resolver_configuration.parse_lock())
                 with TRACER.timed(
                     "Resolving requirements from lock file {lock_file}".format(
-                        lock_file=resolver_configuration.lock_file
+                        lock_file=lock.source
                     )
                 ):
                     pip_configuration = resolver_configuration.pip_configuration
                     result = try_(
                         resolve_from_lock(
                             targets=targets,
-                            lockfile_path=resolver_configuration.lock_file,
+                            lock=lock,
                             requirements=requirement_configuration.requirements,
                             requirement_files=requirement_configuration.requirement_files,
                             constraint_files=requirement_configuration.constraint_files,
@@ -625,7 +626,6 @@ def build_pex(
                             build_isolation=pip_configuration.build_isolation,
                             compile=options.compile,
                             max_parallel_jobs=pip_configuration.max_jobs,
-                            path_mappings=resolver_configuration.path_mappings,
                         )
                     )
             elif isinstance(resolver_configuration, PexRepositoryConfiguration):

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -625,6 +625,7 @@ def build_pex(
                             build_isolation=pip_configuration.build_isolation,
                             compile=options.compile,
                             max_parallel_jobs=pip_configuration.max_jobs,
+                            path_mappings=resolver_configuration.path_mappings,
                         )
                     )
             elif isinstance(resolver_configuration, PexRepositoryConfiguration):

--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -107,12 +107,15 @@ else:
 if PY3:
     from urllib import parse as urlparse
     from urllib.error import HTTPError as HTTPError
+    from urllib.parse import unquote as unquote
     from urllib.request import FileHandler as FileHandler
     from urllib.request import HTTPSHandler as HTTPSHandler
     from urllib.request import ProxyHandler as ProxyHandler
     from urllib.request import Request as Request
     from urllib.request import build_opener as build_opener
 else:
+    from urllib import unquote as unquote
+
     import urlparse as urlparse
     from urllib2 import FileHandler as FileHandler
     from urllib2 import HTTPError as HTTPError

--- a/pex/pip/tool.py
+++ b/pex/pip/tool.py
@@ -15,7 +15,7 @@ from collections import defaultdict, deque
 
 from pex import dist_metadata, targets, third_party
 from pex.common import atomic_directory, safe_mkdtemp
-from pex.compatibility import urlparse
+from pex.compatibility import unquote, urlparse
 from pex.dist_metadata import ProjectNameAndVersion
 from pex.interpreter import PythonInterpreter
 from pex.interpreter_constraints import iter_compatible_versions
@@ -365,7 +365,9 @@ class Locker(_LogAnalyzer):
             hash_ = fingerprint_match.group("hash")
             fingerprint = Fingerprint(algorithm=algorithm, hash=hash_)
 
-        pin = Pin.canonicalize(ProjectNameAndVersion.from_filename(urlparse.urlparse(url).path))
+        pin = Pin.canonicalize(
+            ProjectNameAndVersion.from_filename(unquote(urlparse.urlparse(url).path))
+        )
         partial_artifact = PartialArtifact(url, fingerprint)
         return pin, partial_artifact
 

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -22,6 +22,7 @@ from pex.resolve import lockfile
 from pex.resolve.locked_resolve import DownloadableArtifact, FileArtifact, Resolved, VCSArtifact
 from pex.resolve.lockfile import parse_lockable_requirements
 from pex.resolve.lockfile.download_manager import DownloadedArtifact, DownloadManager
+from pex.resolve.path_mappings import PathMappings
 from pex.resolve.requirement_configuration import RequirementConfiguration
 from pex.resolve.resolver_configuration import ResolverVersion
 from pex.resolve.resolvers import Installed
@@ -192,11 +193,12 @@ def resolve_from_lock(
     transitive=True,  # type: bool
     verify_wheels=True,  # type: bool
     max_parallel_jobs=None,  # type: Optional[int]
+    path_mappings=PathMappings(),  # type: PathMappings
 ):
     # type: (...) -> Union[Installed, Error]
 
     with TRACER.timed("Parsing lock {lockfile}".format(lockfile=lockfile_path)):
-        lock = lockfile.load(lockfile_path)
+        lock = lockfile.load(lockfile_path, path_mappings=path_mappings)
 
     with TRACER.timed("Parsing requirements"):
         requirement_configuration = RequirementConfiguration(

--- a/pex/resolve/locked_resolve.py
+++ b/pex/resolve/locked_resolve.py
@@ -8,7 +8,7 @@ import os
 from collections import OrderedDict, defaultdict, deque
 
 from pex.common import pluralize
-from pex.compatibility import urlparse
+from pex.compatibility import unquote, urlparse
 from pex.dist_metadata import DistMetadata
 from pex.enum import Enum
 from pex.fetcher import URLFetcher
@@ -105,7 +105,7 @@ class Artifact(object):
                 url=url, fingerprint=fingerprint, verified=verified, vcs=parsed_scheme.vcs
             )
         else:
-            filename = os.path.basename(url_info.path)
+            filename = os.path.basename(unquote(url_info.path))
             return FileArtifact(
                 url=url, fingerprint=fingerprint, verified=verified, filename=filename
             )

--- a/pex/resolve/lockfile/__init__.py
+++ b/pex/resolve/lockfile/__init__.py
@@ -37,7 +37,7 @@ from pex.variables import ENV
 from pex.version import __version__
 
 if TYPE_CHECKING:
-    from typing import Dict, Iterable, List, Mapping, Optional, Text, Tuple, Union
+    from typing import Container, Dict, Iterable, List, Mapping, Optional, Text, Tuple, Union
 
     import attr  # vendor:skip
 
@@ -48,6 +48,14 @@ else:
 
 class ParseError(Exception):
     """Indicates an error parsing a Pex lock file."""
+
+
+@attr.s(frozen=True)
+class PathMappingError(ParseError):
+    """Indicates missing path mappings when parsing a Pex lock file."""
+
+    required_path_mappings = attr.ib()  # type: Mapping[str, Optional[str]]
+    unspecified_paths = attr.ib()  # type: Container[str]
 
 
 def load(

--- a/pex/resolve/lockfile/__init__.py
+++ b/pex/resolve/lockfile/__init__.py
@@ -23,6 +23,7 @@ from pex.resolve import resolvers
 from pex.resolve.locked_resolve import Artifact, FileArtifact, LockConfiguration, VCSArtifact
 from pex.resolve.lockfile.download_manager import DownloadedArtifact, DownloadManager
 from pex.resolve.lockfile.lockfile import Lockfile as Lockfile  # For re-export.
+from pex.resolve.path_mappings import PathMappings
 from pex.resolve.requirement_configuration import RequirementConfiguration
 from pex.resolve.resolved_requirement import Pin
 from pex.resolve.resolver_configuration import PipConfiguration
@@ -49,17 +50,22 @@ class ParseError(Exception):
     """Indicates an error parsing a Pex lock file."""
 
 
-def load(lockfile_path):
-    # type: (str) -> Lockfile
+def load(
+    lockfile_path,  # type: str
+    path_mappings=PathMappings(),  # type: PathMappings
+):
+    # type: (...) -> Lockfile
     """Loads the Pex lock file stored at the given path.
 
     :param lockfile_path: The path to the Pex lock file to load.
+    :param path_mappings: Path mappings for any local absolute file paths used when creating the
+                          lock.
     :return: The parsed lock file.
     :raises: :class:`ParseError` if there was a problem parsing the lock file.
     """
     from pex.resolve.lockfile import json_codec
 
-    return json_codec.load(lockfile_path=lockfile_path)
+    return json_codec.load(lockfile_path=lockfile_path, path_mappings=path_mappings)
 
 
 def loads(

--- a/pex/resolve/lockfile/json_codec.py
+++ b/pex/resolve/lockfile/json_codec.py
@@ -12,6 +12,7 @@ from pex.pep_503 import ProjectName
 from pex.resolve.locked_resolve import Artifact, LockedRequirement, LockedResolve, LockStyle
 from pex.resolve.lockfile import ParseError
 from pex.resolve.lockfile.lockfile import Lockfile
+from pex.resolve.path_mappings import PathMappings
 from pex.resolve.resolved_requirement import Fingerprint, Pin
 from pex.resolve.resolver_configuration import ResolverVersion
 from pex.sorted_tuple import SortedTuple
@@ -43,6 +44,7 @@ def _load_json(
 def loads(
     lockfile_contents,  # type: Text
     source="<string>",  # type: str
+    path_mappings=PathMappings(),  # type: PathMappings
 ):
     # type: (...) -> Lockfile
 
@@ -111,7 +113,7 @@ def loads(
     ):
         # type: (...) -> Requirement
         try:
-            return Requirement.parse(raw_requirement)
+            return Requirement.parse(path_mappings.maybe_reify(raw_requirement))
         except RequirementParseError as e:
             raise ParseError(
                 "The requirement string at '{path}' is invalid: {err}".format(path=path, err=e)
@@ -128,6 +130,48 @@ def loads(
             raise ParseError(
                 "The version specifier at '{path}' is invalid: {err}".format(path=path, err=e)
             )
+
+    required_path_mappings = get("path_mappings", dict, optional=True) or {}
+    given_mappings = set(mapping.name for mapping in path_mappings.mappings)
+    unspecified_paths = set(required_path_mappings) - given_mappings
+    if unspecified_paths:
+        raise ParseError(
+            "The lockfile given in {source} requires definition of {required_count} "
+            "'.path_mappings' {entries}: {required_paths}\n"
+            "Given {given_mappings_verbiage}\n"
+            "{maybe_path_mappings}"
+            "Which left the following path mappings unspecified:\n"
+            "{unspecified_paths}".format(
+                source=source,
+                required_count=len(required_path_mappings),
+                entries="entries" if len(required_path_mappings) > 1 else "entry",
+                required_paths=", ".join(sorted(required_path_mappings)),
+                given_mappings_verbiage="the following path mappings:"
+                if path_mappings.mappings
+                else "no path mappings.",
+                maybe_path_mappings="{path_mappings}\n".format(
+                    path_mappings="\n".join(
+                        sorted(
+                            "{root}: {path}".format(root=mapping.name, path=mapping.path)
+                            for mapping in path_mappings.mappings
+                        )
+                    )
+                )
+                if path_mappings.mappings
+                else "",
+                unspecified_paths="\n".join(
+                    sorted(
+                        (
+                            "{path}: {description}".format(path=path, description=description)
+                            if description
+                            else path
+                        )
+                        for path, description in required_path_mappings.items()
+                        if path in unspecified_paths
+                    )
+                ),
+            )
+        )
 
     requirements = [
         parse_requirement(req, path=".requirements[{index}]".format(index=index))
@@ -174,7 +218,7 @@ def loads(
                 ap = '{path}["artifacts"][{index}]'.format(path=req_path, index=i)
                 artifacts.append(
                     Artifact.from_url(
-                        url=get("url", data=artifact, path=ap),
+                        url=path_mappings.maybe_reify(get("url", data=artifact, path=ap)),
                         fingerprint=Fingerprint(
                             algorithm=get("algorithm", data=artifact, path=ap),
                             hash=get("hash", data=artifact, path=ap),
@@ -240,25 +284,33 @@ def loads(
     )
 
 
-def load(lockfile_path):
-    # type: (str) -> Lockfile
+def load(
+    lockfile_path,  # type: str
+    path_mappings=PathMappings(),  # type: PathMappings
+):
+    # type: (...) -> Lockfile
     try:
         with open(lockfile_path) as fp:
-            return loads(fp.read(), source=lockfile_path)
+            return loads(fp.read(), source=lockfile_path, path_mappings=path_mappings)
     except IOError as e:
         raise ParseError(
             "Failed to read lock file at {path}: {err}".format(path=lockfile_path, err=e)
         )
 
 
-def as_json_data(lockfile):
-    # type: (Lockfile) -> Dict[str, Any]
-    return {
+def as_json_data(
+    lockfile,  # type: Lockfile
+    path_mappings=PathMappings(),  # type: PathMappings
+):
+    # type: (...) -> Dict[str, Any]
+    data = {
         "pex_version": lockfile.pex_version,
         "style": str(lockfile.style),
         "requires_python": list(lockfile.requires_python),
         "resolver_version": str(lockfile.resolver_version),
-        "requirements": [str(req) for req in lockfile.requirements],
+        "requirements": [
+            path_mappings.maybe_canonicalize(str(req)) for req in lockfile.requirements
+        ],
         "constraints": [str(constraint) for constraint in lockfile.constraints],
         "allow_prereleases": lockfile.allow_prereleases,
         "allow_wheels": lockfile.allow_wheels,
@@ -278,13 +330,16 @@ def as_json_data(lockfile):
                     {
                         "project_name": str(req.pin.project_name),
                         "version": str(req.pin.version),
-                        "requires_dists": [str(dependency) for dependency in req.requires_dists],
+                        "requires_dists": [
+                            path_mappings.maybe_canonicalize(str(dependency))
+                            for dependency in req.requires_dists
+                        ],
                         "requires_python": str(req.requires_python)
                         if req.requires_python
                         else None,
                         "artifacts": [
                             {
-                                "url": artifact.url,
+                                "url": path_mappings.maybe_canonicalize(artifact.url),
                                 "algorithm": artifact.fingerprint.algorithm,
                                 "hash": artifact.fingerprint.hash,
                             }
@@ -297,3 +352,8 @@ def as_json_data(lockfile):
             for locked_resolve in lockfile.locked_resolves
         ],
     }
+    if path_mappings.mappings:
+        data["path_mappings"] = {
+            path_mapping.name: path_mapping.description for path_mapping in path_mappings.mappings
+        }
+    return data

--- a/pex/resolve/path_mappings.py
+++ b/pex/resolve/path_mappings.py
@@ -1,0 +1,73 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os.path
+import re
+
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Optional, Tuple
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+def _normalize_path(path):
+    # type: (str) -> str
+    return os.path.normpath(path)
+
+
+@attr.s(frozen=True)
+class PathMapping(object):
+    path = attr.ib(converter=_normalize_path)  # type: str
+    name = attr.ib()  # type: str
+    description = attr.ib(default=None)  # type: Optional[str]
+
+    @path.validator
+    def _validate_path(
+        self,
+        _attribute,  # type: Any
+        value,  # type: str
+    ):
+        # type: (...) -> None
+        if not os.path.isabs(value):
+            raise ValueError("Mapped paths must be absolute. Given: {path}".format(path=value))
+
+    @property
+    def substitution_symbol(self):
+        # type: () -> str
+        return "${{{name}}}".format(name=self.name)
+
+
+@attr.s(frozen=True)
+class PathMappings(object):
+    mappings = attr.ib(default=())  # type: Tuple[PathMapping, ...]
+
+    def maybe_canonicalize(self, maybe_path):
+        # type: (str) -> str
+
+        # Inputs will look like:
+        # artifact urls: file://<path>
+        # requirement strings:
+        #   PEP-440: req @ file://<path>
+        #       Pip: <path>
+        #       Pip: file://<path>
+        for mapping in self.mappings:
+            maybe_canonicalized = re.sub(
+                re.escape(mapping.path), mapping.substitution_symbol, maybe_path
+            )
+            if maybe_canonicalized != maybe_path:
+                return maybe_canonicalized
+        return maybe_path
+
+    def maybe_reify(self, maybe_path):
+        # type: (str) -> str
+        for mapping in self.mappings:
+            maybe_reified = re.sub(re.escape(mapping.substitution_symbol), mapping.path, maybe_path)
+            if maybe_reified != maybe_path:
+                return maybe_reified
+        return maybe_path

--- a/pex/resolve/resolver_configuration.py
+++ b/pex/resolve/resolver_configuration.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 from pex.enum import Enum
 from pex.jobs import DEFAULT_MAX_JOBS
 from pex.network_configuration import NetworkConfiguration
+from pex.resolve.path_mappings import PathMappings
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -58,4 +59,5 @@ class PexRepositoryConfiguration(object):
 @attr.s(frozen=True)
 class LockRepositoryConfiguration(object):
     lock_file = attr.ib()  # type: str
+    path_mappings = attr.ib()  # type: PathMappings
     pip_configuration = attr.ib()  # type: PipConfiguration

--- a/pex/resolve/resolver_configuration.py
+++ b/pex/resolve/resolver_configuration.py
@@ -6,13 +6,15 @@ from __future__ import absolute_import
 from pex.enum import Enum
 from pex.jobs import DEFAULT_MAX_JOBS
 from pex.network_configuration import NetworkConfiguration
-from pex.resolve.path_mappings import PathMappings
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Optional, Tuple
+    from typing import Callable, Optional, Tuple, Union
 
     import attr  # vendor:skip
+
+    from pex.resolve.lockfile import Lockfile
+    from pex.result import Error
 else:
     from pex.third_party import attr
 
@@ -58,6 +60,5 @@ class PexRepositoryConfiguration(object):
 
 @attr.s(frozen=True)
 class LockRepositoryConfiguration(object):
-    lock_file = attr.ib()  # type: str
-    path_mappings = attr.ib()  # type: PathMappings
+    parse_lock = attr.ib()  # type: Callable[[], Union[Lockfile, Error]]
     pip_configuration = attr.ib()  # type: PipConfiguration

--- a/pex/resolve/resolver_options.py
+++ b/pex/resolve/resolver_options.py
@@ -9,6 +9,8 @@ from pex import pex_warnings
 from pex.argparse import HandleBoolAction
 from pex.network_configuration import NetworkConfiguration
 from pex.orderedset import OrderedSet
+from pex.resolve import lockfile
+from pex.resolve.lockfile import Lockfile
 from pex.resolve.path_mappings import PathMapping, PathMappings
 from pex.resolve.resolver_configuration import (
     PYPI,
@@ -18,10 +20,12 @@ from pex.resolve.resolver_configuration import (
     ReposConfiguration,
     ResolverVersion,
 )
+from pex.result import Error
+from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from typing import Union
+    from typing import Optional, Union
 
 
 class _ManylinuxAction(Action):
@@ -229,11 +233,12 @@ def register_lock_options(parser):
             "mapping must include the pipe (`|`) separated name and absolute path components, but "
             "the trailing pipe-separated description is optional. The mapping is used when "
             "creating, and later reading, lock files to ensure the lock file created on one "
-            "machine can be used another with a potentially different realization of various paths "
-            "used in the resolve. A typical example is a find-links repo. This might be provided "
-            "on the file-system via a network mount instead of via an HTTP(S) server and that "
-            "network mount may be at different absolute paths on different machines. Classically, "
-            "it may be in a user's home directory; whose path will vary from user to user."
+            "machine can be used on another with a potentially different realization of various "
+            "paths used in the resolve. A typical example is a find-links repo. This might be "
+            "provided on the file-system via a network mount instead of via an HTTP(S) server and "
+            "that network mount may be at different absolute paths on different machines. "
+            "Classically, it may be in a user's home directory; whose path will vary from user to "
+            "user."
         ),
     )
 
@@ -383,10 +388,8 @@ def configure(options):
         )
     pip_configuration = create_pip_configuration(options)
     if lock:
-        path_mappings = get_path_mappings(options)
         return LockRepositoryConfiguration(
-            lock_file=options.lock,
-            path_mappings=path_mappings,
+            parse_lock=lambda: parse_lockfile(options),
             pip_configuration=pip_configuration,
         )
     return pip_configuration
@@ -486,3 +489,64 @@ def get_path_mappings(options):
     return PathMappings(
         mappings=tuple(_parse_path_mapping(path_mapping) for path_mapping in options.path_mappings)
     )
+
+
+def parse_lockfile(
+    options,  # type: Namespace
+    lock_file_path=None,  # type: Optional[str]
+):
+    # type: (...) -> Union[Lockfile, Error]
+    path = lock_file_path or options.lock
+    path_mappings = get_path_mappings(options)
+    with TRACER.timed("Parsing lock {lockfile}".format(lockfile=path)):
+        try:
+            return lockfile.load(path, path_mappings=path_mappings)
+        except lockfile.PathMappingError as e:
+            return Error(
+                "The lockfile at {path} requires specifying {prefix}"
+                "'--path-mapping' {values} for: {required_paths}\n"
+                "Given {given_mappings_verbiage}\n"
+                "{maybe_path_mappings}"
+                "Which left the following path mappings unspecified:\n"
+                "{unspecified_paths}\n"
+                "\n"
+                "To fix, add command line options for:\n{examples}".format(
+                    path=path,
+                    prefix="" if len(e.required_path_mappings) > 1 else "a ",
+                    values="values" if len(e.required_path_mappings) > 1 else "value",
+                    required_paths=", ".join(sorted(e.required_path_mappings)),
+                    given_mappings_verbiage="the following path mappings:"
+                    if path_mappings.mappings
+                    else "no path mappings.",
+                    maybe_path_mappings="{path_mappings}\n".format(
+                        path_mappings="\n".join(
+                            sorted(
+                                "--path-mapping '{mapping}'".format(
+                                    mapping="|".join((mapping.name, mapping.path))
+                                )
+                                for mapping in path_mappings.mappings
+                            )
+                        )
+                    )
+                    if path_mappings.mappings
+                    else "",
+                    unspecified_paths="\n".join(
+                        sorted(
+                            (
+                                "{path}: {description}".format(path=path, description=description)
+                                if description
+                                else path
+                            )
+                            for path, description in e.required_path_mappings.items()
+                            if path in e.unspecified_paths
+                        )
+                    ),
+                    examples="\n".join(
+                        sorted(
+                            "--path-mapping '{path}|<path of {path}>'".format(path=path)
+                            for path in e.required_path_mappings
+                            if path in e.unspecified_paths
+                        )
+                    ),
+                )
+            )

--- a/tests/integration/cli/commands/test_issue_1413.py
+++ b/tests/integration/cli/commands/test_issue_1413.py
@@ -114,10 +114,13 @@ def assert_missing_mappings(
     result = run_pex3(*lock_args)
     result.assert_failure()
     assert result.error == (
-        "The lockfile given in {lock} requires definition of 1 '.path_mappings' entry: FL\n"
+        "The lockfile at {lock} requires specifying a '--path-mapping' value for: FL\n"
         "Given no path mappings.\n"
         "Which left the following path mappings unspecified:\n"
-        "FL: The local find links repo path.\n".format(lock=lock)
+        "FL: The local find links repo path.\n"
+        "\n"
+        "To fix, add command line options for:\n"
+        "--path-mapping 'FL|<path of FL>'\n".format(lock=lock)
     )
 
 

--- a/tests/integration/cli/commands/test_issue_1413.py
+++ b/tests/integration/cli/commands/test_issue_1413.py
@@ -1,0 +1,185 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from pex.cli.testing import run_pex3
+from pex.pep_440 import Version
+from pex.pep_503 import ProjectName
+from pex.resolve import lockfile
+from pex.resolve.locked_resolve import LockedRequirement
+from pex.resolve.lockfile import Lockfile
+from pex.resolve.path_mappings import PathMapping, PathMappings
+from pex.resolve.resolved_requirement import Pin
+from pex.testing import make_env, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+@pytest.fixture(scope="module")
+def td(tmpdir_factory):
+    # type: (Any) -> Any
+    return tmpdir_factory.mktemp("td")
+
+
+@pytest.fixture(scope="module")
+def find_links_repo(td):
+    # type: (Any) -> str
+    ansicolors_seed_pex = str(td.join("ansicolors-seed.pex"))
+    run_pex_command(
+        args=["ansicolors==1.1.8", "-o", ansicolors_seed_pex, "--include-tools"]
+    ).assert_success()
+
+    find_links = str(td.join("find-links", "repo"))
+    subprocess.check_call(
+        args=[ansicolors_seed_pex, "repository", "extract", "-f", find_links],
+        env=make_env(PEX_TOOLS=1),
+    )
+    assert 1 == len(os.listdir(find_links))
+    return find_links
+
+
+FIND_LINKS_NAME = "FL"
+
+
+def create_path_mapping_option_value(path):
+    # type: (str) -> str
+    return "{name}|{path}|The local find links repo path.".format(name=FIND_LINKS_NAME, path=path)
+
+
+def create_path_mappings(path):
+    # type: (str) -> PathMappings
+    return PathMappings((PathMapping(name=FIND_LINKS_NAME, path=path),))
+
+
+@pytest.fixture(scope="module")
+def lock(
+    td,  # type: Any
+    find_links_repo,  # type: str
+):
+    # type: (...) -> str
+    lock = str(td.join("lock"))
+    path_mapping = create_path_mapping_option_value(find_links_repo)
+    run_pex3(
+        "lock",
+        "create",
+        "--no-pypi",
+        "-f",
+        find_links_repo,
+        "--path-mapping",
+        path_mapping,
+        "ansicolors",
+        "-o",
+        lock,
+    ).assert_success()
+    return lock
+
+
+def expect_single_ansicolors_requirement(lock_file):
+    # type: (Lockfile) -> LockedRequirement
+    assert 1 == len(lock_file.locked_resolves)
+    assert 1 == len(lock_file.locked_resolves[0].locked_requirements)
+    ansicolors_requirement = lock_file.locked_resolves[0].locked_requirements[0]
+    assert Pin(ProjectName("ansicolors"), Version("1.1.8")) == ansicolors_requirement.pin
+    return ansicolors_requirement
+
+
+def test_find_links_create(
+    tmpdir,  # type: Any
+    find_links_repo,  # type: str
+    lock,  # type: str
+):
+    # type: (...) -> None
+
+    lock_file = lockfile.load(lock, path_mappings=create_path_mappings("/re/mapped"))
+    ansicolors_requirement = expect_single_ansicolors_requirement(lock_file)
+    assert 0 == len(ansicolors_requirement.additional_artifacts)
+    assert (
+        "file:///re/mapped/ansicolors-1.1.8-py2.py3-none-any.whl"
+        == ansicolors_requirement.artifact.url
+    )
+
+
+def assert_missing_mappings(
+    lock,  # type: str
+    *lock_args  # type: str
+):
+    # type: (...) -> None
+    result = run_pex3(*lock_args)
+    result.assert_failure()
+    assert result.error == (
+        "The lockfile given in {lock} requires definition of 1 '.path_mappings' entry: FL\n"
+        "Given no path mappings.\n"
+        "Which left the following path mappings unspecified:\n"
+        "FL: The local find links repo path.\n".format(lock=lock)
+    )
+
+
+def test_find_links_update(
+    tmpdir,  # type: Any
+    find_links_repo,  # type: str
+    lock,  # type: str
+):
+    # type: (...) -> None
+
+    re_mapped_fl = os.path.join(str(tmpdir), "re", "mapped")
+    os.mkdir(os.path.dirname(re_mapped_fl))
+    shutil.copytree(find_links_repo, re_mapped_fl)
+
+    lock_update_args = ("lock", "update", lock, "--no-pypi", "-f", re_mapped_fl)
+    assert_missing_mappings(lock, *lock_update_args)
+
+    def lock_contents():
+        # type: () -> str
+        with open(lock) as fp:
+            return fp.read()
+
+    original_lock_contents = lock_contents()
+    run_pex3(
+        *(lock_update_args + ("--path-mapping", create_path_mapping_option_value(re_mapped_fl)))
+    ).assert_success()
+    assert (
+        original_lock_contents == lock_contents()
+    ), "Expected a no-op update using the same find links repo at a new location."
+
+
+def test_find_links_export(
+    tmpdir,  # type: Any
+    find_links_repo,  # type: str
+    lock,  # type: str
+):
+    # type: (...) -> None
+
+    requirements_lock = os.path.join(str(tmpdir), "requirements.txt")
+    lock_export_args = (
+        "lock",
+        "export",
+        lock,
+        "-o",
+        requirements_lock,
+    )
+    assert_missing_mappings(lock, *lock_export_args)
+
+    requirements_lock = os.path.join(str(tmpdir), "requirements.txt")
+    run_pex3(
+        *(lock_export_args + ("--path-mapping", create_path_mapping_option_value(find_links_repo)))
+    ).assert_success()
+
+    run_pex_command(
+        args=[
+            "--no-pypi",
+            "-f",
+            find_links_repo,
+            "-r",
+            requirements_lock,
+            "--",
+            "-c",
+            "import colors",
+        ]
+    ).assert_success()

--- a/tests/resolve/lockfile/test_json_codec.py
+++ b/tests/resolve/lockfile/test_json_codec.py
@@ -9,12 +9,12 @@ from textwrap import dedent
 
 import pytest
 
-import pex.resolve.lockfile
 from pex.compatibility import PY2
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.resolve.locked_resolve import Artifact, LockedRequirement, LockedResolve, LockStyle
-from pex.resolve.lockfile import Lockfile, json_codec
+from pex.resolve.lockfile import Lockfile, ParseError, json_codec
+from pex.resolve.path_mappings import PathMapping, PathMappings
 from pex.resolve.resolved_requirement import Fingerprint, Pin
 from pex.resolve.resolver_configuration import ResolverVersion
 from pex.sorted_tuple import SortedTuple
@@ -125,7 +125,7 @@ VALID_LOCK = """\
             {
               "algorithm": "md5",
               "hash": "f357aa02db2466bc24ff1815cff1aeb3",
-              "url": "http://localhost:9999/ansicolors-1.1.8-py2.py3-none-any.whl"
+              "url": "file:///find-links/ansicolors-1.1.8-py2.py3-none-any.whl"
             },
             {
               "algorithm": "md5",
@@ -191,13 +191,24 @@ def patch_tool(tmpdir):
     return PatchTool(str(tmpdir))
 
 
+def parse_patched(
+    patch_tool,  # type: PatchTool
+    patch,  # type: str
+    path_mappings=PathMappings(),  # type: PathMappings
+):
+    # type: (...) -> Lockfile
+    return json_codec.loads(lockfile_contents=patch_tool.apply(patch), path_mappings=path_mappings)
+
+
 def assert_parse_error(
     patch_tool,  # type: PatchTool
     patch,  # type: str
     match,  # type: str
+    path_mappings=PathMappings(),  # type: PathMappings
 ):
-    with pytest.raises(pex.resolve.lockfile.ParseError, match=match):
-        json_codec.loads(patch_tool.apply(patch))
+    # type: (...) -> None
+    with pytest.raises(ParseError, match=match):
+        parse_patched(patch_tool, patch, path_mappings=path_mappings)
 
 
 def test_load_invalid_json(patch_tool):
@@ -264,7 +275,7 @@ def test_load_invalid_key_not_found(patch_tool):
                            "algorithm": "md5",
             -              "hash": "f357aa02db2466bc24ff1815cff1aeb3",
             +              "HASH": "f357aa02db2466bc24ff1815cff1aeb3",
-                           "url": "http://localhost:9999/ansicolors-1.1.8-py2.py3-none-any.whl"
+                           "url": "file:///find-links/ansicolors-1.1.8-py2.py3-none-any.whl"
             """
         ),
         match=re.escape(
@@ -292,7 +303,7 @@ def test_load_invalid_parent_not_json_object(patch_tool):
             -            {
             -              "algorithm": "md5",
             -              "hash": "f357aa02db2466bc24ff1815cff1aeb3",
-            -              "url": "http://localhost:9999/ansicolors-1.1.8-py2.py3-none-any.whl"
+            -              "url": "file:///find-links/ansicolors-1.1.8-py2.py3-none-any.whl"
             -            },
             +            "foo",
                          {
@@ -467,7 +478,7 @@ def test_load_invalid_no_artifacts(patch_tool):
             -            {
             -              "algorithm": "md5",
             -              "hash": "f357aa02db2466bc24ff1815cff1aeb3",
-            -              "url": "http://localhost:9999/ansicolors-1.1.8-py2.py3-none-any.whl"
+            -              "url": "file:///find-links/ansicolors-1.1.8-py2.py3-none-any.whl"
             -            },
             -            {
             -              "algorithm": "md5",
@@ -480,4 +491,117 @@ def test_load_invalid_no_artifacts(patch_tool):
         match=re.escape(
             "Expected '.locked_resolves[0][0]' in <string> to have at least one artifact."
         ),
+    )
+
+
+def test_path_mappings_required_on_parse(patch_tool):
+    # type: (PatchTool) -> None
+
+    patch = dedent(
+        """\
+        @@ -35,2 +35,6 @@
+           ],
+        +  "path_mappings": {
+        +    "FOO": "The fooey find links repo path on the local machine.",
+        +    "BAR": null
+        +  },
+           "pex_version": "2.1.50",
+        """
+    )
+
+    assert_parse_error(
+        patch_tool,
+        patch,
+        match=re.escape(
+            "The lockfile given in <string> requires definition of 2 '.path_mappings' entries: "
+            "BAR, FOO\n"
+            "Given no path mappings.\n"
+            "Which left the following path mappings unspecified:\n"
+            "BAR\n"
+            "FOO: The fooey find links repo path on the local machine."
+        ),
+    )
+
+    assert_parse_error(
+        patch_tool,
+        patch,
+        path_mappings=PathMappings((PathMapping(name="BAR", path="/tmp/bar"),)),
+        match=re.escape(
+            "The lockfile given in <string> requires definition of 2 '.path_mappings' entries: "
+            "BAR, FOO\n"
+            "Given the following path mappings:\n"
+            "BAR: /tmp/bar\n"
+            "Which left the following path mappings unspecified:\n"
+            "FOO: The fooey find links repo path on the local machine."
+        ),
+    )
+
+    assert (
+        parse_patched(
+            patch_tool,
+            patch,
+            path_mappings=PathMappings(
+                (PathMapping(name="FOO", path="/tmp/foo"), PathMapping(name="BAR", path="/tmp/bar"))
+            ),
+        )
+        is not None
+    )
+
+
+def test_path_mappings_round_trip():
+    # type: () -> None
+
+    lock_file = json_codec.loads(VALID_LOCK)
+
+    data = json_codec.as_json_data(
+        lock_file,
+        PathMappings(
+            (
+                PathMapping(
+                    path="/find-links",
+                    name="FL",
+                    description="Our NFS find-links repo local mount path.",
+                ),
+            )
+        ),
+    )
+    locked_resolves = data["locked_resolves"]
+    assert 1 == len(locked_resolves)
+    locked_requirements = locked_resolves[0]["locked_requirements"]
+    assert 1 == len(locked_requirements)
+    artifacts = locked_requirements[0]["artifacts"]
+    assert 2 == len(artifacts)
+    assert "file://${FL}/ansicolors-1.1.8-py2.py3-none-any.whl" == artifacts[0]["url"]
+    assert "http://localhost:9999/ansicolors-1.1.8.zip" == artifacts[1]["url"]
+
+    canonicalized_lock = json.dumps(data)
+    with pytest.raises(
+        ParseError,
+        match=re.escape(
+            "The lockfile given in <string> requires definition of 1 '.path_mappings' entry: FL\n"
+            "Given no path mappings.\n"
+            "Which left the following path mappings unspecified:\n"
+            "FL: Our NFS find-links repo local mount path."
+        ),
+    ):
+        json_codec.loads(canonicalized_lock)
+
+    assert lock_file == json_codec.loads(
+        canonicalized_lock,
+        path_mappings=PathMappings((PathMapping(name="FL", path="/find-links"),)),
+    ), (
+        "Expected a round-trip through canonicalize / reify with the same mappings to return the "
+        "same lock contents."
+    )
+
+    lock_file2 = json_codec.loads(
+        canonicalized_lock,
+        path_mappings=PathMappings((PathMapping(name="FL", path="/at/another/path/find-links"),)),
+    )
+    assert (
+        lock_file2 != lock_file
+    ), "Expected path roots to be reified to different values than we started with."
+    assert (
+        "file:///at/another/path/find-links/ansicolors-1.1.8-py2.py3-none-any.whl"
+        == lock_file2.locked_resolves[0].locked_requirements[0].artifact.url
     )

--- a/tests/resolve/test_path_mappings.py
+++ b/tests/resolve/test_path_mappings.py
@@ -1,0 +1,81 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import re
+
+import pytest
+
+from pex.resolve.path_mappings import PathMapping, PathMappings
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Tuple
+
+
+def create_path_mappings(*mappings):
+    # type: (*Tuple[str, str]) -> PathMappings
+    return PathMappings(tuple(PathMapping(path=path, name=name) for path, name in mappings))
+
+
+def test_invalid():
+    # type: () -> None
+
+    with pytest.raises(ValueError, match=re.escape("Mapped paths must be absolute. Given: foo")):
+        create_path_mappings(("./foo", "A"))
+
+
+def test_normalize():
+    # type: () -> None
+
+    def check_path(
+        path_mappings,  # type: PathMappings
+        expected_path,  # type: str
+    ):
+        # type: (...) -> PathMappings
+        assert 1 == len(path_mappings.mappings)
+        assert expected_path == path_mappings.mappings[0].path
+        return path_mappings
+
+    assert check_path(create_path_mappings(("/tmp/foo", "A")), "/tmp/foo") == check_path(
+        create_path_mappings(("/tmp/./foo/", "A")), "/tmp/foo"
+    )
+
+
+def test_noop():
+    # type: () -> None
+
+    path_mappings = create_path_mappings(("/tmp/foo", "A"))
+
+    assert "foo" == path_mappings.maybe_canonicalize("foo")
+    assert "/tmp/bar" == path_mappings.maybe_canonicalize("/tmp/bar")
+
+    assert "foo" == path_mappings.maybe_reify("foo")
+    assert "/tmp/foo" == path_mappings.maybe_reify("/tmp/foo")
+    assert "A" == path_mappings.maybe_reify("A")
+    assert "$A" == path_mappings.maybe_reify("$A")
+
+
+def test_canonicalize():
+    # type: () -> None
+
+    path_mappings = create_path_mappings(("/tmp/foo", "A"), ("/tmp/bar/", "B"))
+
+    assert "${A}" == path_mappings.maybe_canonicalize("/tmp/foo")
+    assert "${B}/" == path_mappings.maybe_canonicalize("/tmp/bar/")
+    assert "${A}/bar" == path_mappings.maybe_canonicalize("/tmp/foo/bar")
+
+    assert "file://${A}/bar" == path_mappings.maybe_canonicalize("file:///tmp/foo/bar")
+    assert "baz @ file://${B}/baz" == path_mappings.maybe_canonicalize("baz @ file:///tmp/bar/baz")
+
+
+def test_reify():
+    # type: () -> None
+
+    path_mappings = create_path_mappings(("/tmp/foo", "A"), ("/tmp/bar/", "B"))
+
+    assert "/tmp/foo" == path_mappings.maybe_reify("${A}")
+    assert "/tmp/bar/" == path_mappings.maybe_reify("${B}/")
+    assert "/tmp/foo/bar" == path_mappings.maybe_reify("${A}/bar")
+
+    assert "file:///tmp/foo/bar" == path_mappings.maybe_reify("file://${A}/bar")
+    assert "baz @ file:///tmp/bar/baz" == path_mappings.maybe_reify("baz @ file://${B}/baz")


### PR DESCRIPTION
Although you can still create locks that contain absolute paths from the
local system, Pex now supports canonicalizing such paths for portable
locks with the `--path-mapping` option available when creating and
consuming locks.

The classic example where this is useful is a shared find-links repo
accessed as a network mount somewhere in the user's home directory. A 
portable lock for PEXes that get at least some of their distributions
resolved from such a find-links repo can be created like so:
```
pex3 lock create \
  --find-links $HOME/corp/shares/find-links \
  --path-mapping "\
CORP_FL|$HOME/corp/shares/find-links|\
The local path of the corporate find-links repo network mount.\
"
...
```

The lock file will have all paths beginning with
`$HOME/corp/shares/find-links` substituted with the `${CORP_FL}`
placeholder and the lock will centrally encode all such mappings along
with the description given.

When some other user later uses the `--lock` to create a PEX, they will
be prompted to fill in the `--path-mapping`s if they do not supply them:
```
$ python -mpex --lock lock.json 
,,,
pex.resolve.lockfile.ParseError: The lockfile given in lock.json requires definition of 1 '.path_mappings' entry: CORP_FL
Given no path mappings.
Which left the following path mappings unspecified:
CORP_FL: The local path of the corporate find-links repo network mount.
```

The problem is then corrected by giving the needed path mapping:
```
python -mpex --lock lock.json --path-mapping "CORP_FL|/tmp/find-links"
```
Here, the user mounted the corporate find-links repo in a completely
different place than the lock creator had it mounted at.

Fixes #1413