### PR TITLE
Support booting via `/bin/sh` with `--sh-boot`.

### DIFF
--- a/pex/bin/sh_boot.py
+++ b/pex/bin/sh_boot.py
@@ -1,0 +1,241 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, print_function
+
+import itertools
+import os
+import shlex
+from textwrap import dedent
+
+from pex import dist_metadata, variables
+from pex.interpreter import PythonIdentity, PythonInterpreter, calculate_binary_name
+from pex.interpreter_constraints import iter_compatible_versions
+from pex.orderedset import OrderedSet
+from pex.pex_info import PexInfo
+from pex.targets import Targets
+from pex.third_party import pkg_resources
+from pex.typing import TYPE_CHECKING
+from pex.version import __version__
+
+if TYPE_CHECKING:
+    from typing import Iterable, Optional, Tuple
+
+    import attr  # vendor:skip
+
+    from pex.dist_metadata import DistributionLike
+else:
+    from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class PythonBinaryName(object):
+    name = attr.ib()  # type: str
+    version = attr.ib()  # type: Tuple[int, ...]
+
+    def render(self, version_components=2):
+        # type: (int) -> str
+        return "{name}{version}".format(
+            name=self.name, version=".".join(map(str, self.version[:version_components]))
+        )
+
+
+def _calculate_applicable_binary_names(
+    targets,  # type: Targets
+    interpreter_constraints,  # type: Iterable[str]
+    pex_dist=None,  # type: Optional[str]
+):
+    # type: (...) -> Iterable[str]
+
+    # Find all possible major / minor version targeted by this Pex, preferring explicit targets and
+    # then filling in any other versions implied by interpreter constraints to be checked after
+    # those.
+
+    ic_majors_minors = OrderedSet()  # type: OrderedSet[PythonBinaryName]
+    python_requirements = tuple(
+        PythonIdentity.parse_requirement(ic) for ic in interpreter_constraints
+    )
+    if python_requirements:
+        ic_majors_minors.update(
+            PythonBinaryName(
+                name=calculate_binary_name(python_requirement.project_name), version=version
+            )
+            for python_requirement in python_requirements
+            for version in iter_compatible_versions([str(python_requirement.specifier)])
+        )
+    # If we get targets from ICs, we only want explicitly specified local interpreter targets;
+    # otherwise, if there are none, we want the implicit current target interpreter.
+    only_explicit = len(ic_majors_minors) > 0
+
+    names = OrderedSet()  # type: OrderedSet[PythonBinaryName]
+    # 1. Explicit targets 1st.
+    for target in targets.unique_targets(only_explicit=only_explicit):
+        if target.python_version is not None:
+            names.add(
+                PythonBinaryName(
+                    name=target.binary_name(version_components=0), version=target.python_version
+                )
+            )
+
+    # 2. ICs next.
+    names.update(ic_majors_minors)
+
+    # 3. As the final backstop, fill in all the interpreters Pex is compatible with since Pex can do
+    # more sophisticated detection and re-direction from these during its own bootstrap.
+    pex_requires_python = ">=2.7"
+    pex_distribution = pex_dist or pkg_resources.working_set.find(
+        pkg_resources.Requirement.parse("pex=={version}".format(version=__version__))
+    )  # type: DistributionLike
+    if pex_distribution:
+        pex_requires_python = str(dist_metadata.requires_python(pex_distribution))
+    pex_supported_python_versions = tuple(
+        iter_compatible_versions(requires_python=[pex_requires_python])
+    )
+
+    # Favor CPython over PyPy since the interpreter discovered via these names will just be used
+    # to re-execute into Pex using the right interpreter. That should be a low-latency operation
+    # for CPython end targets and for PyPy it need not be quite as fast since it inherently asks you
+    # to trade startup latency for longer term jit performance.
+    names.update(
+        PythonBinaryName(name="python", version=version)
+        for version in pex_supported_python_versions
+    )
+    names.update(
+        PythonBinaryName(name="pypy", version=version) for version in pex_supported_python_versions
+    )
+
+    # Favor more specific interpreter names since these should need re-direction less often.
+    return OrderedSet(
+        itertools.chain(
+            (name.render(version_components=2) for name in names),
+            (name.render(version_components=1) for name in names),
+            (name.render(version_components=0) for name in names),
+        )
+    )
+
+
+def create_sh_boot_script(
+    pex_name,  # type: str
+    pex_info,  # type: PexInfo
+    targets,  # type: Targets
+    interpreter,  # type: PythonInterpreter
+    python_shebang=None,  # type: Optional[str]
+):
+    # type: (...) -> str
+    """Creates the body of a POSIX `sh` compatible script that executes a PEX ZIPAPP appended to it.
+
+    N.B.: The shebang line is not included.
+
+    Although a Python ZIPAPP is self-executing, it is only self-executing if the shebang happens to
+    work on a given machine. Since there is variance with how pythons are named in various installs,
+    this can lead to a failure to launch the ZIPAPP at all at the OS level.
+
+    If the Python ZIPAPP shebang works, PEX still needs to check if it has installed itself in the
+    PEX_ROOT and if the current interpreter selected by the shebang is appropriate and then it needs
+    to re-execute itself using the appropriate interpreter and final installed location. This takes
+    a non-trivial amount of time. Roughly 50ms in the warm case where the current interpreter is
+    correct and the PEX ZIPAPP is already installed in the PEX_ROOT.
+
+    Using this `sh` script can provide higher shebang success rates since almost every Unix has an
+    `sh` interpreter at `/bin/sh`, and it reduces re-exec overhead to ~2ms in the warm case (and
+    adds ~2ms in the cold case).
+    """
+    python = None  # type: Optional[str]
+    python_args = None  # type: Optional[str]
+    if python_shebang:
+        shebang = python_shebang[2:] if python_shebang.startswith("#!") else python_shebang
+        args = shlex.split(shebang)
+        python = args[0]
+        python_args = " ".join(args[1:])
+
+    python_names = tuple(
+        _calculate_applicable_binary_names(
+            targets=targets,
+            interpreter_constraints=pex_info.interpreter_constraints,
+        )
+    )
+
+    venv_dir = pex_info.venv_dir(pex_file=pex_name, interpreter=interpreter)
+    if venv_dir:
+        pex_installed_path = os.path.join(venv_dir, "pex")
+    else:
+        pex_hash = pex_info.pex_hash
+        if pex_hash is None:
+            raise ValueError("Expected pex_hash to be set already in PEX-INFO.")
+        pex_installed_path = variables.unzip_dir(pex_info.pex_root, pex_hash)
+
+    return dedent(
+        """\
+        # N.B.: This script should stick to syntax defined for POSIX `sh` and avoid non-builtins.
+        # See: https://pubs.opengroup.org/onlinepubs/9699919799/idx/shell.html
+        set -eu
+
+        VENV="{venv}"
+
+        # N.B.: This ensures tilde-expansion of the DEFAULT_PEX_ROOT value.
+        DEFAULT_PEX_ROOT="$(echo {pex_root})"
+
+        DEFAULT_PYTHON="{python}"
+        DEFAULT_PYTHON_ARGS="{python_args}"
+
+        PEX_ROOT="${{PEX_ROOT:-${{DEFAULT_PEX_ROOT}}}}"
+        PEX="${{PEX_ROOT}}/{pex_installed_relpath}"
+
+        if [ -n "${{VENV}}" -a -x "${{PEX}}" ]; then
+            # We're a --venv execution mode PEX installed under the PEX_ROOT and the venv
+            # interpreter to use is embedded in the shebang of our venv pex script; so just
+            # execute that script directly.
+            exec "${{PEX}}" "$@"
+        fi
+
+        find_python() {{
+            for python in \\
+        {pythons} \\
+            ; do
+                if command -v "${{python}}" 2>/dev/null; then
+                    return
+                fi
+            done
+        }}
+
+        if [ -x "${{DEFAULT_PYTHON}}" ]; then
+            python_exe="${{DEFAULT_PYTHON}} ${{DEFAULT_PYTHON_ARGS}}"
+        else
+            python_exe="$(find_python)"
+        fi
+        if [ -n "${{python_exe}}" ]; then
+            if [ -n "${{PEX_VERBOSE:-}}" ]; then
+                echo >&2 "$0 used /bin/sh boot to select python: ${{python_exe}} for re-exec..."
+            fi
+            if [ -z "${{VENV}}" -a -e "${{PEX}}" ]; then
+                # We're a --zipapp execution mode PEX installed under the PEX_ROOT with a
+                # __main__.py in our top-level directory; so execute Python against that
+                # directory.
+                exec ${{python_exe}} "${{PEX}}" "$@"
+            else
+                # The slow path: this PEX zipapp is not installed yet. Run the PEX zipapp so it
+                # can install itself, rebuilding its fast path layout under the PEX_ROOT.
+                exec ${{python_exe}} "$0" "$@"
+            fi
+        fi
+
+        echo >&2 "Failed to find any of these python binaries on the PATH:"
+        for python in \\
+        {pythons} \\
+        ; do
+            echo >&2 "${{python}}"
+        done
+        echo >&2 "Either adjust your $PATH which is currently:"
+        echo >&2 "${{PATH}}"
+        echo >&2 -n "Or else install an appropriate Python that provides one of the binaries in "
+        echo >&2 "this list."
+        exit 1
+        """
+    ).format(
+        venv="1" if pex_info.venv else "",
+        python=python,
+        python_args=python_args,
+        pythons=" \\\n".join('"{python}"'.format(python=python) for python in python_names),
+        pex_root=pex_info.raw_pex_root,
+        pex_installed_relpath=os.path.relpath(pex_installed_path, pex_info.pex_root),
+    )

--- a/pex/layout.py
+++ b/pex/layout.py
@@ -8,7 +8,7 @@ import zipfile
 from abc import abstractmethod
 from contextlib import contextmanager
 
-from pex.common import atomic_directory, is_python_script, open_zip, safe_copy, safe_mkdir
+from pex.common import atomic_directory, is_script, open_zip, safe_copy, safe_mkdir
 from pex.enum import Enum
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
@@ -253,7 +253,7 @@ class _PackedPEX(_Layout):
 @contextmanager
 def _identify_layout(pex):
     # type: (str) -> Iterator[Optional[_Layout]]
-    if zipfile.is_zipfile(pex) and is_python_script(
+    if zipfile.is_zipfile(pex) and is_script(
         pex,
         # N.B.: A PEX file need not be executable since it can always be run via `python a.pex`.
         check_executable=False,

--- a/tests/bin/test_sh_boot.py
+++ b/tests/bin/test_sh_boot.py
@@ -1,0 +1,189 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import pytest
+
+from pex.bin import sh_boot
+from pex.bin.sh_boot import PythonBinaryName
+from pex.interpreter import PythonInterpreter
+from pex.orderedset import OrderedSet
+from pex.pep_425 import CompatibilityTags
+from pex.pep_508 import MarkerEnvironment
+from pex.platforms import Platform
+from pex.targets import CompletePlatform, Targets
+from pex.testing import WheelBuilder
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Iterable, List
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class Calculator(object):
+    pex_dist = attr.ib()  # type: str
+
+    def calculate_binary_names(
+        self,
+        targets=Targets(),  # type: Targets
+        interpreter_constraints=(),  # type: Iterable[str]
+    ):
+        return list(
+            sh_boot._calculate_applicable_binary_names(
+                targets=targets,
+                interpreter_constraints=interpreter_constraints,
+                pex_dist=self.pex_dist,
+            )
+        )
+
+
+@pytest.fixture(scope="module")
+def calculator(pex_project_dir):
+    # type: (...) -> Calculator
+    pex_dist = WheelBuilder(pex_project_dir).bdist()
+    return Calculator(pex_dist=pex_dist)
+
+
+def expected(*names):
+    # type: (*PythonBinaryName) -> List[str]
+
+    current_interpreter_identity = PythonInterpreter.get().identity
+
+    # The default expected set of interpreters should always include:
+    # 1. The targeted interpreters or the current interpreter if none were explicitly targeted.
+    # 2. The interpreters Pex supports, CPython 1st since its faster to boot and re-exec with even
+    #    if PyPy is what will be re-exec'd to.
+    # 3. Partially abbreviated names for the above in corresponding order.
+    # 4. Fully abbreviated names for the above in corresponding order.
+    all_names = OrderedSet(name.render(version_components=2) for name in names)
+    if not names:
+        all_names.add(current_interpreter_identity.binary_name(version_components=2))
+    all_names.update(
+        [
+            "python2.7",
+            "python3.5",
+            "python3.6",
+            "python3.7",
+            "python3.8",
+            "python3.9",
+            "python3.10",
+            "pypy2.7",
+            "pypy3.5",
+            "pypy3.6",
+            "pypy3.7",
+            "pypy3.8",
+            "pypy3.9",
+            "pypy3.10",
+        ]
+    )
+
+    if names:
+        all_names.update(name.render(version_components=1) for name in names)
+    else:
+        all_names.add(current_interpreter_identity.binary_name(version_components=1))
+    all_names.update(
+        [
+            "python2",
+            "python3",
+            "pypy2",
+            "pypy3",
+        ]
+    )
+
+    if names:
+        all_names.update(name.render(version_components=0) for name in names)
+    else:
+        all_names.add(current_interpreter_identity.binary_name(version_components=0))
+    all_names.update(
+        [
+            "python",
+            "pypy",
+        ]
+    )
+
+    return list(all_names)
+
+
+def test_calculate_no_targets_no_ics(calculator):
+    # type: (Calculator) -> None
+
+    assert expected() == calculator.calculate_binary_names()
+
+
+def test_calculate_platforms_no_ics(calculator):
+    # type: (Calculator) -> None
+
+    assert expected(
+        PythonBinaryName(name="python", version=(3, 6)),
+        PythonBinaryName(name="pypy", version=(2, 7)),
+    ) == calculator.calculate_binary_names(
+        Targets(
+            platforms=(
+                Platform.create("macosx-10.13-x86_64-cp-36-cp36m"),
+                Platform.create("linux-x86_64-pp-27-pypy_73"),
+            )
+        )
+    )
+
+
+def test_calculate_interpreters_no_ics(
+    calculator,  # type: Calculator
+    py27,  # type: PythonInterpreter
+    py310,  # type: PythonInterpreter
+    py37,  # type: PythonInterpreter
+):
+    # type: (...) -> None
+
+    assert (
+        expected(
+            PythonBinaryName(name="python", version=(2, 7)),
+            PythonBinaryName(name="python", version=(3, 10)),
+            PythonBinaryName(name="python", version=(3, 7)),
+        )
+        == calculator.calculate_binary_names(targets=Targets(interpreters=(py27, py310, py37)))
+    )
+
+
+def test_calculate_no_targets_ics(calculator):
+    # type: (Calculator) -> None
+
+    assert (
+        expected(
+            PythonBinaryName(name="python", version=(3, 7)),
+            PythonBinaryName(name="python", version=(3, 8)),
+            PythonBinaryName(name="python", version=(3, 9)),
+            PythonBinaryName(name="pypy", version=(3, 7)),
+        )
+        == calculator.calculate_binary_names(interpreter_constraints=[">=3.7,<3.10", "PyPy==3.7.*"])
+    )
+
+
+def test_calculate_mixed(
+    calculator,  # type: Calculator
+    py27,  # type: PythonInterpreter
+):
+    # type: (...) -> None
+
+    assert expected(
+        PythonBinaryName(name="python", version=(2, 7)),
+        PythonBinaryName(name="pypy", version=(3, 8)),
+        PythonBinaryName(name="python", version=(3, 6)),
+        PythonBinaryName(name="pypy", version=(3, 7)),
+    ) == calculator.calculate_binary_names(
+        targets=Targets(
+            interpreters=(py27,),
+            complete_platforms=(
+                CompletePlatform.create(
+                    marker_environment=MarkerEnvironment(
+                        platform_python_implementation="PyPy", python_version="3.8"
+                    ),
+                    # N.B.: Unused by the code under test, but we need to supply at least 1 tag.
+                    supported_tags=CompatibilityTags.from_strings(("py3-none-any",)),
+                ),
+            ),
+        ),
+        interpreter_constraints=["CPython==3.6.*", "PyPy>=3.7,<3.9"],
+    )

--- a/tests/integration/test_sh_boot.py
+++ b/tests/integration/test_sh_boot.py
@@ -1,0 +1,119 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import subprocess
+import sys
+from typing import Text, Tuple
+
+import pytest
+
+from pex.testing import ALL_PY_VERSIONS, ensure_python_interpreter, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Iterable, Iterator, List
+
+
+@pytest.mark.parametrize(
+    ["execution_mode_args"],
+    [
+        pytest.param([], id="zipapp"),
+        pytest.param(["--venv"], id="venv"),
+    ],
+)
+def test_execute(
+    tmpdir,  # type: Any
+    execution_mode_args,  # type: List[str]
+):
+    # type: (...) -> None
+
+    cowsay = os.path.join(str(tmpdir), "cowsay.pex")
+    run_pex_command(
+        args=["cowsay==4.0", "-c", "cowsay", "-o", cowsay, "--bash-boot"] + execution_mode_args
+    ).assert_success()
+    assert "4.0" == subprocess.check_output(args=[cowsay, "--version"]).decode("utf-8").strip()
+
+
+def interpreters():
+    # type: () -> Iterable[Tuple[Text, List[Text]]]
+
+    def iter_interpreters():
+        # type: () -> Iterator[Tuple[Text, List[Text]]]
+
+        def entry(path):
+            # type: (Text) -> Tuple[Text, List[Text]]
+            return os.path.basename(path), [path]
+
+        yield entry(sys.executable)
+
+        for version in ALL_PY_VERSIONS:
+            interpreter = ensure_python_interpreter(version)
+            yield entry(interpreter)
+
+        locations = (
+            subprocess.check_output(
+                args=["/usr/bin/env", "bash", "-c", "command -v ash bash busybox dash ksh sh zsh"]
+            )
+            .decode("utf-8")
+            .splitlines()
+        )
+        for location in locations:
+            basename = os.path.basename(location)
+            if "busybox" == basename:
+                yield "ash (via busybox)", [location, "ash"]
+            else:
+                yield entry(location)
+
+    return sorted({name: args for name, args in iter_interpreters()}.items())
+
+
+@pytest.mark.parametrize(
+    ["interpreter_cmd"],
+    [pytest.param(args, id=name) for name, args in interpreters()],
+)
+def test_execute_via_interpreter(
+    tmpdir,  # type: Any
+    interpreter_cmd,  # type: List[str]
+):
+    # type: (...) -> None
+
+    cowsay = os.path.join(str(tmpdir), "cowsay.pex")
+    run_pex_command(
+        args=["cowsay==4.0", "-c", "cowsay", "-o", cowsay, "--bash-boot"]
+    ).assert_success()
+
+    assert (
+        "4.0"
+        == subprocess.check_output(args=interpreter_cmd + [cowsay, "--version"])
+        .decode("utf-8")
+        .strip()
+    )
+
+
+def test_python_shebang_respected(tmpdir):
+    # type: (Any) -> None
+
+    cowsay = os.path.join(str(tmpdir), "cowsay.pex")
+    run_pex_command(
+        args=[
+            "cowsay==4.0",
+            "-c",
+            "cowsay",
+            "-o",
+            cowsay,
+            "--bash-boot",
+            "--python-shebang",
+            # This is a strange shebang ~no-one would use since it short-circuits the PEX execution
+            # to always just print the Python interpreter version, but it serves the purposes of:
+            # 1. Proving our python shebang is honored by the bash boot.
+            # 2. The bash boot treatment can handle shebangs with arguments in them.
+            "{python} -V".format(python=sys.executable),
+        ]
+    ).assert_success()
+
+    assert (
+        subprocess.check_output(args=[cowsay])
+        .decode("utf-8")
+        .startswith("Python {version}".format(version=".".join(map(str, sys.version_info[:3]))))
+    )


### PR DESCRIPTION
Allow users to choose `sh` as the boot mechanism for their PEXes. Not
only is `/bin/sh` probably more widely available than any given Python
shebang, but its also much faster.