### PR TITLE
Fix more pathologic lock creation slowness.

### DIFF
--- a/pex/pip/runtime_patches.py
+++ b/pex/pip/runtime_patches.py
@@ -5,7 +5,6 @@
 
 import os
 import runpy
-
 # N.B.: The following environment variables are used by the Pex runtime to control Pip and must be
 # kept in-sync with `tool.py`.
 skip_markers = os.environ.pop("_PEX_SKIP_MARKERS", None)
@@ -170,8 +169,6 @@ if skip_markers:
             orig_get_candidate_lookup = RequiresPythonRequirement.get_candidate_lookup
             orig_is_satisfied_by = RequiresPythonRequirement.is_satisfied_by
 
-            py_versions = []
-
             # Ensure we do a proper, but minimal, comparison for Python versions. Previously we
             # always tested all `Requires-Python` specifier sets against Python full versions. That
             # can be pathologically slow (see: https://github.com/pantsbuild/pants/issues/14998); so
@@ -185,22 +182,29 @@ if skip_markers:
             # Do not need full versions to evaluate properly:
             # + Requires-Python: >=3.7,<4
             # + Requires-Python: ==3.7.*
+            # + Requires-Python: >=3.6.0
             #
             def needs_full_versions(spec):
                 components = spec.version.split(".", 2)
                 if len(components) < 3:
                     return False
                 major_, minor_, patch = components
+                if spec.operator in ("<", "<=", ">", ">=") and patch == "0":
+                    return False
                 return patch != "*"
 
             def _py_versions(self):
-                if not py_versions:
-                    py_versions.extend(
-                        python_full_versions
-                        if any(needs_full_versions(spec) for spec in self.specifier)
-                        else python_versions
+                if not hasattr(self, "__py_versions"):
+                    self.__py_versions = (
+                        version
+                        for version in (
+                            python_full_versions
+                            if any(needs_full_versions(spec) for spec in self.specifier)
+                            else python_versions
+                        )
+                        if ".".join(map(str, version)) in self.specifier
                     )
-                return py_versions
+                return self.__py_versions
 
             def get_candidate_lookup(self):
                 for py_version in self._py_versions():

--- a/pex/pip/tool.py
+++ b/pex/pip/tool.py
@@ -925,7 +925,7 @@ class Pip(object):
         log = None
         popen_kwargs = {}
         if log_analyzers:
-            log = os.path.join(safe_mkdtemp(), "pip.log")
+            log = os.path.join(safe_mkdtemp(prefix="pex-pip-log"), "pip.log")
             download_cmd = ["--log", log] + download_cmd
             # N.B.: The `pip -q download ...` command is quiet but
             # `pip -q --log log.txt download ...` leaks download progress bars to stdout. We work

--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,8 @@ setenv =
 skip_install = true
 deps =
     black==21.12b0
+    # The 8.1.0 release of click breaks black; so we pin.
+    click==8.0.1
     isort==5.10.1
 commands =
     bash scripts/format.sh


### PR DESCRIPTION
Although #1707 was on the right track, it missed a small corner case
with partial order operators acting against patch versions of zero. More
importantly, it missed trimming the final set of versions picked using
the specifier in question once up-front. This up-front trimming pays
large amortized dividends, cutting resolve times in half or more in some
cases.

Fixes #1722