### PR TITLE
Don't register global args in global position.

### DIFF
--- a/pex/commands/command.py
+++ b/pex/commands/command.py
@@ -284,7 +284,10 @@ def global_environment(options):
     if not hasattr(options, "rc_file"):
         # We don't register the global args on the root command (but do on every subcommand).
         # So if the user runs just `pex` with no subcommand we must not attempt to use those
+        # global args, including rc_file, which we check for here as a representative of the
         # global args.
+        # Note that we can't use command_type here because the legacy command line parser in
+        # pex/bin/pex.py uses this function as well, and it doesn't set command_type.
         with ENV.patch() as env:
             yield env
     with _configured_env(options):

--- a/pex/commands/command.py
+++ b/pex/commands/command.py
@@ -281,6 +281,12 @@ def global_environment(options):
     :yields: The configured global environment.
     :raises: :class:`GlobalConfigurationError` if invalid global option values were specified.
     """
+    if not hasattr(options, "rc_file"):
+        # We don't register the global args on the root command (but do on every subcommand).
+        # So if the user runs just `pex` with no subcommand we must not attempt to use those
+        # global args, including rc_file, which we check for here as a representative of the
+        # global args.
+        yield ENV
     with _configured_env(options):
         verbosity = Variables.PEX_VERBOSE.strip_default(ENV)
         if verbosity is None:

--- a/pex/commands/command.py
+++ b/pex/commands/command.py
@@ -286,7 +286,8 @@ def global_environment(options):
         # So if the user runs just `pex` with no subcommand we must not attempt to use those
         # global args, including rc_file, which we check for here as a representative of the
         # global args.
-        yield ENV
+        with ENV.patch() as env:
+            yield env
     with _configured_env(options):
         verbosity = Variables.PEX_VERBOSE.strip_default(ENV)
         if verbosity is None:

--- a/pex/commands/command.py
+++ b/pex/commands/command.py
@@ -281,7 +281,7 @@ def global_environment(options):
     :yields: The configured global environment.
     :raises: :class:`GlobalConfigurationError` if invalid global option values were specified.
     """
-    if not hasattr(options, "command_type"):
+    if not hasattr(options, "rc_file"):
         # We don't register the global args on the root command (but do on every subcommand).
         # So if the user runs just `pex` with no subcommand we must not attempt to use those
         # global args.

--- a/pex/commands/command.py
+++ b/pex/commands/command.py
@@ -380,7 +380,6 @@ class Main(Generic["_C"]):
         )
         parser.add_argument("-V", "--version", action="version", version=__version__)
         parser.set_defaults(command_type=functools.partial(Command.show_help, parser))
-        register_global_arguments(parser)
         self.add_arguments(parser)
         if self._command_types:
             subparsers = parser.add_subparsers(description=self._subparsers_description)

--- a/pex/commands/command.py
+++ b/pex/commands/command.py
@@ -281,10 +281,9 @@ def global_environment(options):
     :yields: The configured global environment.
     :raises: :class:`GlobalConfigurationError` if invalid global option values were specified.
     """
-    if not hasattr(options, "rc_file"):
+    if not hasattr(options, "command_type"):
         # We don't register the global args on the root command (but do on every subcommand).
         # So if the user runs just `pex` with no subcommand we must not attempt to use those
-        # global args, including rc_file, which we check for here as a representative of the
         # global args.
         with ENV.patch() as env:
             yield env

--- a/tests/commands/test_command.py
+++ b/tests/commands/test_command.py
@@ -39,7 +39,9 @@ def test_main(capsys):
     # type: (Any) -> None
 
     class TestCommand(Command):
-        pass
+        @classmethod
+        def add_arguments(cls, parser):
+            cls.register_global_arguments(parser)
 
     class Command1(TestCommand):
         pass
@@ -70,4 +72,4 @@ def test_main(capsys):
     with pytest.raises(SystemExit) as exc_info:
         cm.__enter__()
     assert 2 == exc_info.value.code
-    assert_output(expected_stderr="test_main [-h] [-V] [-v] [--emit-warnings] ")
+    assert_output(expected_stderr="test_main [-h] [-V]")

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -45,9 +45,7 @@ def test_pex_tools_script():
     # type: () -> None
     command_names = ",".join([command_type.name() for command_type in all_commands()])
     expected_first_line = (
-        "usage: pex-tools [-h] [-V] [-v] [--emit-warnings] [--pex-root PEX_ROOT] [--disable-cache] "
-        "[--cache-dir CACHE_DIR] [--tmpdir TMPDIR] [--rcfile RC_FILE] PATH "
-        "{{{command_names}}} ...".format(command_names=command_names)
+        "usage: pex-tools [-h] [-V] PATH {{{command_names}}} ...".format(command_names=command_names)
     )
 
     # Make sure we don't word-wrap for simplicity of testing.

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -45,7 +45,8 @@ def test_pex_tools_script():
     # type: () -> None
     command_names = ",".join([command_type.name() for command_type in all_commands()])
     expected_first_line = "usage: pex-tools [-h] [-V] PATH {{{command_names}}} ...".format(
-        command_names=command_names)
+        command_names=command_names
+    )
 
     # Make sure we don't word-wrap for simplicity of testing.
     env = make_env(COLUMNS=len(expected_first_line) + 2)

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -44,9 +44,8 @@ def test_pex_script():
 def test_pex_tools_script():
     # type: () -> None
     command_names = ",".join([command_type.name() for command_type in all_commands()])
-    expected_first_line = (
-        "usage: pex-tools [-h] [-V] PATH {{{command_names}}} ...".format(command_names=command_names)
-    )
+    expected_first_line = "usage: pex-tools [-h] [-V] PATH {{{command_names}}} ...".format(
+        command_names=command_names)
 
     # Make sure we don't word-wrap for simplicity of testing.
     env = make_env(COLUMNS=len(expected_first_line) + 2)


### PR DESCRIPTION
They have no effect and are silently overwritten by
the same args (or their defaults) registered on each
subcommand.

Previously, `pex -v subcommand` would silently ignore the
arg in the global position because -v is also registered on
the subcommand (and similarly for all global args).

Now at least you get an error. With this change all args,
including global ones, must appear on the cmd-line after
the subcommand.