### PR TITLE
Fix universal lock creation for ICs.

### DIFF
--- a/pex/resolve/target_configuration.py
+++ b/pex/resolve/target_configuration.py
@@ -18,7 +18,7 @@ from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
 
 if TYPE_CHECKING:
-    from typing import Optional, Tuple
+    from typing import Iterator, Optional, Tuple
 
     import attr  # vendor:skip
 else:
@@ -37,6 +37,41 @@ class InterpreterConfiguration(object):
         # TODO(#1075): stop looking at PEX_PYTHON_PATH and solely consult the `--python-path` flag.
         return self._python_path or ENV.PEX_PYTHON_PATH
 
+    def iter_interpreters(self):
+        # type: () -> Iterator[PythonInterpreter]
+
+        if self.pythons:
+            with TRACER.timed("Resolving interpreters", V=2):
+
+                def to_python_interpreter(full_path_or_basename):
+                    if os.path.isfile(full_path_or_basename):
+                        return PythonInterpreter.from_binary(full_path_or_basename)
+                    else:
+                        interpreter = PythonInterpreter.from_env(
+                            full_path_or_basename, paths=parse_path(self.python_path)
+                        )
+                        if interpreter is None:
+                            raise InterpreterNotFound(
+                                "Failed to find interpreter: {}".format(full_path_or_basename)
+                            )
+                        return interpreter
+
+                for python in self.pythons:
+                    yield to_python_interpreter(python)
+
+        if self.interpreter_constraints:
+            with TRACER.timed("Resolving interpreters", V=2):
+                try:
+                    for interp in iter_compatible_interpreters(
+                        path=self.python_path,
+                        interpreter_constraints=self.interpreter_constraints,
+                    ):
+                        yield interp
+                except UnsatisfiableInterpreterConstraintsError as e:
+                    raise InterpreterConstraintsNotSatisfied(
+                        e.create_message("Could not find a compatible interpreter.")
+                    )
+
     def resolve_interpreters(self):
         # type: () -> OrderedSet[PythonInterpreter]
         """Resolves the interpreters satisfying the interpreter configuration.
@@ -46,41 +81,7 @@ class InterpreterConfiguration(object):
         :raise: :class:`InterpreterConstraintsNotSatisfied` if --interpreter-constraint were
             specified but no conforming interpreters could be found.
         """
-        interpreters = OrderedSet()  # type: OrderedSet[PythonInterpreter]
-
-        if self.pythons:
-            with TRACER.timed("Resolving interpreters", V=2):
-
-                def to_python_interpreter(full_path_or_basename):
-                    if os.path.isfile(full_path_or_basename):
-                        return PythonInterpreter.from_binary(full_path_or_basename)
-                    else:
-                        interp = PythonInterpreter.from_env(
-                            full_path_or_basename, paths=parse_path(self.python_path)
-                        )
-                        if interp is None:
-                            raise InterpreterNotFound(
-                                "Failed to find interpreter: {}".format(full_path_or_basename)
-                            )
-                        return interp
-
-                interpreters.update(to_python_interpreter(interp) for interp in self.pythons)
-
-        if self.interpreter_constraints:
-            with TRACER.timed("Resolving interpreters", V=2):
-                try:
-                    interpreters.update(
-                        iter_compatible_interpreters(
-                            path=self.python_path,
-                            interpreter_constraints=self.interpreter_constraints,
-                        )
-                    )
-                except UnsatisfiableInterpreterConstraintsError as e:
-                    raise InterpreterConstraintsNotSatisfied(
-                        e.create_message("Could not find a compatible interpreter.")
-                    )
-
-        return interpreters
+        return OrderedSet(self.iter_interpreters())
 
 
 class TargetConfigurationError(Exception):
@@ -125,9 +126,7 @@ class TargetConfiguration(object):
         :raise: :class:`InterpreterConstraintsNotSatisfied` if --interpreter-constraint were
             specified but no conforming interpreters could be found.
         """
-        interpreters = OrderedSet(
-            self.interpreter_configuration.resolve_interpreters()
-        )  # type: OrderedSet[PythonInterpreter]
+        interpreters = self.interpreter_configuration.resolve_interpreters()
 
         all_platforms = (
             OrderedDict()

--- a/tests/integration/cli/commands/test_issue_1667.py
+++ b/tests/integration/cli/commands/test_issue_1667.py
@@ -44,6 +44,8 @@ def test_interpreter_constraints_range_coverage(
         "pip-2020-resolver",
         "--interpreter-constraint",
         ">=3.7,<3.11",
+        "--python-path",
+        py37.binary,
         "ipython",
         "-o",
         lock,

--- a/tests/integration/cli/commands/test_issue_1711.py
+++ b/tests/integration/cli/commands/test_issue_1711.py
@@ -5,6 +5,7 @@ import os
 
 from pex.cli.testing import run_pex3
 from pex.compatibility import PY3
+from pex.interpreter import PythonInterpreter
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.resolve import lockfile
@@ -28,8 +29,11 @@ def pypi_artifact(
     )
 
 
-def test_backtrack_links_preserved(tmpdir):
-    # type: (Any) -> None
+def test_backtrack_links_preserved(
+    tmpdir,  # type: Any
+    py37,  # type: PythonInterpreter
+):
+    # type: (...) -> None
 
     lock = os.path.join(str(tmpdir), "lock")
     create_lock_args = [
@@ -41,6 +45,8 @@ def test_backtrack_links_preserved(tmpdir):
         "universal",
         "--interpreter-constraint",
         ">=3.7,<3.10",
+        "--python-path",
+        py37.binary,
         "psutil",
         "psutil<5.5",  # force a back-track
         "-o",

--- a/tests/integration/cli/commands/test_issue_1734.py
+++ b/tests/integration/cli/commands/test_issue_1734.py
@@ -1,0 +1,109 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import subprocess
+
+from pex.cli.testing import run_pex3
+from pex.interpreter import PythonInterpreter
+from pex.testing import run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_lock_create_sdist_requires_python_different_from_current(
+    tmpdir,  # type: Any
+    py27,  # type: PythonInterpreter
+    py37,  # type: PythonInterpreter
+    py310,  # type: PythonInterpreter
+):
+    # type: (...) -> None
+
+    lock = os.path.join(str(tmpdir), "lock")
+    create_lock_args = [
+        "lock",
+        "create",
+        "--resolver-version",
+        "pip-2020-resolver",
+        "--style",
+        "universal",
+        "--interpreter-constraint",
+        "CPython<3.11,>=3.8",
+        "--python-path",
+        ":".join(interp.binary for interp in (py27, py37, py310)),
+        "aioconsole==0.4.1",
+        "-o",
+        lock,
+        "--indent",
+        "2",
+    ]
+
+    # 1st prove this does the wrong thing on prior broken versions of Pex.
+    # N.B.: For some reason, this works with old Pex under Python 2.7; i.e.: It appears Pip behaves
+    # differently - likely because of some collection implementation difference.
+    result = run_pex_command(
+        args=["pex==2.1.82", "-c", "pex3", "--"] + create_lock_args,
+        python=py27.binary,
+        quiet=True,
+    )
+    result.assert_failure()
+    assert (
+        "ERROR: Package 'aioconsole' requires a different Python: {pyver} not in '>=3.7'".format(
+            pyver=py27.identity.version_str
+        )
+        == result.error.splitlines()[0]
+    )
+
+    # Now show it currently works.
+    subprocess.check_call(args=[py27.binary, "-m", "pex.cli"] + create_lock_args)
+    run_pex_command(
+        args=["--lock", lock, "--", "-c", "import aioconsole"],
+        python=py310.binary,
+    ).assert_success()
+
+
+def test_lock_create_universal_interpreter_constraint_unsatisfiable(
+    tmpdir,  # type: Any
+    py27,  # type: PythonInterpreter
+    py37,  # type: PythonInterpreter
+):
+    # type: (...) -> None
+
+    lock = os.path.join(str(tmpdir), "lock")
+    result = run_pex3(
+        "lock",
+        "create",
+        "--resolver-version",
+        "pip-2020-resolver",
+        "--style",
+        "universal",
+        "--interpreter-constraint",
+        "CPython<3.11,>=3.8",
+        "--python-path",
+        ":".join(interp.binary for interp in (py27, py37)),
+        "aioconsole==0.4.1",
+        "-o",
+        lock,
+        "--indent",
+        "2",
+    )
+    result.assert_failure()
+    assert (
+        "When creating a universal lock with an --interpreter-constraint, an interpreter matching "
+        "the constraint must be found on the local system but none was: Could not find a "
+        "compatible interpreter.\n"
+        "\n"
+        "Examined the following interpreters:\n"
+        "1.) {py27_path} {py27_req}\n"
+        "2.) {py37_path} {py37_req}\n"
+        "\n"
+        "No interpreter compatible with the requested constraints was found:\n"
+        "  Version matches CPython<3.11,>=3.8\n".format(
+            py27_path=py27.binary,
+            py27_req=py27.identity.requirement,
+            py37_path=py37.binary,
+            py37_req=py37.identity.requirement,
+        )
+    ) == result.error

--- a/tests/integration/cli/commands/test_issue_1734.py
+++ b/tests/integration/cli/commands/test_issue_1734.py
@@ -41,8 +41,6 @@ def test_lock_create_sdist_requires_python_different_from_current(
     ]
 
     # 1st prove this does the wrong thing on prior broken versions of Pex.
-    # N.B.: For some reason, this works with old Pex under Python 2.7; i.e.: It appears Pip behaves
-    # differently - likely because of some collection implementation difference.
     result = run_pex_command(
         args=["pex==2.1.82", "-c", "pex3", "--"] + create_lock_args,
         python=py27.binary,

--- a/tests/integration/cli/commands/test_lock.py
+++ b/tests/integration/cli/commands/test_lock.py
@@ -84,18 +84,21 @@ def test_create(tmpdir):
     )
 
 
-def test_create_style(tmpdir):
-    # type: (Any) -> None
+def test_create_style(
+    tmpdir,  # type: Any
+    py310,  # type: str
+):
+    # type: (...) -> None
 
     pex_root = os.path.join(str(tmpdir), "pex_root")
 
     def create_lock(
         style,  # type: str
-        interpreter_constraint=None,  # type: Optional[str]
+        *additional_args  # type: str
     ):
         # type: (...) -> LockedRequirement
         lock_file = os.path.join(str(tmpdir), "{}.lock".format(style))
-        args = [
+        args = (
             "lock",
             "create",
             "psutil==5.9.0",
@@ -105,10 +108,8 @@ def test_create_style(tmpdir):
             style,
             "--pex-root",
             pex_root,
-        ]
-        if interpreter_constraint:
-            args.extend(["--interpreter-constraint", interpreter_constraint])
-        run_pex3(*args).assert_success()
+        )
+        run_pex3(*(args + additional_args)).assert_success()
         lock = lockfile.load(lock_file)
         assert 1 == len(lock.locked_resolves)
         locked_resolve = lock.locked_resolves[0]
@@ -155,7 +156,11 @@ def test_create_style(tmpdir):
 
     # We should have 6 total artifacts for a constrained universal lock since we know psutil 5.9.0
     # provides an sdist and 5 Python 3.10 wheels.
-    assert 5 == len(create_lock("universal", interpreter_constraint="~=3.10").additional_artifacts)
+    assert 5 == len(
+        create_lock(
+            "universal", "--interpreter-constraint", "~=3.10", "--python-path", py310
+        ).additional_artifacts
+    )
 
 
 def test_create_local_unsupported(pex_project_dir):

--- a/tox.ini
+++ b/tox.ini
@@ -89,7 +89,7 @@ deps =
     mypy[python2]==0.931
     typing-extensions
     types-mock
-    types-toml
+    types-toml==0.10.5
 commands =
     bash scripts/typecheck.sh
 


### PR DESCRIPTION
Previously the current interpreter was used to perform the lock resolve
(which is OK) and the resolve post-processing (which was not OK). Now
we force finding a local interpreter that meets ICs up-front and use
that for both the resolve and post-processing.

Fixes #1734