### PR TITLE
Fix CI bitrot breaks.

### DIFF
--- a/pex/testing.py
+++ b/pex/testing.py
@@ -506,7 +506,7 @@ def ensure_python_distribution(version):
                 # with with `--disable-new-dtags`.
                 env["LDFLAGS"] = "-Wl,--disable-new-dtags"
             subprocess.check_call([pyenv, "install", "--keep", version], env=env)
-            subprocess.check_call([pip, "install", "-U", "pip"])
+            subprocess.check_call([pip, "install", "-U", "pip<22.1"])
 
     major, minor = version.split(".")[:2]
     python = os.path.join(
@@ -536,7 +536,7 @@ def ensure_python_venv(version, latest_pip=True, system_site_packages=False):
         subprocess.check_call(args=args)
     python, pip = tuple(os.path.join(venv, "bin", exe) for exe in ("python", "pip"))
     if latest_pip:
-        subprocess.check_call(args=[pip, "install", "-U", "pip"])
+        subprocess.check_call(args=[pip, "install", "-U", "pip<22.1"])
     return python, pip
 
 

--- a/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/METADATA
+++ b/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/METADATA
@@ -10,7 +10,6 @@ Project-URL: Documentation, https://pip.pypa.io
 Project-URL: Source, https://github.com/pypa/pip
 Project-URL: Changelog, https://pip.pypa.io/en/stable/news/
 Keywords: distutils easy_install egg setuptools wheel virtualenv
-Platform: UNKNOWN
 Classifier: Development Status :: 5 - Production/Stable
 Classifier: Intended Audience :: Developers
 Classifier: License :: OSI Approved :: MIT License
@@ -91,5 +90,3 @@ rooms, and mailing lists is expected to follow the `PSF Code of Conduct`_.
 .. _User IRC: https://webchat.freenode.net/?channels=%23pypa
 .. _Development IRC: https://webchat.freenode.net/?channels=%23pypa-dev
 .. _PSF Code of Conduct: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
-
-

--- a/tests/test_bdist_pex.py
+++ b/tests/test_bdist_pex.py
@@ -34,8 +34,9 @@ def bdist_pex_venv():
         venv_dir = safe_mkdtemp()
         venv = Virtualenv.create(venv_dir)
         pip = venv.install_pip()
-        # N.B.: The setuptools version is not important.
-        subprocess.check_call(args=[pip, "install", "-U", "pip"])
+        # N.B.: The setuptools version is not important, but there is a break introduced by pip
+        # 22.1; so we must pin that low.
+        subprocess.check_call(args=[pip, "install", "-U", "pip<22.1"])
         subprocess.check_call(args=[pip, "install", pex_project_dir(), "setuptools==43.0.0"])
         BDIST_PEX_VENV = venv
     return BDIST_PEX_VENV


### PR DESCRIPTION
I'm not sure how the vendoring could have drifted. The tox vendor env
has pip, setuptools and wheel pinned. Since the drift is of no
consequence, I'm rolling with it for now.

Also Pin Pip lower then 22.1 since the 22.1 release a few days ago
breaks the bdist_pex tests.