### PR TITLE
Select PEX runtime interpreter robustly.

### DIFF
--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -19,7 +19,7 @@ from pex.venv.bin_path import BinPath
 from pex.version import __version__ as pex_version
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Mapping, Optional, Text, Union
+    from typing import Any, Dict, List, Mapping, Optional, Text, Union
 
     from pex.interpreter import PythonInterpreter
 
@@ -288,6 +288,7 @@ class PexInfo(object):
 
     @property
     def interpreter_constraints(self):
+        # type: () -> List[str]
         """A list of constraints that determine the interpreter compatibility for this pex, using
         the Requirement-style format, e.g. ``'CPython>=3', or just '>=2.7,<3'`` for requirements
         agnostic to interpreter class.

--- a/pex/tools/commands/interpreter.py
+++ b/pex/tools/commands/interpreter.py
@@ -11,6 +11,7 @@ from pex.commands.command import JsonMixin, OutputMixin
 from pex.interpreter import PythonInterpreter
 from pex.interpreter_constraints import UnsatisfiableInterpreterConstraintsError
 from pex.pex import PEX
+from pex.pex_bootstrapper import InterpreterTest
 from pex.result import Error, Ok, Result
 from pex.tools.command import PEXCommand
 from pex.typing import TYPE_CHECKING
@@ -62,9 +63,11 @@ class Interpreter(JsonMixin, OutputMixin, PEXCommand):
                 "Ignoring PEX_PYTHON={} in order to scan for all compatible "
                 "interpreters.".format(ENV.PEX_PYTHON)
             )
+        pex_info = pex.pex_info()
         for interpreter in pex_bootstrapper.iter_compatible_interpreters(
             path=ENV.PEX_PYTHON_PATH,
-            interpreter_constraints=pex.pex_info().interpreter_constraints,
+            interpreter_constraints=pex_info.interpreter_constraints,
+            interpreter_test=InterpreterTest(entry_point=pex.path(), pex_info=pex_info),
         ):
             yield interpreter
 

--- a/pex/tools/main.py
+++ b/pex/tools/main.py
@@ -9,6 +9,7 @@ from argparse import ArgumentParser, Namespace
 from pex import pex_bootstrapper
 from pex.commands.command import GlobalConfigurationError, Main
 from pex.pex import PEX
+from pex.pex_bootstrapper import InterpreterTest
 from pex.pex_info import PexInfo
 from pex.result import Result, catch
 from pex.tools import commands
@@ -84,7 +85,7 @@ def main(pex=None):
                 pex_info = PexInfo.from_pex(pex_file_path)
                 pex_info.update(PexInfo.from_env())
                 interpreter = pex_bootstrapper.find_compatible_interpreter(
-                    interpreter_constraints=pex_info.interpreter_constraints
+                    interpreter_test=InterpreterTest(entry_point=pex_file_path, pex_info=pex_info)
                 )
                 pex = PEX(pex_file_path, interpreter=interpreter)
 

--- a/tests/integration/test_pex_bootstrapper.py
+++ b/tests/integration/test_pex_bootstrapper.py
@@ -324,13 +324,13 @@ def test_boot_compatible_issue_1020_ic_min_compatible_build_time_hole(tmpdir):
             "{python}=={major}.{minor}.*".format(
                 python=max_interpreter.identity.interpreter,
                 major=min_interpreter.version[0],
-                minor=min_interpreter.version[1]
+                minor=min_interpreter.version[1],
             ),
             "--interpreter-constraint",
             "{python}=={major}.{minor}.*".format(
                 python=max_interpreter.identity.interpreter,
                 major=max_interpreter.version[0],
-                minor=max_interpreter.version[1]
+                minor=max_interpreter.version[1],
             ),
         ]
     ).assert_success()

--- a/tests/integration/test_pex_bootstrapper.py
+++ b/tests/integration/test_pex_bootstrapper.py
@@ -321,12 +321,16 @@ def test_boot_compatible_issue_1020_ic_min_compatible_build_time_hole(tmpdir):
             "--python-path",
             max_interpreter.binary,
             "--interpreter-constraint",
-            "=={major}.{minor}.*".format(
-                major=min_interpreter.version[0], minor=min_interpreter.version[1]
+            "{python}=={major}.{minor}.*".format(
+                python=max_interpreter.identity.interpreter,
+                major=min_interpreter.version[0],
+                minor=min_interpreter.version[1]
             ),
             "--interpreter-constraint",
-            "=={major}.{minor}.*".format(
-                major=max_interpreter.version[0], minor=max_interpreter.version[1]
+            "{python}=={major}.{minor}.*".format(
+                python=max_interpreter.identity.interpreter,
+                major=max_interpreter.version[0],
+                minor=max_interpreter.version[1]
             ),
         ]
     ).assert_success()

--- a/tests/integration/test_pex_bootstrapper.py
+++ b/tests/integration/test_pex_bootstrapper.py
@@ -4,21 +4,23 @@
 import os.path
 import re
 import subprocess
+import sys
 from textwrap import dedent
 
 import pytest
 
 from pex.common import safe_open
+from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.pex_bootstrapper import ensure_venv
 from pex.pex_info import PexInfo
-from pex.testing import make_env, run_pex_command
+from pex.testing import PY27, PY37, PY_VER, ensure_python_interpreter, make_env, run_pex_command
 from pex.typing import TYPE_CHECKING
 from pex.venv.pex import CollisionError
 from pex.venv.virtualenv import Virtualenv
 
 if TYPE_CHECKING:
-    from typing import Any, Set, Text
+    from typing import Any, Optional, Set, Text
 
 
 def test_ensure_venv_short_link(
@@ -258,3 +260,94 @@ def test_ensure_venv_site_packages_copies(
 
     assert_venv_site_packages_copies(copies=True)
     assert_venv_site_packages_copies(copies=False)
+
+
+def test_boot_compatible_issue_1020_no_ic(tmpdir):
+    # type: (Any) -> None
+
+    pex = os.path.join(str(tmpdir), "pex")
+    run_pex_command(args=["psutil==5.9.0", "-o", pex]).assert_success()
+
+    def assert_boot(python=None):
+        # type: (Optional[str]) -> None
+        args = [python] if python else []
+        args.extend([pex, "-c", "import psutil, sys; print(sys.executable)"])
+        output = subprocess.check_output(args=args, stderr=subprocess.PIPE)
+
+        # N.B.: We expect the current interpreter the PEX was built with to be selected since the
+        # PEX contains a single platform specific distribution that only works with that
+        # interpreter. If the current interpreter is in a venv though, we expect the PEX bootstrap
+        # to have broken out of the venv and used its base system interpreter.
+        # See:
+        #   https://github.com/pantsbuild/pex/pull/1130
+        #   https://github.com/pantsbuild/pex/issues/1031
+        assert (
+            PythonInterpreter.get().resolve_base_interpreter()
+            == PythonInterpreter.from_binary(
+                str(output.decode("ascii").strip())
+            ).resolve_base_interpreter()
+        )
+
+    assert_boot()
+    assert_boot(sys.executable)
+
+    other_interpreter = (
+        ensure_python_interpreter(PY27) if PY_VER != (2, 7) else ensure_python_interpreter(PY37)
+    )
+    assert_boot(other_interpreter)
+
+
+def test_boot_compatible_issue_1020_ic_min_compatible_build_time_hole(tmpdir):
+    # type: (Any) -> None
+    other_interpreter = PythonInterpreter.from_binary(
+        ensure_python_interpreter(PY27) if PY_VER != (2, 7) else ensure_python_interpreter(PY37)
+    )
+    current_interpreter = PythonInterpreter.get()
+
+    min_interpreter, max_interpreter = (
+        (other_interpreter, current_interpreter)
+        if other_interpreter.version < current_interpreter.version
+        else (current_interpreter, other_interpreter)
+    )
+    assert min_interpreter.version < max_interpreter.version
+
+    # Try to build a PEX that works for min and max, but only find max locally.
+    pex = os.path.join(str(tmpdir), "pex")
+    run_pex_command(
+        args=[
+            "psutil==5.9.0",
+            "-o",
+            pex,
+            "--python-path",
+            max_interpreter.binary,
+            "--interpreter-constraint",
+            "=={major}.{minor}.*".format(
+                major=min_interpreter.version[0], minor=min_interpreter.version[1]
+            ),
+            "--interpreter-constraint",
+            "=={major}.{minor}.*".format(
+                major=max_interpreter.version[0], minor=max_interpreter.version[1]
+            ),
+        ]
+    ).assert_success()
+
+    # Now try to run the PEX remotely where both min and max exist.
+    output = subprocess.check_output(
+        args=[min_interpreter.binary, pex, "-c", "import psutil, sys; print(sys.executable)"],
+        env=make_env(PEX_PYTHON_PATH=":".join((min_interpreter.binary, max_interpreter.binary))),
+        stderr=subprocess.PIPE,
+    )
+
+    # N.B.: We expect the max interpreter the PEX was built with to be selected since the
+    # PEX contains a single platform specific distribution that only works with that
+    # interpreter. If the max interpreter is in a venv though, we expect the PEX bootstrap
+    # to have broken out of the venv and used its base system interpreter.
+    # See:
+    #   https://github.com/pantsbuild/pex/pull/1130
+    #   https://github.com/pantsbuild/pex/issues/1031
+    assert (
+        max_interpreter.resolve_base_interpreter()
+        == PythonInterpreter.from_binary(
+            str(output.decode("ascii").strip())
+        ).resolve_base_interpreter()
+    )


### PR DESCRIPTION
Previously two proxies for interpreter applicability were used:
1. The shebang selected interpreter or the explicit interpreter used
   to invoke the PEX.
2. Any embedded interpreter constraints.

This could lead to selecting an interpreter that was not actually able
to resolve all required distributions from within the PEX, which is the
only real criteria, and a failure to boot.

Fix the runtime interpreter resolution process to test an interpreter
can resolve the PEX before using it or re-execing to it.

In the use case, the resolve test performed is cached work and leads to
no extra overhead. In the re-exec case the resolve test can cost
O(100ms), but at the benefit of ensuring either the selected interpreter
will definitely work or no interpreters on the search path can work.

Fixes #1020