### PR TITLE
Ensure that lockfiles end in newlines.

### DIFF
--- a/pex/cli/commands/lock.py
+++ b/pex/cli/commands/lock.py
@@ -300,6 +300,10 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
         else:
             with self.output(self.options) as output:
                 dump(out=output)
+        # json.dump() does not write the newline terminating the last line, but some
+        # JSON linters, and line-based tools in general, expect it, and since these
+        # files are intended to be checked in to repos that may enforce this, we oblige.
+        output.write("\n")
 
     def _export(self):
         # type: () -> Result


### PR DESCRIPTION
I encountered a repo whose precommit checks choked on our lockfiles because they didn't end in newlines.
Since this is a reasonable expectation from a text file (indeed POSIX requires it, so various CLI tools assume it),
we oblige.