### PR TITLE
Remove support for adding whl files to PEXBuilder.

### DIFF
--- a/pex/testing.py
+++ b/pex/testing.py
@@ -264,14 +264,21 @@ def make_bdist(
     with built_wheel(
         name=name, version=version, zip_safe=zip_safe, interpreter=interpreter, **kwargs
     ) as dist_location:
+        yield install_wheel(dist_location, interpreter=interpreter)
 
-        install_dir = os.path.join(safe_mkdtemp(), os.path.basename(dist_location))
-        get_pip(interpreter=interpreter).spawn_install_wheel(
-            wheel=dist_location,
-            install_dir=install_dir,
-            target=LocalInterpreter.create(interpreter),
-        ).wait()
-        yield Distribution.load(install_dir)
+
+def install_wheel(
+    wheel,  # type: str
+    interpreter=None,  # type: Optional[PythonInterpreter]
+):
+    # type: (...) -> Distribution
+    install_dir = os.path.join(safe_mkdtemp(), os.path.basename(wheel))
+    get_pip(interpreter=interpreter).spawn_install_wheel(
+        wheel=wheel,
+        install_dir=install_dir,
+        target=LocalInterpreter.create(interpreter),
+    ).wait()
+    return Distribution.load(install_dir)
 
 
 COVERAGE_PREAMBLE = """

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -29,6 +29,7 @@ from pex.testing import (
     PY37,
     WheelBuilder,
     ensure_python_interpreter,
+    install_wheel,
     make_bdist,
     temporary_content,
     temporary_filename,
@@ -146,8 +147,8 @@ def assert_force_local_implicit_ns_packages_issues_598(
     def add_wheel(builder, content):
         # type: (PEXBuilder, Dict[str, str]) -> None
         with temporary_content(content) as project:
-            dist = WheelBuilder(project, interpreter=builder.interpreter).bdist()
-            builder.add_dist_location(dist)
+            dist = install_wheel(WheelBuilder(project, interpreter=builder.interpreter).bdist())
+            builder.add_dist_location(dist.location)
 
     def add_sources(builder, content):
         # type: (PEXBuilder, Dict[str, str]) -> None


### PR DESCRIPTION
This was only used by tests. The rest of Pex operates only on installed
wheels.

This is part of a series of a refactors needed to remove dependency
cycles in support of #1696.
