### PR TITLE
Fix `--sh-boot` argv0.

### DIFF
--- a/pex/bin/sh_boot.py
+++ b/pex/bin/sh_boot.py
@@ -177,13 +177,14 @@ def create_sh_boot_script(
         DEFAULT_PYTHON_ARGS="{python_args}"
 
         PEX_ROOT="${{PEX_ROOT:-${{DEFAULT_PEX_ROOT}}}}"
-        PEX="${{PEX_ROOT}}/{pex_installed_relpath}"
+        INSTALLED_PEX="${{PEX_ROOT}}/{pex_installed_relpath}"
 
-        if [ -n "${{VENV}}" -a -x "${{PEX}}" ]; then
+        if [ -n "${{VENV}}" -a -x "${{INSTALLED_PEX}}" ]; then
             # We're a --venv execution mode PEX installed under the PEX_ROOT and the venv
             # interpreter to use is embedded in the shebang of our venv pex script; so just
             # execute that script directly.
-            exec "${{PEX}}" "$@"
+            export PEX="$0"
+            exec "${{INSTALLED_PEX}}" "$@"
         fi
 
         find_python() {{
@@ -205,11 +206,12 @@ def create_sh_boot_script(
             if [ -n "${{PEX_VERBOSE:-}}" ]; then
                 echo >&2 "$0 used /bin/sh boot to select python: ${{python_exe}} for re-exec..."
             fi
-            if [ -z "${{VENV}}" -a -e "${{PEX}}" ]; then
+            if [ -z "${{VENV}}" -a -e "${{INSTALLED_PEX}}" ]; then
                 # We're a --zipapp execution mode PEX installed under the PEX_ROOT with a
                 # __main__.py in our top-level directory; so execute Python against that
                 # directory.
-                exec ${{python_exe}} "${{PEX}}" "$@"
+                export __PEX_EXE__="$0"
+                exec ${{python_exe}} "${{INSTALLED_PEX}}" "$@"
             else
                 # The slow path: this PEX zipapp is not installed yet. Run the PEX zipapp so it
                 # can install itself, rebuilding its fast path layout under the PEX_ROOT.

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -638,7 +638,7 @@ class PEX(object):  # noqa: T000
             elif arg == "-m":
                 module = args[1]
                 sys.argv = args[1:]
-                return self.execute_module(module, alter_sys=True)
+                return self.execute_module(module)
             else:
                 try:
                     if arg == "-":
@@ -756,28 +756,15 @@ class PEX(object):  # noqa: T000
         if isinstance(entry_point, CallableEntryPoint):
             return self.execute_entry_point(entry_point)
 
-        # When running as a zipapp we can't usefully `alter_sys` to point to the module we're
-        # executing as argv[0] since that module will be contained in a zipfile. In other words, if
-        # we did do this, sys.argv[0] would be `/path/to/pex.zip/path/to/module.py` and that value
-        # would not be usable in the standard way. Its not a file you can read or re-execute
-        # against like a loose python module source file would be.
-        #
-        # Python itself disallows this case altogether in the standard zipapp module (probably for
-        # similar reasons). See: https://docs.python.org/3/library/zipapp.html#cmdoption-zipapp-m
-        alter_sys = not zipfile.is_zipfile(self._pex)
-        return self.execute_module(entry_point.module, alter_sys)
+        return self.execute_module(entry_point.module)
 
-    def execute_module(
-        self,
-        module_name,  # type: str
-        alter_sys,  # type: bool
-    ):
-        # type: (...) -> None
+    def execute_module(self, module_name):
+        # type: (str) -> None
         self.demote_bootstrap()
 
         import runpy
 
-        runpy.run_module(module_name, run_name="__main__", alter_sys=alter_sys)
+        runpy.run_module(module_name, run_name="__main__", alter_sys=True)
 
     @classmethod
     def execute_entry_point(cls, entry_point):

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -112,7 +112,7 @@ if __entry_point__ is None:
   sys.exit(2)
 
 __installed_from__ = os.environ.pop(__INSTALLED_FROM__, None)
-sys.argv[0] = __installed_from__ or sys.argv[0]
+sys.argv[0] = os.path.realpath(__installed_from__ or sys.argv[0])
 
 sys.path[0] = os.path.abspath(sys.path[0])
 sys.path.insert(0, os.path.abspath(os.path.join(__entry_point__, {bootstrap_dir!r})))

--- a/pex/venv/pex.py
+++ b/pex/venv/pex.py
@@ -342,6 +342,9 @@ def _populate_sources(
 
             pex_file = os.environ.get("PEX", None)
             if pex_file:
+                pex_file_path = os.path.realpath(pex_file)
+                sys.argv[0] = pex_file_path
+                os.environ["PEX"] = pex_file_path
                 try:
                     from setproctitle import setproctitle
 


### PR DESCRIPTION
Now `--sh-boot` mode PEXes have `sys.argv[0]` and the `PEX` environment
variable set consistently with all other modes of PEX execution.

Fixes #1782