### PR TITLE
CI maintenance.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [[2, 7], [3, 5], [3, 6], [3, 7], [3, 8], [3, 9], [3, 10], [3, 11, "0-beta.1"]]
+        python-version: [[2, 7], [3, 5], [3, 6], [3, 7], [3, 8], [3, 9], [3, 10], [3, 11, "0-beta.3"]]
         os: [ubuntu-20.04, macos-10.15]
         exclude:
           - os: macos-10.15
@@ -79,7 +79,7 @@ jobs:
           - os: macos-10.15
             python-version: [3, 9]
           - os: macos-10.15
-            python-version: [3, 11, "0-beta.1"]
+            python-version: [3, 11, "0-beta.3"]
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -149,11 +149,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [[2, 7], [3, 10], [3, 11, "0-beta.1"]]
+        python-version: [[2, 7], [3, 10], [3, 11, "0-beta.3"]]
         os: [ubuntu-20.04, macos-10.15]
         exclude:
           - os: macos-10.15
-            python-version: [3, 11, "0-beta.1"]
+            python-version: [3, 11, "0-beta.3"]
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose

--- a/tests/integration/tools/commands/test_venv.py
+++ b/tests/integration/tools/commands/test_venv.py
@@ -109,7 +109,7 @@ def test_collisions_mergeable_issue_1570(tmpdir):
     # type: (Any) -> None
 
     pex = os.path.join(str(tmpdir), "pex")
-    run_pex_command(args=["opencensus==0.8.0", "opencensus_context==0.1.2", "-o", pex])
+    run_pex_command(args=["opencensus==0.8.0", "opencensus_context==0.1.2", "-o", pex, "--resolver-version", "pip-2020-resolver"]).assert_success()
 
     venv_dir = os.path.join(str(tmpdir), "venv")
     run_pex_tools(pex, "venv", venv_dir).assert_success()

--- a/tests/integration/tools/commands/test_venv.py
+++ b/tests/integration/tools/commands/test_venv.py
@@ -109,7 +109,16 @@ def test_collisions_mergeable_issue_1570(tmpdir):
     # type: (Any) -> None
 
     pex = os.path.join(str(tmpdir), "pex")
-    run_pex_command(args=["opencensus==0.8.0", "opencensus_context==0.1.2", "-o", pex, "--resolver-version", "pip-2020-resolver"]).assert_success()
+    run_pex_command(
+        args=[
+            "opencensus==0.8.0",
+            "opencensus_context==0.1.2",
+            "-o",
+            pex,
+            "--resolver-version",
+            "pip-2020-resolver",
+        ]
+    ).assert_success()
 
     venv_dir = os.path.join(str(tmpdir), "venv")
     run_pex_tools(pex, "venv", venv_dir).assert_success()


### PR DESCRIPTION
Two fixes:

1. Fix dependency drift in test.
   A protobuf release foiled the legacy resolver and this went
   unchecked.

2. Bump 3.11 shards to latest beta.