### PR TITLE
Surface `pip download` logging.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -698,6 +698,7 @@ def build_pex(
                         compile=options.compile,
                         max_parallel_jobs=resolver_configuration.max_jobs,
                         ignore_errors=options.ignore_errors,
+                        preserve_log=resolver_configuration.preserve_log,
                     )
 
             for installed_dist in result.installed_distributions:

--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -10,13 +10,12 @@ import os
 import re
 import sys
 from abc import ABCMeta
-from io import BytesIO
 from sys import version_info as sys_version_info
 
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from typing import AnyStr, Callable, Optional, Text, Tuple, Type
+    from typing import IO, AnyStr, BinaryIO, Callable, Optional, Text, Tuple, Type
 
 
 try:
@@ -156,9 +155,19 @@ WINDOWS = os.name == "nt"
 MODE_READ_UNIVERSAL_NEWLINES = "rU" if PY2 else "r"
 
 
+def _get_stdio_bytes_buffer(stdio):
+    # type: (IO[str]) -> BinaryIO
+    return cast("BinaryIO", getattr(stdio, "buffer", stdio))
+
+
 def get_stdout_bytes_buffer():
-    # type: () -> BytesIO
-    return cast(BytesIO, getattr(sys.stdout, "buffer", sys.stdout))
+    # type: () -> BinaryIO
+    return _get_stdio_bytes_buffer(sys.stdout)
+
+
+def get_stderr_bytes_buffer():
+    # type: () -> BinaryIO
+    return _get_stdio_bytes_buffer(sys.stderr)
 
 
 if PY3:

--- a/pex/pip/tailer.py
+++ b/pex/pip/tailer.py
@@ -1,0 +1,126 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, print_function
+
+import errno
+import os
+import re
+from threading import Condition, Event, Thread
+
+from pex.compatibility import get_stdout_bytes_buffer
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import BinaryIO, Iterable, Optional, Pattern
+
+
+class Tailer(Thread):
+    @classmethod
+    def tail(
+        cls,
+        path,  # type: str
+        encoding="utf-8",  # type: str
+        filters=(),  # type: Iterable[Pattern]
+        poll_interval=0.1,  # type: float
+        output=get_stdout_bytes_buffer(),  # type: BinaryIO
+    ):
+        # type: (...) -> Tailer
+        tailer = cls(
+            path, encoding=encoding, filters=filters, poll_interval=poll_interval, output=output
+        )
+        tailer.start()
+        return tailer
+
+    def __init__(
+        self,
+        path,  # type: str
+        encoding="utf-8",  # type: str
+        filters=(),  # type: Iterable[Pattern]
+        poll_interval=0.1,  # type: float
+        output=get_stdout_bytes_buffer(),  # type: BinaryIO
+    ):
+        super(Tailer, self).__init__(name="Tailing {path}".format(path=path))
+        self.daemon = True
+
+        self._path = path
+        self._encoding = encoding
+        self._filters = filters or [re.compile(r".*")]
+        self._poll_interval = poll_interval
+        self._output = output
+
+        self._offset = 0
+        self._observer = Condition()
+        self._stopped = Event()
+
+    def __enter__(self):
+        if not self._stopped.is_set() and not self.is_alive():
+            self.start()
+        return self
+
+    def __exit__(self, _exc_type, _exc_val, _exc_tb):
+        self.stop()
+
+    def run(self):
+        while not self._stopped.is_set():
+            if not self._tail():
+                self._stopped.wait(self._poll_interval)
+        self._tail()
+
+    def _tail(self):
+        # type: () -> bool
+        try:
+            offset = os.path.getsize(self._path)
+            if offset <= self._offset:
+                # We do not handle generic tailing here where the file may be truncated and then
+                # re-grow. The Pip log case is a simple always growing file.
+                return False
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                # The file may not exist yet; so we just wait for it to appear.
+                return False
+            raise e
+
+        with open(self._path, "rb") as fp:
+            fp.seek(self._offset)
+            while fp.tell() < offset:
+                line_bytes = fp.readline()
+                line = line_bytes.decode(self._encoding)
+                for pattern in self._filters:
+                    match = pattern.match(line)
+                    if match:
+                        if match.groups():
+                            eol = re.search(r"(?P<eol>\r\n|\r|\n)$", line)
+                            self._output.write(
+                                "{groups}{eol}".format(
+                                    groups="".join(match.groups()),
+                                    eol=eol.group("eol") if eol else "",
+                                ).encode(self._encoding)
+                            )
+                        else:
+                            self._output.write(line_bytes)
+                        break
+            self._offset = fp.tell()
+
+        self._notify_observers()
+        return True
+
+    def _notify_observers(self):
+        with self._observer:
+            self._observer.notify_all()
+
+    def observe(self, timeout=None):
+        # type: (Optional[float]) -> None
+        """Wait for at least one new line of tailer output to be observable.
+
+        Waits forever unless `timeout` is specified, in which case wait at most that many seconds,
+        but returns immediately if the tailer is stopped.
+        """
+        if not self._stopped.is_set():
+            with self._observer:
+                self._observer.wait(timeout=timeout)
+
+    def stop(self):
+        # type: () -> None
+        self._stopped.set()
+        self.join()

--- a/pex/resolve/lockfile/operations.py
+++ b/pex/resolve/lockfile/operations.py
@@ -271,6 +271,7 @@ def create(
             max_parallel_jobs=pip_configuration.max_jobs,
             observer=lock_observer,
             dest=download_dir,
+            preserve_log=pip_configuration.preserve_log,
         )
     except resolvers.ResolveError as e:
         return Error(str(e))

--- a/pex/resolve/resolver_configuration.py
+++ b/pex/resolve/resolver_configuration.py
@@ -72,6 +72,7 @@ class PipConfiguration(object):
     build_isolation = attr.ib(default=True)  # type: bool
     transitive = attr.ib(default=True)  # type: bool
     max_jobs = attr.ib(default=DEFAULT_MAX_JOBS)  # type: int
+    preserve_log = attr.ib(default=False)  # type: bool
 
 
 @attr.s(frozen=True)

--- a/pex/resolve/resolver_options.py
+++ b/pex/resolve/resolver_options.py
@@ -213,6 +213,13 @@ def register(
         help="Whether to transitively resolve requirements.",
     )
     register_max_jobs_option(parser)
+    parser.add_argument(
+        "--preserve-pip-download-log",
+        "--no-preserve-pip-download-log",
+        default=default_resolver_configuration.preserve_log,
+        action=HandleBoolAction,
+        help="Preserve the `pip download` log and print its location to stderr.",
+    )
 
 
 def register_lock_options(parser):
@@ -415,6 +422,7 @@ def create_pip_configuration(options):
         build_isolation=options.build_isolation,
         transitive=options.transitive,
         max_jobs=get_max_jobs_value(options),
+        preserve_log=options.preserve_pip_download_log,
     )
 
 

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -65,6 +65,7 @@ class DownloadRequest(object):
     use_pep517 = attr.ib(default=None)  # type: Optional[bool]
     build_isolation = attr.ib(default=True)  # type: bool
     observer = attr.ib(default=None)  # type: Optional[ResolveObserver]
+    preserve_log = attr.ib(default=False)  # type: bool
 
     def iter_local_projects(self):
         # type: () -> Iterator[BuildRequest]
@@ -120,6 +121,7 @@ class DownloadRequest(object):
             use_pep517=self.use_pep517,
             build_isolation=self.build_isolation,
             observer=observer,
+            preserve_log=self.preserve_log,
         )
 
         return SpawnedJob.wait(job=download_job, result=download_result)
@@ -811,6 +813,7 @@ def resolve(
     max_parallel_jobs=None,  # type: Optional[int]
     ignore_errors=False,  # type: bool
     verify_wheels=True,  # type: bool
+    preserve_log=False,  # type: bool
 ):
     # type: (...) -> Installed
     """Resolves all distributions needed to meet requirements for multiple distribution targets.
@@ -855,6 +858,8 @@ def resolve(
       building and installing distributions in a resolve. Defaults to the number of CPUs available.
     :keyword ignore_errors: Whether to ignore resolution solver errors. Defaults to ``False``.
     :keyword verify_wheels: Whether to verify wheels have valid metadata. Defaults to ``True``.
+    :keyword preserve_log: Preserve the `pip download` log and print its location to stderr.
+      Defaults to ``False``.
     :returns: The installed distributions meeting all requirements and constraints.
     :raises Unsatisfiable: If ``requirements`` is not transitively satisfiable.
     :raises Untranslatable: If no compatible distributions could be acquired for
@@ -915,6 +920,7 @@ def resolve(
         use_pep517=use_pep517,
         build_isolation=build_isolation,
         max_parallel_jobs=max_parallel_jobs,
+        preserve_log=preserve_log,
     )
 
     install_requests = []  # type: List[InstallRequest]
@@ -960,6 +966,7 @@ def _download_internal(
     dest=None,  # type: Optional[str]
     max_parallel_jobs=None,  # type: Optional[int]
     observer=None,  # type: Optional[ResolveObserver]
+    preserve_log=False,  # type: bool
 ):
     # type: (...) -> Tuple[List[BuildRequest], List[DownloadResult]]
 
@@ -979,6 +986,7 @@ def _download_internal(
         use_pep517=use_pep517,
         build_isolation=build_isolation,
         observer=observer,
+        preserve_log=preserve_log,
     )
 
     local_projects = list(download_request.iter_local_projects())
@@ -1039,6 +1047,7 @@ def download(
     dest=None,  # type: Optional[str]
     max_parallel_jobs=None,  # type: Optional[int]
     observer=None,  # type: Optional[ResolveObserver]
+    preserve_log=False,  # type: bool
 ):
     # type: (...) -> Downloaded
     """Downloads all distributions needed to meet requirements for multiple distribution targets.
@@ -1078,6 +1087,8 @@ def download(
     :keyword max_parallel_jobs: The maximum number of parallel jobs to use when resolving,
       building and installing distributions in a resolve. Defaults to the number of CPUs available.
     :keyword observer: An optional observer of the download internals.
+    :keyword preserve_log: Preserve the `pip download` log and print its location to stderr.
+      Defaults to ``False``.
     :returns: The local distributions meeting all requirements and constraints.
     :raises Unsatisfiable: If the resolution of download of distributions fails for any reason.
     :raises ValueError: If a foreign platform was provided in `platforms`, and `use_wheel=False`.
@@ -1108,6 +1119,7 @@ def download(
         dest=dest,
         max_parallel_jobs=max_parallel_jobs,
         observer=observer,
+        preserve_log=preserve_log,
     )
 
     local_distributions = []

--- a/tests/integration/cli/commands/test_issue_1801.py
+++ b/tests/integration/cli/commands/test_issue_1801.py
@@ -1,0 +1,49 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+import re
+
+from pex.cli.testing import run_pex3
+from pex.resolve.lockfile import json_codec
+
+
+def test_preserve_pip_download_log():
+    # type: () -> None
+
+    result = run_pex3("lock", "create", "ansicolors==1.1.8", "--preserve-pip-download-log")
+    result.assert_success()
+
+    match = re.search(r"^pex: Preserving `pip download` log at (?P<log_path>.*)\.$", result.error)
+    assert match is not None
+    log_path = match.group("log_path")
+    assert os.path.exists(log_path)
+    expected_url = (
+        "https://files.pythonhosted.org/packages/53/18/"
+        "a56e2fe47b259bb52201093a3a9d4a32014f9d85071ad07e9d60600890ca/"
+        "ansicolors-1.1.8-py2.py3-none-any.whl"
+    )
+    expected_algorithm = "sha256"
+    expected_hash = "00d2dde5a675579325902536738dd27e4fac1fd68f773fe36c21044eb559e187"
+    with open(log_path) as fp:
+        assert (
+            "Added ansicolors==1.1.8 from {url}#{algorithm}={hash} to build tracker".format(
+                url=expected_url, algorithm=expected_algorithm, hash=expected_hash
+            )
+            in fp.read()
+        )
+
+    lockfile = json_codec.loads(result.output)
+    assert 1 == len(lockfile.locked_resolves)
+
+    locked_resolve = lockfile.locked_resolves[0]
+    assert 1 == len(locked_resolve.locked_requirements)
+
+    locked_requirement = locked_resolve.locked_requirements[0]
+    artifacts = tuple(locked_requirement.iter_artifacts())
+    assert 1 == len(artifacts)
+
+    artifact = artifacts[0]
+    assert expected_url == artifact.url
+    assert expected_algorithm == artifact.fingerprint.algorithm
+    assert expected_hash == artifact.fingerprint.hash

--- a/tests/pip/test_tailer.py
+++ b/tests/pip/test_tailer.py
@@ -1,0 +1,110 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+import re
+from contextlib import contextmanager
+
+from pex.pip.tailer import Tailer
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, BinaryIO, Iterator, Optional, Pattern
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class TailerTestHarness(object):
+    @classmethod
+    @contextmanager
+    def create(
+        cls,
+        tmpdir,  # type: Any
+        *filters  # type: Pattern
+    ):
+        # type: (...) -> Iterator[TailerTestHarness]
+
+        log = os.path.join(str(tmpdir), "log")
+        tail_to = os.path.join(str(tmpdir), "redirect")
+
+        with open(tail_to, "wb") as tail_to_fp, Tailer(
+            path=log, filters=filters, poll_interval=0.01, output=tail_to_fp
+        ) as tailer:
+            yield TailerTestHarness(log=log, tail_to_fp=tail_to_fp, tailer=tailer)
+
+    _log = attr.ib()  # type: str
+    _tail_to_fp = attr.ib()  # type: BinaryIO
+    _tailer = attr.ib()  # type: Tailer
+
+    def __enter__(self):
+        # type: () -> TailerTestHarness
+        self._tailer.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._tailer.__exit__(exc_type, exc_val, exc_tb)
+
+    def write_log(self, content):
+        with open(self._log, "a") as log_fp:
+            log_fp.write(content)
+
+    def assert_redirected_content(
+        self,
+        content,  # type: str
+        timeout=None,  # type: Optional[float]
+    ):
+        # type: (...) -> None
+
+        self._tailer.observe(timeout=timeout)
+        self._tail_to_fp.flush()
+        with open(self._tail_to_fp.name) as observe_fp:
+            assert content == observe_fp.read()
+
+
+def test_tailer_all_lines(tmpdir):
+    # type: (Any) -> None
+
+    with TailerTestHarness.create(tmpdir) as harness:
+        harness.assert_redirected_content("", timeout=0.1)
+
+        harness.write_log("1st line\n")
+        harness.assert_redirected_content("1st line\n")
+
+        harness.write_log("2nd line\n")
+        harness.assert_redirected_content("1st line\n2nd line\n")
+
+        harness.write_log("3rd line\n4th line\n")
+        harness.assert_redirected_content("1st line\n2nd line\n3rd line\n4th line\n")
+
+        harness.write_log("tail content")
+        harness.assert_redirected_content("1st line\n2nd line\n3rd line\n4th line\ntail content")
+
+
+def test_tailer_filter(tmpdir):
+    # type: (Any) -> None
+
+    with TailerTestHarness.create(
+        tmpdir,
+        re.compile(r"^2nd.*"),
+        re.compile(r"^(\S+) content$"),
+        re.compile(r"^multi (\S+) (\S+).*$"),
+    ) as harness:
+        harness.assert_redirected_content("", timeout=0.1)
+
+        harness.write_log("1st line\n")
+        harness.assert_redirected_content("")
+
+        harness.write_log("2nd line\n")
+        harness.assert_redirected_content("2nd line\n")
+
+        harness.write_log("3rd line\n4th line\n")
+        harness.assert_redirected_content("2nd line\n")
+
+        harness.write_log("multi one two three\n")
+        harness.assert_redirected_content("2nd line\nonetwo\n")
+
+        harness.write_log("tail content")
+        harness.assert_redirected_content("2nd line\nonetwo\ntail")


### PR DESCRIPTION
Introduce a `pip download` log tailer that can redirect selected log
lines to stderr. Use this to surface Pip backtracking warnings for long
running downloads to provide some visibility into slow resolves when
Pex verbosity is turned on.

Also add an option to preserve the `pip download` log in full for both
live and post-mortem inspection.

Fixes #1801