### PR TITLE
Use `pip download` instead or `URLFetcher`.

### DIFF
--- a/pex/auth.py
+++ b/pex/auth.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 
 import os
+import re
 from netrc import NetrcParseError, netrc
 
 from pex import pex_warnings
@@ -19,16 +20,48 @@ else:
 
 
 @attr.s(frozen=True)
-class PasswordEntry(object):
-    @staticmethod
-    def _reduced_url(url_info):
-        # type: (urlparse.ParseResult) -> str
-        return "{scheme}://{host}{port}".format(
-            scheme=url_info.scheme,
+class BaseURL(object):
+    @classmethod
+    def from_url_info(cls, url_info):
+        # type: (urlparse.ParseResult) -> BaseURL
+
+        if not url_info.scheme:
+            raise ValueError(
+                "Expected a scheme for the BaseURL. Given: {url_info}".format(url_info=url_info)
+            )
+
+        if not url_info.hostname and "file" != url_info.scheme:
+            raise ValueError(
+                "Expected a hostname for a BaseURL with {scheme} scheme. Given: {url_info}".format(
+                    scheme=url_info.scheme, url_info=url_info
+                )
+            )
+
+        if "file" == url_info.scheme:
+            return cls(reduced_url="file://{path}".format(path=url_info.path))
+
+        return cls(
+            reduced_url="{scheme}://{host}{port}".format(
+                scheme=url_info.scheme,
+                host=url_info.hostname,
+                port=":{port}".format(port=url_info.port) if url_info.port is not None else "",
+            ),
             host=url_info.hostname,
-            port=":{port}".format(port=url_info.port) if url_info.port is not None else "",
+            port=url_info.port,
         )
 
+    @classmethod
+    def from_url(cls, url):
+        # type: (Text) -> BaseURL
+        return cls.from_url_info(urlparse.urlparse(url))
+
+    reduced_url = attr.ib()  # type: str
+    host = attr.ib(default=None)  # type: Optional[str]
+    port = attr.ib(default=None)  # type: Optional[int]
+
+
+@attr.s(frozen=True)
+class PasswordEntry(object):
     @classmethod
     def maybe_extract_from_url(cls, url):
         # type: (str) -> Optional[PasswordEntry]
@@ -37,18 +70,36 @@ class PasswordEntry(object):
             return None
 
         return cls(
-            uri=cls._reduced_url(url_info),
+            base_url=BaseURL.from_url_info(url_info),
             username=url_info.username,
             password=url_info.password,
         )
 
     username = attr.ib()  # type: str
     password = attr.ib()  # type: str
-    uri = attr.ib(default=None)  # type: Optional[str]
+    base_url = attr.ib(default=None)  # type: Optional[BaseURL]
 
     def uri_or_default(self, url):
         # type: (Text) -> str
-        return self.uri or self._reduced_url(urlparse.urlparse(url))
+        return (self.base_url or BaseURL.from_url(url)).reduced_url
+
+    def maybe_inject_in_url(self, url):
+        # type: (str) -> Optional[str]
+        url_info = urlparse.urlparse(url)
+
+        if url_info.username or url_info.password:
+            # Don't stomp credentials already embedded in an URL.
+            return None
+
+        if self.base_url:
+            if BaseURL.from_url_info(url_info) != self.base_url:
+                return None
+
+        scheme, netloc, path, params, query, fragment = url_info
+        netloc = "{username}:{password}@{netloc}".format(
+            username=self.username, password=self.password, netloc=netloc
+        )
+        return urlparse.urlunparse((scheme, netloc, path, params, query, fragment))
 
 
 @attr.s(frozen=True)
@@ -80,7 +131,7 @@ class PasswordDatabase(object):
 
                 if machine == "default":
                     # The `default` entry is special and means just that; so we omit any qualifying
-                    # URI.
+                    # base URL.
                     yield PasswordEntry(username=login, password=password)
 
                 # Traditionally, ~/.netrc machine entries just contain a bare hostname but we allow
@@ -88,13 +139,21 @@ class PasswordDatabase(object):
                 # used as the beholder sees fit (it's a shared ~community format at this point and
                 # used differently by a wide range of tools; I think FTP originally - thus it has
                 # `macros` entries which ~no-one knows about / uses).
-                if urlparse.urlparse(machine).scheme:
-                    yield PasswordEntry(uri=machine, username=login, password=password)
+                #
+                # For scheme syntax, see: https://datatracker.ietf.org/doc/html/rfc3986#section-3.1
+                if re.search(r"^(?P<scheme>[a-zA-Z][a-zA-Z\d+.-]*)://", machine):
+                    yield PasswordEntry(
+                        base_url=BaseURL.from_url(machine),
+                        username=login,
+                        password=password,
+                    )
                     continue
 
                 for scheme in "http", "https":
                     yield PasswordEntry(
-                        uri="{scheme}://{machine}".format(scheme=scheme, machine=machine),
+                        base_url=BaseURL.from_url(
+                            "{scheme}://{machine}".format(scheme=scheme, machine=machine)
+                        ),
                         username=login,
                         password=password,
                     )

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -43,7 +43,7 @@ from pex.resolve.resolver_configuration import (
 )
 from pex.resolve.resolvers import Unsatisfiable
 from pex.resolver import resolve
-from pex.result import try_
+from pex.result import catch, try_
 from pex.targets import Targets
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING, cast
@@ -770,13 +770,16 @@ def main(args=None):
             except target_configuration.InterpreterConstraintsNotSatisfied as e:
                 die(str(e), exit_code=CANNOT_SETUP_INTERPRETER)
 
-            do_main(
-                options=options,
-                requirement_configuration=requirement_configuration,
-                resolver_configuration=resolver_configuration,
-                targets=targets,
-                cmdline=cmdline,
-                env=env,
+            sys.exit(
+                catch(
+                    do_main,
+                    options=options,
+                    requirement_configuration=requirement_configuration,
+                    resolver_configuration=resolver_configuration,
+                    targets=targets,
+                    cmdline=cmdline,
+                    env=env,
+                )
             )
     except GlobalConfigurationError as e:
         die(str(e))

--- a/pex/hashing.py
+++ b/pex/hashing.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import hashlib
 import os
+from contextlib import contextmanager
 
 from pex.typing import TYPE_CHECKING, Generic
 
@@ -65,6 +66,10 @@ class Fingerprint(str):
 
     def __ne__(self, other):
         return not self == other
+
+    def __hash__(self):
+        # type: () -> int
+        return hash((self.algorithm, str(self)))
 
 
 def new_fingerprint(

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -21,7 +21,7 @@ from pex.common import is_exe, safe_mkdtemp, safe_rmtree
 from pex.compatibility import string
 from pex.dist_metadata import DistMetadata, Distribution, Requirement, RequirementParseError
 from pex.executor import Executor
-from pex.jobs import ErrorHandler, Job, Retain, SpawnedJob, execute_parallel
+from pex.jobs import Job, Retain, SpawnedJob, execute_parallel
 from pex.orderedset import OrderedSet
 from pex.pep_425 import CompatibilityTags
 from pex.pep_440 import Version
@@ -607,7 +607,7 @@ class PythonInterpreter(object):
         def iter_interpreters():
             # type: () -> Iterator[PythonInterpreter]
             for candidate in cls._find(
-                cls._paths(paths=paths), path_filter=path_filter, error_handler=Retain()
+                cls._paths(paths=paths), path_filter=path_filter, error_handler=Retain[str]()
             ):
                 if isinstance(candidate, cls):
                     yield candidate
@@ -899,7 +899,7 @@ class PythonInterpreter(object):
     def _find(
         cls,
         paths,  # type: Iterable[str]
-        error_handler,  # type: Retain
+        error_handler,  # type: Retain[str]
         path_filter=None,  # type: Optional[PathFilter]
     ):
         # type: (...) -> Iterator[InterpreterOrJobError]
@@ -909,7 +909,7 @@ class PythonInterpreter(object):
     def _find(
         cls,
         paths,  # type: Iterable[str]
-        error_handler=None,  # type: Optional[ErrorHandler]
+        error_handler=None,  # type: Optional[Retain[str]]
         path_filter=None,  # type: Optional[PathFilter]
     ):
         # type: (...) -> Union[Iterator[PythonInterpreter], Iterator[InterpreterOrJobError]]
@@ -937,7 +937,7 @@ class PythonInterpreter(object):
     def _identify_interpreters(
         cls,
         filter,  # type: PathFilter
-        error_handler,  # type: Retain
+        error_handler,  # type: Retain[str]
         paths=None,  # type: Optional[Iterable[str]]
     ):
         # type: (...) -> Iterator[InterpreterOrJobError]
@@ -947,7 +947,7 @@ class PythonInterpreter(object):
     def _identify_interpreters(
         cls,
         filter,  # type: PathFilter
-        error_handler=None,  # type: Optional[ErrorHandler]
+        error_handler=None,  # type: Optional[Retain[str]]
         paths=None,  # type: Optional[Iterable[str]]
     ):
         # type: (...) -> Union[Iterator[PythonInterpreter], Iterator[InterpreterOrJobError]]

--- a/pex/jobs.py
+++ b/pex/jobs.py
@@ -8,16 +8,20 @@ import subprocess
 from abc import abstractmethod
 from threading import BoundedSemaphore, Event, Thread
 
-from pex.compatibility import AbstractClass, Queue, cpu_count
+from pex.compatibility import Queue, cpu_count
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING, Generic
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Iterable, Optional, Text, Tuple, TypeVar
+    from typing import Any, Callable, Iterable, Iterator, Optional, Text, Tuple, TypeVar, Union
 
     import attr  # vendor:skip
 
+    _I = TypeVar("_I")
+    _O = TypeVar("_O")
     _T = TypeVar("_T")
+    _SE = TypeVar("_SE")
+    _JE = TypeVar("_JE")
 else:
     from pex.third_party import attr
 
@@ -339,17 +343,27 @@ def _sanitize_max_jobs(max_jobs=None):
         return min(max_jobs, _ABSOLUTE_MAX_JOBS)
 
 
-class ErrorHandler(AbstractClass):  # type: ignore[valid-type, misc]
+class ErrorHandler(Generic["_I", "_SE", "_JE"]):
     """Handles errors encountered in the context of spawning and awaiting the result of a `Job`."""
 
     @classmethod
-    def spawn_error_message(cls, item, exception):
+    def spawn_error_message(
+        cls,
+        item,  # type: _I
+        exception,  # type: Exception
+    ):
+        # type: (...) -> str
         return "Failed to spawn a job for {item}: {exception}".format(
             item=item, exception=exception
         )
 
     @classmethod
-    def job_error_message(cls, _item, job_error):
+    def job_error_message(
+        cls,
+        _item,  # type: _I
+        job_error,  # type: Job.Error
+    ):
+        # type: (...) -> str
         return "pid {pid} -> {command} exited with {exitcode} and STDERR:\n{stderr}".format(
             pid=job_error.pid,
             command=" ".join(job_error.command),
@@ -358,7 +372,12 @@ class ErrorHandler(AbstractClass):  # type: ignore[valid-type, misc]
         )
 
     @abstractmethod
-    def handle_spawn_error(self, item, exception):
+    def handle_spawn_error(
+        self,
+        item,  # type: _I
+        exception,  # type: Exception
+    ):
+        # type: (...) -> _SE
         """Handle an error encountered spawning a job.
 
         :param item: The item that was the input for the spawned job.
@@ -370,7 +389,12 @@ class ErrorHandler(AbstractClass):  # type: ignore[valid-type, misc]
         """
 
     @abstractmethod
-    def handle_job_error(self, item, job_error):
+    def handle_job_error(
+        self,
+        item,  # type: _I
+        job_error,  # type: Job.Error
+    ):
+        # type: (...) -> _JE
         """Handle a job that exits unsuccessfully.
 
         :param item: The item that was the input for the spawned job.
@@ -382,7 +406,7 @@ class ErrorHandler(AbstractClass):  # type: ignore[valid-type, misc]
         """
 
 
-class Raise(ErrorHandler):
+class Raise(ErrorHandler["_I", "_O", "_O"], Generic["_I", "_O"]):
     """Re-raises errors encountered spawning or awaiting the result of a `Job`."""
 
     def __init__(self, raise_type):
@@ -399,7 +423,7 @@ class Raise(ErrorHandler):
         raise self._raise_type(self.job_error_message(item, job_error))
 
 
-class Retain(ErrorHandler):
+class Retain(ErrorHandler["_I", "Tuple[_I, Exception]", "Tuple[_I, Job.Error]"], Generic["_I"]):
     """Retains errors encountered spawning or awaiting the result of a `Job`.
 
     The retained errors are returned as the result of the failed `Job` in the form of (item, error)
@@ -414,7 +438,7 @@ class Retain(ErrorHandler):
         return item, job_error
 
 
-class Log(ErrorHandler):
+class Log(ErrorHandler["_I", "_O", "_O"], Generic["_I", "_O"]):
     """Logs errors encountered spawning or awaiting the result of a `Job`."""
 
     def handle_spawn_error(self, item, exception):
@@ -426,7 +450,13 @@ class Log(ErrorHandler):
         return None
 
 
-def execute_parallel(inputs, spawn_func, error_handler=None, max_jobs=None):
+def execute_parallel(
+    inputs,  # type: Iterable[_I]
+    spawn_func,  # type: Callable[[_I], SpawnedJob[_O]]
+    error_handler=None,  # type: Optional[ErrorHandler[_I, _SE, _JE]]
+    max_jobs=None,  # type: Optional[int]
+):
+    # type: (...) -> Iterator[Union[_O, _SE, _JE]]
     """Execute jobs for the given inputs in parallel.
 
     :param int max_jobs: The maximum number of parallel jobs to spawn.
@@ -436,14 +466,9 @@ def execute_parallel(inputs, spawn_func, error_handler=None, max_jobs=None):
     :returns: An iterator over the spawned job results as they come in.
     :raises: A `raise_type` exception if any individual job errors and `raise_type` is not `None`.
     """
-    error_handler = error_handler or Log()
-    if not isinstance(error_handler, ErrorHandler):
-        raise ValueError(
-            "Given error_handler {} of type {}, expected an {}".format(
-                error_handler, type(error_handler), ErrorHandler
-            )
-        )
-
+    handler = (
+        error_handler or Log["_I", "_O"]()
+    )  # type: Union[ErrorHandler[_I, _SE, _JE], Log[_I, _O]]
     size = _sanitize_max_jobs(max_jobs)
     TRACER.log(
         "Spawning a maximum of {} parallel jobs to process:\n  {}".format(
@@ -464,8 +489,12 @@ def execute_parallel(inputs, spawn_func, error_handler=None, max_jobs=None):
 
     stop = Event()  # Used as a signal to stop spawning further jobs once any one job fails.
     job_slots = BoundedSemaphore(value=size)
-    done_sentinel = object()
-    spawn_queue = Queue()  # Queue[Union[Spawn, SpawnError, Literal[done_sentinel]]]
+
+    class DoneSentinel(object):
+        pass
+
+    done_sentinel = DoneSentinel()
+    spawn_queue = Queue()  # type: Queue[Union[Spawn, SpawnError, DoneSentinel]]
 
     def spawn_jobs():
         for item in inputs:
@@ -488,7 +517,7 @@ def execute_parallel(inputs, spawn_func, error_handler=None, max_jobs=None):
     while True:
         spawn_result = spawn_queue.get()
 
-        if spawn_result is done_sentinel:
+        if isinstance(spawn_result, DoneSentinel):
             if error:
                 raise error
             return
@@ -496,9 +525,9 @@ def execute_parallel(inputs, spawn_func, error_handler=None, max_jobs=None):
         try:
             if isinstance(spawn_result, SpawnError):
                 try:
-                    result = error_handler.handle_spawn_error(spawn_result.item, spawn_result.error)
-                    if result is not None:
-                        yield result
+                    se_result = handler.handle_spawn_error(spawn_result.item, spawn_result.error)
+                    if se_result is not None:
+                        yield se_result
                 except Exception as e:
                     # Fail fast and proceed to kill all outstanding spawned jobs.
                     stop.set()
@@ -512,9 +541,9 @@ def execute_parallel(inputs, spawn_func, error_handler=None, max_jobs=None):
                     yield spawn_result.spawned_job.await_result()
                 except Job.Error as e:
                     try:
-                        result = error_handler.handle_job_error(spawn_result.item, e)
-                        if result is not None:
-                            yield result
+                        je_result = handler.handle_job_error(spawn_result.item, e)
+                        if je_result is not None:
+                            yield je_result
                     except Exception as e:
                         # Fail fast and proceed to kill all outstanding spawned jobs.
                         stop.set()

--- a/pex/pip/tool.py
+++ b/pex/pip/tool.py
@@ -331,6 +331,8 @@ class Pip(object):
             #   (a)bort.
             "--exists-action",
             "a",
+            # We are not interactive.
+            "--no-input",
         ]
         python_interpreter = interpreter or PythonInterpreter.get()
         pip_args.extend(
@@ -398,6 +400,7 @@ class Pip(object):
             # + https://github.com/pypa/pip/issues/9420
             if "stdout" not in popen_kwargs:
                 popen_kwargs["stdout"] = sys.stderr.fileno()
+            popen_kwargs.update(stderr=subprocess.PIPE)
 
             args = [self._pip_pex_path] + command
             return args, subprocess.Popen(args=args, env=env, **popen_kwargs)
@@ -530,7 +533,7 @@ class Pip(object):
         log = None
         popen_kwargs = {}
         if log_analyzers:
-            log = os.path.join(safe_mkdtemp(prefix="pex-pip-log"), "pip.log")
+            log = os.path.join(safe_mkdtemp(prefix="pex-pip-log."), "pip.log")
             download_cmd = ["--log", log] + download_cmd
             # N.B.: The `pip -q download ...` command is quiet but
             # `pip -q --log log.txt download ...` leaks download progress bars to stdout. We work

--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -7,7 +7,7 @@ import os
 import re
 from contextlib import contextmanager
 
-from pex import attrs, dist_metadata
+from pex import attrs, dist_metadata, pex_warnings
 from pex.compatibility import urlparse
 from pex.dist_metadata import (
     MetadataError,
@@ -56,6 +56,11 @@ class Source(object):
         is_constraints=False,  # type: bool
     ):
         # type: (...) -> Iterator[Source]
+        pex_warnings.warn(
+            "Fetching {subject} files via url is deprecated: {url}".format(
+                url=url, subject="constraints" if is_constraints else "requirements"
+            )
+        )
         with fetcher.get_body_iter(url) as lines:
             yield cls(origin=url, is_file=False, is_constraints=is_constraints, lines=lines)
 

--- a/pex/resolve/downloads.py
+++ b/pex/resolve/downloads.py
@@ -1,0 +1,158 @@
+from __future__ import absolute_import
+
+import os.path
+import shutil
+
+from pex import hashing
+from pex.common import atomic_directory, safe_mkdir, safe_mkdtemp
+from pex.compatibility import urlparse
+from pex.hashing import Sha256
+from pex.jobs import Job, Raise, SpawnedJob, execute_parallel
+from pex.pip.tool import PackageIndexConfiguration, Pip, get_pip
+from pex.resolve.locked_resolve import Artifact, FileArtifact
+from pex.resolve.resolved_requirement import Fingerprint, PartialArtifact
+from pex.result import Error
+from pex.targets import LocalInterpreter, Target
+from pex.typing import TYPE_CHECKING
+from pex.variables import ENV
+
+if TYPE_CHECKING:
+    from typing import Dict, Iterable, Iterator, Optional, Union
+
+    import attr  # vendor:skip
+
+    from pex.hashing import HintedDigest
+else:
+    from pex.third_party import attr
+
+
+_DOWNLOADS_DIRS = {}  # type: Dict[str, str]
+
+
+def get_downloads_dir(pex_root=None):
+    # type: (Optional[str]) -> str
+    root_dir = pex_root or ENV.PEX_ROOT
+    downloads_dir = _DOWNLOADS_DIRS.get(root_dir)
+    if downloads_dir is None:
+        downloads_dir = os.path.join(root_dir, "downloads")
+        safe_mkdir(downloads_dir)
+        _DOWNLOADS_DIRS[root_dir] = downloads_dir
+    return downloads_dir
+
+
+def _strip_indexes_and_repos(package_index_configuration):
+    # type: (PackageIndexConfiguration) -> PackageIndexConfiguration
+    return PackageIndexConfiguration.create(
+        resolver_version=package_index_configuration.resolver_version,
+        indexes=[],
+        find_links=None,
+        network_configuration=package_index_configuration.network_configuration,
+        password_entries=package_index_configuration.password_entries,
+    )
+
+
+@attr.s(frozen=True)
+class ArtifactDownloader(object):
+    package_index_configuration = attr.ib(
+        default=PackageIndexConfiguration.create(), converter=_strip_indexes_and_repos
+    )  # type: PackageIndexConfiguration
+    target = attr.ib(default=LocalInterpreter.create())  # type: Target
+    _pip = attr.ib(init=False)  # type: Pip
+
+    def __attrs_post_init__(self):
+        object.__setattr__(self, "_pip", get_pip(interpreter=self.target.get_interpreter()))
+
+    @staticmethod
+    def _fingerprint_and_move(path):
+        # type: (str) -> Fingerprint
+        digest = Sha256()
+        hashing.file_hash(path, digest)
+        fingerprint = digest.hexdigest()
+        target_dir = os.path.join(get_downloads_dir(), fingerprint)
+        with atomic_directory(target_dir, exclusive=True) as atomic_dir:
+            if not atomic_dir.is_finalized():
+                shutil.move(path, os.path.join(atomic_dir.work_dir, os.path.basename(path)))
+        return Fingerprint(algorithm=fingerprint.algorithm, hash=fingerprint)
+
+    @staticmethod
+    def _create_file_artifact(
+        url,  # type: str
+        fingerprint,  # type: Fingerprint
+        verified,  # type: bool
+    ):
+        # type: (...) -> FileArtifact
+        fingerprinted_artifact = Artifact.from_url(url, fingerprint, verified=verified)
+        if not isinstance(fingerprinted_artifact, FileArtifact):
+            raise ValueError(
+                "Expected a file artifact, given url {url} which is a {artifact}.".format(
+                    url=url, artifact=fingerprinted_artifact
+                )
+            )
+        return fingerprinted_artifact
+
+    def _download(
+        self,
+        url,  # type: str
+        download_dir,  # type: str
+    ):
+        # type: (...) -> Job
+
+        for password_entry in self.package_index_configuration.password_entries:
+            credentialed_url = password_entry.maybe_inject_in_url(url)
+            if credentialed_url:
+                url = credentialed_url
+                break
+
+        return self._pip.spawn_download_distributions(
+            download_dir=download_dir,
+            requirements=[url],
+            transitive=False,
+            target=self.target,
+            package_index_configuration=self.package_index_configuration,
+        )
+
+    def _download_and_fingerprint(self, url):
+        # type: (str) -> SpawnedJob[FileArtifact]
+        downloads = get_downloads_dir()
+        download_dir = safe_mkdtemp(prefix="fingerprint_artifact.", dir=downloads)
+        temp_dest = os.path.join(
+            download_dir, os.path.basename(urlparse.unquote(urlparse.urlparse(url).path))
+        )
+        return SpawnedJob.and_then(
+            self._download(url=url, download_dir=download_dir),
+            result_func=lambda: self._create_file_artifact(
+                url, fingerprint=self._fingerprint_and_move(temp_dest), verified=True
+            ),
+        )
+
+    def _to_file_artifact(self, artifact):
+        # type: (PartialArtifact) -> SpawnedJob[FileArtifact]
+        url = artifact.url
+        fingerprint = artifact.fingerprint
+        if fingerprint:
+            return SpawnedJob.completed(
+                self._create_file_artifact(url, fingerprint, verified=artifact.verified)
+            )
+        return self._download_and_fingerprint(url)
+
+    def fingerprint(self, artifacts):
+        # type: (Iterable[PartialArtifact]) -> Iterator[FileArtifact]
+        return execute_parallel(
+            inputs=artifacts,
+            spawn_func=self._to_file_artifact,
+            error_handler=Raise[PartialArtifact, FileArtifact](IOError),
+        )
+
+    def download(
+        self,
+        artifact,  # type: FileArtifact
+        dest_dir,  # type: str
+        digest,  # type: HintedDigest
+    ):
+        # type: (...) -> Union[str, Error]
+        try:
+            self._download(url=artifact.url, download_dir=dest_dir).wait()
+        except Job.Error as e:
+            return Error((e.stderr or str(e)).splitlines()[-1])
+        hashing.file_hash(os.path.join(dest_dir, artifact.filename), digest)
+        return artifact.filename

--- a/pex/resolve/resolved_requirement.py
+++ b/pex/resolve/resolved_requirement.py
@@ -83,8 +83,8 @@ class ResolvedRequirement(object):
         for artifact in self.additional_artifacts:
             yield artifact
 
-    def iter_urls_to_fingerprint(self):
-        # type: () -> Iterator[str]
+    def iter_artifacts_to_fingerprint(self):
+        # type: () -> Iterator[PartialArtifact]
         for artifact in self.iter_artifacts():
             if not artifact.fingerprint:
-                yield artifact.url
+                yield artifact

--- a/pex/result.py
+++ b/pex/result.py
@@ -8,7 +8,7 @@ import sys
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, TypeVar, Union
+    from typing import Any, Callable, Text, TypeVar, Union
 
     import attr  # vendor:skip
 
@@ -20,7 +20,7 @@ else:
 @attr.s(frozen=True)
 class Result(object):
     exit_code = attr.ib()  # type: int
-    _message = attr.ib(default="")  # type: str
+    _message = attr.ib(default="")  # type: Text
 
     @property
     def is_error(self):
@@ -35,19 +35,19 @@ class Result(object):
 
     def __str__(self):
         # type: () -> str
-        return self._message
+        return str(self._message)
 
 
 class Ok(Result):
     def __init__(self, message=""):
-        # type: (str) -> None
+        # type: (Text) -> None
         super(Ok, self).__init__(exit_code=0, message=message)
 
 
 class Error(Result):
     def __init__(
         self,
-        message="",  # type: str
+        message="",  # type: Text
         exit_code=1,  # type: int
     ):
         # type: (...) -> None

--- a/pex/tools/commands/repository.py
+++ b/pex/tools/commands/repository.py
@@ -34,7 +34,7 @@ from pex.tools.command import PEXCommand
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from typing import IO, Callable, Iterable, Iterator, Text, Tuple
+    from typing import IO, Callable, Iterable, Iterator, List, Text, Tuple
 
     import attr  # vendor:skip
 
@@ -272,8 +272,10 @@ class Repository(JsonMixin, OutputMixin, PEXCommand):
             )
 
         with self._distributions_output(pex) as (distributions, output):
-            errors = []
-            for result in execute_parallel(distributions, spawn_extract, error_handler=Retain()):
+            errors = []  # type: List[Distribution]
+            for result in execute_parallel(
+                distributions, spawn_extract, error_handler=Retain[Distribution]()
+            ):
                 if isinstance(result, tuple):
                     distribution, error = result
                     errors.append(distribution)

--- a/tests/integration/cli/commands/test_lock.py
+++ b/tests/integration/cli/commands/test_lock.py
@@ -35,7 +35,6 @@ from pex.testing import (
     built_wheel,
     ensure_python_interpreter,
     make_env,
-    make_project,
     run_pex_command,
 )
 from pex.typing import TYPE_CHECKING
@@ -690,9 +689,6 @@ def test_update_targeted_impossible(
 
     error_lines = result.error.splitlines()
     assert [
-        "ERROR: Could not find a version that satisfies the requirement urllib3<1.27,>=1.21.1 "
-        "(from requests)",
-        "ERROR: No matching distribution found for urllib3<1.27,>=1.21.1",
         "ERROR: The following lock update constraints could not be satisfied:",
         "certifi==2021.5.30",
         "charset-normalizer==2.0.6",
@@ -700,13 +696,19 @@ def test_update_targeted_impossible(
         "requests==2.26",
         "urllib3<1.16",
         "Encountered 1 error updating {lock_file_path}:".format(lock_file_path=lock_file_path),
-    ] == error_lines[:9]
+    ] == error_lines[:7]
     assert re.match(
         r"^1\.\) {platform}: pid [\d]+ -> ".format(
             platform=LocalInterpreter.create(PythonInterpreter.from_binary(py310)).platform.tag
         ),
-        error_lines[9],
+        error_lines[7],
     )
+    assert [
+        "ERROR: Could not find a version that satisfies the requirement urllib3<1.27,>=1.21.1 "
+        "(from requests)",
+        "ERROR: No matching distribution found for urllib3<1.27,>=1.21.1",
+        "",
+    ] == error_lines[8:]
 
     # The pip legacy resolver, though is not strict and will let us get away with this.
     updated_lock_file_path = os.path.join(str(tmpdir), "lock.updated")
@@ -756,9 +758,6 @@ def test_update_add_impossible(
 
     error_lines = result.error.splitlines()
     assert [
-        "ERROR: Could not find a version that satisfies the requirement certifi<2017.4.17 "
-        "(from conflicting-certifi-requirement)",
-        "ERROR: No matching distribution found for certifi<2017.4.17",
         "ERROR: The following lock update constraints could not be satisfied:",
         "certifi==2021.5.30",
         "charset-normalizer==2.0.6",
@@ -766,13 +765,19 @@ def test_update_add_impossible(
         "requests==2.26",
         "urllib3==1.25.11",
         "Encountered 1 error updating {lock_file_path}:".format(lock_file_path=lock_file_path),
-    ] == error_lines[:9]
+    ] == error_lines[:7]
     assert re.match(
         r"^1\.\) {platform}: pid [\d]+ -> ".format(
             platform=LocalInterpreter.create(PythonInterpreter.from_binary(py310)).platform.tag
         ),
-        error_lines[9],
+        error_lines[7],
     )
+    assert [
+        "ERROR: Could not find a version that satisfies the requirement certifi<2017.4.17 "
+        "(from conflicting-certifi-requirement)",
+        "ERROR: No matching distribution found for certifi<2017.4.17",
+        "",
+    ] == error_lines[8:]
 
     # The pip legacy resolver, though is not strict and will let us get away with this.
     updated_lock_file_path = os.path.join(str(tmpdir), "lock.updated")

--- a/tests/integration/cli/commands/test_lock_resolve_auth.py
+++ b/tests/integration/cli/commands/test_lock_resolve_auth.py
@@ -166,8 +166,14 @@ def assert_unauthorized(
     assert (
         "There was 1 error downloading required artifacts:\n"
         "1. ansicolors 1.1.8 from {repo_url}/ansicolors-1.1.8-py2.py3-none-any.whl\n"
-        "    HTTP Error 401: Unauthorized".format(repo_url=secured_ansicolors_lock.repo_url)
-    ) in result.error
+        "    ERROR: Could not install requirement ansicolors==1.1.8 from "
+        "{repo_url}/ansicolors-1.1.8-py2.py3-none-any.whl because of HTTP error 401 Client Error: "
+        "Unauthorized for url: {repo_url}/ansicolors-1.1.8-py2.py3-none-any.whl for URL "
+        "{repo_url}/ansicolors-1.1.8-py2.py3-none-any.whl".format(
+            repo_url=secured_ansicolors_lock.repo_url
+        )
+    ) in result.error, result.error
+
     return result
 
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -34,7 +34,6 @@ from pex.testing import (
     PY310,
     PY_VER,
     IntegResults,
-    WheelBuilder,
     built_wheel,
     ensure_python_interpreter,
     get_dep_dist_names_from_pex,
@@ -1525,7 +1524,9 @@ def test_pip_issues_9420_workaround():
         quiet=True,
     )
     results.assert_failure()
-    normalized_stderr = "\n".join(line.strip() for line in results.error.strip().splitlines())
+    error_lines = [line.strip() for line in results.error.strip().splitlines()]
+    assert re.match(r"^pid \d+ -> .*", error_lines[0])
+    normalized_stderr = "\n".join(error_lines[1:])
     assert normalized_stderr.startswith(
         dedent(
             """\

--- a/tests/integration/test_lock_resolver.py
+++ b/tests/integration/test_lock_resolver.py
@@ -279,7 +279,7 @@ def test_unavailable_artifacts(
     assert re.search(
         r"There was 1 error downloading required artifacts:\n"
         r"1\. requests 2\.25\.1 from file://{requests_distribution}\n"
-        r"    .* No such file or directory: .*'{requests_distribution}'>".format(
+        r"    .* No such file or directory: .*'{requests_distribution}'".format(
             requests_distribution=re.escape(requests_distribution)
         ),
         result.error,

--- a/tests/integration/test_locked_resolve.py
+++ b/tests/integration/test_locked_resolve.py
@@ -7,7 +7,7 @@ import os
 import pytest
 
 from pex import dist_metadata, resolver, targets
-from pex.fetcher import URLFetcher
+from pex.auth import PasswordDatabase
 from pex.pip.tool import PackageIndexConfiguration
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.locked_resolve import LockConfiguration, LockedResolve, LockStyle
@@ -44,21 +44,22 @@ def normalize(
 def create_lock_observer(lock_configuration):
     # type: (LockConfiguration) -> LockObserver
     pip_configuration = PipConfiguration()
+    package_index_configuration = PackageIndexConfiguration.create(
+        resolver_version=pip_configuration.resolver_version,
+        indexes=pip_configuration.repos_configuration.indexes,
+        find_links=pip_configuration.repos_configuration.find_links,
+        network_configuration=pip_configuration.network_configuration,
+    )
     return LockObserver(
         lock_configuration=lock_configuration,
         resolver=ConfiguredResolver(pip_configuration=pip_configuration),
         wheel_builder=WheelBuilder(
-            package_index_configuration=PackageIndexConfiguration.create(
-                resolver_version=pip_configuration.resolver_version,
-                indexes=pip_configuration.repos_configuration.indexes,
-                find_links=pip_configuration.repos_configuration.find_links,
-                network_configuration=pip_configuration.network_configuration,
-            ),
+            package_index_configuration,
             prefer_older_binary=pip_configuration.prefer_older_binary,
             use_pep517=pip_configuration.use_pep517,
             build_isolation=pip_configuration.build_isolation,
         ),
-        url_fetcher=URLFetcher(network_configuration=pip_configuration.network_configuration),
+        package_index_configuration=package_index_configuration,
     )
 
 


### PR DESCRIPTION
This aligns lock file use network access with lock file creation
network access, leveraging Pip's internal vendored requests.

Fixes #1803