### PR TITLE
Simplify `PEX` teardown / leave stderr in tact.

### DIFF
--- a/pex/variables.py
+++ b/pex/variables.py
@@ -237,8 +237,9 @@ class Variables(object):
             )
         if "PEX_TEARDOWN_VERBOSE" in self._environ:
             pex_warnings.warn(
-                # TODO(John Sirois): XXX
-                ""
+                "The `PEX_TEARDOWN_VERBOSE` env var is deprecated. This env var is no longer read "
+                "since PEX teardown has been removed in favor of the natural teardown environment "
+                "provided by the Python runtime."
             )
 
     def copy(self):

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -235,6 +235,11 @@ class Variables(object):
                 "The `PEX_UNZIP` env var is deprecated. This env var is no longer read since "
                 "unzipping PEX zip files before execution is now the default."
             )
+        if "PEX_TEARDOWN_VERBOSE" in self._environ:
+            pex_warnings.warn(
+                # TODO(John Sirois): XXX
+                ""
+            )
 
     def copy(self):
         # type: () -> Dict[str, str]

--- a/tests/integration/test_issue_1802.py
+++ b/tests/integration/test_issue_1802.py
@@ -1,0 +1,96 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import os.path
+import subprocess
+from textwrap import dedent
+
+import pytest
+
+from pex.common import safe_open
+from pex.compatibility import PY2
+from pex.testing import run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+@pytest.mark.skipif(PY2, reason="Example code used to drive test is Python 3 only.")
+def test_stderr_not_torn_down(tmpdir):
+    # type: (Any) -> None
+
+    exe = os.path.join(str(tmpdir), "exe")
+    with safe_open(exe, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                import sys
+                import logging
+                import atexit
+                import logging.handlers
+                import queue
+                import sys
+                import faulthandler
+
+                import absl.app as absl_app
+                import absl.logging as absl_logging
+                from absl.flags import FLAGS
+
+
+                def run():
+                    print("hello")
+                    absl_logging.error("HELP ME")
+
+
+                def init_sys_logging():
+                    root_logger = logging.getLogger()
+
+                    FLAGS.alsologtostderr = True
+
+                    # No limit on queue size.
+                    log_queue = queue.Queue(-1)
+                    queue_forwarder = logging.handlers.QueueHandler(log_queue)
+                    root_logger.addHandler(queue_forwarder)
+
+                    queue_handlers = []
+
+                    # If absl logging is enabled; re-parent it to the queue.
+                    absl_handler = absl_logging.get_absl_handler()
+                    if absl_handler in root_logger.handlers:
+                        root_logger.handlers.remove(absl_handler)
+                        queue_handlers.append(absl_handler)
+
+                    queue_log_listener = logging.handlers.QueueListener(
+                        log_queue, *queue_handlers, respect_handler_level=True
+                    )
+                    queue_log_listener.start()
+
+                    atexit.register(queue_log_listener.stop)
+
+                    FLAGS.mark_as_parsed()
+
+
+                if __name__ == "__main__":
+                    absl_logging.set_verbosity(0)
+                    absl_logging.use_absl_handler()
+                    absl_logging.get_absl_handler().use_absl_log_file()
+
+                    faulthandler.enable()
+
+                    init_sys_logging()
+
+                    def run_wrapper(fn) -> int:
+                        absl_app._run_main(lambda args: fn(), sys.argv)
+                        return 0
+
+                    sys.exit(run_wrapper(run))
+                """
+            )
+        )
+    pex = os.path.join(str(tmpdir), "pex")
+    run_pex_command(args=["absl-py==0.10.0", "--exe", exe, "-o", pex]).assert_success()
+    process = subprocess.Popen(args=[pex], stderr=subprocess.PIPE)
+    _, stderr = process.communicate()
+    error = stderr.decode("utf-8")
+    assert 0 == process.returncode
+    assert "HELP ME" in error

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -22,7 +22,6 @@ from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
 from pex.testing import (
-    IS_PYPY3,
     PY27,
     PY310,
     WheelBuilder,
@@ -113,7 +112,6 @@ def test_pex_sys_exit_prints_objects():
     _test_sys_exit('Exception("derp")', b"derp\n", 1)
 
 
-@pytest.mark.xfail(IS_PYPY3, reason="https://github.com/pantsbuild/pex/issues/1210")
 def test_pex_atexit_swallowing():
     # type: () -> None
     body = textwrap.dedent(
@@ -128,12 +126,6 @@ def test_pex_atexit_swallowing():
     )
 
     so, rc = run_simple_pex_test(body)
-    assert so == b""
-    assert rc == 0
-
-    env_copy = os.environ.copy()
-    env_copy.update(PEX_TEARDOWN_VERBOSE="1")
-    so, rc = run_simple_pex_test(body, env=env_copy)
     assert b"This is an exception" in so
     assert rc == 0
 

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -22,6 +22,7 @@ from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
 from pex.testing import (
+    IS_PYPY,
     PY27,
     PY310,
     WheelBuilder,
@@ -66,7 +67,6 @@ def test_excepthook_honored():
 
         def excepthook(ex_type, ex, tb):
             print('Custom hook called with: {0}'.format(ex))
-            sys.exit(42)
 
         sys.excepthook = excepthook
 
@@ -76,7 +76,7 @@ def test_excepthook_honored():
 
     so, rc = run_simple_pex_test(body)
     assert so == b"Custom hook called with: This is an exception\n", "Standard out was: %r" % so
-    assert rc == 42
+    assert rc == 1
 
 
 def _test_sys_exit(arg, expected_output, expected_rc):


### PR DESCRIPTION
For historical reasons that are no longer relevant, `PEX` accrued
complicated teardown code that, among other things, replaced
`sys.stderr` with `/dev/null`. This could lead to lost messages to
stderr. Simply remove the complicated and no-longer useful code.

Fixes #1802