### PR TITLE
Fix `pex --lock ...` handling of sdists.

### DIFF
--- a/pex/resolve/downloads.py
+++ b/pex/resolve/downloads.py
@@ -40,21 +40,10 @@ def get_downloads_dir(pex_root=None):
     return downloads_dir
 
 
-def _strip_indexes_and_repos(package_index_configuration):
-    # type: (PackageIndexConfiguration) -> PackageIndexConfiguration
-    return PackageIndexConfiguration.create(
-        resolver_version=package_index_configuration.resolver_version,
-        indexes=[],
-        find_links=None,
-        network_configuration=package_index_configuration.network_configuration,
-        password_entries=package_index_configuration.password_entries,
-    )
-
-
 @attr.s(frozen=True)
 class ArtifactDownloader(object):
     package_index_configuration = attr.ib(
-        default=PackageIndexConfiguration.create(), converter=_strip_indexes_and_repos
+        default=PackageIndexConfiguration.create()
     )  # type: PackageIndexConfiguration
     target = attr.ib(default=LocalInterpreter.create())  # type: Target
     _pip = attr.ib(init=False)  # type: Pip

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -331,7 +331,8 @@ def resolve_from_lock(
             if package_index_configuration is None:
                 package_index_configuration = PackageIndexConfiguration.create(
                     resolver_version=resolver_version,
-                    indexes=[],
+                    indexes=indexes,
+                    find_links=find_links,
                     network_configuration=network_configuration,
                     password_entries=PasswordDatabase.from_netrc().append(password_entries).entries,
                 )

--- a/tests/integration/test_issue_1817.py
+++ b/tests/integration/test_issue_1817.py
@@ -1,0 +1,65 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import shutil
+
+from pex.cli.testing import run_pex3
+from pex.testing import run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def assert_create_and_use_sdist_lock(
+    tmpdir,  # type: Any
+    requirement,  # type: str
+    test,  # type: str
+):
+    # type: (...) -> None
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    lock = os.path.join(str(tmpdir), "lock.json")
+
+    run_pex3(
+        "lock",
+        "create",
+        "--pex-root",
+        pex_root,
+        "--no-wheel",
+        requirement,
+        "-o",
+        lock,
+        "--indent",
+        "2",
+    ).assert_success()
+
+    shutil.rmtree(pex_root)
+    run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--lock",
+            lock,
+            "--",
+            "-c",
+            test,
+        ]
+    ).assert_success()
+
+
+def test_sdist_for_project_universal(tmpdir):
+    # type: (Any) -> None
+    assert_create_and_use_sdist_lock(tmpdir, "ansicolors==1.1.8", "import colors")
+
+
+def test_sdist_for_project_with_native_extensions(tmpdir):
+    # type: (Any) -> None
+    assert_create_and_use_sdist_lock(tmpdir, "psutil==5.9.1", "import psutil")
+
+
+def test_sdist_for_project_with_pep517_build(tmpdir):
+    # type: (Any) -> None
+    assert_create_and_use_sdist_lock(tmpdir, "PyYAML==5.4.1", "import yaml")


### PR DESCRIPTION
As of Pex 2.1.93, sdists that built native extensions or used a PEP-517
build system would not be successfully downloaded when constructing a
PEX from a lock.

Fixes #1817