### PR TITLE
Avoid ENOEXEC for --venv shebangs.

### DIFF
--- a/pex/bin/sh_boot.py
+++ b/pex/bin/sh_boot.py
@@ -155,7 +155,7 @@ def create_sh_boot_script(
 
     venv_dir = pex_info.venv_dir(pex_file=pex_name, interpreter=interpreter)
     if venv_dir:
-        pex_installed_path = os.path.join(venv_dir, "pex")
+        pex_installed_path = venv_dir
     else:
         pex_hash = pex_info.pex_hash
         if pex_hash is None:
@@ -184,7 +184,7 @@ def create_sh_boot_script(
             # interpreter to use is embedded in the shebang of our venv pex script; so just
             # execute that script directly.
             export PEX="$0"
-            exec "${{INSTALLED_PEX}}" "$@"
+            exec "${{INSTALLED_PEX}}/bin/python" "${{INSTALLED_PEX}}" "$@"
         fi
 
         find_python() {{

--- a/pex/bin/sh_boot.py
+++ b/pex/bin/sh_boot.py
@@ -184,7 +184,7 @@ def create_sh_boot_script(
             # interpreter to use is embedded in the shebang of our venv pex script; so just
             # execute that script directly.
             export PEX="$0"
-            exec "${{INSTALLED_PEX}}/bin/python" "${{INSTALLED_PEX}}" "$@"
+            exec "${{INSTALLED_PEX}}/bin/python" -sE "${{INSTALLED_PEX}}" "$@"
         fi
 
         find_python() {{

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -559,7 +559,8 @@ def bootstrap_pex(entry_point):
                 venv_pex = ensure_venv(pex.PEX(entry_point, interpreter=target))
             except ValueError as e:
                 die(str(e))
-            os.execv(venv_pex, [venv_pex] + sys.argv[1:])
+            venv_python = os.path.join(os.path.dirname(venv_pex), "bin", "python")
+            os.execv(venv_python, [venv_python, venv_pex] + sys.argv[1:])
         else:
             maybe_reexec_pex(interpreter_test=interpreter_test)
             from . import pex

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -560,7 +560,7 @@ def bootstrap_pex(entry_point):
             except ValueError as e:
                 die(str(e))
             venv_python = os.path.join(os.path.dirname(venv_pex), "bin", "python")
-            os.execv(venv_python, [venv_python, venv_pex] + sys.argv[1:])
+            os.execv(venv_python, [venv_python, "-sE", venv_pex] + sys.argv[1:])
         else:
             maybe_reexec_pex(interpreter_test=interpreter_test)
             from . import pex

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -95,7 +95,7 @@ def __maybe_run_venv__(pex, pex_root, pex_path):
 
   TRACER.log('Executing venv PEX for {{}} at {{}}'.format(pex, venv_pex))
   venv_python = os.path.join(venv_home, 'bin', 'python')
-  __re_exec__(venv_python, venv_pex)
+  __re_exec__(venv_python, '-sE', venv_pex)
 
 
 __entry_point__ = None

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -94,7 +94,8 @@ def __maybe_run_venv__(pex, pex_root, pex_path):
     return
 
   TRACER.log('Executing venv PEX for {{}} at {{}}'.format(pex, venv_pex))
-  __re_exec__(venv_pex)
+  venv_python = os.path.join(venv_home, 'bin', 'python')
+  __re_exec__(venv_python, venv_pex)
 
 
 __entry_point__ = None

--- a/pex/venv/pex.py
+++ b/pex/venv/pex.py
@@ -331,10 +331,15 @@ def _populate_sources(
                         os.path.basename(python_binary)
                     )
 
+            def iter_sys_executable_paths():
+                yield sys.executable
+                if os.path.islink(sys.executable):
+                    yield os.path.realpath(sys.executable)
+
             current_interpreter_blessed_env_var = "_PEX_SHOULD_EXIT_VENV_REEXEC"
             if (
                 not os.environ.pop(current_interpreter_blessed_env_var, None)
-                and sys.executable not in tuple(iter_valid_venv_pythons())
+                and set(iter_sys_executable_paths()).isdisjoint(iter_valid_venv_pythons())
             ):
                 sys.stderr.write("Re-execing from {{}}\\n".format(sys.executable))
                 os.environ[current_interpreter_blessed_env_var] = "1"

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1408,17 +1408,10 @@ def test_venv_mode(
         pex_root = str(tmpdir)
         args = [pex_file] if pex_python else [sys.executable, pex_file]
         stdout = subprocess.check_output(
-            args=args + ["-c", "import sys; print(sys.executable); print(sys.prefix)"],
+            args=args + ["-c", "import sys; print(sys.executable)"],
             env=make_env(PEX_ROOT=pex_root, PEX_INTERPRETER=1, PEX_PYTHON=pex_python),
         )
-        pex_interpreter, venv_home = cast(
-            "Tuple[str, str]", stdout.decode("utf-8").strip().splitlines()
-        )
-        actual_venv_home = os.path.realpath(venv_home)
-        assert venv_home != actual_venv_home, "Expected the venv home to be a symlink"
-        assert len(venv_home) < len(
-            actual_venv_home
-        ), "Expected the venv home symlink path length to be shorter than the actual path length"
+        pex_interpreter = cast(str, stdout.decode("utf-8").strip())
 
         with ENV.patch(PEX_PYTHON=pex_python):
             pex_info = PexInfo.from_pex(pex_file)
@@ -1430,7 +1423,7 @@ def test_venv_mode(
                 pex_hash=pex_hash,
                 has_interpreter_constraints=False,
             )
-        assert expected_venv_home == os.path.commonprefix([actual_venv_home, expected_venv_home])
+        assert expected_venv_home == os.path.commonprefix([pex_interpreter, expected_venv_home])
         return pex_interpreter
 
     isort_pex_interpreter1 = run_isort_pex()

--- a/tests/integration/test_setproctitle.py
+++ b/tests/integration/test_setproctitle.py
@@ -107,9 +107,9 @@ def test_setproctitle(
         assert "{pex_file} --some arguments here".format(pex_file=pex_file) == args
     elif venv:
         # A `--venv` mode PEX boot terminates in a final process of:
-        # ~/.pex/venvs/<venv short dir>/bin/python -sE ~/.pex/venvs/<venv long dir>/pex <args...>
+        # ~/.pex/venvs/<venv long dir>/bin/python -sE ~/.pex/venvs/<venv long dir>/pex <args...>
         python_args, installed_location, rest = args.split(" ", 2)
-        assert "-sE" == python_args
+        assert "-sE" == python_args, "exe: {} args:{}".format(exe, args)
         assert (
             os.path.join(
                 variables.venv_dir(

--- a/tests/integration/test_setproctitle.py
+++ b/tests/integration/test_setproctitle.py
@@ -109,7 +109,7 @@ def test_setproctitle(
         # A `--venv` mode PEX boot terminates in a final process of:
         # ~/.pex/venvs/<venv long dir>/bin/python -sE ~/.pex/venvs/<venv long dir>/pex <args...>
         python_args, installed_location, rest = args.split(" ", 2)
-        assert "-sE" == python_args, "exe: {} args:{}".format(exe, args)
+        assert "-sE" == python_args
         assert (
             os.path.join(
                 variables.venv_dir(

--- a/tests/integration/test_sh_boot.py
+++ b/tests/integration/test_sh_boot.py
@@ -262,7 +262,7 @@ def file_path_length_limit(tmpdir_factory):
             try:
                 touch(path)
             except (IOError, OSError) as e:
-                if e.errno != errno.ENAMETOOLONG:
+                if e.errno == errno.ENAMETOOLONG:
                     return True
                 raise e
 
@@ -286,7 +286,7 @@ def file_name_length_limit(
         try:
             touch(os.path.join(path, "x" * length))
         except (IOError, OSError) as e:
-            if e.errno != errno.ENAMETOOLONG:
+            if e.errno == errno.ENAMETOOLONG:
                 return True
             raise e
 
@@ -331,7 +331,7 @@ def shebang_length_limit(
         try:
             return 0 != subprocess.call(args=[script])
         except OSError as e:
-            if e.errno != errno.ENOEXEC:
+            if e.errno == errno.ENOEXEC:
                 return True
             raise e
 

--- a/tests/integration/test_sh_boot.py
+++ b/tests/integration/test_sh_boot.py
@@ -321,7 +321,7 @@ def test_shebang_length_limit(
     #   <PEX_ROOT>/venvs/s/592c68dc/venv/bin/python
     # With no collisions, the hash dir is 8 characters, and we expect no collisions in this bespoke
     # new empty temporary dir PEX_ROOT>
-    long_dir_name = "x" * (
+    padding_dirs_length = (
         shebang_length_limit
         - len(
             "#!"
@@ -338,7 +338,7 @@ def test_shebang_length_limit(
             + "\n"
         )
     )
-    if len(long_dir_name) > file_path_length_limit:
+    if padding_dirs_length > file_path_length_limit:
         pytest.skip(
             "Cannot create a PEX_ROOT in the tmp dir that both generates a too-long venv pex "
             "script shebang and yet does not generate a path to that venv pex script that is too "
@@ -354,7 +354,14 @@ def test_shebang_length_limit(
             )
         )
 
-    pex_root = os.path.realpath(os.path.join(str(tmpdir), long_dir_name, "pex_root"))
+    padding_dirs_path = "directory"
+    while len(padding_dirs_path) < padding_dirs_length - len(os.path.join("directory", "x")):
+        padding_dirs_path = os.path.join(padding_dirs_path, "directory")
+    padding_dirs_path = os.path.join(
+        padding_dirs_path, "x" * (padding_dirs_length - len(padding_dirs_path + os.sep))
+    )
+
+    pex_root = os.path.realpath(os.path.join(str(tmpdir), padding_dirs_path, "pex_root"))
     pex = os.path.realpath(os.path.join(str(tmpdir), "pex.sh"))
     result = run_pex_command(
         args=[

--- a/tests/integration/test_sh_boot.py
+++ b/tests/integration/test_sh_boot.py
@@ -263,8 +263,8 @@ def file_path_length_limit(tmpdir_factory):
                 touch(path)
             except (IOError, OSError) as e:
                 if e.errno != errno.ENAMETOOLONG:
-                    raise e
-                return True
+                    return True
+                raise e
 
         return False
 
@@ -280,19 +280,19 @@ def file_name_length_limit(
 ):
     # type: (...) -> int
 
-    def file_path_too_long(length):
+    def file_name_too_long(length):
         # type: (int) -> bool
         path = str(tmpdir_factory.mktemp("td"))
         try:
             touch(os.path.join(path, "x" * length))
         except (IOError, OSError) as e:
             if e.errno != errno.ENAMETOOLONG:
-                raise e
-            return True
+                return True
+            raise e
 
         return False
 
-    limit = find_max_length(seed_max=file_path_length_limit, is_too_long=file_path_too_long)
+    limit = find_max_length(seed_max=file_path_length_limit, is_too_long=file_name_too_long)
     sys.stderr.write(">>> Calculated file name length limit of: {}\n".format(limit))
     return limit
 
@@ -332,8 +332,8 @@ def shebang_length_limit(
             return 0 != subprocess.call(args=[script])
         except OSError as e:
             if e.errno != errno.ENOEXEC:
-                raise e
-            return True
+                return True
+            raise e
 
     limit = find_max_length(
         seed_max=file_path_length_limit - len(os.sep + "script.sh"), is_too_long=shebang_too_long

--- a/tests/integration/test_sh_boot.py
+++ b/tests/integration/test_sh_boot.py
@@ -233,6 +233,11 @@ def find_max_length(
         sys.stderr.write("Took {} steps.\n".format(steps))
 
 
+# Pytest fails to cleanup tmp dirs used probing file_path_length_limit and this squashes a very
+# large ream of warnings.
+pytestmark = pytest.mark.filterwarnings("ignore:\\(rm_rf\\) error removing.*:pytest.PytestWarning")
+
+
 @pytest.fixture(scope="module")
 def file_path_length_limit(tmpdir_factory):
     # type: (Any) -> int
@@ -255,7 +260,7 @@ def file_path_length_limit(tmpdir_factory):
             path = os.path.join(path, "x" * padding)
             try:
                 touch(path)
-            except OSError as e:
+            except (IOError, OSError) as e:
                 if e.errno != errno.ENAMETOOLONG:
                     raise e
                 return True
@@ -279,7 +284,7 @@ def file_name_length_limit(
         path = str(tmpdir_factory.mktemp("td"))
         try:
             touch(os.path.join(path, "x" * length))
-        except OSError as e:
+        except (IOError, OSError) as e:
             if e.errno != errno.ENAMETOOLONG:
                 raise e
             return True

--- a/tests/integration/test_sh_boot.py
+++ b/tests/integration/test_sh_boot.py
@@ -12,7 +12,13 @@ from typing import Callable, Text, Tuple
 import pytest
 
 from pex.common import chmod_plus_x, safe_open, touch
-from pex.testing import ALL_PY_VERSIONS, ensure_python_interpreter, make_env, run_pex_command
+from pex.testing import (
+    ALL_PY_VERSIONS,
+    IS_PYPY,
+    ensure_python_interpreter,
+    make_env,
+    run_pex_command,
+)
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -320,7 +326,14 @@ def test_shebang_length_limit(
         - len(
             "#!"
             + os.path.join(
-                str(tmpdir), "pex_root", "venvs", "s", "12345678", "venv", "bin", "python"
+                str(tmpdir),
+                "pex_root",
+                "venvs",
+                "s",
+                "12345678",
+                "venv",
+                "bin",
+                "pypy" if IS_PYPY else "python",
             )
             + "\n"
         )

--- a/tests/integration/test_sh_boot.py
+++ b/tests/integration/test_sh_boot.py
@@ -321,22 +321,19 @@ def test_shebang_length_limit(
     #   <PEX_ROOT>/venvs/s/592c68dc/venv/bin/python
     # With no collisions, the hash dir is 8 characters, and we expect no collisions in this bespoke
     # new empty temporary dir PEX_ROOT>
-    padding_dirs_length = (
-        shebang_length_limit
-        - len(
-            "#!"
-            + os.path.join(
-                str(tmpdir),
-                "pex_root",
-                "venvs",
-                "s",
-                "12345678",
-                "venv",
-                "bin",
-                "pypy" if IS_PYPY else "python",
-            )
-            + "\n"
+    padding_dirs_length = shebang_length_limit - len(
+        "#!"
+        + os.path.join(
+            str(tmpdir),
+            "pex_root",
+            "venvs",
+            "s",
+            "12345678",
+            "venv",
+            "bin",
+            "pypy" if IS_PYPY else "python",
         )
+        + "\n"
     )
     if padding_dirs_length > file_path_length_limit:
         pytest.skip(

--- a/tests/integration/test_sh_boot.py
+++ b/tests/integration/test_sh_boot.py
@@ -1,5 +1,6 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 import errno
 import json
 import os

--- a/tests/tools/commands/test_repository.py
+++ b/tests/tools/commands/test_repository.py
@@ -63,7 +63,7 @@ def pex():
                 "-D",
                 src,
                 "requests==2.25.1",
-                "-c",
+                "--constraints",
                 constraints,
                 "-e",
                 "main:do",

--- a/tests/tools/commands/test_repository.py
+++ b/tests/tools/commands/test_repository.py
@@ -52,11 +52,19 @@ def pex():
                     """
                 )
             )
+
+        constraints = os.path.join(str(tmpdir), "constraints.txt")
+        with open(constraints, "w") as fp:
+            # N.B.: urllib3 1.26.10 dropped support for Python 3.5 which we test against.
+            fp.write("urllib3<1.26.10")
+
         result = run_pex_command(
             args=[
                 "-D",
                 src,
                 "requests==2.25.1",
+                "-c",
+                constraints,
                 "-e",
                 "main:do",
                 "--interpreter-constraint",


### PR DESCRIPTION
Re-work both ZIPAPP and --sh-boot execution of --venv PEXes to avoid shebang
length limits.