### PR TITLE
Fix `PEX_EXTRA_SYS_PATH` propagation.

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -124,7 +124,7 @@ class PythonIdentity(object):
         # Pex identifies interpreters using a bit of Pex code injected via an extraction of that
         # code under the `PEX_ROOT` adjoined to `sys.path` via `PYTHONPATH`. We ignore such adjoined
         # `sys.path` entries to discover the true base interpreter `sys.path`.
-        pythonpath = frozenset(os.environ.get("PYTHONPATH", "").split(os.pathsep))
+        pythonpath = frozenset(os.environ.get("PYTHONPATH", "").split(":"))
         sys_path = [item for item in sys.path if item and item not in pythonpath]
 
         return cls(

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -124,7 +124,7 @@ class PythonIdentity(object):
         # Pex identifies interpreters using a bit of Pex code injected via an extraction of that
         # code under the `PEX_ROOT` adjoined to `sys.path` via `PYTHONPATH`. We ignore such adjoined
         # `sys.path` entries to discover the true base interpreter `sys.path`.
-        pythonpath = frozenset(os.environ.get("PYTHONPATH", "").split(":"))
+        pythonpath = frozenset(os.environ.get("PYTHONPATH", "").split(os.pathsep))
         sys_path = [item for item in sys.path if item and item not in pythonpath]
 
         return cls(

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -414,6 +414,11 @@ class PEX(object):  # noqa: T000
         if self._vars.PEX_EXTRA_SYS_PATH:
             TRACER.log("Adding %s to sys.path" % self._vars.PEX_EXTRA_SYS_PATH)
             new_sys_path.extend(self._vars.PEX_EXTRA_SYS_PATH.split(":"))
+
+            # Let Python subprocesses see the same sys.path additions we see. If those Python
+            # subprocesses are PEX subprocesses, they'll do their own (re-)scrubbing as needed.
+            os.environ["PYTHONPATH"] = self._vars.PEX_EXTRA_SYS_PATH
+
         TRACER.log("New sys.path: %s" % new_sys_path)
 
         patch_all(new_sys_path, new_sys_path_importer_cache, new_sys_modules)
@@ -580,7 +585,7 @@ class PEX(object):  # noqa: T000
         # type: () -> Any
 
         # A Python interpreter always inserts the CWD at the head of the sys.path.
-        sys.path.insert(0, ".")
+        sys.path.insert(0, "")
 
         args = sys.argv[1:]
         python_options = []

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -327,35 +327,26 @@ class PEX(object):  # noqa: T000
 
         pythonpath = cls.unstash_pythonpath()
         if pythonpath is not None:
-            original_pythonpath = pythonpath.split(":")
-            user_pythonpath_entries = list(OrderedSet(original_pythonpath) - set(sys.path))
-            user_pythonpath = ":".join(user_pythonpath_entries)
-            if original_pythonpath == user_pythonpath_entries:
+            original_pythonpath = pythonpath.split(os.pathsep)
+            user_pythonpath = list(OrderedSet(original_pythonpath) - set(sys.path))
+            if original_pythonpath == user_pythonpath:
                 TRACER.log("Unstashed PYTHONPATH of %s" % pythonpath, V=2)
             else:
                 TRACER.log(
-                    "Extracted user PYTHONPATH of {user_pythonpath} from unstashed PYTHONPATH of "
-                    "{pythonpath}".format(user_pythonpath=user_pythonpath, pythonpath=pythonpath),
+                    "Extracted user PYTHONPATH of %s from unstashed PYTHONPATH of %s"
+                    % (os.pathsep.join(user_pythonpath), pythonpath),
                     V=2,
                 )
 
             if inherit_path == InheritPath.FALSE:
-                for path in user_pythonpath_entries:
-                    TRACER.log("Scrubbing user PYTHONPATH element: {path}".format(path=path))
+                for path in user_pythonpath:
+                    TRACER.log("Scrubbing user PYTHONPATH element: %s" % path)
             elif inherit_path == InheritPath.PREFER:
-                TRACER.log(
-                    "Prepending user PYTHONPATH: {user_pythonpath}".format(
-                        user_pythonpath=user_pythonpath
-                    )
-                )
-                scrubbed_sys_path = user_pythonpath_entries + scrubbed_sys_path
+                TRACER.log("Prepending user PYTHONPATH: %s" % os.pathsep.join(user_pythonpath))
+                scrubbed_sys_path = user_pythonpath + scrubbed_sys_path
             elif inherit_path == InheritPath.FALLBACK:
-                TRACER.log(
-                    "Appending user PYTHONPATH: {user_pythonpath}".format(
-                        user_pythonpath=user_pythonpath
-                    )
-                )
-                scrubbed_sys_path = scrubbed_sys_path + user_pythonpath_entries
+                TRACER.log("Appending user PYTHONPATH: %s" % os.pathsep.join(user_pythonpath))
+                scrubbed_sys_path = scrubbed_sys_path + user_pythonpath
 
         scrub_from_importer_cache = filter(
             lambda key: any(key.startswith(path) for path in scrub_paths),
@@ -431,9 +422,9 @@ class PEX(object):  # noqa: T000
                 pythonpath_entries = extra_sys_path
             else:
                 raw_pythonpath = os.environ.get(self._PYTHONPATH)
-                pythonpath = raw_pythonpath.split(":") if raw_pythonpath else []
+                pythonpath = raw_pythonpath.split(os.pathsep) if raw_pythonpath else []
                 pythonpath_entries = pythonpath + extra_sys_path
-            os.environ[self._PYTHONPATH] = ":".join(pythonpath_entries)
+            os.environ[self._PYTHONPATH] = os.pathsep.join(pythonpath_entries)
 
         TRACER.log("New sys.path: %s" % new_sys_path)
 

--- a/pex/venv/pex.py
+++ b/pex/venv/pex.py
@@ -417,7 +417,17 @@ def _populate_sources(
                 )
 
             os.environ["VIRTUAL_ENV"] = venv_dir
-            sys.path.extend(os.environ.get("PEX_EXTRA_SYS_PATH", "").split(os.pathsep))
+
+            # A Python interpreter always inserts the CWD at the head of the sys.path.
+            sys.path.insert(0, "")
+
+            pex_extra_sys_path = os.environ.get("PEX_EXTRA_SYS_PATH")
+            if pex_extra_sys_path:
+                sys.path.extend(pex_extra_sys_path.split(":"))
+
+                # Let Python subprocesses see the same sys.path additions we see. If those Python
+                # subprocesses are PEX subprocesses, they'll do their own (re-)scrubbing as needed.
+                os.environ["PYTHONPATH"] = pex_extra_sys_path
 
             bin_path = os.environ.get("PEX_VENV_BIN_PATH", {bin_path!r})
             if bin_path != "false":

--- a/tests/integration/test_issue_1825.py
+++ b/tests/integration/test_issue_1825.py
@@ -1,0 +1,118 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import json
+import os.path
+import subprocess
+from textwrap import dedent
+
+import pytest
+
+from pex.common import safe_open
+from pex.orderedset import OrderedSet
+from pex.testing import make_env, run_pex_command
+from pex.typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from typing import Any, List
+
+
+DUMP_SYS_PATH_CODE = dedent(
+    """\
+    import json
+    import sys
+
+
+    json.dump(sys.path, sys.stdout)
+    """
+)
+
+
+def create_sys_path_dump_pex(
+    tmpdir,  # type: Any
+    *additional_args  # type: str
+):
+    # type: (...) -> str
+
+    exe = os.path.join(str(tmpdir), "exe.py")
+    with open(exe, "w") as fp:
+        fp.write(DUMP_SYS_PATH_CODE)
+
+    pex = os.path.join(str(tmpdir), "pex")
+    run_pex_command(args=["--exe", exe, "-o", pex] + list(additional_args)).assert_success()
+    return pex
+
+
+def execute_sys_path_dump_pex(
+    pex,  # type: str
+    *additional_args,  # type: str
+    **additional_env  # type: Any
+):
+    # type: (...) -> OrderedSet[str]
+
+    return OrderedSet(
+        os.path.realpath(entry)
+        for entry in cast(
+            "List[str]",
+            json.loads(
+                subprocess.check_output(
+                    args=[pex] + list(additional_args), env=make_env(**additional_env)
+                )
+            ),
+        )
+    )
+
+
+def read_additional_sys_path(
+    pex,  # type: str
+    *additional_args,  # type: str
+    **additional_env  # type: Any
+):
+    # type: (...) -> List[str]
+
+    isolated_sys_path = execute_sys_path_dump_pex(pex)
+    return list(
+        execute_sys_path_dump_pex(pex, *additional_args, **additional_env) - isolated_sys_path
+    )
+
+
+@pytest.mark.parametrize(
+    "execution_mode_args",
+    [
+        pytest.param([], id="ZIPAPP"),
+        pytest.param(["--venv"], id="VENV"),
+    ],
+)
+def test_pex_run_extra_sys_path(
+    tmpdir,  # type: Any
+    execution_mode_args,  # type: List[str]
+):
+    # type: (...) -> None
+
+    pex = create_sys_path_dump_pex(tmpdir, *execution_mode_args)
+
+    foo = os.path.join(str(tmpdir), "foo")
+    assert [foo] == read_additional_sys_path(pex, PEX_EXTRA_SYS_PATH=foo)
+
+    other_exe = os.path.join(str(tmpdir), "other_exe.py")
+    with safe_open(other_exe, "w") as fp:
+        fp.write(DUMP_SYS_PATH_CODE)
+
+    subprocess_proof = os.path.join(str(tmpdir), "proof")
+    assert not os.path.exists(subprocess_proof)
+
+    code = dedent(
+        """\
+        import subprocess
+        import sys
+
+
+        open({subprocess_proof!r}, "w").close()
+        sys.exit(subprocess.call([sys.executable, {other_exe!r}]))
+        """
+    ).format(subprocess_proof=subprocess_proof, other_exe=other_exe)
+    bar = os.path.join(str(tmpdir), "bar")
+    assert bar in read_additional_sys_path(
+        pex, "-c", code, PEX_INTERPRETER=1, PEX_EXTRA_SYS_PATH=bar
+    )
+    assert os.path.exists(subprocess_proof)

--- a/tests/integration/test_issue_1825.py
+++ b/tests/integration/test_issue_1825.py
@@ -9,6 +9,7 @@ from textwrap import dedent
 import pytest
 
 from pex.common import safe_open
+from pex.inherit_path import InheritPath
 from pex.orderedset import OrderedSet
 from pex.testing import make_env, run_pex_command
 from pex.typing import TYPE_CHECKING, cast
@@ -76,6 +77,40 @@ def read_additional_sys_path(
     )
 
 
+def assert_inherited(
+    tmpdir,  # type: Any
+    pex,  # type: str
+    *expected_inherited_sys_path_entries,  # type: str
+    **additional_env  # type: Any
+):
+    other_exe = os.path.join(str(tmpdir), "other_exe.py")
+    with safe_open(other_exe, "w") as fp:
+        fp.write(DUMP_SYS_PATH_CODE)
+
+    subprocess_proof = os.path.join(str(tmpdir), "proof")
+    assert not os.path.exists(subprocess_proof)
+
+    code = dedent(
+        """\
+        import subprocess
+        import sys
+
+
+        open({subprocess_proof!r}, "w").close()
+        sys.exit(subprocess.call([sys.executable, {other_exe!r}]))
+        """
+    ).format(subprocess_proof=subprocess_proof, other_exe=other_exe)
+    actual = read_additional_sys_path(pex, "-c", code, PEX_INTERPRETER=1, **additional_env)
+    assert os.path.exists(subprocess_proof)
+
+    previous = -1
+    for expected_inherited_sys_path_entry in expected_inherited_sys_path_entries:
+        assert expected_inherited_sys_path_entry in actual
+        current_index = actual.index(expected_inherited_sys_path_entry)
+        assert current_index > previous
+        previous = current_index
+
+
 @pytest.mark.parametrize(
     "execution_mode_args",
     [
@@ -94,25 +129,29 @@ def test_pex_run_extra_sys_path(
     foo = os.path.join(str(tmpdir), "foo")
     assert [foo] == read_additional_sys_path(pex, PEX_EXTRA_SYS_PATH=foo)
 
-    other_exe = os.path.join(str(tmpdir), "other_exe.py")
-    with safe_open(other_exe, "w") as fp:
-        fp.write(DUMP_SYS_PATH_CODE)
-
-    subprocess_proof = os.path.join(str(tmpdir), "proof")
-    assert not os.path.exists(subprocess_proof)
-
-    code = dedent(
-        """\
-        import subprocess
-        import sys
-
-
-        open({subprocess_proof!r}, "w").close()
-        sys.exit(subprocess.call([sys.executable, {other_exe!r}]))
-        """
-    ).format(subprocess_proof=subprocess_proof, other_exe=other_exe)
     bar = os.path.join(str(tmpdir), "bar")
-    assert bar in read_additional_sys_path(
-        pex, "-c", code, PEX_INTERPRETER=1, PEX_EXTRA_SYS_PATH=bar
+    assert_inherited(tmpdir, pex, bar, PEX_EXTRA_SYS_PATH=bar)
+
+
+@pytest.mark.parametrize(
+    "inherit_path",
+    [pytest.param(inherit_path, id=str(inherit_path)) for inherit_path in InheritPath.values()],
+)
+def test_pex_run_inherit_path_and_extra_sys_path(
+    tmpdir,  # type: Any
+    inherit_path,  # type: InheritPath.Value
+):
+    # type: (...) -> None
+
+    pex = create_sys_path_dump_pex(
+        tmpdir, "--inherit-path={inherit_path}".format(inherit_path=inherit_path)
     )
-    assert os.path.exists(subprocess_proof)
+
+    esp = os.path.join(str(tmpdir), "esp")
+    pp1 = os.path.join(str(tmpdir), "pp1")
+    pp2 = os.path.join(str(tmpdir), "pp2")
+
+    expected = [esp] if inherit_path is InheritPath.FALSE else [pp1, pp2, esp]
+    assert_inherited(
+        tmpdir, pex, *expected, PEX_EXTRA_SYS_PATH=esp, PYTHONPATH=":".join((pp1, pp2))
+    )


### PR DESCRIPTION
Previously PEXes were not behaving like a Python interpreter when
`PEX_EXTRA_SYS_PATH` was used to add entries to the `sys.path`. In a
traditional Python interpreter those would be added with `PYTHONPATH`
which subprocesses forked from the Python interpreter would inherit by
default.

Fixes #1825