### PR TITLE
Change user agent of vendored pip version

### DIFF
--- a/pex/vendor/_vendored/pip/pip/_internal/network/session.py
+++ b/pex/vendor/_vendored/pip/pip/_internal/network/session.py
@@ -100,7 +100,7 @@ def user_agent():
     Return a string representing the user agent.
     """
     data = {
-        "installer": {"name": "pip", "version": __version__},
+        "installer": {"name": "pex-pip", "version": __version__},
         "python": platform.python_version(),
         "implementation": {
             "name": platform.python_implementation(),


### PR DESCRIPTION
this will allow distinguishing (in the pypi BigQuery data set, for example) between pip downloads of pex and pex using the vendored pip to download packages.