### PR TITLE
Add support for importing from PEXes.

### DIFF
--- a/pex/pip/foreign_platform.py
+++ b/pex/pip/foreign_platform.py
@@ -124,10 +124,9 @@ def patch(target):
     if isinstance(target, AbbreviatedPlatform):
         args = tuple(iter_platform_args(target.platform, target.manylinux))
 
-    if isinstance(target, CompletePlatform):
-        compatible_tags = target.supported_tags
-        if compatible_tags:
-            env.update(patch_tags(compatible_tags).env)
+    compatible_tags = target.supported_tags
+    if compatible_tags:
+        env.update(patch_tags(compatible_tags).env)
 
     TRACER.log(
         "Patching environment markers for {} with {}".format(target, patched_environment),

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -7,14 +7,20 @@ import contextlib
 import importlib
 import os
 import re
+import shutil
 import sys
 import zipfile
 from collections import OrderedDict, namedtuple
 
-
-# NB: All pex imports are performed lazily to play well with the un-imports performed by both the
+# NB: ~All pex imports are performed lazily to play well with the un-imports performed by both the
 # PEX runtime when it demotes the bootstrap code and any pex modules that uninstalled
 # VendorImporters un-import.
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Container, Optional, Tuple
+
+
 def _tracer():
     from pex.tracer import TRACER
 
@@ -334,6 +340,47 @@ class IsolationResult(namedtuple("IsolatedPex", ["pex_hash", "chroot_path"])):
 _ISOLATED = None
 
 
+def _isolate_pex_from_dir(
+    pex_directory,  # type: str
+    isolate_to_dir,  # type: str
+    exclude_files,  # type: Container[str]
+):
+    from pex.common import filter_pyc_dirs, filter_pyc_files, is_pyc_temporary_file, safe_copy
+
+    for root, dirs, files in os.walk(pex_directory):
+        relroot = os.path.relpath(root, pex_directory)
+        for d in filter_pyc_dirs(dirs):
+            os.makedirs(os.path.join(isolate_to_dir, "pex", relroot, d))
+        for f in filter_pyc_files(files):
+            rel_f = os.path.join(relroot, f)
+            if not is_pyc_temporary_file(rel_f) and rel_f not in exclude_files:
+                safe_copy(
+                    os.path.join(root, f),
+                    os.path.join(isolate_to_dir, "pex", rel_f),
+                )
+
+
+def _isolate_pex_from_zip(
+    pex_zip,  # type: str
+    pex_package_relpath,  # type: str
+    isolate_to_dir,  # type: str
+    exclude_files,  # type: Container[str]
+):
+    from pex.common import open_zip, safe_open
+
+    with open_zip(pex_zip) as zf:
+        for name in zf.namelist():
+            if name.endswith("/") or not name.startswith(pex_package_relpath):
+                continue
+            rel_name = os.path.relpath(name, pex_package_relpath)
+            if rel_name in exclude_files:
+                continue
+            with zf.open(name) as from_fp, safe_open(
+                os.path.join(isolate_to_dir, rel_name), "wb"
+            ) as to_fp:
+                shutil.copyfileobj(from_fp, to_fp)
+
+
 def isolated():
     """Returns a chroot for third_party isolated from the ``sys.path``.
 
@@ -347,14 +394,8 @@ def isolated():
     """
     global _ISOLATED
     if _ISOLATED is None:
-        from pex import vendor
-        from pex.common import (
-            atomic_directory,
-            filter_pyc_dirs,
-            filter_pyc_files,
-            is_pyc_temporary_file,
-            safe_copy,
-        )
+        from pex import layout, vendor
+        from pex.common import atomic_directory
         from pex.util import CacheHelper
         from pex.variables import ENV
 
@@ -367,37 +408,56 @@ def isolated():
             for vendor_spec in vendor.iter_vendor_specs()
         )
 
+        pex_zip_paths = None  # type: Optional[Tuple[str, str]]
         pex_path = os.path.join(vendor.VendorSpec.ROOT, "pex")
         with _tracer().timed("Hashing pex"):
-            assert os.path.isdir(pex_path), (
-                "Expected the `pex` module to be available via an installed distribution or "
-                "else via an installed or loose PEX. Loaded the `pex` module from {} and argv0 is "
-                "{}.".format(pex_path, sys.argv[0])
-            )
-            dir_hash = CacheHelper.dir_hash(pex_path)
-        isolated_dir = os.path.join(ENV.PEX_ROOT, "isolated", dir_hash)
+            if os.path.isdir(pex_path):
+                pex_hash = CacheHelper.dir_hash(pex_path)
+            else:
+                # The zip containing the `pex` package could either be a traditional PEX zipapp
+                # with the `pex` package in `.bootstrap/pex` or a .bootstrap zip with the `pex`
+                # package in the root of the zip. We deal with both cases below.
+                zip_path = os.path.dirname(pex_path)
+                if (
+                    not zipfile.is_zipfile(zip_path)
+                    and os.path.basename(zip_path) == layout.BOOTSTRAP_DIR
+                ):
+                    zip_path = os.path.dirname(zip_path)
+                assert zipfile.is_zipfile(zip_path), (
+                    "Expected the `pex` module to be available via an installed distribution "
+                    "or else via a PEX. Loaded the `pex` module from {} and but the enclosing "
+                    "PEX has an unexpected layout {}".format(pex_path, zip_path)
+                )
 
+                pex_package_relpath = (
+                    ""
+                    if os.path.basename(zip_path) == layout.BOOTSTRAP_DIR
+                    else layout.BOOTSTRAP_DIR
+                )
+                pex_zip_paths = (zip_path, pex_package_relpath)
+                pex_hash = CacheHelper.zip_hash(zip_path, relpath=pex_package_relpath)
+
+        isolated_dir = os.path.join(ENV.PEX_ROOT, "isolated", pex_hash)
         with _tracer().timed("Isolating pex"):
             with atomic_directory(isolated_dir, exclusive=True) as chroot:
                 if not chroot.is_finalized():
                     with _tracer().timed("Extracting pex to {}".format(isolated_dir)):
-                        pex_path = os.path.join(vendor.VendorSpec.ROOT, "pex")
-                        for root, dirs, files in os.walk(pex_path):
-                            relroot = os.path.relpath(root, pex_path)
-                            for d in filter_pyc_dirs(dirs):
-                                os.makedirs(os.path.join(chroot.work_dir, "pex", relroot, d))
-                            for f in filter_pyc_files(files):
-                                rel_f = os.path.join(relroot, f)
-                                if (
-                                    not is_pyc_temporary_file(rel_f)
-                                    and rel_f not in vendor_lockfiles
-                                ):
-                                    safe_copy(
-                                        os.path.join(root, f),
-                                        os.path.join(chroot.work_dir, "pex", rel_f),
-                                    )
+                        if pex_zip_paths:
+                            pex_zip, pex_package_relpath = pex_zip_paths
+                            _isolate_pex_from_zip(
+                                pex_zip=pex_zip,
+                                pex_package_relpath=pex_package_relpath,
+                                isolate_to_dir=chroot.work_dir,
+                                exclude_files=vendor_lockfiles,
+                            )
+                        else:
+                            _isolate_pex_from_dir(
+                                pex_directory=pex_path,
+                                isolate_to_dir=chroot.work_dir,
+                                exclude_files=vendor_lockfiles,
+                            )
 
-        _ISOLATED = IsolationResult(pex_hash=dir_hash, chroot_path=isolated_dir)
+        _ISOLATED = IsolationResult(pex_hash=pex_hash, chroot_path=isolated_dir)
     return _ISOLATED
 
 

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -64,7 +64,11 @@ class _Importable(namedtuple("_Importable", ["module", "is_pkg", "path", "prefix
             target = fullname
 
         if target == self.module or self.is_pkg and target.startswith(self.module + "."):
-            vendor_path = os.path.join(self.path, *target.split("."))
+            vendor_path = (
+                os.path.join(*target.split("."))
+                if not self.path or self.path == os.curdir
+                else os.path.join(self.path, *target.split("."))
+            )
             vendor_module_name = vendor_path.replace(os.sep, ".")
             return _Loader(fullname, vendor_module_name)
 

--- a/pex/util.py
+++ b/pex/util.py
@@ -84,12 +84,12 @@ class CacheHelper(object):
         return digest.hexdigest()
 
     @classmethod
-    def pex_code_hash(cls, d):
+    def pex_code_hash(cls, directory):
         # type: (str) -> str
         """Return a reproducible hash of the contents of a loose PEX; excluding all `.pyc` files."""
         digest = hashlib.sha1()
         hashing.dir_hash(
-            directory=d,
+            directory=directory,
             digest=digest,
             dir_filter=filter_pyc_dirs,
             file_filter=lambda files: (f for f in filter_pyc_files(files) if not f.startswith(".")),
@@ -97,13 +97,34 @@ class CacheHelper(object):
         return digest.hexdigest()
 
     @classmethod
-    def dir_hash(cls, d, digest=None, hasher=sha1):
+    def dir_hash(cls, directory, digest=None, hasher=sha1):
         # type: (str, Optional[Hasher], Callable[[], Hasher]) -> str
         """Return a reproducible hash of the contents of a directory; excluding all `.pyc` files."""
         if digest is None:
             digest = hasher()
         hashing.dir_hash(
-            directory=d, digest=digest, dir_filter=filter_pyc_dirs, file_filter=filter_pyc_files
+            directory=directory,
+            digest=digest,
+            dir_filter=filter_pyc_dirs,
+            file_filter=filter_pyc_files,
+        )
+        return digest.hexdigest()
+
+    @classmethod
+    def zip_hash(
+        cls,
+        zip_path,  # type: str
+        relpath=None,  # type: Optional[str]
+    ):
+        # type: (...) -> str
+        """Return a reproducible hash of the contents of a zip; excluding all `.pyc` files."""
+        digest = hashlib.sha1()
+        hashing.zip_hash(
+            zip_path=zip_path,
+            digest=digest,
+            relpath=relpath,
+            dir_filter=filter_pyc_dirs,
+            file_filter=filter_pyc_files,
         )
         return digest.hexdigest()
 

--- a/tests/integration/test_pex_import.py
+++ b/tests/integration/test_pex_import.py
@@ -1,0 +1,135 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+import subprocess
+import sys
+from textwrap import dedent
+
+import colors
+import pytest
+
+from pex.common import safe_open
+from pex.layout import DEPS_DIR, Layout
+from pex.testing import IS_PYPY, PY27, PY_VER, ensure_python_interpreter, make_env, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, List, Text
+
+
+@pytest.mark.parametrize(
+    "layout", [pytest.param(layout, id=layout.value) for layout in Layout.values()]
+)
+@pytest.mark.parametrize(
+    "execution_mode_args", [pytest.param([], id="UNZIPPED"), pytest.param(["--venv"], id="VENV")]
+)
+def test_import_from_pex(
+    tmpdir,  # type: Any
+    layout,  # type: Layout.Value
+    execution_mode_args,  # type: List[str]
+):
+    # type: (...) -> None
+
+    # For CPython 2.7 we work around bad virtualenvs created by tox that lead to the following
+    # error by using a pyenv CPython 2.7 interpreter instead:
+    #
+    # Traceback (most recent call last):
+    #   File "<string>", line 1, in <module>
+    #   File "/tmp/pytest-of-jsirois/pytest-10/popen-gw5/test_import_from_pex_UNZIPPED_0/importable.pex/.bootstrap/pex/third_party/__init__.py", line 39, in load_module
+    #   File "/home/jsirois/.pyenv/versions/2.7.18/lib/python2.7/importlib/__init__.py", line 37, in import_module
+    #     __import__(name)
+    #   File "/home/jsirois/dev/pantsbuild/jsirois-pex/.tox/py27-integration/lib/python2.7/site-packages/_virtualenv.py", line 112, in find_module
+    #     if fullname in _DISTUTILS_PATCH:
+    # TypeError: argument of type 'NoneType' is not iterable
+    python = ensure_python_interpreter(PY27) if (2, 7) == PY_VER and not IS_PYPY else sys.executable
+
+    src = os.path.join(str(tmpdir), "src")
+    with safe_open(os.path.join(src, "first_party.py"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                import colors
+
+
+                def warn(msg):
+                    print(colors.yellow(msg))
+                """
+            )
+        )
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    pex = os.path.join(str(tmpdir), "importable.pex")
+    is_venv = "--venv" in execution_mode_args
+
+    run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "-D",
+            src,
+            "ansicolors==1.1.8",
+            "-o",
+            pex,
+            "--layout",
+            layout.value,
+        ]
+        + execution_mode_args,
+        python=python,
+    ).assert_success()
+
+    def execute_with_pex_on_pythonpath(code):
+        # type: (str) -> Text
+        return (
+            subprocess.check_output(args=[python, "-c", code], env=make_env(PYTHONPATH=pex))
+            .decode("utf-8")
+            .strip()
+        )
+
+    # Verify 3rd party code can be imported.
+    third_party_path = execute_with_pex_on_pythonpath(
+        "from __pex__ import colors; print(colors.__file__)"
+    )
+    if is_venv:
+        expected_prefix = os.path.join(pex_root, "venvs")
+    elif layout is Layout.LOOSE:
+        expected_prefix = os.path.join(pex, DEPS_DIR)
+    else:
+        expected_prefix = os.path.join(pex_root, "installed_wheels")
+    assert third_party_path.startswith(
+        expected_prefix
+    ), "Expected 3rdp party ansicolors path {path} to start with {expected_prefix}".format(
+        path=third_party_path, expected_prefix=expected_prefix
+    )
+
+    # Verify 1st party code can be imported.
+    first_party_path = execute_with_pex_on_pythonpath(
+        "from __pex__ import first_party; print(first_party.__file__)"
+    )
+    if not is_venv and layout is Layout.LOOSE:
+        assert os.path.join(pex, "first_party.py") == first_party_path
+    else:
+        expected_prefix = os.path.join(pex_root, "venvs" if is_venv else "unzipped_pexes")
+        assert first_party_path.startswith(
+            expected_prefix
+        ), "Expected 1st party first_party.py path {path} to start with {expected_prefix}".format(
+            path=first_party_path, expected_prefix=expected_prefix
+        )
+
+    # Verify a single early import of __pex__ allows remaining imports to be "normal".
+    assert "\n".join((colors.blue("42"), colors.yellow("Vogon"))) == execute_with_pex_on_pythonpath(
+        dedent(
+            """\
+            import __pex__
+
+            import colors
+            import first_party
+            
+            
+            print(colors.blue("42"))
+            first_party.warn("Vogon")
+            """
+        )
+    )


### PR DESCRIPTION
You can now use a PEX as a mostly normal `sys.path` entry. You do need
to activate it though and that can be done in two ways:

1. Perform an `import __pex__` before importing anything else you
   might need that lives in a PEX `sys.path` entry.
2. Import what you need in one step via `from __pex__ import colors` in
   the case where the PEX contains `ansicolors`, for example.

The second method is useful in cases where you can't influence which
python interpreter to run (In which case you could just specify the PEX
file itself), but you can influence the `sys.path`. The motivating
example of this is AWS Lambda functions for Python. One mode of
deploying these is in a zip. Here you can't pick the Python interpreter,
just its version, but you can specify the zip and an entry point. As
such you can specify a PEX as the zip and a `__pex__` psuedo-package
prefixed entry-point. This should obviate the need for projects like
Lambdex or at least simplify their integration with Pex, which currently
relies on using the unsupported `pex.pex_bootstrapper` APIs which I'd
like to drop in Pex 3.
