### PR TITLE
Tags should be patched for `--platform`.

### DIFF
--- a/pex/pip/foreign_platform.py
+++ b/pex/pip/foreign_platform.py
@@ -124,10 +124,9 @@ def patch(target):
     if isinstance(target, AbbreviatedPlatform):
         args = tuple(iter_platform_args(target.platform, target.manylinux))
 
-    if isinstance(target, CompletePlatform):
-        compatible_tags = target.supported_tags
-        if compatible_tags:
-            env.update(patch_tags(compatible_tags).env)
+    compatible_tags = target.supported_tags
+    if compatible_tags:
+        env.update(patch_tags(compatible_tags).env)
 
     TRACER.log(
         "Patching environment markers for {} with {}".format(target, patched_environment),


### PR DESCRIPTION
This was broken from the get-go in #1787. It's unclear to me how the
`test_create_universal_platform_check` test added in #1824 didn't fail
from the get-go, but it does now and this fix fixes that test for the
`--platform macosx_10.9_x86_64-cp-310-cp310 psutil==5.9.1` abbreviated
platform case.

Discovered in CI for #1845 as a failure unrelated to that change.