### PR TITLE
Fix `pex --lock ...` concurrent download errors.

### DIFF
--- a/pex/pep_376.py
+++ b/pex/pep_376.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 import base64
 import csv
 import errno
-import fileinput
 import hashlib
 import itertools
 import json
@@ -599,7 +598,7 @@ class Record(object):
         if not scripts:
             return
 
-        with closing(fileinput.input(files=scripts.keys(), inplace=True, mode="rb")) as script_fi:
+        with closing(FileInput(files=scripts.keys(), inplace=True, mode="rb")) as script_fi:
             first_non_shebang_line = None  # type: Optional[bytes]
             for line in script_fi:
                 buffer = get_stdout_bytes_buffer()

--- a/pex/resolve/downloads.py
+++ b/pex/resolve/downloads.py
@@ -8,7 +8,7 @@ from pex.common import atomic_directory, safe_mkdir, safe_mkdtemp
 from pex.compatibility import unquote, urlparse
 from pex.hashing import Sha256
 from pex.jobs import Job, Raise, SpawnedJob, execute_parallel
-from pex.pip.tool import PackageIndexConfiguration, get_pip
+from pex.pip.tool import PackageIndexConfiguration, Pip, get_pip
 from pex.resolve import locker
 from pex.resolve.locked_resolve import Artifact, FileArtifact, LockConfiguration, LockStyle
 from pex.resolve.resolved_requirement import Fingerprint, PartialArtifact
@@ -44,6 +44,7 @@ def get_downloads_dir(pex_root=None):
 @attr.s(frozen=True)
 class ArtifactDownloader(object):
     resolver = attr.ib()  # type: Resolver
+    pip = attr.ib(factory=get_pip)  # type: Pip
     package_index_configuration = attr.ib(
         default=PackageIndexConfiguration.create()
     )  # type: PackageIndexConfiguration
@@ -98,7 +99,7 @@ class ArtifactDownloader(object):
             lock_configuration=LockConfiguration(style=LockStyle.UNIVERSAL),
             download_dir=download_dir,
         )
-        return get_pip().spawn_download_distributions(
+        return self.pip.spawn_download_distributions(
             download_dir=download_dir,
             requirements=[url],
             transitive=False,

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -14,6 +14,7 @@ from pex.auth import PasswordDatabase, PasswordEntry
 from pex.common import FileLockStyle, pluralize
 from pex.compatibility import cpu_count
 from pex.network_configuration import NetworkConfiguration
+from pex.orderedset import OrderedSet
 from pex.pep_503 import ProjectName
 from pex.pip.local_project import digest_local_project
 from pex.pip.tool import PackageIndexConfiguration
@@ -33,12 +34,12 @@ from pex.resolve.resolver_configuration import ResolverVersion
 from pex.resolve.resolvers import Installed, Resolver
 from pex.resolver import BuildAndInstallRequest, BuildRequest, InstallRequest
 from pex.result import Error, catch, try_
-from pex.targets import Target, Targets
+from pex.targets import Targets
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Dict, Iterable, Mapping, Optional, Sequence, Tuple, Union
+    from typing import Dict, Iterable, Optional, Sequence, Union
 
     from pex.hashing import HintedDigest
 
@@ -175,14 +176,12 @@ class LocalProjectDownloadManager(DownloadManager[LocalProjectArtifact]):
 
 
 def download_artifact(
-    downloadable_artifact_and_target,  # type: Tuple[DownloadableArtifact, Target]
-    file_download_managers_by_target,  # type: Mapping[Target, FileArtifactDownloadManager]
+    downloadable_artifact,  # type: DownloadableArtifact
+    file_download_manager,  # type: FileArtifactDownloadManager
     vcs_download_manager,  # type: VCSArtifactDownloadManager
     local_project_download_manager,  # type: LocalProjectDownloadManager
 ):
     # type: (...) -> Union[DownloadedArtifact, Error]
-
-    downloadable_artifact, target = downloadable_artifact_and_target
 
     if isinstance(downloadable_artifact.artifact, VCSArtifact):
         return catch(
@@ -192,7 +191,6 @@ def download_artifact(
         )
 
     if isinstance(downloadable_artifact.artifact, FileArtifact):
-        file_download_manager = file_download_managers_by_target[target]
         return catch(
             file_download_manager.store,
             downloadable_artifact.artifact,
@@ -251,8 +249,8 @@ def resolve_from_lock(
             transitive=transitive,
         )
     )
-    target_by_downloadable_artifact = OrderedDict(
-        (downloadable_artifact, resolved_subset.target)
+    downloadable_artifacts = OrderedSet(
+        downloadable_artifact
         for resolved_subset in subset_result.subsets
         for downloadable_artifact in resolved_subset.resolved.downloadable_artifacts
     )
@@ -264,25 +262,19 @@ def resolve_from_lock(
     # errors under the right interleaving of processes and threads and download artifact targets.
     file_lock_style = FileLockStyle.BSD
 
-    file_download_managers_by_target = {}
-    package_index_configuration = None  # type: Optional[PackageIndexConfiguration]
-    for downloadable_artifact, target in target_by_downloadable_artifact.items():
-        if target not in file_download_managers_by_target:
-            if package_index_configuration is None:
-                package_index_configuration = PackageIndexConfiguration.create(
-                    resolver_version=resolver_version,
-                    indexes=indexes,
-                    find_links=find_links,
-                    network_configuration=network_configuration,
-                    password_entries=PasswordDatabase.from_netrc().append(password_entries).entries,
-                )
-            file_download_managers_by_target[target] = FileArtifactDownloadManager(
-                file_lock_style=file_lock_style,
-                downloader=ArtifactDownloader(
-                    resolver=resolver,
-                    package_index_configuration=package_index_configuration,
-                ),
-            )
+    file_download_manager = FileArtifactDownloadManager(
+        file_lock_style=file_lock_style,
+        downloader=ArtifactDownloader(
+            resolver=resolver,
+            package_index_configuration=PackageIndexConfiguration.create(
+                resolver_version=resolver_version,
+                indexes=indexes,
+                find_links=find_links,
+                network_configuration=network_configuration,
+                password_entries=PasswordDatabase.from_netrc().append(password_entries).entries,
+            ),
+        ),
+    )
 
     vcs_download_manager = VCSArtifactDownloadManager(
         file_lock_style=file_lock_style,
@@ -301,12 +293,12 @@ def resolve_from_lock(
     )
 
     max_threads = min(
-        len(target_by_downloadable_artifact) or 1,
+        len(downloadable_artifacts) or 1,
         min(MAX_PARALLEL_DOWNLOADS, 4 * (max_parallel_jobs or cpu_count() or 1)),
     )
     with TRACER.timed(
         "Downloading {url_count} distributions to satisfy {requirement_count} requirements".format(
-            url_count=len(target_by_downloadable_artifact),
+            url_count=len(downloadable_artifacts),
             requirement_count=len(subset_result.requirements),
         )
     ):
@@ -314,15 +306,15 @@ def resolve_from_lock(
         try:
             download_results = tuple(
                 zip(
-                    target_by_downloadable_artifact,
+                    downloadable_artifacts,
                     pool.map(
                         functools.partial(
                             download_artifact,
-                            file_download_managers_by_target=file_download_managers_by_target,
+                            file_download_manager=file_download_manager,
                             vcs_download_manager=vcs_download_manager,
                             local_project_download_manager=local_project_download_manager,
                         ),
-                        target_by_downloadable_artifact.items(),
+                        downloadable_artifacts,
                     ),
                 )
             )

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -17,7 +17,7 @@ from pex.network_configuration import NetworkConfiguration
 from pex.orderedset import OrderedSet
 from pex.pep_503 import ProjectName
 from pex.pip.local_project import digest_local_project
-from pex.pip.tool import PackageIndexConfiguration
+from pex.pip.tool import PackageIndexConfiguration, get_pip
 from pex.pip.vcs import digest_vcs_archive
 from pex.resolve.downloads import ArtifactDownloader
 from pex.resolve.locked_resolve import (
@@ -262,10 +262,15 @@ def resolve_from_lock(
     # errors under the right interleaving of processes and threads and download artifact targets.
     file_lock_style = FileLockStyle.BSD
 
+    # We eagerly initialize a Pip tool for reasons alluded to above, creation of the Pip tool venv
+    # is not thread-safe and this can lead to errors.
+    pip = get_pip()
+
     file_download_manager = FileArtifactDownloadManager(
         file_lock_style=file_lock_style,
         downloader=ArtifactDownloader(
             resolver=resolver,
+            pip=pip,
             package_index_configuration=PackageIndexConfiguration.create(
                 resolver_version=resolver_version,
                 indexes=indexes,

--- a/pex/resolve/lockfile/create.py
+++ b/pex/resolve/lockfile/create.py
@@ -14,7 +14,7 @@ from pex.dist_metadata import DistMetadata, ProjectNameAndVersion
 from pex.orderedset import OrderedSet
 from pex.pep_503 import ProjectName
 from pex.pip.download_observer import DownloadObserver
-from pex.pip.tool import PackageIndexConfiguration, get_pip
+from pex.pip.tool import PackageIndexConfiguration
 from pex.resolve import lock_resolver, locker, resolvers
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.downloads import ArtifactDownloader

--- a/pex/resolve/lockfile/create.py
+++ b/pex/resolve/lockfile/create.py
@@ -14,7 +14,7 @@ from pex.dist_metadata import DistMetadata, ProjectNameAndVersion
 from pex.orderedset import OrderedSet
 from pex.pep_503 import ProjectName
 from pex.pip.download_observer import DownloadObserver
-from pex.pip.tool import PackageIndexConfiguration
+from pex.pip.tool import PackageIndexConfiguration, get_pip
 from pex.resolve import lock_resolver, locker, resolvers
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.downloads import ArtifactDownloader

--- a/pex/venv/virtualenv.py
+++ b/pex/venv/virtualenv.py
@@ -3,11 +3,12 @@
 
 from __future__ import absolute_import
 
-import fileinput
 import logging
 import os
 import pkgutil
 import re
+from fileinput import FileInput
+
 import sys
 from contextlib import closing
 from pex.common import AtomicDirectory, is_exe, safe_mkdir
@@ -286,7 +287,7 @@ class Virtualenv(object):
         ]
         if scripts:
             rewritten_files = set()
-            with closing(fileinput.input(files=sorted(scripts), inplace=True)) as fi:
+            with closing(FileInput(files=sorted(scripts), inplace=True)) as fi:
                 for line in fi:
                     rewritten_line = line.replace(self._venv_dir, real_venv_dir)
                     if rewritten_line != line:
@@ -307,9 +308,9 @@ class Virtualenv(object):
         ]
         if python_scripts:
             with closing(
-                fileinput.input(files=sorted(python_scripts), inplace=True, mode="rb")
+                FileInput(files=sorted(python_scripts), inplace=True, mode="rb")
             ) as fi:
-                # N.B.: `fileinput` is strange, but useful: the context manager above monkey-patches
+                # N.B.: `FileInput` is strange, but useful: the context manager above monkey-patches
                 # sys.stdout to print to the corresponding original input file, which is has moved
                 # aside.
                 for line in fi:


### PR DESCRIPTION
The lock resolver uses multiple threads to effect parallel downloads and
this was leading to errors in the non-thread-safe `fileinput.input` API
Pex uses as part of re-writing certain venv files when it tried to
initialize the Pip tool venv in multiple threads. Switch to a
thread-safe version of the `fileinput` API and also ensure the Pip tool
venv is created once in the main thread to avoid other multi-thread
issues.

Fixes #1852