### PR TITLE
Fix lock creation `--target-system` handling.

### DIFF
--- a/pex/resolve/locker.py
+++ b/pex/resolve/locker.py
@@ -309,6 +309,11 @@ class Locker(LogAnalyzer):
 
 
 # See https://www.python.org/dev/peps/pep-0508/#environment-markers for more about these values.
+_OS_NAME = {
+    TargetSystem.LINUX: "posix",
+    TargetSystem.MAC: "posix",
+    TargetSystem.WINDOWS: "nt",
+}
 _PLATFORM_SYSTEM = {
     TargetSystem.LINUX: "Linux",
     TargetSystem.MAC: "Darwin",
@@ -364,6 +369,9 @@ def patch(
             TargetSystem.values()
         ):
             target_systems = {
+                "os_names": [
+                    _OS_NAME[target_system] for target_system in lock_configuration.target_systems
+                ],
                 "platform_systems": [
                     _PLATFORM_SYSTEM[target_system]
                     for target_system in lock_configuration.target_systems

--- a/pex/resolve/locker_patches.py
+++ b/pex/resolve/locker_patches.py
@@ -9,6 +9,7 @@ python_full_versions = []
 python_versions = []
 python_majors = []
 
+os_names = []
 platform_systems = []
 sys_platforms = []
 platform_tag_regexps = []

--- a/pex/resolve/locker_patches.py
+++ b/pex/resolve/locker_patches.py
@@ -31,6 +31,7 @@ if target_systems_file:
 
     with open(target_systems_file) as fp:
         target_systems = json.load(fp)
+    os_names = target_systems["os_names"]
     platform_systems = target_systems["platform_systems"]
     sys_platforms = target_systems["sys_platforms"]
     platform_tag_regexps = target_systems["platform_tag_regexps"]
@@ -56,6 +57,7 @@ def patch_marker_evaluate():
 
     python_versions_strings = versions_to_string(python_versions) or skip
     python_full_versions_strings = versions_to_string(python_full_versions) or skip
+    os_names_strings = os_names or skip
     platform_systems_strings = platform_systems or skip
     sys_platforms_strings = sys_platforms or skip
 
@@ -66,6 +68,8 @@ def patch_marker_evaluate():
             return python_versions_strings
         if name == "python_full_version":
             return python_full_versions_strings
+        if name == "os_name":
+            return os_names_strings
         if name == "platform_system":
             return platform_systems_strings
         if name == "sys_platform":

--- a/pex/venv/pex.py
+++ b/pex/venv/pex.py
@@ -418,6 +418,7 @@ def _populate_sources(
                     "_PEX_PATCHED_TAGS_FILE",
                     # These are used by Pex's Pip venv to implement universal locks.
                     "_PEX_PYTHON_VERSIONS_FILE",
+                    "_PEX_TARGET_SYSTEMS_FILE",
                 )
             ]
             if ignored_pex_env_vars:

--- a/tests/integration/test_issue_1856.py
+++ b/tests/integration/test_issue_1856.py
@@ -1,0 +1,64 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import sys
+
+from pex.cli.testing import run_pex3
+from pex.resolve.lockfile import json_codec
+from pex.testing import PY37, ensure_python_interpreter, make_env
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_os_name_spoofing(tmpdir):
+    # type: (Any) -> None
+
+    lock = os.path.join(str(tmpdir), "lock.json")
+
+    create_lock_args = [
+        "lock",
+        "create",
+        "--style",
+        "universal",
+        "--resolver-version",
+        "pip-2020-resolver",
+        "pywinpty==2.0.6; os_name == 'nt'",
+        "--interpreter-constraint",
+        "CPython<4,>=3.7.5",
+        "--indent",
+        "2",
+        "-o",
+        lock,
+        "--target-system",
+        "linux",
+        "--target-system",
+        "mac",
+    ]
+
+    # This ensures that, even if the machine has a functioning cargo / rust toolchain on the PATH,
+    # it becomes non-functioning without altering the system permanently. This is needed to ensure
+    # we can't build the pywinpty sdist to extract needed resolve metadata from it.
+    #
+    # For more info on this corner to reproducing the prior failure, see:
+    #   https://github.com/pantsbuild/pex/issues/1856#issuecomment-1193054493
+    env = make_env(RUSTC=os.devnull)
+
+    # The above attempt to get pywinpty dependency metadata by building the sdist requires a
+    # CPython>=3.7.5 on the PATH which we arrange for if not already present here.
+    if sys.version_info[:3] < (3, 7, 5):
+        python_path = os.environ["PATH"].split(os.pathsep) + [ensure_python_interpreter(PY37)]
+        create_lock_args.extend(["--python-path", ":".join(python_path)])
+
+    run_pex3(*create_lock_args, env=env).assert_success()
+
+    lockfile = json_codec.load(lockfile_path=lock)
+    assert 1 == len(lockfile.locked_resolves)
+
+    locked_resolve = lockfile.locked_resolves[0]
+    assert 0 == len(locked_resolve.locked_requirements), (
+        "Since we're not running on `os_name == 'nt'`, we shouldn't have been able to lock any "
+        "requirements at all."
+    )


### PR DESCRIPTION
When this feature was added in #1821 the `sys_platform` and
`platform_system` environment markers were handled but the `os_name`
environment marker was missed. This allowed Windows-only deps to sneak
through and attempt to be locked even when passing
`--target-system linux --target-system mac`.

Fixes #1856