### PR TITLE
Inline `pex.common.find_site_packages`.

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -49,16 +49,6 @@ _UNIX_EPOCH = datetime(year=1970, month=1, day=1, hour=0, minute=0, second=0, tz
 DETERMINISTIC_DATETIME_TIMESTAMP = (DETERMINISTIC_DATETIME - _UNIX_EPOCH).total_seconds()
 
 
-def find_site_packages(prefix_dir):
-    # type: (str) -> Optional[str]
-    """Return the absolute path to the site-packages directory of the given Python installation."""
-    for root, dirs, _ in os.walk(prefix_dir):
-        for d in dirs:
-            if "site-packages" == d:
-                return os.path.join(root, d)
-    return None
-
-
 def filter_pyc_dirs(dirs):
     # type: (Iterable[str]) -> Iterator[str]
     """Return an iterator over the input `dirs` filtering out Python bytecode cache directories."""

--- a/pex/vendor/__main__.py
+++ b/pex/vendor/__main__.py
@@ -14,14 +14,7 @@ from collections import OrderedDict, defaultdict
 from colors import bold, green, yellow
 from redbaron import CommentNode, LiteralyEvaluable, NameNode, RedBaron
 
-from pex.common import (
-    find_site_packages,
-    safe_delete,
-    safe_mkdir,
-    safe_mkdtemp,
-    safe_open,
-    safe_rmtree,
-)
+from pex.common import safe_delete, safe_mkdir, safe_mkdtemp, safe_open, safe_rmtree
 from pex.vendor import VendorSpec, iter_vendor_specs
 
 
@@ -199,6 +192,18 @@ class ImportRewriter(object):
 
 class VendorizeError(Exception):
     """Indicates an error was encountered updating vendored libraries."""
+
+
+def find_site_packages(prefix_dir):
+    for root, dirs, _ in os.walk(prefix_dir):
+        for d in dirs:
+            if "site-packages" == d:
+                return os.path.join(root, d)
+
+    raise VendorizeError(
+        "Failed to locate a site-packages directory within installation prefix "
+        "{prefix_dir}.".format(prefix_dir=prefix_dir)
+    )
 
 
 def vendorize(root_dir, vendor_specs, prefix, update):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -15,11 +15,9 @@ from pex.common import (
     atomic_directory,
     can_write_dir,
     chmod_plus_x,
-    find_site_packages,
     is_exe,
     is_script,
     open_zip,
-    safe_mkdir,
     safe_open,
     temporary_dir,
     touch,
@@ -388,31 +386,3 @@ def test_is_script(tmpdir):
     assert is_script(exe, check_executable=False)
     assert not is_script(exe)
     assert not is_exe(exe)
-
-
-def test_find_site_packages(tmpdir):
-    # type: (Any) -> None
-
-    def tmp_path(*components):
-        # type: (*str) -> str
-        return os.path.join(str(tmpdir), *components)
-
-    assert find_site_packages(tmp_path("does_not_exist")) is None
-
-    file_path = tmp_path("file")
-    touch(file_path)
-    assert find_site_packages(file_path) is None
-
-    empty = tmp_path("empty")
-    os.mkdir(empty)
-    assert find_site_packages(empty) is None
-
-    pypy_venv = tmp_path("pypy_venv")
-    pypy_site_packages = os.path.join(pypy_venv, "site-packages")
-    safe_mkdir(pypy_site_packages)
-    assert pypy_site_packages == find_site_packages(pypy_venv)
-
-    cpython_venv = tmp_path("cpython_venv")
-    cpython_site_packages = os.path.join(cpython_venv, "lib", "python3.10", "site-packages")
-    safe_mkdir(cpython_site_packages)
-    assert cpython_site_packages == find_site_packages(cpython_venv)


### PR DESCRIPTION
The function is only used by the vendoring script where its
non-robustness in the general case is fine and where its use instead of
`pex.venv.virtualenv.find_site_packages_dir` is necessitated by the
bootstrapping issues inherent in using vendored code while vendoring it.

Follow up to #1863