### PR TITLE
Fix wheel installs: account for purelib & platlib.

### DIFF
--- a/pex/pep_376.py
+++ b/pex/pep_376.py
@@ -425,8 +425,8 @@ class Record(object):
         # `site-packages` that are not in-fact located in site-packages (the "purelib" or "platlib"
         # sysconfig install paths). Work around these broken packages by just looking for all
         # `site-packages` subdirectories of the `prefix_dir` and checking each for the installation
-        # RECORD. There should always be just one such installation RECORD resulting from a
-        # `pip install --prefix <prefix_dir> --no-deps ...` and so this is safe.
+        # `RECORD`. There should always be just one such installation `RECORD` resulting from a
+        # `pip install --prefix <prefix_dir> --no-deps <wheel file>` and so this is safe.
         site_packages_dirs = [
             os.path.join(root, d)
             for root, dirs, _ in os.walk(prefix_dir)

--- a/pex/pip/tool.py
+++ b/pex/pip/tool.py
@@ -712,7 +712,6 @@ class Pip(object):
                 prefix_dir=install_dir,
                 project_name=project_name_and_version.project_name,
                 version=project_name_and_version.version,
-                interpreter=interpreter,
             )
             record.fixup_install(interpreter=interpreter)
 


### PR DESCRIPTION
This fixes a further corner-case detecting `--prefix` installation
`site-packages` directories surfaced by Red Hat based OSes where
"purelib" and "platlib" installation directories differ (`lib/` vs.
`lib64/`). We now simply check each `site-packages` directory found
under the installation `--prefix` for an installation `RECORD` and use
the first such one found. This is safe since we know
`pip install --no-deps --prefix <dist>` only installs one distribution
once.

Fixes #1866