### PR TITLE
Fix `--inhert-path` handling.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,19 +66,19 @@ jobs:
     strategy:
       matrix:
         python-version: [[2, 7], [3, 5], [3, 6], [3, 7], [3, 8], [3, 9], [3, 10], [3, 11, "0-beta.4"]]
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-11]
         exclude:
-          - os: macos-10.15
+          - os: macos-11
             python-version: [3, 5]
-          - os: macos-10.15
+          - os: macos-11
             python-version: [3, 6]
-          - os: macos-10.15
+          - os: macos-11
             python-version: [3, 7]
-          - os: macos-10.15
+          - os: macos-11
             python-version: [3, 8]
-          - os: macos-10.15
+          - os: macos-11
             python-version: [3, 9]
-          - os: macos-10.15
+          - os: macos-11
             python-version: [3, 11, "0-beta.4"]
     steps:
       - name: Calculate Pythons to Expose
@@ -150,9 +150,9 @@ jobs:
     strategy:
       matrix:
         python-version: [[2, 7], [3, 10], [3, 11, "0-beta.4"]]
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-11]
         exclude:
-          - os: macos-10.15
+          - os: macos-11
             python-version: [3, 11, "0-beta.4"]
     steps:
       - name: Calculate Pythons to Expose

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -383,7 +383,7 @@ def maybe_reexec_pex(interpreter_test):
     os.environ.pop("PEX_PYTHON", None)
     os.environ.pop("PEX_PYTHON_PATH", None)
 
-    if ENV.PEX_INHERIT_PATH == InheritPath.FALSE:
+    if interpreter_test.pex_info.inherit_path == InheritPath.FALSE:
         # Now that we've found a compatible Python interpreter, make sure we resolve out of any
         # virtual environments it may be contained in since virtual environments created with
         # `--system-site-packages` foil PEX attempts to scrub the sys.path.

--- a/tests/integration/test_issue_1870.py
+++ b/tests/integration/test_issue_1870.py
@@ -1,0 +1,69 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import subprocess
+
+import colors
+import pytest
+
+from pex.inherit_path import InheritPath
+from pex.testing import PY_VER, make_env, run_pex_command
+from pex.typing import TYPE_CHECKING
+from pex.venv.virtualenv import Virtualenv
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+@pytest.mark.parametrize(
+    "inherit_path",
+    [pytest.param(inherit_path, id=inherit_path.value) for inherit_path in InheritPath.values()],
+)
+def test_inherit_path_pex_info(
+    tmpdir,  # type: Any
+    inherit_path,  # type: InheritPath.Value
+):
+    # type: (...) -> None
+
+    venv_dir = os.path.join(str(tmpdir), "venv")
+    run_pex_command(
+        args=["ansicolors==1.1.8", "--include-tools", "--", "venv", venv_dir],
+        env=make_env(PEX_TOOLS=1),
+    ).assert_success()
+    venv_python = Virtualenv(venv_dir).interpreter.binary
+
+    def assert_inherit_path(
+        pex,  # type: str
+        **env  # type: Any
+    ):
+        # type: (...) -> None
+
+        expect_success = inherit_path is not InheritPath.FALSE
+        process = subprocess.Popen(
+            args=[venv_python, pex, "-c", "import colors; print(colors.yellow('Babel Fish'))"],
+            env=make_env(**env),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdout, stderr = process.communicate()
+        if expect_success:
+            assert process.returncode == 0, stderr
+            assert colors.yellow("Babel Fish") == stdout.decode("utf-8").strip()
+        else:
+            assert process.returncode != 0
+            assert (
+                "ImportError: No module named colors"
+                if PY_VER == (2, 7)
+                else "ModuleNotFoundError: No module named 'colors'"
+            ) in stderr.decode("utf-8")
+
+    empty_pex_build_time = os.path.join(str(tmpdir), "empty-build-time.pex")
+    run_pex_command(
+        args=["--inherit-path={value}".format(value=inherit_path.value), "-o", empty_pex_build_time]
+    ).assert_success()
+    assert_inherit_path(empty_pex_build_time)
+
+    empty_pex_run_time = os.path.join(str(tmpdir), "empty-run-time.pex")
+    run_pex_command(args=["-o", empty_pex_run_time]).assert_success()
+    assert_inherit_path(empty_pex_run_time, PEX_INHERIT_PATH=inherit_path)

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -324,6 +324,17 @@ class PythonpathIsolationTest(object):
                 exe_contents=self.exe,
             )
 
+            # Test the PEX.run API.
+            process = PEX(pex_builder.path()).run(
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+                blocking=False,
+            )
+            stdout, stderr = process.communicate()
+            assert process.returncode == 0, stderr.decode("utf-8")
+            assert expected_output == stdout.decode("utf-8")
+
             # Test direct PEX execution.
             assert expected_output == subprocess.check_output(
                 [sys.executable, pex_builder.path()], env=env

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -326,7 +326,10 @@ class PythonpathIsolationTest(object):
 
             # Test the PEX.run API.
             process = PEX(pex_builder.path()).run(
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, blocking=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+                blocking=False,
             )
             stdout, stderr = process.communicate()
             assert process.returncode == 0, stderr.decode("utf-8")

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -324,17 +324,6 @@ class PythonpathIsolationTest(object):
                 exe_contents=self.exe,
             )
 
-            # Test the PEX.run API.
-            process = PEX(pex_builder.path()).run(
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env=env,
-                blocking=False,
-            )
-            stdout, stderr = process.communicate()
-            assert process.returncode == 0, stderr.decode("utf-8")
-            assert expected_output == stdout.decode("utf-8")
-
             # Test direct PEX execution.
             assert expected_output == subprocess.check_output(
                 [sys.executable, pex_builder.path()], env=env

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -316,26 +316,26 @@ class PythonpathIsolationTest(object):
     def assert_isolation(self, inherit_path, expected_output):
         # type: (Union[str, bool], str) -> None
         env = dict(PYTHONPATH=self.pythonpath)
-        with named_temporary_file() as fake_stdout:
-            with temporary_dir() as temp_dir:
-                pex_builder = write_simple_pex(
-                    temp_dir,
-                    pex_info=self.pex_info(inherit_path),
-                    dists=self.dists,
-                    exe_contents=self.exe,
-                )
+        with temporary_dir() as temp_dir:
+            pex_builder = write_simple_pex(
+                temp_dir,
+                pex_info=self.pex_info(inherit_path),
+                dists=self.dists,
+                exe_contents=self.exe,
+            )
 
-                # Test the PEX.run API.
-                rc = PEX(pex_builder.path()).run(stdout=fake_stdout, env=env)
-                assert rc == 0
+            # Test the PEX.run API.
+            process = PEX(pex_builder.path()).run(
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, blocking=False,
+            )
+            stdout, stderr = process.communicate()
+            assert process.returncode == 0, stderr.decode("utf-8")
+            assert expected_output == stdout.decode("utf-8")
 
-                fake_stdout.seek(0)
-                assert expected_output == fake_stdout.read().decode("utf-8")
-
-                # Test direct PEX execution.
-                assert expected_output == subprocess.check_output(
-                    [sys.executable, pex_builder.path()], env=env
-                ).decode("utf-8")
+            # Test direct PEX execution.
+            assert expected_output == subprocess.check_output(
+                [sys.executable, pex_builder.path()], env=env
+            ).decode("utf-8")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Although runtime over-rides worked, e.g.:
`PEX_INHERIT_PATH=prefer ./my.pex`, build-time configuration via 
`--inherit-path={prefer,fallback}` did not.

Fixing this exposed #992 in tests which is also fixed here by skipping
un-import of virtualenv's `_virtualenv` `sys.meta_path` importer used
by it for patching `distutils`.

Fixes #1870
Fixes #992