### PR TITLE
Fix `pex3 lock ...` when run from the Pex PEX.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,128 +21,6 @@ jobs:
     steps:
       - name: Noop
         run: "true"
-  checks:
-    name:  TOXENV=${{ matrix.tox-env }}
-    needs: org-check
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        include:
-          - check-name: Formatting
-            python-version: "3.10"
-            tox-env: format-check
-            fetch-depth: 1
-          - check-name: Types
-            python-version: "3.10"
-            tox-env: typecheck
-            fetch-depth: 1
-          - check-name: Vendoring
-            python-version: "3.8"
-            tox-env: vendor-check
-            fetch-depth: 1
-          - check-name: Packaging
-            python-version: "3.10"
-            tox-env: package -- --additional-format sdist --additional-format wheel
-            # We need branches and tags since package leans on `git describe`. Passing 0 gets us
-            # complete history.
-            fetch-depth: 0
-    steps:
-      - name: Checkout Pex
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: ${{ matrix.fetch-depth }}
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
-        with:
-          python-version: "${{ matrix.python-version }}"
-      - name: Check ${{ matrix.check-name }}
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
-        with:
-          tox-env: ${{ matrix.tox-env }}
-  cpython-unit-tests:
-    name: (${{ matrix.os }}) TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}
-    needs: org-check
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        python-version: [[2, 7], [3, 5], [3, 6], [3, 7], [3, 8], [3, 9], [3, 10], [3, 11, "0-beta.4"]]
-        os: [ubuntu-20.04, macos-11]
-        exclude:
-          - os: macos-11
-            python-version: [3, 5]
-          - os: macos-11
-            python-version: [3, 6]
-          - os: macos-11
-            python-version: [3, 7]
-          - os: macos-11
-            python-version: [3, 8]
-          - os: macos-11
-            python-version: [3, 9]
-          - os: macos-11
-            python-version: [3, 11, "0-beta.4"]
-    steps:
-      - name: Calculate Pythons to Expose
-        id: calculate-pythons-to-expose
-        run: |
-          skip=""
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
-          fi
-          echo "::set-output name=skip::${skip}"
-      - name: Checkout Pex
-        uses: actions/checkout@v2
-      - name: Setup Python ${{ join(matrix.python-version, '.') }}
-        uses: actions/setup-python@v3
-        with:
-          python-version: "${{ join(matrix.python-version, '.') }}"
-      - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
-        with:
-          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
-      - name: Cache Pyenv Interpreters
-        uses: actions/cache@v2
-        with:
-          path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v3
-      - name: Run Unit Tests
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
-        with:
-          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}
-  pypy-unit-tests:
-    name: (PyPy ${{ join(matrix.pypy-version, '.') }}) TOXENV=pypy${{ join(matrix.pypy-version, '') }}
-    needs: org-check
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        pypy-version: [[2, 7], [3, 9]]
-    steps:
-      - name: Calculate Pythons to Expose
-        id: calculate-pythons-to-expose
-        run: |
-          skip=""
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
-          fi
-          echo "::set-output name=skip::${skip}"
-      - name: Checkout Pex
-        uses: actions/checkout@v2
-      - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
-        uses: actions/setup-python@v3
-        with:
-          python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
-      - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
-        with:
-          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
-      - name: Cache Pyenv Interpreters
-        uses: actions/cache@v2
-        with:
-          path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v3
-      - name: Run Unit Tests
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
-        with:
-          tox-env: pypy${{ join(matrix.pypy-version, '') }}
   cpython-integration-tests:
     name: (${{ matrix.os }}) TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-integration
     needs: org-check
@@ -184,7 +62,7 @@ jobs:
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
-          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-integration
+          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-integration -- -vvsk test_issue_1872 -n0
   pypy-integration-tests:
     name: (PyPy ${{ join(matrix.pypy-version, '.') }}) TOXENV=pypy${{ join(matrix.pypy-version, '') }}-integration
     needs: org-check
@@ -226,13 +104,10 @@ jobs:
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
-          tox-env: pypy${{ join(matrix.pypy-version, '') }}-integration
+          tox-env: pypy${{ join(matrix.pypy-version, '') }}-integration -- -vvsk test_issue_1872 -n0
   final-status:
     name: Gather Final Status
     needs:
-      - checks
-      - cpython-unit-tests
-      - pypy-unit-tests
       - cpython-integration-tests
       - pypy-integration-tests
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,128 @@ jobs:
     steps:
       - name: Noop
         run: "true"
+  checks:
+    name:  TOXENV=${{ matrix.tox-env }}
+    needs: org-check
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - check-name: Formatting
+            python-version: "3.10"
+            tox-env: format-check
+            fetch-depth: 1
+          - check-name: Types
+            python-version: "3.10"
+            tox-env: typecheck
+            fetch-depth: 1
+          - check-name: Vendoring
+            python-version: "3.8"
+            tox-env: vendor-check
+            fetch-depth: 1
+          - check-name: Packaging
+            python-version: "3.10"
+            tox-env: package -- --additional-format sdist --additional-format wheel
+            # We need branches and tags since package leans on `git describe`. Passing 0 gets us
+            # complete history.
+            fetch-depth: 0
+    steps:
+      - name: Checkout Pex
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: ${{ matrix.fetch-depth }}
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: "${{ matrix.python-version }}"
+      - name: Check ${{ matrix.check-name }}
+        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        with:
+          tox-env: ${{ matrix.tox-env }}
+  cpython-unit-tests:
+    name: (${{ matrix.os }}) TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}
+    needs: org-check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [[2, 7], [3, 5], [3, 6], [3, 7], [3, 8], [3, 9], [3, 10], [3, 11, "0-beta.5"]]
+        os: [ubuntu-20.04, macos-11]
+        exclude:
+          - os: macos-11
+            python-version: [3, 5]
+          - os: macos-11
+            python-version: [3, 6]
+          - os: macos-11
+            python-version: [3, 7]
+          - os: macos-11
+            python-version: [3, 8]
+          - os: macos-11
+            python-version: [3, 9]
+          - os: macos-11
+            python-version: [3, 11, "0-beta.5"]
+    steps:
+      - name: Calculate Pythons to Expose
+        id: calculate-pythons-to-expose
+        run: |
+          skip=""
+          if [[ "$(uname -s)" == "Linux" ]]; then
+            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
+          fi
+          echo "::set-output name=skip::${skip}"
+      - name: Checkout Pex
+        uses: actions/checkout@v2
+      - name: Setup Python ${{ join(matrix.python-version, '.') }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: "${{ join(matrix.python-version, '.') }}"
+      - name: Expose Pythons
+        uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
+        with:
+          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
+      - name: Cache Pyenv Interpreters
+        uses: actions/cache@v2
+        with:
+          path: ${{ env._PEX_TEST_PYENV_ROOT }}
+          key: ${{ runner.os }}-pyenv-root-v3
+      - name: Run Unit Tests
+        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        with:
+          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}
+  pypy-unit-tests:
+    name: (PyPy ${{ join(matrix.pypy-version, '.') }}) TOXENV=pypy${{ join(matrix.pypy-version, '') }}
+    needs: org-check
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        pypy-version: [[2, 7], [3, 9]]
+    steps:
+      - name: Calculate Pythons to Expose
+        id: calculate-pythons-to-expose
+        run: |
+          skip=""
+          if [[ "$(uname -s)" == "Linux" ]]; then
+            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
+          fi
+          echo "::set-output name=skip::${skip}"
+      - name: Checkout Pex
+        uses: actions/checkout@v2
+      - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
+      - name: Expose Pythons
+        uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
+        with:
+          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
+      - name: Cache Pyenv Interpreters
+        uses: actions/cache@v2
+        with:
+          path: ${{ env._PEX_TEST_PYENV_ROOT }}
+          key: ${{ runner.os }}-pyenv-root-v3
+      - name: Run Unit Tests
+        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        with:
+          tox-env: pypy${{ join(matrix.pypy-version, '') }}
   cpython-integration-tests:
     name: (${{ matrix.os }}) TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-integration
     needs: org-check
@@ -43,9 +165,6 @@ jobs:
           echo "::set-output name=skip::${skip}"
       - name: Checkout Pex
         uses: actions/checkout@v2
-        with:
-          # We need branches and tags for some ITs.
-          fetch-depth: 0
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
         uses: actions/setup-python@v3
         with:
@@ -62,7 +181,7 @@ jobs:
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
-          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-integration -- -vvsk test_issue_1872 -n0
+          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-integration
   pypy-integration-tests:
     name: (PyPy ${{ join(matrix.pypy-version, '.') }}) TOXENV=pypy${{ join(matrix.pypy-version, '') }}-integration
     needs: org-check
@@ -81,9 +200,6 @@ jobs:
           echo "::set-output name=skip::${skip}"
       - name: Checkout Pex
         uses: actions/checkout@v2
-        with:
-          # We need branches and tags for some ITs.
-          fetch-depth: 0
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
         uses: actions/setup-python@v3
         with:
@@ -104,10 +220,13 @@ jobs:
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
-          tox-env: pypy${{ join(matrix.pypy-version, '') }}-integration -- -vvsk test_issue_1872 -n0
+          tox-env: pypy${{ join(matrix.pypy-version, '') }}-integration
   final-status:
     name: Gather Final Status
     needs:
+      - checks
+      - cpython-unit-tests
+      - pypy-unit-tests
       - cpython-integration-tests
       - pypy-integration-tests
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,9 @@ jobs:
           echo "::set-output name=skip::${skip}"
       - name: Checkout Pex
         uses: actions/checkout@v2
+        with:
+          # We need branches and tags for some ITs.
+          fetch-depth: 0
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
         uses: actions/setup-python@v3
         with:
@@ -200,6 +203,9 @@ jobs:
           echo "::set-output name=skip::${skip}"
       - name: Checkout Pex
         uses: actions/checkout@v2
+        with:
+          # We need branches and tags for some ITs.
+          fetch-depth: 0
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
         uses: actions/setup-python@v3
         with:

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -11,13 +11,13 @@ from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path, PurePath
 from typing import Tuple
 
-import toml
-
 PROJECT_METADATA = Path("pyproject.toml")
 DIST_DIR = Path("dist")
 
 
 def python_requires() -> str:
+    import toml
+
     project_metadata = toml.loads(PROJECT_METADATA.read_text())
     return project_metadata["tool"]["flit"]["metadata"]["requires-python"].strip()
 

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -16,6 +16,9 @@ DIST_DIR = Path("dist")
 
 
 def python_requires() -> str:
+    # N.B.: We run this script directly from integration tests where toml is not needed; so we lazy
+    # import to allow for this direct running of the script without dependency installation by tox
+    # in ITs.
     import toml
 
     project_metadata = toml.loads(PROJECT_METADATA.read_text())

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -93,9 +93,12 @@ def build_pex_dists(dist_fmt: Format, *additional_dist_fmts: Format, verbose: bo
 
 
 def main(
-    *additional_dist_formats: Format, verbosity: int = 0, local: bool = False, serve: bool = False
+    *additional_dist_formats: Format,
+    verbosity: int = 0,
+    pex_output_file: Path = DIST_DIR / "pex",
+    local: bool = False,
+    serve: bool = False
 ) -> None:
-    pex_output_file = DIST_DIR / "pex"
     print(f"Building Pex PEX to `{pex_output_file}` ...")
     build_pex_pex(pex_output_file, local, verbosity)
 
@@ -150,6 +153,12 @@ if __name__ == "__main__":
         help="Package Pex in additional formats.",
     )
     parser.add_argument(
+        "--pex-output-file",
+        default=DIST_DIR / "pex",
+        type=Path,
+        help="Build the Pex PEX at this path.",
+    )
+    parser.add_argument(
         "--local",
         default=False,
         action="store_true",
@@ -166,6 +175,7 @@ if __name__ == "__main__":
     main(
         *(args.additional_formats or ()),
         verbosity=args.verbosity,
+        pex_output_file=args.pex_output_file,
         local=args.local,
         serve=args.serve
     )

--- a/tests/build_system/test_pep_518.py
+++ b/tests/build_system/test_pep_518.py
@@ -13,6 +13,7 @@ from pex.pep_503 import ProjectName
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.result import Error
 from pex.typing import TYPE_CHECKING
+from pex.variables import ENV
 
 if TYPE_CHECKING:
     from typing import Any, Optional, Union
@@ -71,3 +72,18 @@ def test_load_build_system_pyproject(
     subprocess.check_call(
         args=[build_system.venv_pex.pex, "-c", "import {}".format(build_system.build_backend)]
     )
+
+
+def test_load_build_system_env_strip_issue_1872(
+    tmpdir,  # type: Any
+    pex_project_dir,  # type: str
+):
+    # type: (...) -> None
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    with ENV.patch(PEX_ROOT=pex_root, PEX_VERBOSE="2", PEX_SCRIPT="pex3"):
+        build_system = load_build_system(pex_project_dir)
+        assert isinstance(build_system, BuildSystem)
+        assert pex_root == build_system.env["PEX_ROOT"]
+        assert "2" == build_system.env["PEX_VERBOSE"]
+        assert "PEX_SCRIPT" not in build_system.env

--- a/tests/integration/build_system/test_pep_517.py
+++ b/tests/integration/build_system/test_pep_517.py
@@ -1,7 +1,6 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-import os.path
-import subprocess
+
 from typing import Callable
 
 import pytest

--- a/tests/integration/test_issue_1872.py
+++ b/tests/integration/test_issue_1872.py
@@ -24,8 +24,21 @@ def test_pep_518_venv_pex_env_scrubbing(
     # type: (...) -> None
 
     pex_pex = os.path.join(str(tmpdir), "pex")
-    subprocess.check_call(
-        args=["tox", "-e", "package", "--", "--local", "--pex-output-file", pex_pex]
+    process = subprocess.Popen(
+        args=["tox", "-e", "package", "--", "--local", "--pex-output-file", pex_pex],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    stdout, stderr = process.communicate()
+    assert 0 == process.returncode, (
+        "Failed to package a Pex PEX: {returncode}\n"
+        "STDOUT:\n"
+        "===\n"
+        "{stdout}\n"
+        "\n"
+        "STDERR:\n"
+        "===\n"
+        "{stderr}\n".format(returncode=process.returncode, stdout=stdout, stderr=stderr)
     )
 
     lock = os.path.join(str(tmpdir), "lock.json")

--- a/tests/integration/test_issue_1872.py
+++ b/tests/integration/test_issue_1872.py
@@ -1,54 +1,22 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import print_function
-
 import os
 import subprocess
 import sys
 
+from pex.compatibility import PY3
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.resolve.locked_resolve import LocalProjectArtifact
 from pex.resolve.lockfile import json_codec
 from pex.resolve.resolved_requirement import Pin
-from pex.testing import make_env
+from pex.testing import PY37, ensure_python_interpreter, make_env
 from pex.typing import TYPE_CHECKING
 from pex.version import __version__
 
 if TYPE_CHECKING:
     from typing import Any
-
-
-def execute(
-    *args,  # type: str
-    **env  # type: Any
-):
-    # type: (...) -> str
-    env = make_env(**env)
-    process = subprocess.Popen(args=args, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, stderr = process.communicate()
-    message = (
-        "Executed `{args}` exit code {exit_code}:\n"
-        "Environment:\n"
-        "{env}\n"
-        "\n"
-        "STDOUT:\n"
-        "===\n"
-        "{stdout}\n"
-        "\n"
-        "STDERR:\n"
-        "===\n"
-        "{stderr}\n".format(
-            args=" ".join(args),
-            env="\n".join("{key}={value}".format(key=k, value=v) for k, v in env.items()),
-            exit_code=process.returncode,
-            stdout=stdout.decode("utf-8"),
-            stderr=stderr.decode("utf-8"),
-        )
-    )
-    assert 0 == process.returncode, message
-    return message
 
 
 def test_pep_518_venv_pex_env_scrubbing(
@@ -57,25 +25,29 @@ def test_pep_518_venv_pex_env_scrubbing(
 ):
     # type: (...) -> None
 
+    # N.B.: The package script requires Python 3.
+    python = sys.executable if PY3 else ensure_python_interpreter(PY37)
+
+    package_script = os.path.join(pex_project_dir, "scripts", "package.py")
     pex_pex = os.path.join(str(tmpdir), "pex")
-    message = execute("tox", "-e", "package", "--", "--local", "--pex-output-file", pex_pex)
-    print(">>> {}".format(message), file=sys.stderr)
-    print(">>> Exists {}?: {}".format(pex_pex, os.path.exists(pex_pex)), file=sys.stderr)
+    subprocess.check_call(args=[python, package_script, "--local", "--pex-output-file", pex_pex])
 
     lock = os.path.join(str(tmpdir), "lock.json")
-    execute(
-        # Although the package script requires Python 3 to create the Pex PEX, we should be able to
-        # execute the Pex PEX with any interpreter.
-        sys.executable,
-        pex_pex,
-        "lock",
-        "create",
-        pex_project_dir,
-        "-o",
-        lock,
-        "--indent",
-        "2",
-        PEX_SCRIPT="pex3",
+    subprocess.check_call(
+        args=[
+            # Although the package script requires Python 3 to create the Pex PEX, we should be
+            # able to execute the Pex PEX with any interpreter.
+            sys.executable,
+            pex_pex,
+            "lock",
+            "create",
+            pex_project_dir,
+            "-o",
+            lock,
+            "--indent",
+            "2",
+        ],
+        env=make_env(PEX_SCRIPT="pex3"),
     )
 
     lockfile = json_codec.load(lock)

--- a/tests/integration/test_issue_1872.py
+++ b/tests/integration/test_issue_1872.py
@@ -38,7 +38,11 @@ def test_pep_518_venv_pex_env_scrubbing(
         "\n"
         "STDERR:\n"
         "===\n"
-        "{stderr}\n".format(returncode=process.returncode, stdout=stdout, stderr=stderr)
+        "{stderr}\n".format(
+            returncode=process.returncode,
+            stdout=stdout.decode("utf-8"),
+            stderr=stderr.decode("utf-8"),
+        )
     )
 
     lock = os.path.join(str(tmpdir), "lock.json")

--- a/tests/integration/test_issue_1872.py
+++ b/tests/integration/test_issue_1872.py
@@ -1,0 +1,46 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import subprocess
+
+from pex.pep_440 import Version
+from pex.pep_503 import ProjectName
+from pex.resolve.locked_resolve import LocalProjectArtifact
+from pex.resolve.lockfile import json_codec
+from pex.resolve.resolved_requirement import Pin
+from pex.testing import make_env
+from pex.typing import TYPE_CHECKING
+from pex.version import __version__
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_pep_518_venv_pex_env_scrubbing(
+    tmpdir,  # type: Any
+    pex_project_dir,  # type: str
+):
+    # type: (...) -> None
+
+    pex_pex = os.path.join(str(tmpdir), "pex")
+    subprocess.check_call(
+        args=["tox", "-e", "package", "--", "--local", "--pex-output-file", pex_pex]
+    )
+
+    lock = os.path.join(str(tmpdir), "lock.json")
+    subprocess.check_call(
+        args=[pex_pex, "lock", "create", pex_project_dir, "-o", lock, "--indent", "2"],
+        env=make_env(PEX_SCRIPT="pex3"),
+    )
+    lockfile = json_codec.load(lock)
+    assert 1 == len(lockfile.locked_resolves)
+
+    locked_resolve = lockfile.locked_resolves[0]
+    assert 1 == len(locked_resolve.locked_requirements)
+
+    locked_requirement = locked_resolve.locked_requirements[0]
+    assert Pin(ProjectName("pex"), Version(__version__)) == locked_requirement.pin
+    assert isinstance(locked_requirement.artifact, LocalProjectArtifact)
+    assert pex_project_dir == locked_requirement.artifact.directory
+    assert not locked_requirement.additional_artifacts

--- a/tests/integration/test_issue_1872.py
+++ b/tests/integration/test_issue_1872.py
@@ -58,10 +58,12 @@ def test_pep_518_venv_pex_env_scrubbing(
     # type: (...) -> None
 
     pex_pex = os.path.join(str(tmpdir), "pex")
-    execute("tox", "-e", "package", "--", "--local", "--pex-output-file", pex_pex)
+    message = execute("tox", "-e", "package", "--", "--local", "--pex-output-file", pex_pex)
+    print(">>> {}".format(message), file=sys.stderr)
+    print(">>> Exists {}?: {}".format(pex_pex, os.path.exists(pex_pex)), file=sys.stderr)
 
     lock = os.path.join(str(tmpdir), "lock.json")
-    message = execute(
+    execute(
         # Although the package script requires Python 3 to create the Pex PEX, we should be able to
         # execute the Pex PEX with any interpreter.
         sys.executable,
@@ -75,8 +77,6 @@ def test_pep_518_venv_pex_env_scrubbing(
         "2",
         PEX_SCRIPT="pex3",
     )
-    print(">>> {}".format(message), file=sys.stderr)
-    print(">>> Exists {}?: {}".format(pex_pex, os.path.exists(pex_pex)))
 
     lockfile = json_codec.load(lock)
     assert 1 == len(lockfile.locked_resolves)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 isolated_build = true
 skip_missing_interpreters = True
-minversion = 3.24.4
+minversion = 3.25.1
 
 [tox:.package]
 # N.B.: tox will use the same python version as under what tox is installed to package, so unless


### PR DESCRIPTION
Previously locking would fail for local projects when attempted from a
Pex PEX.

Fixes #1872