### PR TITLE
Add support for PEP-691.

### DIFF
--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -31,6 +31,8 @@ PY2 = sys_version_info[0] == 2
 PY3 = sys_version_info[0] == 3
 
 string = cast("Tuple[Type, ...]", (str,) if PY3 else (str, unicode))  # type: ignore[name-defined]
+text = cast("Type[Text]", str if PY3 else unicode)  # type: ignore[name-defined]
+
 
 if PY2:
     from collections import Iterable as Iterable

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -31,7 +31,7 @@ from pex.resolve.lockfile.model import Lockfile
 from pex.resolve.lockfile.subset import subset
 from pex.resolve.requirement_configuration import RequirementConfiguration
 from pex.resolve.resolver_configuration import ResolverVersion
-from pex.resolve.resolvers import Installed, Resolver
+from pex.resolve.resolvers import MAX_PARALLEL_DOWNLOADS, Installed, Resolver
 from pex.resolver import BuildAndInstallRequest, BuildRequest, InstallRequest
 from pex.result import Error, catch, try_
 from pex.targets import Targets
@@ -202,11 +202,6 @@ def download_artifact(
         downloadable_artifact.artifact,
         downloadable_artifact.pin.project_name,
     )
-
-
-# Derived from notes in the bandersnatch PyPI mirroring tool:
-# https://github.com/pypa/bandersnatch/blob/1485712d6aa77fba54bbf5a2df0d7314124ad097/src/bandersnatch/default.conf#L30-L35
-MAX_PARALLEL_DOWNLOADS = 10
 
 
 def resolve_from_lock(

--- a/pex/resolve/pep_691/__init__.py
+++ b/pex/resolve/pep_691/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).

--- a/pex/resolve/pep_691/api.py
+++ b/pex/resolve/pep_691/api.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import
 
+import io
 import json
 
 from pex.compatibility import HTTPError, text, urlparse
@@ -70,7 +71,9 @@ class Client(object):
                 with self._url_fetcher.get_body_stream(
                     endpoint.url, extra_headers={"Accept": endpoint.content_type}
                 ) as fp:
-                    data = json.load(fp)
+                    # JSON exchanged between systems must be UTF-8:
+                    # https://www.rfc-editor.org/rfc/rfc8259#section-8.1
+                    data = json.load(io.TextIOWrapper(fp, encoding="utf-8"))
         except (IOError, OSError, HTTPError) as e:
             raise request_error("failed: {err}".format(err=e))
         except ValueError as e:

--- a/pex/resolve/pep_691/api.py
+++ b/pex/resolve/pep_691/api.py
@@ -80,8 +80,8 @@ class Client(object):
                         if sys.version_info[:2] == (3, 5)
                         else fp
                     )
-                    # The above is tested to work with PyPy 27,3.{6,7,8,9} and
-                    # CPython 2.7,3.{5,6,7,8,9,10,11}, so the type suppression is well vetted here.
+                    # The above is tested to work with PyPy 2.7, PyPy 3.{6,7,8,9}, CPython 2.7 and
+                    # CPython 3.{5,6,7,8,9,10,11}; so the type suppression is well vetted here.
                     data = json.load(stream)  # type: ignore[arg-type]
         except (IOError, OSError, HTTPError) as e:
             raise request_error("failed: {err}".format(err=e))

--- a/pex/resolve/pep_691/api.py
+++ b/pex/resolve/pep_691/api.py
@@ -1,0 +1,185 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import json
+
+from pex.compatibility import HTTPError, text, urlparse
+from pex.fetcher import URLFetcher
+from pex.pep_440 import Version
+from pex.pep_503 import ProjectName
+from pex.resolve.pep_691.model import Endpoint, File, Meta, Project
+from pex.resolve.resolved_requirement import Fingerprint
+from pex.sorted_tuple import SortedTuple
+from pex.third_party.packaging.version import Version as PackagingVersion
+from pex.tracer import TRACER
+from pex.typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional, Type, TypeVar
+
+    import attr  # vendor:skip
+
+    _V = TypeVar("_V")
+else:
+    from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class Client(object):
+    class Error(Exception):
+        """Indicates an error accessing or parsing the results of a PEP-691 API endpoint."""
+
+    ACCEPT = ("application/vnd.pypi.simple.v1+json",)
+
+    _url_fetcher = attr.ib(factory=URLFetcher)  # type: URLFetcher
+
+    def request(self, endpoint):
+        # type: (Endpoint) -> Project
+        """Fetches PEP-691 project file metadata from the endpoint.
+
+        Raises :class:`Client.Error` if there is a problem accessing the endpoint or parsing the
+        results returned from it.
+        """
+
+        if endpoint.content_type not in self.ACCEPT:
+            raise ValueError(
+                "Asked to request project metadata from {url} for {content_type} but only the "
+                "following API content types are accepted: {accepted}".format(
+                    url=endpoint.url,
+                    content_type=endpoint.content_type,
+                    accepted=", ".join(self.ACCEPT),
+                )
+            )
+
+        def request_error(msg):
+            # type: (str) -> Client.Error
+            return self.Error(
+                "PEP-691 API request to {url} for {content_type} {msg}".format(
+                    url=endpoint.url, content_type=endpoint.content_type, msg=msg
+                )
+            )
+
+        try:
+            with TRACER.timed(
+                "Fetching PEP-691 index metadata from {url} for {content_type}".format(
+                    url=endpoint.url, content_type=endpoint.content_type
+                )
+            ):
+                with self._url_fetcher.get_body_stream(
+                    endpoint.url, extra_headers={"Accept": endpoint.content_type}
+                ) as fp:
+                    data = json.load(fp)
+        except (IOError, OSError, HTTPError) as e:
+            raise request_error("failed: {err}".format(err=e))
+        except ValueError as e:
+            raise request_error("returned invalid JSON: {err}".format(err=e))
+
+        def response_error(msg):
+            # type: (str) -> Client.Error
+            return self.Error(
+                "PEP-691 API response from {url} for {content_type} {msg}:\n{response}".format(
+                    url=endpoint.url,
+                    content_type=endpoint.content_type,
+                    msg=msg,
+                    response=json.dumps(data, indent=2),
+                )
+            )
+
+        if not isinstance(data, dict):
+            raise response_error(
+                "was supposed to return a JSON object but returned a JSON {type}.".format(
+                    type=type(data).__name__
+                )
+            )
+
+        def get(
+            key,  # type: str
+            expected_type,  # type: Type[_V]
+            obj=None,  # type: Optional[Dict[str, Any]]
+            default=None,  # type: Optional[_V]
+            path=".",  # type: str
+        ):
+            # type: (...) -> _V
+            if obj and not isinstance(obj, dict):
+                raise response_error(
+                    "was expected to contain an object at '{path}' but contained a {type} "
+                    "instead".format(path=path, type=type(obj).__name__)
+                )
+
+            obj = obj or data
+            try:
+                value = obj[key]
+            except KeyError:
+                if default is not None:
+                    return default
+                raise response_error(
+                    "did not contain the expected key '{path}[\"{key}\"]'".format(
+                        path=path, key=key
+                    )
+                )
+
+            if not isinstance(value, expected_type):
+                raise response_error(
+                    "was expected to contain a {expected_type} at '{path}[\"{key}\"]' but "
+                    "contained a {type} instead.".format(
+                        expected_type=expected_type.__name__,
+                        path=path,
+                        key=key,
+                        type=type(value).__name__,
+                    )
+                )
+
+            return value
+
+        api_version = Version(get("api-version", text, obj=get("meta", dict), path=".meta"))
+        if not isinstance(api_version.parsed_version, PackagingVersion):
+            raise response_error(
+                "reports an api-version of {api_version} which does not have the required "
+                "<major>.<minor> structure.".format(api_version=api_version.raw)
+            )
+        if api_version.parsed_version.major != 1:
+            raise response_error(
+                "reports an api-version of {api_version} and Pex currently only supports "
+                "api-version 1.x".format(api_version=api_version.raw)
+            )
+
+        name = ProjectName(get("name", text))
+
+        files = []
+        for index, file in enumerate(get("files", list, default=[]), start=0):
+            path = ".files[{index}]".format(index=index)
+
+            fingerprints = []
+            for algorithm, hash_ in get("hashes", dict, obj=file, path=path).items():
+                if not isinstance(hash_, text):
+                    raise response_error(
+                        "reports a hash value of {hash} of type {type} for "
+                        "'{path}.hashes[\"{algorithm}\"]' but hash values should be strings".format(
+                            hash=hash_, type=type(hash_).__name__, path=path, algorithm=algorithm
+                        )
+                    )
+                fingerprints.append(
+                    Fingerprint(
+                        algorithm=algorithm,
+                        # N.B.: Hash values are hex which is ascii; so cast(str, hash_) is correct
+                        # for Python 2.7.
+                        hash=cast(str, hash_),
+                    )
+                )
+
+            files.append(
+                File(
+                    filename=get("filename", text, obj=file, path=path),
+                    # N.B.: All URLs in the PEP-691 API are allowed to be relative, see:
+                    #   https://peps.python.org/pep-0691/#json-serialization
+                    # The `urljoin` functions does the right thing here and creates an absolute URL
+                    # only when needed (never for the current PyPI scheme, potentially for other
+                    # indexes though).
+                    url=urlparse.urljoin(endpoint.url, get("url", text, obj=file, path=path)),
+                    hashes=SortedTuple(fingerprints),
+                )
+            )
+
+        return Project(name=name, files=SortedTuple(files), meta=Meta(api_version=api_version))

--- a/pex/resolve/pep_691/fingerprint_service.py
+++ b/pex/resolve/pep_691/fingerprint_service.py
@@ -66,7 +66,7 @@ class FingerprintService(object):
                         url TEXT PRIMARY KEY ASC,
                         algorithm TEXT,
                         hash TEXT
-                    ) STRICT, WITHOUT ROWID;
+                    ) WITHOUT ROWID;
                     """
                 ).close()
                 # N.B.: Maximum parameter count is 999 in pre-2020 versions of SQLite 3; so we limit

--- a/pex/resolve/pep_691/fingerprint_service.py
+++ b/pex/resolve/pep_691/fingerprint_service.py
@@ -1,0 +1,217 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os
+import sqlite3
+from contextlib import closing
+from itertools import repeat
+from multiprocessing.pool import ThreadPool
+
+from pex import pex_warnings
+from pex.compatibility import cpu_count
+from pex.fetcher import URLFetcher
+from pex.resolve.pep_691.api import Client
+from pex.resolve.pep_691.model import Endpoint, Project
+from pex.resolve.resolved_requirement import Fingerprint, PartialArtifact
+from pex.resolve.resolvers import MAX_PARALLEL_DOWNLOADS
+from pex.result import Error, catch
+from pex.tracer import TRACER
+from pex.typing import TYPE_CHECKING
+from pex.variables import ENV
+
+if TYPE_CHECKING:
+    from typing import Iterable, Iterator, List, Optional, Sequence, Set, Tuple, Union
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class _FingerprintedURL(object):
+    url = attr.ib()  # type: str
+    fingerprint = attr.ib()  # type: Fingerprint
+
+
+@attr.s(frozen=True)
+class FingerprintService(object):
+    @classmethod
+    def create(
+        cls,
+        url_fetcher,  # type: URLFetcher
+        max_parallel_jobs=None,  # type: Optional[int]
+    ):
+        return cls(api=Client(url_fetcher=url_fetcher), max_parallel_jobs=max_parallel_jobs)
+
+    _api = attr.ib(factory=Client)  # type: Client
+    _path = attr.ib(factory=lambda: os.path.join(ENV.PEX_ROOT, "fingerprints.db"))  # type: str
+    _max_parallel_jobs = attr.ib(default=None)  # type: Optional[int]
+
+    @property
+    def accept(self):
+        # type: () -> Tuple[str, ...]
+        return self._api.ACCEPT
+
+    def _iter_cached(self, urls_to_fingerprint):
+        # type: (Iterable[str]) -> Iterator[_FingerprintedURL]
+
+        urls = sorted(urls_to_fingerprint)
+        with TRACER.timed("Searching for {count} fingerprints in database".format(count=len(urls))):
+            with sqlite3.connect(self._path) as conn:
+                conn.executescript(
+                    """
+                    CREATE TABLE IF NOT EXISTS hashes (
+                        url TEXT PRIMARY KEY ASC,
+                        algorithm TEXT,
+                        hash TEXT
+                    ) STRICT, WITHOUT ROWID;
+                    """
+                ).close()
+                # N.B.: Maximum parameter count is 999 in pre-2020 versions of SQLite 3; so we limit
+                # to an even lower chunk size to be safe: https://www.sqlite.org/limits.html
+                chunk_size = 100
+                for index in range(0, len(urls), chunk_size):
+                    chunk = urls[index : index + chunk_size]
+                    with closing(
+                        conn.execute(
+                            "SELECT url, algorithm, hash FROM hashes WHERE url IN ({})".format(
+                                ", ".join(repeat("?", len(chunk)))
+                            ),
+                            tuple(chunk),
+                        )
+                    ) as cursor:
+                        for url, algorithm, hash_ in cursor:
+                            yield _FingerprintedURL(
+                                url=url, fingerprint=Fingerprint(algorithm=algorithm, hash=hash_)
+                            )
+
+    def _cache(self, fingerprinted_urls):
+        # type: (Sequence[_FingerprintedURL]) -> None
+
+        with TRACER.timed(
+            "Caching {count} fingerprints in database".format(count=len(fingerprinted_urls))
+        ):
+            with sqlite3.connect(self._path) as conn:
+                conn.executemany(
+                    "INSERT OR REPLACE INTO hashes (url, algorithm, hash) VALUES (?, ?, ?)",
+                    tuple(
+                        (
+                            fingerprinted_url.url,
+                            fingerprinted_url.fingerprint.algorithm,
+                            fingerprinted_url.fingerprint.hash,
+                        )
+                        for fingerprinted_url in fingerprinted_urls
+                    ),
+                ).close()
+
+    def _safe_request(self, endpoint):
+        # type: (Endpoint) -> Union[Project, Error]
+        return catch(self._api.request, endpoint)
+
+    def fingerprint(
+        self,
+        endpoints,  # type: Set[Endpoint]
+        artifacts,  # type: Iterable[PartialArtifact]
+    ):
+        # type: (...) -> Iterator[PartialArtifact]
+        """Attempts to fingerprint all artifacts that are missing a fingerprint.
+
+        Fingerprints are obtained via the PEP-691 JSON API and are not verified.
+
+        :param artifacts: The artifacts to fill in missing fingerprints for.
+        :return: An iterator over all the artifacts given, where some returned artifacts may have
+                 previously missing fingerprints filled in (but not verified).
+        """
+        # N.B.: In the absence of having an advertised fingerprint for an artifact, Pex will
+        # download the artifact and hash it at higher layers; so simply warning about the error is
+        # enough; we need not fail the whole endeavor. The partial artifact just remains partial
+        # and becomes more expensive to lock. The warning is likely un-actionable by the user but
+        # also rare; so it can be reported to maintainers in case the 5s default sqlite3 timeout is
+        # being hit or something similar that might be mitigated by adding more code here.
+
+        artifacts_to_fingerprint = {}
+        for artifact in artifacts:
+            if artifact.fingerprint:
+                yield artifact
+            else:
+                artifacts_to_fingerprint[artifact.url] = artifact
+
+        if not artifacts_to_fingerprint:
+            return
+
+        try:
+            cached = 0
+            for fingerprinted_url in self._iter_cached(artifacts_to_fingerprint):
+                yield attr.evolve(
+                    artifacts_to_fingerprint[fingerprinted_url.url],
+                    fingerprint=fingerprinted_url.fingerprint,
+                )
+                artifacts_to_fingerprint.pop(fingerprinted_url.url)
+                cached += 1
+            TRACER.log("Found {count} fingerprints cached in database.".format(count=cached))
+        except sqlite3.DatabaseError as e:
+            pex_warnings.warn(
+                "Failed to read fingerprints from the cache, continuing to fetch them via the "
+                "PEP-691 JSON API instead: {err}".format(err=e)
+            )
+
+        if not artifacts_to_fingerprint:
+            return
+
+        max_threads = min(
+            len(endpoints) or 1,
+            min(MAX_PARALLEL_DOWNLOADS, 4 * (self._max_parallel_jobs or cpu_count() or 1)),
+        )
+        with TRACER.timed(
+            "Making {api_count} PEP-691 JSON API requests across {thread_count} threads to "
+            "fingerprint {artifact_count} artifacts".format(
+                api_count=len(endpoints),
+                thread_count=max_threads,
+                artifact_count=len(artifacts_to_fingerprint),
+            )
+        ):
+            pool = ThreadPool(processes=max_threads)
+            try:
+                api_results = pool.map(self._safe_request, endpoints)
+            finally:
+                pool.close()
+                pool.join()
+
+        fingerprinted_urls = []  # type: List[_FingerprintedURL]
+        for result in api_results:
+            if isinstance(result, Error):
+                pex_warnings.warn(
+                    "Failed to fetch project metadata, continuing: {error}".format(error=result)
+                )
+                continue
+
+            for file in result.files:
+                fingerprinted_artifact = artifacts_to_fingerprint.pop(file.url, None)
+                if not fingerprinted_artifact:
+                    continue
+
+                maybe_fingerprint = file.select_fingerprint()
+                yield attr.evolve(fingerprinted_artifact, fingerprint=maybe_fingerprint)
+                if maybe_fingerprint:
+                    fingerprinted_urls.append(
+                        _FingerprintedURL(url=file.url, fingerprint=maybe_fingerprint)
+                    )
+
+        # The remaining artifacts have no fingerprint and no endpoint to fetch the data from; so we
+        # just return them as-is.
+        for artifact in artifacts_to_fingerprint.values():
+            yield artifact
+
+        if not fingerprinted_urls:
+            return
+
+        try:
+            self._cache(fingerprinted_urls)
+        except sqlite3.DatabaseError as e:
+            pex_warnings.warn(
+                "Failed to cache fingerprints for {count} URLs, continuing: {err}".format(
+                    count=len(fingerprinted_urls), err=e
+                )
+            )

--- a/pex/resolve/pep_691/fingerprint_service.py
+++ b/pex/resolve/pep_691/fingerprint_service.py
@@ -171,7 +171,7 @@ class FingerprintService(object):
                 message=(
                     "Failed to read fingerprints from the cache, continuing to fetch them via the "
                     "PEP-691 JSON API instead"
-                )
+                ),
             )
 
         if not artifacts_to_fingerprint:
@@ -231,5 +231,5 @@ class FingerprintService(object):
                 error=e,
                 message="Failed to cache fingerprints for {count} URLs, continuing".format(
                     count=len(fingerprinted_urls)
-                )
+                ),
             )

--- a/pex/resolve/pep_691/fingerprint_service.py
+++ b/pex/resolve/pep_691/fingerprint_service.py
@@ -64,8 +64,8 @@ class FingerprintService(object):
                     """
                     CREATE TABLE IF NOT EXISTS hashes (
                         url TEXT PRIMARY KEY ASC,
-                        algorithm TEXT,
-                        hash TEXT
+                        algorithm TEXT NOT NULL,
+                        hash TEXT NOT NULL
                     ) WITHOUT ROWID;
                     """
                 ).close()

--- a/pex/resolve/pep_691/model.py
+++ b/pex/resolve/pep_691/model.py
@@ -52,11 +52,13 @@ class File(object):
     def select_fingerprint(self):
         # type: () -> Optional[Fingerprint]
         """Selects the "best" fingerprint, if any, for this file from amongst its hashes."""
-        hashes = {fingerprint.algorithm: fingerprint.hash for fingerprint in self.hashes}
-        algorithm = self._select_algorithm(hashes)
+        fingerprints_by_algorithm = {
+            fingerprint.algorithm: fingerprint for fingerprint in self.hashes
+        }
+        algorithm = self._select_algorithm(fingerprints_by_algorithm)
         if algorithm is None:
             return None
-        return Fingerprint(algorithm=algorithm, hash=hashes[algorithm])
+        return fingerprints_by_algorithm[algorithm]
 
 
 @attr.s(frozen=True)

--- a/pex/resolve/pep_691/model.py
+++ b/pex/resolve/pep_691/model.py
@@ -21,8 +21,10 @@ else:
 
 @attr.s(frozen=True)
 class File(object):
-    _GUARANTEED_HASH_ALGORITHM_DIGEST_SIZES = {
-        algorithm: hashlib.new(algorithm).digest_size for algorithm in hashlib.algorithms_guaranteed
+    # These ranks prefer the highest digest size and then use alphabetic order for a tie-break.
+    _GUARANTEED_HASH_ALGORITHM_DIGEST_RANKS = {
+        algorithm: (-hashlib.new(algorithm).digest_size, algorithm)
+        for algorithm in hashlib.algorithms_guaranteed
     }
 
     @classmethod
@@ -39,9 +41,8 @@ class File(object):
             return "sha256"
 
         ranked_algorithms = sorted(
-            (alg for alg in algorithms if alg in cls._GUARANTEED_HASH_ALGORITHM_DIGEST_SIZES),
-            key=lambda alg: cls._GUARANTEED_HASH_ALGORITHM_DIGEST_SIZES[alg],
-            reverse=True,  # We want to select the largest digest size.
+            (alg for alg in algorithms if alg in cls._GUARANTEED_HASH_ALGORITHM_DIGEST_RANKS),
+            key=lambda alg: cls._GUARANTEED_HASH_ALGORITHM_DIGEST_RANKS[alg],
         )
         return ranked_algorithms[0] if ranked_algorithms else None
 

--- a/pex/resolve/pep_691/model.py
+++ b/pex/resolve/pep_691/model.py
@@ -1,0 +1,79 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import hashlib
+
+from pex.pep_440 import Version
+from pex.pep_503 import ProjectName
+from pex.resolve.resolved_requirement import Fingerprint
+from pex.sorted_tuple import SortedTuple
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Iterable, Optional, Text
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class File(object):
+    _GUARANTEED_HASH_ALGORITHM_DIGEST_SIZES = {
+        algorithm: hashlib.new(algorithm).digest_size for algorithm in hashlib.algorithms_guaranteed
+    }
+
+    @classmethod
+    def _select_algorithm(cls, algorithms):
+        # type: (Iterable[str]) -> Optional[str]
+
+        # See: https://peps.python.org/pep-0691/#project-detail
+        # In short, sha256 is recommended, but it is highly recommended that at
+        # least 1 guaranteed available hash is presented. We only collect from
+        # guaranteed so that our lock files are usefully portable. If there are
+        # hashes present but none are in the guaranteed set, this just means we'll
+        # fall back to downloading the artifact and hashing it with sha256.
+        if "sha256" in algorithms:
+            return "sha256"
+
+        ranked_algorithms = sorted(
+            (alg for alg in algorithms if alg in cls._GUARANTEED_HASH_ALGORITHM_DIGEST_SIZES),
+            key=lambda alg: cls._GUARANTEED_HASH_ALGORITHM_DIGEST_SIZES[alg],
+            reverse=True,  # We want to select the largest digest size.
+        )
+        return ranked_algorithms[0] if ranked_algorithms else None
+
+    filename = attr.ib()  # type: Text
+    url = attr.ib()  # type: Text
+    hashes = attr.ib()  # type: SortedTuple[Fingerprint]
+
+    def select_fingerprint(self):
+        # type: () -> Optional[Fingerprint]
+        """Selects the "best" fingerprint, if any, for this file from amongst its hashes."""
+        hashes = {fingerprint.algorithm: fingerprint.hash for fingerprint in self.hashes}
+        algorithm = self._select_algorithm(hashes)
+        if algorithm is None:
+            return None
+        return Fingerprint(algorithm=algorithm, hash=hashes[algorithm])
+
+
+@attr.s(frozen=True)
+class Meta(object):
+    api_version = attr.ib()  # type: Version
+
+
+@attr.s(frozen=True)
+class Project(object):
+    """The required data in a PEP-691 project response."""
+
+    name = attr.ib()  # type: ProjectName
+    files = attr.ib()  # type: SortedTuple[File]
+    meta = attr.ib()
+
+
+@attr.s(frozen=True)
+class Endpoint(object):
+    url = attr.ib()  # type: str
+    content_type = attr.ib()  # type: str

--- a/pex/resolve/resolvers.py
+++ b/pex/resolve/resolvers.py
@@ -7,7 +7,6 @@ from abc import abstractmethod
 
 from pex.dist_metadata import Distribution, Requirement
 from pex.fingerprinted_distribution import FingerprintedDistribution
-from pex.resolve.locked_resolve import LockedResolve
 from pex.resolve.lockfile.model import Lockfile
 from pex.sorted_tuple import SortedTuple
 from pex.targets import Target, Targets
@@ -19,6 +18,11 @@ if TYPE_CHECKING:
     import attr  # vendor:skip
 else:
     from pex.third_party import attr
+
+
+# Derived from notes in the bandersnatch PyPI mirroring tool:
+# https://github.com/pypa/bandersnatch/blob/1485712d6aa77fba54bbf5a2df0d7314124ad097/src/bandersnatch/default.conf#L30-L35
+MAX_PARALLEL_DOWNLOADS = 10
 
 
 class ResolveError(Exception):

--- a/tests/integration/resolve/__init__.py
+++ b/tests/integration/resolve/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).

--- a/tests/integration/resolve/pep_691/__init__.py
+++ b/tests/integration/resolve/pep_691/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).

--- a/tests/integration/resolve/pep_691/test_api.py
+++ b/tests/integration/resolve/pep_691/test_api.py
@@ -1,0 +1,96 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import re
+
+import pytest
+
+from pex.pep_503 import ProjectName
+from pex.resolve.pep_691.api import Client
+from pex.resolve.pep_691.model import Endpoint, Project
+from pex.resolve.resolved_requirement import Fingerprint
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Type
+
+
+def request(
+    url,  # type: str
+    content_type,  # type: str
+):
+    # type: (...) -> Project
+    return Client().request(Endpoint(url=url, content_type=content_type))
+
+
+def assert_error(
+    url,  # type: str
+    content_type,  # type: str
+    expected_exception_type,  # type: Type[Exception]
+    prefix,  # type: str
+):
+    # type: (...) -> None
+
+    with pytest.raises(expected_exception_type, match="^{}.*".format(re.escape(prefix))):
+        request(url, content_type)
+
+
+def test_invalid_content_type():
+    # type: () -> None
+
+    assert_error(
+        url="https://example.org",
+        content_type="text/html",
+        expected_exception_type=ValueError,
+        prefix=(
+            "Asked to request project metadata from https://example.org for text/html but only the "
+            "following API content types are accepted:"
+        ),
+    )
+
+
+def test_invalid_json():
+    # type: () -> None
+
+    assert_error(
+        url="https://example.org",
+        content_type="application/vnd.pypi.simple.v1+json",
+        expected_exception_type=Client.Error,
+        prefix=(
+            "PEP-691 API request to https://example.org for application/vnd.pypi.simple.v1+json "
+            "returned invalid JSON: "
+        ),
+    )
+
+
+def test_http_error():
+    # type: () -> None
+
+    assert_error(
+        url="https://pypi.org/simple/p527-DNE",
+        content_type="application/vnd.pypi.simple.v1+json",
+        expected_exception_type=Client.Error,
+        prefix=(
+            "PEP-691 API request to https://pypi.org/simple/p527-DNE for "
+            "application/vnd.pypi.simple.v1+json failed: HTTP Error 404: Not Found"
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "content_type", [pytest.param(content_type, id=content_type) for content_type in Client.ACCEPT]
+)
+def test_valid(content_type):
+    # type: (str) -> None
+
+    p537 = request(url="https://pypi.org/simple/p537", content_type=content_type)
+    assert ProjectName("p537") == p537.name
+
+    files_by_filename = {file.filename: file for file in p537.files}
+    assert (
+        Fingerprint(
+            algorithm="sha256",
+            hash="c1300324000522387b1f0c474db53b081308f78868030e53a2df6f162d3feb86",
+        )
+        == files_by_filename["p537-1.0.0-cp36-cp36m-macosx_10_13_x86_64.whl"].select_fingerprint()
+    )

--- a/tests/resolve/pep_691/__init__.py
+++ b/tests/resolve/pep_691/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).

--- a/tests/resolve/pep_691/test_api.py
+++ b/tests/resolve/pep_691/test_api.py
@@ -1,0 +1,200 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import json
+import re
+from io import BytesIO
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock  # type: ignore[no-redef,import]
+
+import pytest
+
+from pex.fetcher import URLFetcher
+from pex.pep_440 import Version
+from pex.pep_503 import ProjectName
+from pex.resolve.pep_691.api import Client
+from pex.resolve.pep_691.model import Endpoint, File, Meta, Project
+from pex.resolve.resolved_requirement import Fingerprint
+from pex.sorted_tuple import SortedTuple
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Dict
+
+
+def client_request(response_body):
+    # type: (bytes) -> Project
+    with mock.patch.object(URLFetcher, "get_body_stream", return_value=BytesIO(response_body)):
+        return Client().request(
+            Endpoint(
+                url="https://example.org/simple/",
+                content_type="application/vnd.pypi.simple.v1+json",
+            )
+        )
+
+
+def test_request_nominal():
+    # type: () -> None
+    assert Project(
+        name=ProjectName("p537"),
+        files=SortedTuple(
+            [
+                File(
+                    filename="file.tar.gz",
+                    url="https://files.example.org/simple/file.tar.gz",
+                    hashes=SortedTuple(
+                        [
+                            Fingerprint("md5", "weak"),
+                            Fingerprint("sha256", "strong"),
+                        ]
+                    ),
+                ),
+            ]
+        ),
+        meta=Meta(api_version=Version("1.2")),
+    ) == client_request(
+        json.dumps(
+            {
+                "name": "p537",
+                "files": [
+                    {
+                        "filename": "file.tar.gz",
+                        "url": "https://files.example.org/simple/file.tar.gz",
+                        "hashes": {"md5": "weak", "sha256": "strong"},
+                    },
+                ],
+                "meta": {"api-version": "1.2"},
+            }
+        ).encode("utf-8")
+    )
+
+
+def test_request_url_absolutize():
+    # type: () -> None
+    assert Project(
+        name=ProjectName("p537"),
+        files=SortedTuple(
+            [
+                File(
+                    filename="file.whl",
+                    url="https://example.org/simple/__files/relative/file.whl",
+                    hashes=SortedTuple([Fingerprint("md5", "collision")]),
+                ),
+            ]
+        ),
+        meta=Meta(api_version=Version("1.2")),
+    ) == client_request(
+        json.dumps(
+            {
+                "name": "p537",
+                "files": [
+                    {
+                        "filename": "file.whl",
+                        "url": "__files/relative/file.whl",
+                        "hashes": {"md5": "collision"},
+                    },
+                ],
+                "meta": {"api-version": "1.2"},
+            }
+        ).encode("utf-8")
+    )
+
+
+def test_bad_json_response():
+    # type: () -> None
+    with pytest.raises(
+        Client.Error,
+        match=r"^{}.*".format(
+            re.escape(
+                "PEP-691 API request to https://example.org/simple/ for "
+                "application/vnd.pypi.simple.v1+json returned invalid JSON: "
+            )
+        ),
+    ):
+        client_request(b"[[]")
+
+
+def serialize_response(data):
+    # type: (Dict[str, Any]) -> bytes
+    return json.dumps(data, indent=2).encode("utf-8")
+
+
+def assert_response_error_starts_with(
+    response,  # type: Dict[str, Any]
+    prefix,  # type: str
+):
+    # type: (...) -> None
+
+    with pytest.raises(Client.Error, match=r"^{}.*".format(re.escape(prefix))):
+        client_request(serialize_response(response))
+
+
+def test_unsupported_api_version():
+    assert_response_error_starts_with(
+        {"name": "p537", "files": [], "meta": {"api-version": "2.0"}},
+        prefix=(
+            "PEP-691 API response from https://example.org/simple/ for "
+            "application/vnd.pypi.simple.v1+json reports an api-version of 2.0 and Pex "
+            "currently only supports api-version 1.x:"
+        ),
+    )
+
+
+@pytest.fixture
+def valid_response():
+    # type: () -> Dict[str, Any]
+    return {
+        "name": "p537",
+        "files": [
+            {
+                "filename": "file.whl",
+                "url": "__files/relative/file.whl",
+                "hashes": {"md5": "collision"},
+            }
+        ],
+        "meta": {"api-version": "1.2"},
+    }
+
+
+def test_missing_name(valid_response):
+    # type: (Dict[str, Any]) -> None
+
+    valid_response.pop("name")
+    assert_response_error_starts_with(
+        valid_response,
+        prefix=(
+            "PEP-691 API response from https://example.org/simple/ for "
+            "application/vnd.pypi.simple.v1+json did not contain the expected key '.[\"name\"]':"
+        ),
+    )
+
+
+def test_missing_meta_version(valid_response):
+    # type: (Dict[str, Any]) -> None
+
+    valid_response["meta"].pop("api-version")
+    assert_response_error_starts_with(
+        valid_response,
+        prefix=(
+            "PEP-691 API response from https://example.org/simple/ for "
+            "application/vnd.pypi.simple.v1+json did not contain the expected key "
+            "'.meta[\"api-version\"]':"
+        ),
+    )
+
+
+def test_bad_hash(valid_response):
+    # type: (Dict[str, Any]) -> None
+
+    valid_response["files"][0]["hashes"]["sha256"] = 42
+    assert_response_error_starts_with(
+        valid_response,
+        prefix=(
+            "PEP-691 API response from https://example.org/simple/ for "
+            "application/vnd.pypi.simple.v1+json reports a hash value of 42 of type int for "
+            "'.files[0].hashes[\"sha256\"]' but hash values should be strings:"
+        ),
+    )

--- a/tests/resolve/pep_691/test_fingerprint_service.py
+++ b/tests/resolve/pep_691/test_fingerprint_service.py
@@ -1,0 +1,212 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+
+import pytest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock  # type: ignore[no-redef,import]
+
+from pex.compatibility import urlparse
+from pex.pep_440 import Version
+from pex.pep_503 import ProjectName
+from pex.resolve.pep_691.api import Client
+from pex.resolve.pep_691.fingerprint_service import FingerprintService
+from pex.resolve.pep_691.model import Endpoint, File, Meta, Project
+from pex.resolve.resolved_requirement import Fingerprint, PartialArtifact
+from pex.sorted_tuple import SortedTuple
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+ENDPOINT = Endpoint("https://example.org/simple/foo", "x/y")
+
+
+@pytest.fixture
+def database_path(tmpdir):
+    # type: (Any) -> str
+    return os.path.join(str(tmpdir), "fingerprints.db")
+
+
+def file(
+    url,  # type: str
+    **hashes  # type: str
+):
+    # type: (...) -> File
+    return File(
+        filename=os.path.basename(urlparse.urlparse(url).path),
+        url=url,
+        hashes=SortedTuple(
+            Fingerprint(algorithm=algorithm, hash=hash_) for algorithm, hash_ in hashes.items()
+        ),
+    )
+
+
+def create_project(
+    name,  # type: str
+    *files  # type: File
+):
+    # type: (...) -> Project
+    return Project(
+        name=ProjectName(name), files=SortedTuple(files), meta=Meta(api_version=Version("1.0"))
+    )
+
+
+def test_no_fingerprints(database_path):
+    # type: (str) -> None
+
+    with mock.patch.object(Client, "request", return_value=create_project("foo")) as request:
+        fingerprint_service = FingerprintService(path=database_path)
+        artifacts = list(
+            fingerprint_service.fingerprint(
+                endpoints={ENDPOINT},
+                artifacts=[PartialArtifact(url="https://files.example.org/foo")],
+            )
+        )
+        assert [PartialArtifact(url="https://files.example.org/foo")] == artifacts
+    request.assert_called_once_with(ENDPOINT)
+
+
+def test_no_matching_fingerprints(database_path):
+    # type: (str) -> None
+
+    with mock.patch.object(
+        Client,
+        "request",
+        return_value=create_project(
+            "foo",
+            file("https://files.example.org/foo-1.0.tar.gz", md5="weak"),
+            file("https://files.example.org/foo-2.0.tar.gz", sha256="strong"),
+        ),
+    ) as request:
+        fingerprint_service = FingerprintService(path=database_path)
+        artifacts = list(
+            fingerprint_service.fingerprint(
+                endpoints={ENDPOINT},
+                artifacts=[PartialArtifact(url="https://files.example.org/foo-1.1.tar.gz")],
+            )
+        )
+        assert [PartialArtifact(url="https://files.example.org/foo-1.1.tar.gz")] == artifacts
+    request.assert_called_once_with(ENDPOINT)
+
+
+def test_cache_miss_retries(database_path):
+    # type: (Any) -> None
+
+    endpoint = Endpoint("https://example.org/simple/foo", "x/y")
+    attempts = 3
+
+    with mock.patch.object(
+        Client,
+        "request",
+        return_value=create_project(
+            "foo",
+            file("https://files.example.org/foo-1.0.tar.gz", md5="weak"),
+            file("https://files.example.org/foo-2.0.tar.gz", sha256="strong"),
+        ),
+    ) as request:
+        fingerprint_service = FingerprintService(path=database_path)
+        for _ in range(attempts):
+
+            artifacts = list(
+                fingerprint_service.fingerprint(
+                    endpoints={endpoint},
+                    artifacts=[PartialArtifact(url="https://files.example.org/foo-1.1.tar.gz")],
+                )
+            )
+            assert [PartialArtifact(url="https://files.example.org/foo-1.1.tar.gz")] == artifacts
+
+    # We shouldn't cache misses.
+    request.assert_has_calls([mock.call(endpoint) for _ in range(attempts)])
+
+
+def test_cache_hit(tmpdir):
+    # type: (Any) -> None
+
+    database_path = os.path.join(str(tmpdir), "fingerprints.db")
+    endpoint = Endpoint("https://example.org/simple/foo", "x/y")
+    initial_artifact = PartialArtifact(url="https://files.example.org/foo-1.1.tar.gz")
+    expected_artifact = PartialArtifact(
+        url="https://files.example.org/foo-1.1.tar.gz",
+        fingerprint=Fingerprint(algorithm="md5", hash="weak"),
+    )
+
+    with mock.patch.object(
+        Client,
+        "request",
+        return_value=create_project(
+            "foo", file("https://files.example.org/foo-1.1.tar.gz", md5="weak")
+        ),
+    ) as request:
+        fingerprint_service = FingerprintService(path=database_path)
+        for _ in range(3):
+            artifacts = list(
+                fingerprint_service.fingerprint(endpoints={endpoint}, artifacts=[initial_artifact])
+            )
+            assert [expected_artifact] == artifacts
+
+        # We should cache the hit and not need to call the API again.
+        request.assert_called_once_with(endpoint)
+
+        # Unless the cache is wiped out.
+        os.unlink(database_path)
+        request.reset_mock()
+        assert [expected_artifact] == list(
+            fingerprint_service.fingerprint(endpoints={endpoint}, artifacts=[initial_artifact])
+        )
+        request.assert_called_once_with(endpoint)
+
+
+def test_mixed(database_path):
+    # type: (str) -> None
+
+    responses = {
+        Endpoint("https://example.org/simple/foo", "a/b"): create_project(
+            "foo",
+            file("https://files.example.org/foo-1.0.tar.gz", md5="weak"),
+            file("https://files.example.org/foo-2.0.tar.gz", sha256="strong", sha384="fancy"),
+        ),
+        Endpoint("https://example.org/simple/bar", "x/y"): create_project(
+            "bar", file("https://files.example.org/bar-1.1.tar.gz", sha1="middling", sha384="fancy")
+        ),
+    }
+
+    with mock.patch.object(Client, "request", side_effect=responses.get) as request:
+        fingerprint_service = FingerprintService(path=database_path)
+        artifacts = sorted(
+            fingerprint_service.fingerprint(
+                endpoints=set(responses),
+                artifacts=[
+                    PartialArtifact(url="https://files.example.org/foo-1.0.tar.gz"),
+                    PartialArtifact(url="https://files.example.org/foo-2.0.tar.gz"),
+                    PartialArtifact(url="https://files.example.org/bar-1.1.tar.gz"),
+                    PartialArtifact(url="https://files.example.org/baz-2.0.tar.gz"),
+                ],
+            )
+        )
+        assert (
+            sorted(
+                [
+                    PartialArtifact(
+                        url="https://files.example.org/foo-1.0.tar.gz",
+                        fingerprint=Fingerprint("md5", "weak"),
+                    ),
+                    PartialArtifact(
+                        url="https://files.example.org/foo-2.0.tar.gz",
+                        fingerprint=Fingerprint("sha256", "strong"),
+                    ),
+                    PartialArtifact(
+                        url="https://files.example.org/bar-1.1.tar.gz",
+                        fingerprint=Fingerprint("sha384", "fancy"),
+                    ),
+                    PartialArtifact(url="https://files.example.org/baz-2.0.tar.gz"),
+                ]
+            )
+            == artifacts
+        )
+    request.assert_has_calls([mock.call(endpoint) for endpoint in responses], any_order=True)

--- a/tests/resolve/pep_691/test_model.py
+++ b/tests/resolve/pep_691/test_model.py
@@ -1,0 +1,96 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import hashlib
+import itertools
+from collections import defaultdict
+
+import pytest
+
+from pex.resolve.pep_691.model import File
+from pex.resolve.resolved_requirement import Fingerprint
+from pex.sorted_tuple import SortedTuple
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import DefaultDict, List, Tuple
+
+
+def file(**hashes):
+    # type (**str) -> File
+    return File(
+        filename="foo.tar.gz",
+        url="https://files.example.org/foo.tar.gz",
+        hashes=SortedTuple(Fingerprint(algorithm, hash_) for algorithm, hash_ in hashes.items()),
+    )
+
+
+def test_select_fingerprint_none():
+    # type: () -> None
+
+    assert file().select_fingerprint() is None
+
+
+@pytest.mark.parametrize("guaranteed_algorithm", sorted(hashlib.algorithms_guaranteed))
+def test_select_fingerprint_single_guaranteed(guaranteed_algorithm):
+    # type: (str) -> None
+
+    hashes = {guaranteed_algorithm: "hash_hex_value"}
+    assert (
+        Fingerprint(algorithm=guaranteed_algorithm, hash="hash_hex_value")
+        == file(**hashes).select_fingerprint()
+    )
+
+
+def test_select_fingerprint_sha256_trumps_all_others():
+    # type: () -> None
+
+    hashes = {algorithm: "hash_hex_value" for algorithm in hashlib.algorithms_available}
+    hashes["sha256"] = "preferred"
+    assert Fingerprint(algorithm="sha256", hash="preferred") == file(**hashes).select_fingerprint()
+
+
+def test_select_fingerpint_none_guaranteed():
+    # type: () -> None
+
+    hashes = {
+        algorithm: "hash_hex_value"
+        for algorithm in set(hashlib.algorithms_available) - set(hashlib.algorithms_guaranteed)
+    }
+    assert file(**hashes).select_fingerprint() is None
+
+
+@pytest.mark.parametrize(
+    "guaranteed_algorithm_pair",
+    [
+        pytest.param(
+            (one, two),
+            id="{one}[{one_size}] vs {two}[{two_size}]".format(
+                one=one,
+                one_size=hashlib.new(one).digest_size,
+                two=two,
+                two_size=hashlib.new(two).digest_size,
+            ),
+        )
+        for one, two in sorted(
+            itertools.combinations(set(hashlib.algorithms_guaranteed) - {"sha256"}, 2)
+        )
+    ],
+)
+def test_select_fingerprint_ranking(guaranteed_algorithm_pair):
+    # type: (Tuple[str, str]) -> None
+
+    algorithms_by_size = defaultdict(list)  # type: DefaultDict[int, List[str]]
+    hashes = {}
+    for algorithm in guaranteed_algorithm_pair:
+        algorithms_by_size[hashlib.new(algorithm).digest_size].append(algorithm)
+        hashes[algorithm] = "{algorithm}_hash_hex_value".format(algorithm=algorithm)
+
+    # We expect algorithms are preferred for greatest digest size and then tie-broken by alphabetic
+    # order.
+    expected_algorithm = sorted(algorithms_by_size[max(algorithms_by_size)])[0]
+    expected_hash = hashes[expected_algorithm]
+
+    assert (
+        Fingerprint(algorithm=expected_algorithm, hash=expected_hash)
+        == file(**hashes).select_fingerprint()
+    )


### PR DESCRIPTION
This is needed to support newer Pip where fingerprints are hidden from the
verbose logs Pex scrapes to build locks. The Pex fallback of downloading
every artifact locked and hashing it works but is just too expensive to
be the normal case.

Work towards #1805