### PR TITLE
Support dynamic Pip installations.

### DIFF
--- a/pex/build_system/testing.py
+++ b/pex/build_system/testing.py
@@ -10,7 +10,7 @@ from pex.build_system.pep_517 import build_sdist
 from pex.dist_metadata import Distribution
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
-from pex.pip.tool import get_pip
+from pex.pip.installation import get_pip
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.result import Error
 from pex.typing import TYPE_CHECKING

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
         Mapping,
         MutableMapping,
         Optional,
+        Sequence,
         Text,
         Tuple,
         Union,
@@ -1264,7 +1265,7 @@ def spawn_python_job(
     args,  # type: Iterable[str]
     env=None,  # type: Optional[Mapping[str, str]]
     interpreter=None,  # type: Optional[PythonInterpreter]
-    expose=None,  # type: Optional[Iterable[str]]
+    expose=None,  # type: Optional[Sequence[str]]
     pythonpath=None,  # type: Optional[Iterable[str]]
     **subprocess_kwargs  # type: Any
 ):

--- a/pex/pip/installation.py
+++ b/pex/pip/installation.py
@@ -1,0 +1,223 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os
+from textwrap import dedent
+
+from pex import pex_warnings, third_party
+from pex.common import atomic_directory
+from pex.interpreter import PythonInterpreter
+from pex.orderedset import OrderedSet
+from pex.pex import PEX
+from pex.pex_bootstrapper import VenvPex, ensure_venv
+from pex.pip.tool import Pip
+from pex.pip.version import PipVersion, PipVersionValue
+from pex.resolve.resolvers import Resolver
+from pex.targets import LocalInterpreter, RequiresPythonError, Targets
+from pex.third_party import isolated
+from pex.typing import TYPE_CHECKING
+from pex.util import named_temporary_file
+from pex.variables import ENV
+
+if TYPE_CHECKING:
+    from typing import Callable, Dict, Iterator, Optional
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+def _pip_venv(
+    version,  # type: PipVersionValue
+    iter_distribution_locations,  # type: Callable[[], Iterator[str]]
+    interpreter=None,  # type: Optional[PythonInterpreter]
+):
+    # type: (...) -> VenvPex
+    path = os.path.join(ENV.PEX_ROOT, "pip-{version}.pex".format(version=version))
+    pip_interpreter = interpreter or PythonInterpreter.get()
+    pip_pex_path = os.path.join(path, isolated().pex_hash)
+    with atomic_directory(pip_pex_path, exclusive=True) as chroot:
+        if not chroot.is_finalized():
+            from pex.pex_builder import PEXBuilder
+
+            isolated_pip_builder = PEXBuilder(path=chroot.work_dir)
+            isolated_pip_builder.info.venv = True
+            for dist_location in iter_distribution_locations():
+                isolated_pip_builder.add_dist_location(dist=dist_location)
+            with named_temporary_file(prefix="", suffix=".py", mode="w") as fp:
+                fp.write(
+                    dedent(
+                        """\
+                        import os
+                        import runpy
+
+                        patches_module = os.environ.pop({patches_module_env_var_name!r}, None)
+                        if patches_module:
+                            # Apply runtime patches to Pip to work around issues or else bend
+                            # Pip to Pex's needs.
+                            __import__(patches_module)
+
+                        runpy.run_module(mod_name="pip", run_name="__main__", alter_sys=True)
+                        """
+                    ).format(patches_module_env_var_name=Pip._PATCHES_MODULE_ENV_VAR_NAME)
+                )
+                fp.close()
+                isolated_pip_builder.set_executable(fp.name, "__pex_patched_pip__.py")
+            isolated_pip_builder.freeze()
+    return ensure_venv(PEX(pip_pex_path, interpreter=pip_interpreter))
+
+
+def _vendored_installation(interpreter=None):
+    # type: (Optional[PythonInterpreter]) -> VenvPex
+
+    return _pip_venv(
+        version=PipVersion.VENDORED,
+        iter_distribution_locations=lambda: third_party.expose(("pip", "setuptools", "wheel")),
+        interpreter=interpreter,
+    )
+
+
+def _resolved_installation(
+    version,  # type: PipVersionValue
+    resolver,  # type: Resolver
+    interpreter=None,  # type: Optional[PythonInterpreter]
+):
+    # type: (...) -> VenvPex
+    if version is PipVersion.VENDORED:
+        return _vendored_installation(interpreter=interpreter)
+
+    def resolve_distribution_locations():
+        for installed_distribution in resolver.resolve_requirements(
+            requirements=version.requirements,
+            targets=Targets(interpreters=(interpreter or PythonInterpreter.get(),)),
+            pip_version=PipVersion.VENDORED,
+        ).installed_distributions:
+            yield installed_distribution.distribution.location
+
+    return _pip_venv(
+        version=version,
+        iter_distribution_locations=resolve_distribution_locations,
+        interpreter=interpreter,
+    )
+
+
+@attr.s(frozen=True)
+class PipInstallation(object):
+    interpreter = attr.ib()  # type: PythonInterpreter
+    version = attr.ib()  # type: PipVersionValue
+
+    def check_python_applies(self):
+        # type: () -> None
+        if not self.version.requires_python_applies(LocalInterpreter.create(self.interpreter)):
+            raise RequiresPythonError(
+                "The Pip requested was {pip_requirement} but it does not work with the interpreter "
+                "selected which is {python_impl} {python_version} at {python_binary}. Pip "
+                "{pip_version} requires Python {requires_python}.".format(
+                    pip_requirement=self.version.requirement,
+                    pip_version=self.version.value,
+                    python_impl=self.interpreter.identity.interpreter,
+                    python_version=self.interpreter.identity.version_str,
+                    python_binary=self.interpreter.binary,
+                    requires_python=self.version.requires_python,
+                )
+            )
+
+
+def validate_targets(
+    targets,  # type: Targets
+    version,  # type: PipVersionValue
+    context,  # type: str
+):
+    # type: (...) -> None
+    all_targets = targets.unique_targets()
+    invalid_targets = [
+        target for target in all_targets if not version.requires_python_applies(target)
+    ]
+    if invalid_targets:
+        raise RequiresPythonError(
+            "The Pip requested for {context} was {pip_requirement} but it does not work with "
+            "{quantifier} targets selected.\n"
+            "\n"
+            "Pip {pip_version} requires Python {requires_python} and the following {targets_do} "
+            "not apply:\n"
+            "{invalid_targets}"
+            "".format(
+                context=context,
+                pip_requirement=version.requirement,
+                quantifier="any of the"
+                if len(invalid_targets) == len(all_targets)
+                else "{invalid} out of the {total}".format(
+                    invalid=len(invalid_targets), total=len(all_targets)
+                ),
+                pip_version=version.value,
+                requires_python=version.requires_python,
+                targets_do="target does" if len(invalid_targets) == 1 else "targets do",
+                invalid_targets="\n".join(
+                    "{index}. {target}".format(index=index, target=target)
+                    for index, target in enumerate(invalid_targets, start=1)
+                ),
+            )
+        )
+
+
+def compatible_version(
+    targets,  # type: Targets
+    requested_version,  # type: PipVersionValue
+    context,  # type: str
+):
+    # type: (...) -> PipVersionValue
+    try:
+        validate_targets(targets, requested_version, context)
+        return requested_version
+    except RequiresPythonError as e:
+        remaining_versions = OrderedSet([requested_version] + list(PipVersion.values()))
+        remaining_versions.discard(requested_version)
+        for version in remaining_versions:
+            try:
+                validate_targets(targets, version, context)
+                pex_warnings.warn(
+                    "{err}\n" "\n" "Using Pip {version} instead.".format(err=e, version=version)
+                )
+                return version
+            except RequiresPythonError:
+                continue
+    return PipVersion.v20_3_4_patched
+
+
+_PIP = {}  # type: Dict[PipInstallation, Pip]
+
+
+def get_pip(
+    interpreter=None,
+    version=PipVersion.VENDORED,  # type: PipVersionValue
+    resolver=None,  # type: Optional[Resolver]
+):
+    # type: (...) -> Pip
+    """Returns a lazily instantiated global Pip object that is safe for un-coordinated use."""
+    installation = PipInstallation(
+        interpreter=interpreter or PythonInterpreter.get(),
+        version=version,
+    )
+    pip = _PIP.get(installation)
+    if pip is None:
+        installation.check_python_applies()
+        if version is PipVersion.VENDORED:
+            pip = Pip(pip_pex=_vendored_installation(interpreter=interpreter))
+        else:
+            if resolver is None:
+                raise ValueError(
+                    "A resolver is required to install {requirement}".format(
+                        requirement=version.requirement
+                    )
+                )
+            pip = Pip(
+                pip_pex=_resolved_installation(
+                    version=version,
+                    resolver=resolver,
+                    interpreter=interpreter,
+                )
+            )
+        _PIP[installation] = pip
+    return pip

--- a/pex/pip/version.py
+++ b/pex/pip/version.py
@@ -1,0 +1,87 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from pex.dist_metadata import Requirement
+from pex.enum import Enum
+from pex.targets import LocalInterpreter, Target
+from pex.third_party.packaging.specifiers import SpecifierSet
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Iterable, Optional, Tuple
+
+
+class PipVersionValue(Enum.Value):
+    def __init__(
+        self,
+        version,  # type: str
+        requirement=None,  # type: Optional[str]
+        setuptools_version=None,  # type: Optional[str]
+        wheel_version=None,  # type: Optional[str]
+        requires_python=None,  # type: Optional[str]
+    ):
+        # type: (...) -> None
+        super(PipVersionValue, self).__init__(version)
+
+        def to_requirement(
+            project_name,  # type: str
+            project_version=None,  # type: Optional[str]
+        ):
+            # type: (...) -> str
+            return (
+                "{project_name}=={project_version}".format(
+                    project_name=project_name, project_version=project_version
+                )
+                if project_version
+                else project_name
+            )
+
+        self.requirement = requirement or to_requirement("pip", version)
+        self.setuptools_requirement = to_requirement("setuptools", setuptools_version)
+        self.wheel_requirement = to_requirement("wheel", wheel_version)
+        self.requires_python = SpecifierSet(requires_python) if requires_python else None
+
+    @property
+    def requirements(self):
+        # type: () -> Iterable[str]
+        return self.requirement, self.setuptools_requirement, self.wheel_requirement
+
+    def requires_python_applies(self, target):
+        # type: (Target) -> bool
+        if not self.requires_python:
+            return True
+
+        return LocalInterpreter.create(target.get_interpreter()).requires_python_applies(
+            requires_python=self.requires_python,
+            source=Requirement.parse(self.requirement),
+        )
+
+
+class PipVersion(Enum["PipVersionValue"]):
+    @classmethod
+    def values(cls):
+        # type: () -> Tuple[PipVersionValue, ...]
+        if cls._values is None:
+            cls._values = tuple(PipVersionValue._iter_values())
+        return cls._values
+
+    v20_3_4_patched = PipVersionValue(
+        version="20.3.4-patched",
+        requirement=(
+            "pip @ git+https://github.com/pantsbuild/pip@386a54f097ece66775d0c7f34fd29bb596c6b0be"
+        ),
+    )
+
+    v22_2_2 = PipVersionValue(
+        # TODO(John Sirois): Consider exposing pip version via an env var since changing that is
+        #  advanced.
+        version="22.2.2",
+        # TODO(John Sirois): Expose setuptools and wheel version flags - these don't affect
+        #  Pex; so we should allow folks to experiment with upgrade easily.
+        setuptools_version="65.3.0",
+        wheel_version="0.37.1",
+        requires_python=">=3.7",
+    )
+    VENDORED = v20_3_4_patched

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -212,7 +212,7 @@ class Platform(object):
     ):
         # type: (...) -> Iterator[tags.Tag]
         from pex.jobs import SpawnedJob
-        from pex.pip.tool import get_pip
+        from pex.pip.installation import get_pip
 
         def parse_tags(output):
             # type: (bytes) -> Iterator[tags.Tag]

--- a/pex/resolve/configured_resolver.py
+++ b/pex/resolve/configured_resolver.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 
 from pex import resolver
+from pex.pip.version import PipVersionValue
 from pex.resolve import lock_resolver
 from pex.resolve.lockfile.model import Lockfile
 from pex.resolve.resolver_configuration import PipConfiguration, ReposConfiguration
@@ -13,7 +14,7 @@ from pex.targets import Targets
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Iterable
+    from typing import Iterable, Optional
 
     import attr  # vendor:skip
 else:
@@ -39,8 +40,10 @@ class ConfiguredResolver(Resolver):
         self,
         lock,  # type: Lockfile
         targets=Targets(),  # type: Targets
+        pip_version=None,  # type: Optional[PipVersionValue]
     ):
         # type: (...) -> Installed
+        # TODO(John Sirois): Use pip_version.
         return try_(
             lock_resolver.resolve_from_lock(
                 targets=targets,
@@ -66,8 +69,10 @@ class ConfiguredResolver(Resolver):
         self,
         requirements,  # type: Iterable[str]
         targets=Targets(),  # type: Targets
+        pip_version=None,  # type: Optional[PipVersionValue]
     ):
         # type: (...) -> Installed
+        # TODO(John Sirois): Use pip_version.
         return resolver.resolve(
             targets=targets,
             requirements=requirements,

--- a/pex/resolve/downloads.py
+++ b/pex/resolve/downloads.py
@@ -8,7 +8,8 @@ from pex.common import atomic_directory, safe_mkdir, safe_mkdtemp
 from pex.compatibility import unquote, urlparse
 from pex.hashing import Sha256
 from pex.jobs import Job, Raise, SpawnedJob, execute_parallel
-from pex.pip.tool import PackageIndexConfiguration, Pip, get_pip
+from pex.pip.installation import get_pip
+from pex.pip.tool import PackageIndexConfiguration, Pip
 from pex.resolve import locker
 from pex.resolve.locked_resolve import Artifact, FileArtifact, LockConfiguration, LockStyle
 from pex.resolve.resolved_requirement import Fingerprint, PartialArtifact

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -16,8 +16,9 @@ from pex.compatibility import cpu_count
 from pex.network_configuration import NetworkConfiguration
 from pex.orderedset import OrderedSet
 from pex.pep_503 import ProjectName
+from pex.pip.installation import get_pip
 from pex.pip.local_project import digest_local_project
-from pex.pip.tool import PackageIndexConfiguration, get_pip
+from pex.pip.tool import PackageIndexConfiguration
 from pex.pip.vcs import digest_vcs_archive
 from pex.resolve.downloads import ArtifactDownloader
 from pex.resolve.locked_resolve import (

--- a/pex/resolve/resolvers.py
+++ b/pex/resolve/resolvers.py
@@ -7,6 +7,7 @@ from abc import abstractmethod
 
 from pex.dist_metadata import Distribution, Requirement
 from pex.fingerprinted_distribution import FingerprintedDistribution
+from pex.pip.version import PipVersionValue
 from pex.resolve.lockfile.model import Lockfile
 from pex.sorted_tuple import SortedTuple
 from pex.targets import Target, Targets
@@ -94,6 +95,7 @@ class Resolver(object):
         self,
         lock,  # type: Lockfile
         targets=Targets(),  # type: Targets
+        pip_version=None,  # type: Optional[PipVersionValue]
     ):
         # type: (...) -> Installed
         raise NotImplementedError()
@@ -102,6 +104,7 @@ class Resolver(object):
         self,
         requirements,  # type: Iterable[str]
         targets=Targets(),  # type: Targets
+        pip_version=None,  # type: Optional[PipVersionValue]
     ):
         # type: (...) -> Installed
         raise NotImplementedError()

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -23,7 +23,8 @@ from pex.orderedset import OrderedSet
 from pex.pep_503 import ProjectName
 from pex.pex_info import PexInfo
 from pex.pip.download_observer import DownloadObserver
-from pex.pip.tool import PackageIndexConfiguration, get_pip
+from pex.pip.installation import get_pip
+from pex.pip.tool import PackageIndexConfiguration
 from pex.requirements import LocalProjectRequirement
 from pex.resolve.downloads import get_downloads_dir
 from pex.resolve.requirement_configuration import RequirementConfiguration

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -29,7 +29,7 @@ from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
-from pex.pip.tool import get_pip
+from pex.pip.installation import get_pip
 from pex.targets import LocalInterpreter
 from pex.typing import TYPE_CHECKING
 from pex.util import named_temporary_file

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -18,7 +18,7 @@ from collections import OrderedDict, namedtuple
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Container, Optional, Tuple
+    from typing import Container, Iterator, Optional, Sequence, Tuple
 
 
 def _tracer():
@@ -521,14 +521,14 @@ def install(root=None, expose=None):
 
 
 def expose(dists):
+    # type: (Sequence[str]) -> Iterator[str]
     """Exposes vendored code in isolated chroots.
 
-    Any vendored distributions listed in ``dists`` will be unpacked to individual chroots for addition
-    to the ``sys.path``; ie: ``expose(['setuptools', 'wheel'])`` will unpack these vendored
+    Any vendored distributions listed in ``dists`` will be unpacked to individual chroots for
+    addition to the ``sys.path``; ie: ``expose(['setuptools', 'wheel'])`` will unpack these vendored
     distributions and yield the two chroot paths they were unpacked to.
 
-    :param dists: A list of vendored distribution names to expose.
-    :type dists: list of str
+    :param dists: A sequence of vendored distribution names to expose.
     :raise: :class:`ValueError` if any distributions to expose cannot be found.
     :returns: An iterator of exposed vendored distribution chroot paths.
     """

--- a/tests/integration/cli/commands/test_issue_1801.py
+++ b/tests/integration/cli/commands/test_issue_1801.py
@@ -17,7 +17,7 @@ def test_preserve_pip_download_log():
     result = run_pex3("lock", "create", "ansicolors==1.1.8", "--preserve-pip-download-log")
     result.assert_success()
 
-    match = re.search(r"^pex: Preserving `pip download` log at (?P<log_path>.*)\.$", result.error)
+    match = re.search(r"^pex: Preserving `pip download` log at (?P<log_path>.*)$", result.error)
     assert match is not None
     log_path = match.group("log_path")
     assert os.path.exists(log_path)

--- a/tests/integration/test_issue_539.py
+++ b/tests/integration/test_issue_539.py
@@ -8,7 +8,7 @@ import subprocess
 import pytest
 
 from pex.common import temporary_dir
-from pex.pip.tool import get_pip
+from pex.pip.installation import get_pip
 from pex.testing import IS_PYPY, PY_VER, run_pex_command
 
 

--- a/tests/test_dist_metadata.py
+++ b/tests/test_dist_metadata.py
@@ -23,7 +23,7 @@ from pex.dist_metadata import (
     requires_python,
 )
 from pex.pex_warnings import PEXWarning
-from pex.pip.tool import get_pip
+from pex.pip.installation import get_pip
 from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -10,7 +10,7 @@ from pex.finders import get_entry_point_from_console_script, get_script_from_dis
 from pex.pep_376 import InstalledWheel
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
-from pex.pip.tool import get_pip
+from pex.pip.installation import get_pip
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:


### PR DESCRIPTION
This is unused in this commit except in tests, but forms the heart of
support for newer Pip versions behind firewalls. Vendored Pip with all
user Pip configuration is used to fetch newer Pip.

Work towards #1805