### PR TITLE
Add support for Pip 22.2.2.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,54 +22,38 @@ jobs:
       - name: Noop
         run: "true"
   checks:
-    name:  TOXENV=${{ matrix.tox-env }}
+    name:  TOXENV=format-check,typecheck,vendor-check,package -- --additional-format sdist --additional-format wheel
     needs: org-check
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        include:
-          - check-name: Formatting
-            python-version: "3.10"
-            tox-env: format-check
-            fetch-depth: 1
-          - check-name: Types
-            # N.B.: Python 3.10.6 introduces support for parenthesized context managers which
-            # breaks typechecking against --python-version 2.7 and so we pin low.
-            python-version: "3.10.5"
-            tox-env: typecheck
-            fetch-depth: 1
-          - check-name: Vendoring
-            python-version: "3.8"
-            tox-env: vendor-check
-            fetch-depth: 1
-          - check-name: Packaging
-            python-version: "3.10"
-            tox-env: package -- --additional-format sdist --additional-format wheel
-            # We need branches and tags since package leans on `git describe`. Passing 0 gets us
-            # complete history.
-            fetch-depth: 0
     steps:
       - name: Checkout Pex
         uses: actions/checkout@v2
         with:
-          fetch-depth: ${{ matrix.fetch-depth }}
-      - name: Setup Python ${{ matrix.python-version }}
+          # We need branches and tags since package leans on `git describe`. Passing 0 gets us
+          # complete history.
+          fetch-depth: 0
+      - name: Setup Python 3.8
         uses: actions/setup-python@v3
         with:
-          python-version: "${{ matrix.python-version }}"
-      - name: Check ${{ matrix.check-name }}
+          # We need to keep Python 3.8 for consistent vendoring with tox.
+          python-version: "3.8"
+      - name: Check Formatting, Types, Vendoring and Packaging
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
-          tox-env: ${{ matrix.tox-env }}
+          tox-env: format-check,typecheck,vendor-check,package -- --additional-format sdist --additional-format wheel
   cpython-unit-tests:
-    name: (${{ matrix.os }}) TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}
+    name: (${{ matrix.os }}) Pip ${{ matrix.pip-version }} TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}
     needs: org-check
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: [[2, 7], [3, 5], [3, 6], [3, 7], [3, 8], [3, 9], [3, 10], [3, 11, "0-rc.1"]]
         os: [ubuntu-20.04, macos-11]
+        pip-version: ["20", "22"]
         exclude:
+          - os: macos-11
+            python-version: [2, 7]
+            pip-version: "22"
           - os: macos-11
             python-version: [3, 5]
           - os: macos-11
@@ -81,7 +65,28 @@ jobs:
           - os: macos-11
             python-version: [3, 9]
           - os: macos-11
+            python-version: [3, 10]
+            pip-version: "20"
+          - os: macos-11
             python-version: [3, 11, "0-rc.1"]
+          - os: ubuntu-20.04
+            python-version: [3, 5]
+            pip-version: "22"
+          - os: ubuntu-20.04
+            python-version: [3, 6]
+            pip-version: "22"
+          - os: ubuntu-20.04
+            python-version: [3, 7]
+            pip-version: "20"
+          - os: ubuntu-20.04
+            python-version: [3, 8]
+            pip-version: "20"
+          - os: ubuntu-20.04
+            python-version: [3, 9]
+            pip-version: "20"
+          - os: ubuntu-20.04
+            python-version: [3, 11, "0-rc.1"]
+            pip-version: "20"
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -109,14 +114,18 @@ jobs:
       - name: Run Unit Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
-          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}
+          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}
   pypy-unit-tests:
-    name: (PyPy ${{ join(matrix.pypy-version, '.') }}) TOXENV=pypy${{ join(matrix.pypy-version, '') }}
+    name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}
     needs: org-check
     runs-on: ubuntu-20.04
     strategy:
       matrix:
         pypy-version: [[2, 7], [3, 9]]
+        pip-version: ["20", "22"]
+        exclude:
+          - pypy-version: [2, 7]
+            pip-version: "22"
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -144,18 +153,25 @@ jobs:
       - name: Run Unit Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
-          tox-env: pypy${{ join(matrix.pypy-version, '') }}
+          tox-env: pypy${{ join(matrix.pypy-version, '') }}-pip${{ matrix.pip-version }}
   cpython-integration-tests:
-    name: (${{ matrix.os }}) TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-integration
+    name: (${{ matrix.os }}) Pip ${{ matrix.pip-version }} TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-integration
     needs: org-check
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: [[2, 7], [3, 10], [3, 11, "0-rc.1"]]
         os: [ubuntu-20.04, macos-11]
+        pip-version: ["20", "22"]
         exclude:
           - os: macos-11
             python-version: [3, 11, "0-rc.1"]
+          - os: macos-11
+            python-version: [2, 7]
+            pip-version: "22"
+          - os: ubuntu-20.04
+            python-version: [3, 11, "0-rc.1"]
+            pip-version: "22"
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -186,14 +202,18 @@ jobs:
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
-          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-integration
+          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}-integration
   pypy-integration-tests:
-    name: (PyPy ${{ join(matrix.pypy-version, '.') }}) TOXENV=pypy${{ join(matrix.pypy-version, '') }}-integration
+    name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}-integration
     needs: org-check
     runs-on: ubuntu-20.04
     strategy:
       matrix:
         pypy-version: [[2, 7], [3, 9]]
+        pip-version: ["20", "22"]
+        exclude:
+          - pypy-version: [2, 7]
+            pip-version: "22"
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -228,7 +248,7 @@ jobs:
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
-          tox-env: pypy${{ join(matrix.pypy-version, '') }}-integration
+          tox-env: pypy${{ join(matrix.pypy-version, '') }}-pip${{ matrix.pip-version }}-integration
   final-status:
     name: Gather Final Status
     needs:

--- a/pex/build_system/testing.py
+++ b/pex/build_system/testing.py
@@ -11,7 +11,9 @@ from pex.dist_metadata import Distribution
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.pip.installation import get_pip
+from pex.pip.version import PipVersion
 from pex.resolve.configured_resolver import ConfiguredResolver
+from pex.resolve.resolver_configuration import PipConfiguration
 from pex.result import Error
 from pex.typing import TYPE_CHECKING
 
@@ -33,7 +35,17 @@ def assert_build_sdist(
         assert Version(version) == dist.metadata.version
 
     sdist_dir = os.path.join(str(tmpdir), "sdist_dir")
-    location = build_sdist(project_dir, sdist_dir, ConfiguredResolver.default())
+
+    # This test utility is used by all versions of Python Pex supports; so we need to use the
+    # vendored Pip which is guaranteed to work with all those Python versions.
+    pip_version = PipVersion.VENDORED
+
+    location = build_sdist(
+        project_dir,
+        sdist_dir,
+        pip_version,
+        ConfiguredResolver(PipConfiguration(version=pip_version)),
+    )
     assert not isinstance(location, Error)
     assert sdist_dir == os.path.dirname(location)
 

--- a/pex/pip/local_project.py
+++ b/pex/pip/local_project.py
@@ -10,6 +10,7 @@ from pex import hashing
 from pex.build_system import pep_517
 from pex.common import temporary_dir
 from pex.hashing import Fingerprint, Sha256
+from pex.pip.version import PipVersionValue
 from pex.resolve.resolvers import Resolver
 from pex.result import Error, try_
 from pex.tracer import TRACER
@@ -23,17 +24,19 @@ if TYPE_CHECKING:
 
 def fingerprint_local_project(
     directory,  # type: str
+    pip_version,  # type: PipVersionValue
     resolver,  # type: Resolver
 ):
     # type: (...) -> Fingerprint
     digest = Sha256()
-    try_(digest_local_project(directory, digest, resolver))
+    try_(digest_local_project(directory, digest, pip_version, resolver))
     return digest.hexdigest()
 
 
 def digest_local_project(
     directory,  # type: str
     digest,  # type: HintedDigest
+    pip_version,  # type: PipVersionValue
     resolver,  # type: Resolver
     dest_dir=None,  # type: Optional[str]
 ):
@@ -43,6 +46,7 @@ def digest_local_project(
             sdist_or_error = pep_517.build_sdist(
                 project_directory=directory,
                 dist_dir=os.path.join(td, "dists"),
+                pip_version=pip_version,
                 resolver=resolver,
             )
             if isinstance(sdist_or_error, Error):

--- a/pex/pip/version.py
+++ b/pex/pip/version.py
@@ -75,11 +75,10 @@ class PipVersion(Enum["PipVersionValue"]):
     )
 
     v22_2_2 = PipVersionValue(
-        # TODO(John Sirois): Consider exposing pip version via an env var since changing that is
-        #  advanced.
         version="22.2.2",
         # TODO(John Sirois): Expose setuptools and wheel version flags - these don't affect
-        #  Pex; so we should allow folks to experiment with upgrade easily.
+        #  Pex; so we should allow folks to experiment with upgrade easily:
+        #  https://github.com/pantsbuild/pex/issues/1895
         setuptools_version="65.3.0",
         wheel_version="0.37.1",
         requires_python=">=3.7",

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -234,7 +234,10 @@ class Platform(object):
                     raise AssertionError("Finished with count {}.".format(count))
 
         job = SpawnedJob.stdout(
-            job=get_pip().spawn_debug(platform=self, manylinux=manylinux), result_func=parse_tags
+            # TODO(John Sirois): Plumb pip_version and resolver:
+            #  https://github.com/pantsbuild/pex/issues/1894
+            job=get_pip().spawn_debug(platform=self, manylinux=manylinux),
+            result_func=parse_tags,
         )
         return job.await_result()
 

--- a/pex/resolve/config.py
+++ b/pex/resolve/config.py
@@ -1,0 +1,81 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from pex.pip.installation import compatible_version, validate_targets
+from pex.pip.version import PipVersionValue
+from pex.resolve.resolver_configuration import (
+    LockRepositoryConfiguration,
+    PexRepositoryConfiguration,
+    PipConfiguration,
+)
+from pex.result import Error, catch, try_
+from pex.targets import Targets
+from pex.typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from typing import Optional, TypeVar, Union
+
+    import attr  # vendor:skip
+
+    Configuration = Union[LockRepositoryConfiguration, PexRepositoryConfiguration, PipConfiguration]
+    _C = TypeVar("_C", bound=Configuration)
+
+else:
+    from pex.third_party import attr
+
+
+def _finalize_pip_configuration(
+    pip_configuration,  # type: PipConfiguration
+    targets,  # type: Targets
+    context,  # type: str
+    pip_version=None,  # type: Optional[PipVersionValue]
+):
+    # type: (...) -> Union[PipConfiguration, Error]
+    version = pip_version or pip_configuration.version
+    if pip_configuration.allow_version_fallback:
+        return attr.evolve(pip_configuration, version=compatible_version(targets, version, context))
+
+    result = catch(validate_targets, targets, version, context)
+    if isinstance(result, Error):
+        return result
+    return attr.evolve(pip_configuration, version=version)
+
+
+def finalize(
+    resolver_configuration,  # type: _C
+    targets,  # type: Targets
+    context,  # type: str
+    pip_version=None,  # type: Optional[PipVersionValue]
+):
+    # type: (...) -> Union[_C, Error]
+
+    if isinstance(resolver_configuration, PipConfiguration):
+        return cast(
+            "_C",
+            _finalize_pip_configuration(
+                resolver_configuration, targets, context, pip_version=pip_version
+            ),
+        )
+
+    if isinstance(resolver_configuration, LockRepositoryConfiguration):
+        lock_file = try_(resolver_configuration.parse_lock())
+        pip_configuration = try_(
+            _finalize_pip_configuration(
+                resolver_configuration.pip_configuration,
+                targets,
+                context,
+                pip_version=pip_version or lock_file.pip_version,
+            )
+        )
+        return cast(
+            "_C",
+            attr.evolve(
+                resolver_configuration,
+                parse_lock=lambda: lock_file,
+                pip_configuration=pip_configuration,
+            ),
+        )
+
+    return resolver_configuration

--- a/pex/resolve/configured_resolver.py
+++ b/pex/resolve/configured_resolver.py
@@ -62,6 +62,7 @@ class ConfiguredResolver(Resolver):
                 transitive=self.pip_configuration.transitive,
                 verify_wheels=True,
                 max_parallel_jobs=self.pip_configuration.max_jobs,
+                pip_version=pip_version or self.pip_configuration.version,
             )
         )
 
@@ -91,4 +92,6 @@ class ConfiguredResolver(Resolver):
             max_parallel_jobs=self.pip_configuration.max_jobs,
             ignore_errors=False,
             verify_wheels=True,
+            pip_version=pip_version or self.pip_configuration.version,
+            resolver=self,
         )

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -16,7 +16,6 @@ from pex.compatibility import cpu_count
 from pex.network_configuration import NetworkConfiguration
 from pex.orderedset import OrderedSet
 from pex.pep_503 import ProjectName
-from pex.pip.installation import get_pip
 from pex.pip.local_project import digest_local_project
 from pex.pip.tool import PackageIndexConfiguration
 from pex.pip.vcs import digest_vcs_archive

--- a/pex/resolve/locked_resolve.py
+++ b/pex/resolve/locked_resolve.py
@@ -24,7 +24,6 @@ from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import (
-        IO,
         Any,
         DefaultDict,
         Deque,
@@ -35,7 +34,6 @@ if TYPE_CHECKING:
         Optional,
         Protocol,
         Set,
-        Sized,
         Tuple,
         Union,
     )

--- a/pex/resolve/locker_patches.py
+++ b/pex/resolve/locker_patches.py
@@ -154,6 +154,11 @@ def patch_wheel_model():
         check(*args, **kwargs) for check in supported_checks
     )
 
+    # N.B.: This patch is a noop for the 20.3.4-patched Pip but is required in newer Pip.
+    # The method is used as a speedup hack by newer Pip in some cases instead of
+    # Wheel.support_index_min.
+    Wheel.find_most_preferred_tag = lambda *args, **kwargs: 0
+
 
 patch_wheel_model()
 del patch_wheel_model

--- a/pex/resolve/lockfile/model.py
+++ b/pex/resolve/lockfile/model.py
@@ -7,6 +7,7 @@ import os
 
 from pex.dist_metadata import Requirement
 from pex.orderedset import OrderedSet
+from pex.pip.version import PipVersionValue
 from pex.requirements import LocalProjectRequirement
 from pex.resolve.locked_resolve import LocalProjectArtifact, LockedResolve, LockStyle, TargetSystem
 from pex.resolve.resolver_configuration import ResolverVersion
@@ -32,6 +33,7 @@ class Lockfile(object):
         style,  # type: LockStyle.Value
         requires_python,  # type: Iterable[str]
         target_systems,  # type: Iterable[TargetSystem.Value]
+        pip_version,  # type: PipVersionValue
         resolver_version,  # type: ResolverVersion.Value
         requirements,  # type: Iterable[Union[Requirement, ParsedRequirement]]
         constraints,  # type: Iterable[Requirement]
@@ -83,6 +85,7 @@ class Lockfile(object):
             style=style,
             requires_python=SortedTuple(requires_python),
             target_systems=SortedTuple(target_systems),
+            pip_version=pip_version,
             resolver_version=resolver_version,
             requirements=SortedTuple(resolve_requirements, key=str),
             constraints=SortedTuple(constraints, key=str),
@@ -102,6 +105,7 @@ class Lockfile(object):
     style = attr.ib()  # type: LockStyle.Value
     requires_python = attr.ib()  # type: SortedTuple[str]
     target_systems = attr.ib()  # type: SortedTuple[TargetSystem.Value]
+    pip_version = attr.ib()  # type: PipVersionValue
     resolver_version = attr.ib()  # type: ResolverVersion.Value
     requirements = attr.ib()  # type: SortedTuple[Requirement]
     constraints = attr.ib()  # type: SortedTuple[Requirement]

--- a/pex/resolve/lockfile/updater.py
+++ b/pex/resolve/lockfile/updater.py
@@ -3,7 +3,6 @@
 
 from __future__ import absolute_import
 
-import itertools
 import logging
 import os
 from collections import OrderedDict
@@ -392,6 +391,7 @@ class LockUpdater(object):
             target_systems=lock_file.target_systems,
         )
         pip_configuration = PipConfiguration(
+            version=lock_file.pip_version,
             resolver_version=lock_file.resolver_version,
             allow_prereleases=lock_file.allow_prereleases,
             allow_wheels=lock_file.allow_wheels,

--- a/pex/resolve/resolver_configuration.py
+++ b/pex/resolve/resolver_configuration.py
@@ -9,6 +9,7 @@ from pex.auth import PasswordEntry
 from pex.enum import Enum
 from pex.jobs import DEFAULT_MAX_JOBS
 from pex.network_configuration import NetworkConfiguration
+from pex.pip.version import PipVersion, PipVersionValue
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -73,6 +74,8 @@ class PipConfiguration(object):
     transitive = attr.ib(default=True)  # type: bool
     max_jobs = attr.ib(default=DEFAULT_MAX_JOBS)  # type: int
     preserve_log = attr.ib(default=False)  # type: bool
+    version = attr.ib(default=PipVersion.VENDORED)  # type: PipVersionValue
+    allow_version_fallback = attr.ib(default=False)  # type: bool
 
 
 @attr.s(frozen=True)

--- a/pex/resolve/resolver_configuration.py
+++ b/pex/resolve/resolver_configuration.py
@@ -4,10 +4,12 @@
 from __future__ import absolute_import
 
 import itertools
+import os
 
 from pex.auth import PasswordEntry
 from pex.enum import Enum
 from pex.jobs import DEFAULT_MAX_JOBS
+from pex.layout import PEX_INFO_PATH
 from pex.network_configuration import NetworkConfiguration
 from pex.pip.version import PipVersion, PipVersionValue
 from pex.typing import TYPE_CHECKING
@@ -60,6 +62,12 @@ class ReposConfiguration(object):
     password_entries = attr.ib(default=())  # type: Tuple[PasswordEntry, ...]
 
 
+# We make an affordance for CI with a purposefully undocumented PEX env var.
+_DEFAULT_PIP_VERSION = PipVersion.for_value(
+    os.environ.get("_PEX_PIP_VERSION", PipVersion.VENDORED.value)
+)
+
+
 @attr.s(frozen=True)
 class PipConfiguration(object):
     resolver_version = attr.ib(default=ResolverVersion.PIP_LEGACY)  # type: ResolverVersion.Value
@@ -74,8 +82,8 @@ class PipConfiguration(object):
     transitive = attr.ib(default=True)  # type: bool
     max_jobs = attr.ib(default=DEFAULT_MAX_JOBS)  # type: int
     preserve_log = attr.ib(default=False)  # type: bool
-    version = attr.ib(default=PipVersion.VENDORED)  # type: PipVersionValue
-    allow_version_fallback = attr.ib(default=False)  # type: bool
+    version = attr.ib(default=_DEFAULT_PIP_VERSION)  # type: PipVersionValue
+    allow_version_fallback = attr.ib(default=True)  # type: bool
 
 
 @attr.s(frozen=True)

--- a/pex/result.py
+++ b/pex/result.py
@@ -4,8 +4,10 @@
 from __future__ import absolute_import, print_function
 
 import sys
+import traceback
 
 from pex.typing import TYPE_CHECKING
+from pex.variables import ENV
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Text, TypeVar, Union
@@ -103,3 +105,7 @@ def catch(
         return func(*args, **kwargs)
     except ResultError as e:
         return e.error
+    except Exception as e:
+        if ENV.PEX_VERBOSE > 0:
+            traceback.print_exc()
+        return Error(str(e))

--- a/pex/venv/pex.py
+++ b/pex/venv/pex.py
@@ -407,9 +407,10 @@ def _populate_sources(
                     "PEX_EMIT_WARNINGS",
                     # This is used by the vendoring system.
                     "__PEX_UNVENDORED__",
-                    # This is _not_ used (it is ignored), but it's present under CI and simplest to
-                    # add an exception for here and not warn about in CI runs.
+                    # These are _not_ used at runtime, but are present under CI and simplest to add
+                    # an exception for here and not warn about in CI runs.
                     "_PEX_TEST_PYENV_ROOT",
+                    "_PEX_PIP_VERSION",
                     # This is used by Pex's Pip to inject runtime patches dynamically.
                     "_PEX_PIP_RUNTIME_PATCHES",
                     # These are used by Pex's Pip venv to provide foreign platform support and work

--- a/tests/build_system/test_pep_517.py
+++ b/tests/build_system/test_pep_517.py
@@ -6,6 +6,7 @@ import os.path
 from pex.build_system.pep_517 import build_sdist
 from pex.build_system.testing import assert_build_sdist
 from pex.common import touch
+from pex.pip.version import PipVersion
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.result import Error
 from pex.testing import make_project
@@ -21,7 +22,7 @@ def test_build_sdist_project_directory_dne(tmpdir):
 
     project_dir = os.path.join(str(tmpdir), "project_dir")
     dist_dir = os.path.join(str(tmpdir), "dists")
-    result = build_sdist(project_dir, dist_dir, ConfiguredResolver.default())
+    result = build_sdist(project_dir, dist_dir, PipVersion.VENDORED, ConfiguredResolver.default())
     assert isinstance(result, Error)
     assert str(result).startswith(
         "Project directory {project_dir} does not exist.".format(project_dir=project_dir)
@@ -34,7 +35,7 @@ def test_build_sdist_project_directory_is_file(tmpdir):
     project_dir = os.path.join(str(tmpdir), "project_dir")
     touch(project_dir)
     dist_dir = os.path.join(str(tmpdir), "dists")
-    result = build_sdist(project_dir, dist_dir, ConfiguredResolver.default())
+    result = build_sdist(project_dir, dist_dir, PipVersion.VENDORED, ConfiguredResolver.default())
     assert isinstance(result, Error)
     assert str(result).startswith(
         "Project directory {project_dir} is not a directory.".format(project_dir=project_dir)

--- a/tests/build_system/test_pep_518.py
+++ b/tests/build_system/test_pep_518.py
@@ -10,7 +10,9 @@ from pex.build_system.pep_518 import BuildSystem
 from pex.common import touch
 from pex.environment import PEXEnvironment
 from pex.pep_503 import ProjectName
+from pex.pip.version import PipVersion
 from pex.resolve.configured_resolver import ConfiguredResolver
+from pex.resolve.resolver_configuration import PipConfiguration
 from pex.result import Error
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
@@ -21,7 +23,9 @@ if TYPE_CHECKING:
 
 def load_build_system(project_directory):
     # type: (...) -> Union[Optional[BuildSystem], Error]
-    return pep_518.load_build_system(ConfiguredResolver.default(), project_directory)
+    return pep_518.load_build_system(
+        ConfiguredResolver(PipConfiguration(version=PipVersion.VENDORED)), project_directory
+    )
 
 
 def test_load_build_system_not_a_python_project(tmpdir):

--- a/tests/integration/cli/commands/test_export.py
+++ b/tests/integration/cli/commands/test_export.py
@@ -12,6 +12,7 @@ from pex.cli.testing import run_pex3
 from pex.dist_metadata import Requirement
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
+from pex.pip.version import PipVersion
 from pex.resolve.locked_resolve import Artifact, LockedRequirement, LockedResolve, LockStyle
 from pex.resolve.lockfile import json_codec
 from pex.resolve.lockfile.model import Lockfile
@@ -33,6 +34,7 @@ UNIVERSAL_ANSICOLORS = Lockfile(
     style=LockStyle.UNIVERSAL,
     requires_python=SortedTuple(),
     target_systems=SortedTuple(),
+    pip_version=PipVersion.VENDORED,
     resolver_version=ResolverVersion.PIP_2020,
     requirements=SortedTuple([Requirement.parse("ansicolors")]),
     constraints=SortedTuple(),

--- a/tests/integration/cli/commands/test_issue_1734.py
+++ b/tests/integration/cli/commands/test_issue_1734.py
@@ -51,11 +51,13 @@ def test_lock_create_sdist_requires_python_different_from_current(
         "ERROR: Package 'aioconsole' requires a different Python: {pyver} not in '>=3.7'".format(
             pyver=py27.identity.version_str
         )
-        == result.error.splitlines()[0]
+        in result.error.splitlines()
     )
 
     # Now show it currently works.
-    subprocess.check_call(args=[py27.binary, "-m", "pex.cli"] + create_lock_args)
+    subprocess.check_call(
+        args=[py27.binary, "-m", "pex.cli"] + create_lock_args + ["--pip-version", "20.3.4-patched"]
+    )
     run_pex_command(
         args=["--lock", lock, "--", "-c", "import aioconsole"],
         python=py310.binary,

--- a/tests/integration/cli/commands/test_local_project_lock.py
+++ b/tests/integration/cli/commands/test_local_project_lock.py
@@ -84,9 +84,8 @@ def test_fingerprint_stability(
     assert re.search(
         r"There was 1 error downloading required artifacts:\n"
         r"1\. ansicolors 1\.1\.8 from file://{project_dir}\n"
-        r"    Expected sha256 hash of "
-        r"fca533d24ea5fc1b0fc8bc10ee146535bddda1c40c85510544c5766cef4d10b6 when downloading "
-        r"ansicolors but hashed to ".format(project_dir=ansicolors_1_1_8),
+        r"    Expected sha256 hash of [a-f0-9]+ when downloading "
+        r"ansicolors but hashed to [a-f0-9]+".format(project_dir=ansicolors_1_1_8),
         result.error,
     ), result.error
 

--- a/tests/integration/cli/commands/test_lock_resolve_auth.py
+++ b/tests/integration/cli/commands/test_lock_resolve_auth.py
@@ -148,6 +148,8 @@ def secured_ansicolors_lock(
             "--no-pypi",
             "--find-links",
             secured_lock.repo_url_with_credentials,
+            # Since we have no PyPI access, ensure we're using vendored Pip for this test.
+            "--pip-version=vendored",
             "ansicolors",
             "--indent",
             "2",

--- a/tests/integration/test_reproducible.py
+++ b/tests/integration/test_reproducible.py
@@ -158,7 +158,10 @@ def test_reproducible_build_c_flag_from_source():
         {"setup.cfg": setup_cfg, "setup.py": setup_py, "my_app.py": my_app}
     ) as project_dir:
         assert_reproducible_build(
-            [project_dir, "-c", "my_app_function"], pythons=MIXED_MAJOR_PYTHONS
+            [project_dir, "-c", "my_app_function"],
+            # Modern Pip / Setuptools produce different metadata for sdists than legacy Pip /
+            # Setuptools; so we don't mix them.
+            pythons=MAJOR_COMPATIBLE_PYTHONS,
         )
 
 

--- a/tests/integration/tools/commands/test_venv.py
+++ b/tests/integration/tools/commands/test_venv.py
@@ -91,8 +91,7 @@ def test_collisions(
     result = run_pex_tools(collisions_pex, "venv", venv_dir)
     result.assert_failure()
     assert (
-        "CollisionError: Encountered collision building venv at {venv_dir} "
-        "from {pex}:\n"
+        "Encountered collision building venv at {venv_dir} from {pex}:\n"
         "1. {venv_dir}/bin/pex was provided by:".format(venv_dir=venv_dir, pex=collisions_pex)
     ) in result.error
 

--- a/tests/resolve/lockfile/test_json_codec.py
+++ b/tests/resolve/lockfile/test_json_codec.py
@@ -14,6 +14,7 @@ from pex.compatibility import PY2
 from pex.dist_metadata import Requirement
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
+from pex.pip.version import PipVersion
 from pex.resolve.locked_resolve import Artifact, LockedRequirement, LockedResolve, LockStyle
 from pex.resolve.lockfile import json_codec
 from pex.resolve.lockfile.json_codec import ParseError, PathMappingError
@@ -44,6 +45,7 @@ def test_roundtrip(tmpdir):
         style=LockStyle.STRICT,
         requires_python=(),
         target_systems=(),
+        pip_version=PipVersion.VENDORED,
         resolver_version=ResolverVersion.PIP_2020,
         requirements=(
             Requirement.parse("ansicolors"),

--- a/tests/resolve/lockfile/test_lockfile.py
+++ b/tests/resolve/lockfile/test_lockfile.py
@@ -73,6 +73,7 @@ LOCK_STYLE_SOURCES = json_codec.loads(
             }
           ],
           "pex_version": "2.1.50",
+          "pip_version": "20.3.4-patched",
           "prefer_older_binary": false,
           "requirements": [
             "p537==1.0.4"

--- a/tests/test_bdist_pex.py
+++ b/tests/test_bdist_pex.py
@@ -194,7 +194,7 @@ def test_unwriteable_contents():
         my_app_whl = WheelBuilder(my_app_project_dir).bdist()
 
         with make_project(name="uses_my_app", install_reqs=["my_app"]) as uses_my_app_project_dir:
-            pex_args = "--pex-args=--disable-cache --no-pypi -f {}".format(
+            pex_args = "--pex-args=--disable-cache --pip-version=vendored --no-pypi -f {}".format(
                 os.path.dirname(my_app_whl)
             )
             with bdist_pex(uses_my_app_project_dir, bdist_args=[pex_args]) as (uses_my_app_pex,):

--- a/tests/test_pex_binary.py
+++ b/tests/test_pex_binary.py
@@ -115,6 +115,9 @@ def test_clp_prereleases_resolver():
 
         options = parser.parse_args(
             args=[
+                # This test is run against all Pythons; so ensure we have a Pip that works with all
+                # the pythons we support.
+                "--pip-version=vendored",
                 "--no-index",
                 "--find-links",
                 dist_dir,
@@ -137,6 +140,9 @@ def test_clp_prereleases_resolver():
         # When we specify `--pre`, allow_prereleases is True
         options = parser.parse_args(
             args=[
+                # This test is run against all Pythons; so ensure we have a Pip that works with all
+                # the pythons we support.
+                "--pip-version=vendored",
                 "--no-index",
                 "--find-links",
                 dist_dir,

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,16 @@ minversion = 3.25.1
 # projects.
 basepython = python3
 
+[_printenv]
+commands =
+    bash -c ' \
+      echo "Test Control Environment Variables:"; \
+      env | grep -E "PEX|PYTHON" | grep -v "PYTHONHASHSEED" | sort || true \
+    '
+
 [testenv]
 commands =
+    {[_printenv]commands}
     pytest --ignore=tests/integration {posargs:-vvs}
 
     # Ensure pex's main entrypoint can be run externally.
@@ -37,6 +45,8 @@ passenv =
     LDFLAGS
     PEX_VERBOSE
 setenv =
+    pip20: _PEX_PIP_VERSION=20.3.4-patched
+    pip22: _PEX_PIP_VERSION=22.2.2
     # Python 3 (until a fix here in 3.9: https://bugs.python.org/issue13601) switched from stderr
     # being unbuffered to stderr being buffered by default. This can lead to tests checking stderr
     # failing to see what they expect if the stderr buffer block has not been flushed. Force stderr
@@ -48,19 +58,13 @@ whitelist_externals =
     bash
     git
 
-[testenv:py{py27-subprocess,py27,py35,py36,py37,py38,py39,27,35,36,37,38,39,310,311}-integration]
+[testenv:py{py27-subprocess,py27,py35,py36,py37,py38,py39,27,35,36,37,38,39,310,311}-{,pip20-,pip22-}integration]
 deps =
     pytest-xdist==1.34.0
     {[testenv]deps}
 commands =
+    {[_printenv]commands}
     pytest -n auto tests/integration {posargs:-vvs}
-setenv =
-    # Python 3 (until a fix here in 3.9: https://bugs.python.org/issue13601) switched from stderr
-    # being unbuffered to stderr being buffered by default. This can lead to tests checking stderr
-    # failing to see what they expect if the stderr buffer block has not been flushed. Force stderr
-    # line buffering (which is what setting PYTHONUNBUFFERED nets you) so that tests can rely on
-    # stderr lines being observable.
-    py{py35,py36,py37,py38,py39,35,36,37,38}-integration: PYTHONUNBUFFERED=1
 
 [testenv:format-run]
 skip_install = true


### PR DESCRIPTION
Pex can now support multiple Pip versions and be configured to fallback
as needed when newer Pip does not support a specified interpreter.

Fixes #1805
