### PR TITLE
Fail on atomic_directory work_dir collision.

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -466,7 +466,7 @@ def atomic_directory(
             return
 
     try:
-        safe_mkdir(atomic_dir.work_dir)
+        os.makedirs(atomic_dir.work_dir)
         yield atomic_dir
         atomic_dir.finalize(source=source)
     finally:


### PR DESCRIPTION
Previously, in the astronomically unlikely case that two (or more) attempts at creating an atomic directory collided on their UUID4-based work directory, the colliding attempts would all succeed and possibly lead to a corrupt final target directory. Now work directory creation fails loudly when the work directory already exists. Re-try of the Pex command will ~always work in this case but we'll have a paper trail of a UUID4 collision.

Fixes #1901