### PR TITLE
Upgrade 3.7 pyenv interpreter to 3.8.

### DIFF
--- a/pex/testing.py
+++ b/pex/testing.py
@@ -455,11 +455,11 @@ def bootstrap_python_installer(dest):
 # issues with the combination of 7 total unique interpreter versions and a Travis-CI timeout of 50
 # minutes for a shard.
 PY27 = "2.7.18"
-PY37 = "3.7.11"
+PY38 = "3.8.10"
 PY310 = "3.10.1"
 
-ALL_PY_VERSIONS = (PY27, PY37, PY310)
-_ALL_PY3_VERSIONS = (PY37, PY310)
+ALL_PY_VERSIONS = (PY27, PY38, PY310)
+_ALL_PY3_VERSIONS = (PY38, PY310)
 
 
 def ensure_python_distribution(version):

--- a/tests/bin/test_sh_boot.py
+++ b/tests/bin/test_sh_boot.py
@@ -115,7 +115,7 @@ def test_calculate_platforms_no_ics():
 def test_calculate_interpreters_no_ics(
     py27,  # type: PythonInterpreter
     py310,  # type: PythonInterpreter
-    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
 ):
     # type: (...) -> None
 
@@ -123,9 +123,9 @@ def test_calculate_interpreters_no_ics(
         expected(
             PythonBinaryName(name="python", version=(2, 7)),
             PythonBinaryName(name="python", version=(3, 10)),
-            PythonBinaryName(name="python", version=(3, 7)),
+            PythonBinaryName(name="python", version=(3, 8)),
         )
-        == calculate_binary_names(targets=Targets(interpreters=(py27, py310, py37)))
+        == calculate_binary_names(targets=Targets(interpreters=(py27, py310, py38)))
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 from pex import testing
 from pex.interpreter import PythonInterpreter
 from pex.platforms import Platform
-from pex.testing import PY27, PY37, PY310, ensure_python_interpreter
+from pex.testing import PY27, PY38, PY310, ensure_python_interpreter
 
 
 @pytest.fixture(scope="session")
@@ -36,9 +36,9 @@ def py27():
 
 
 @pytest.fixture
-def py37():
+def py38():
     # type: () -> PythonInterpreter
-    return PythonInterpreter.from_binary(ensure_python_interpreter(PY37))
+    return PythonInterpreter.from_binary(ensure_python_interpreter(PY38))
 
 
 @pytest.fixture

--- a/tests/integration/cli/commands/test_interpreter_inspect.py
+++ b/tests/integration/cli/commands/test_interpreter_inspect.py
@@ -105,7 +105,7 @@ def test_inspect_all():
 
 def test_inspect_interpreter_selection(
     py27,  # type: PythonInterpreter
-    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
     py310,  # type: PythonInterpreter
 ):
     # type: (...) -> None
@@ -114,13 +114,13 @@ def test_inspect_interpreter_selection(
         "--python", py27.binary, "--python", py310.binary
     ).splitlines()
 
-    assert [py37.binary, py310.binary] == assert_inspect(
-        "--all", "--python-path", os.pathsep.join([os.path.dirname(py37.binary), py310.binary])
+    assert [py38.binary, py310.binary] == assert_inspect(
+        "--all", "--python-path", os.pathsep.join([os.path.dirname(py38.binary), py310.binary])
     ).splitlines()
 
-    assert [py37.binary] == assert_inspect(
+    assert [py38.binary] == assert_inspect(
         "--interpreter-constraint",
         "<3.10",
         "--python-path",
-        os.pathsep.join([os.path.dirname(py37.binary), py310.binary]),
+        os.pathsep.join([os.path.dirname(py38.binary), py310.binary]),
     ).splitlines()

--- a/tests/integration/cli/commands/test_issue_1667.py
+++ b/tests/integration/cli/commands/test_issue_1667.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 )
 def test_interpreter_constraints_range_coverage(
     tmpdir,  # type: Any
-    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
 ):
     # type: (...) -> None
 
@@ -50,7 +50,7 @@ def test_interpreter_constraints_range_coverage(
         "--interpreter-constraint",
         ">=3.7,<3.11",
         "--python-path",
-        py37.binary,
+        py38.binary,
         "--constraints",
         constraints,
         "ipython",
@@ -86,6 +86,6 @@ def test_interpreter_constraints_range_coverage(
             .startswith(pex_root)
         )
 
-    assert_pex_works(py37.binary)
+    assert_pex_works(py38.binary)
     if (3, 7) <= sys.version_info[:2] < (3, 11):
         assert_pex_works(sys.executable)

--- a/tests/integration/cli/commands/test_issue_1688.py
+++ b/tests/integration/cli/commands/test_issue_1688.py
@@ -18,12 +18,12 @@ if TYPE_CHECKING:
 def test_multiplatform_sdist(
     tmpdir,  # type: Any
     py27,  # type: PythonInterpreter
-    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
     py310,  # type: PythonInterpreter
 ):
     # type: (...) -> None
 
-    all_interpreters = (py27, py37, py310)
+    all_interpreters = (py27, py38, py310)
     python_path = os.pathsep.join((interp.binary for interp in all_interpreters))
     interpreter_selection_args = [
         "--python-path",

--- a/tests/integration/cli/commands/test_issue_1711.py
+++ b/tests/integration/cli/commands/test_issue_1711.py
@@ -31,7 +31,7 @@ def pypi_artifact(
 
 def test_backtrack_links_preserved(
     tmpdir,  # type: Any
-    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
 ):
     # type: (...) -> None
 
@@ -46,7 +46,7 @@ def test_backtrack_links_preserved(
         "--interpreter-constraint",
         ">=3.7,<3.10",
         "--python-path",
-        py37.binary,
+        py38.binary,
         "psutil",
         "psutil<5.5",  # force a back-track
         "-o",
@@ -90,7 +90,7 @@ def test_backtrack_links_preserved(
         run_pex_command(
             args=["pex==2.1.77", "-c", "pex3", "--"] + create_lock_args,
             # N.B.: Pex 2.1.77 only works on CPython 3.10 and older and PyPy 3.7 and older.
-            python=py37.binary if PY_VER > (3, 10) or (IS_PYPY and PY_VER > (3, 7)) else None,
+            python=py38.binary if PY_VER > (3, 10) or (IS_PYPY and PY_VER > (3, 7)) else None,
         ).assert_success()
         psutil_old = assert_psutil_basics()
         assert 0 == len(psutil_old.additional_artifacts), (

--- a/tests/integration/cli/commands/test_issue_1734.py
+++ b/tests/integration/cli/commands/test_issue_1734.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 def test_lock_create_sdist_requires_python_different_from_current(
     tmpdir,  # type: Any
     py27,  # type: PythonInterpreter
-    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
     py310,  # type: PythonInterpreter
 ):
     # type: (...) -> None
@@ -32,7 +32,7 @@ def test_lock_create_sdist_requires_python_different_from_current(
         "--interpreter-constraint",
         "CPython<3.11,>=3.8",
         "--python-path",
-        os.pathsep.join(interp.binary for interp in (py27, py37, py310)),
+        os.pathsep.join(interp.binary for interp in (py27, py38, py310)),
         "aioconsole==0.4.1",
         "-o",
         lock,
@@ -67,7 +67,7 @@ def test_lock_create_sdist_requires_python_different_from_current(
 def test_lock_create_universal_interpreter_constraint_unsatisfiable(
     tmpdir,  # type: Any
     py27,  # type: PythonInterpreter
-    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
 ):
     # type: (...) -> None
 
@@ -80,9 +80,9 @@ def test_lock_create_universal_interpreter_constraint_unsatisfiable(
         "--style",
         "universal",
         "--interpreter-constraint",
-        "CPython<3.11,>=3.8",
+        "CPython<3.11,>=3.9",
         "--python-path",
-        os.pathsep.join(interp.binary for interp in (py27, py37)),
+        os.pathsep.join(interp.binary for interp in (py27, py38)),
         "aioconsole==0.4.1",
         "-o",
         lock,
@@ -97,14 +97,14 @@ def test_lock_create_universal_interpreter_constraint_unsatisfiable(
         "\n"
         "Examined the following interpreters:\n"
         "1.) {py27_path} {py27_req}\n"
-        "2.) {py37_path} {py37_req}\n"
+        "2.) {py38_path} {py38_req}\n"
         "\n"
         "No interpreter compatible with the requested constraints was found:\n"
         "\n"
-        "  Version matches CPython<3.11,>=3.8\n".format(
+        "  Version matches CPython<3.11,>=3.9\n".format(
             py27_path=py27.binary,
             py27_req=py27.identity.requirement,
-            py37_path=py37.binary,
-            py37_req=py37.identity.requirement,
+            py38_path=py38.binary,
+            py38_req=py38.identity.requirement,
         )
     ) == result.error

--- a/tests/integration/cli/commands/test_lock.py
+++ b/tests/integration/cli/commands/test_lock.py
@@ -1012,7 +1012,7 @@ DUAL_UPDATE_LOCKFILE_CONTENTS = """\
   "pex_version": "2.1.50",
   "prefer_older_binary": false,
   "requirements": [
-    "p537"
+    "p537==1.0.4"
   ],
   "requires_python": [],
   "resolver_version": "pip-2020-resolver",
@@ -1066,6 +1066,8 @@ def test_update_partial(tmpdir):
     )
 
     result = run_lock_update(
+        "-p",
+        "p537==1.0.4",
         "--platform",
         "macosx-10.13-x86_64-cp-37-m",
         "--non-strict",

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -30,7 +30,7 @@ from pex.testing import (
     NOT_CPYTHON27,
     NOT_CPYTHON27_OR_OSX,
     PY27,
-    PY37,
+    PY38,
     PY310,
     PY_VER,
     IntegResults,
@@ -111,11 +111,11 @@ def test_pex_root_build():
 
 def test_pex_root_run():
     # type: () -> None
-    python37 = ensure_python_interpreter(PY37)
+    python38 = ensure_python_interpreter(PY38)
     python310 = ensure_python_interpreter(PY310)
 
     with temporary_dir() as td, temporary_dir() as runtime_pex_root, temporary_dir() as home:
-        pex_env = make_env(HOME=home, PEX_PYTHON_PATH=os.pathsep.join((python37, python310)))
+        pex_env = make_env(HOME=home, PEX_PYTHON_PATH=os.pathsep.join((python38, python310)))
 
         buildtime_pex_root = os.path.join(td, "buildtime_pex_root")
         output_dir = os.path.join(td, "output_dir")
@@ -130,7 +130,7 @@ def test_pex_root_run():
             "--not-zip-safe",
             "--pex-root={}".format(buildtime_pex_root),
             "--runtime-pex-root={}".format(runtime_pex_root),
-            "--interpreter-constraint=CPython=={version}".format(version=PY37),
+            "--interpreter-constraint=CPython=={version}".format(version=PY38),
         ]
         results = run_pex_command(args=args, env=pex_env, python=python310)
         results.assert_success()
@@ -272,18 +272,18 @@ def test_pex_multi_resolve():
     # type: () -> None
     """Tests multi-interpreter + multi-platform resolution."""
     python27 = ensure_python_interpreter(PY27)
-    python37 = ensure_python_interpreter(PY37)
+    python38 = ensure_python_interpreter(PY38)
     with temporary_dir() as output_dir:
         pex_path = os.path.join(output_dir, "pex.pex")
         results = run_pex_command(
             [
                 "--disable-cache",
-                "lxml==4.2.4",
+                "lxml==4.4.3",
                 "--no-build",
                 "--platform=linux-x86_64-cp-36-m",
-                "--platform=macosx-10.6-x86_64-cp-36-m",
+                "--platform=macosx-10.9-x86_64-cp-36-m",
                 "--python={}".format(python27),
-                "--python={}".format(python37),
+                "--python={}".format(python38),
                 "-o",
                 pex_path,
             ]
@@ -292,7 +292,7 @@ def test_pex_multi_resolve():
 
         included_dists = get_dep_dist_names_from_pex(pex_path, "lxml")
         assert len(included_dists) == 4
-        for dist_substr in ("-cp27-", "-cp36-", "-cp37-", "-manylinux1_x86_64", "-macosx_"):
+        for dist_substr in ("-cp27-", "-cp36-", "-cp38-", "-manylinux1_x86_64", "-macosx_"):
             assert any(dist_substr in f for f in included_dists)
 
 
@@ -771,15 +771,15 @@ def test_multiplatform_entrypoint():
     # type: () -> None
     with temporary_dir() as td:
         pex_out_path = os.path.join(td, "p537.pex")
-        interpreter = ensure_python_interpreter(PY37)
+        interpreter = ensure_python_interpreter(PY38)
         res = run_pex_command(
             [
-                "p537==1.0.4",
+                "p537==1.0.5",
                 "--no-build",
                 "--python={}".format(interpreter),
                 "--python-shebang=#!{}".format(interpreter),
                 "--platform=linux-x86_64-cp-37-m",
-                "--platform=macosx-10.13-x86_64-cp-37-m",
+                "--platform=macosx-10.15-x86_64-cp-37-m",
                 "-c",
                 "p537",
                 "-o",
@@ -911,7 +911,7 @@ def test_setup_python_path():
     # type: () -> None
     """Check that `--python-path` is used rather than the default $PATH."""
     py27_interpreter_dir = os.path.dirname(ensure_python_interpreter(PY27))
-    py37_interpreter_dir = os.path.dirname(ensure_python_interpreter(PY37))
+    py38_interpreter_dir = os.path.dirname(ensure_python_interpreter(PY38))
     with temporary_dir() as out:
         pex = os.path.join(out, "pex.pex")
         # Even though we set $PATH="", we still expect for both interpreters to be used when
@@ -920,9 +920,9 @@ def test_setup_python_path():
             [
                 "more-itertools==5.0.0",
                 "--disable-cache",
-                "--interpreter-constraint=CPython>={},<={}".format(PY27, PY37),
+                "--interpreter-constraint=CPython>={},<={}".format(PY27, PY38),
                 "--python-path={}".format(
-                    os.pathsep.join([py27_interpreter_dir, py37_interpreter_dir])
+                    os.pathsep.join([py27_interpreter_dir, py38_interpreter_dir])
                 ),
                 "-o",
                 pex,
@@ -943,7 +943,7 @@ def test_setup_python_path():
         assert rc == 0
         assert b"(2, 7)" in stdout
 
-        py37_env = make_env(PEX_IGNORE_RCFILES="1", PATH=py37_interpreter_dir)
+        py37_env = make_env(PEX_IGNORE_RCFILES="1", PATH=py38_interpreter_dir)
         stdout, rc = run_simple_pex(
             pex,
             interpreter=py310_interpreter,
@@ -951,7 +951,7 @@ def test_setup_python_path():
             stdin=b"import more_itertools, sys; print(sys.version_info[:2])",
         )
         assert rc == 0
-        assert b"(3, 7)" in stdout
+        assert b"(3, 8)" in stdout
 
 
 def test_setup_python_multiple_transitive_markers():
@@ -985,12 +985,12 @@ def test_setup_python_multiple_transitive_markers():
         stdout = subprocess.check_output(both_program, env=py27_env)
         assert to_bytes(os.path.realpath(py27_interpreter)) == stdout.strip()
 
-        py38_env = make_env(PATH=os.path.dirname(py310_interpreter))
+        py310_env = make_env(PATH=os.path.dirname(py310_interpreter))
         with pytest.raises(subprocess.CalledProcessError) as err:
-            subprocess.check_output(py2_only_program, stderr=subprocess.STDOUT, env=py38_env)
+            subprocess.check_output(py2_only_program, stderr=subprocess.STDOUT, env=py310_env)
         assert b"ModuleNotFoundError: No module named 'functools32'" in err.value.output
 
-        stdout = subprocess.check_output(both_program, env=py38_env)
+        stdout = subprocess.check_output(both_program, env=py310_env)
         assert to_bytes(os.path.realpath(py310_interpreter)) == stdout.strip()
 
 
@@ -1184,7 +1184,7 @@ def iter_distributions(pex_root, project_name):
 
 def test_pex_cache_dir_and_pex_root():
     # type: () -> None
-    python = ensure_python_interpreter(PY37)
+    python = ensure_python_interpreter(PY38)
     with temporary_dir() as td:
         cache_dir = os.path.join(td, "cache_dir")
         pex_root = os.path.join(td, "pex_root")
@@ -1193,7 +1193,7 @@ def test_pex_cache_dir_and_pex_root():
         pex_file = os.path.join(td, "pex_file")
         run_pex_command(
             python=python,
-            args=["--cache-dir", cache_dir, "--pex-root", cache_dir, "p537==1.0.4", "-o", pex_file],
+            args=["--cache-dir", cache_dir, "--pex-root", cache_dir, "p537==1.0.5", "-o", pex_file],
         ).assert_success()
 
         dists = list(iter_distributions(pex_root=cache_dir, project_name="p537"))
@@ -1205,7 +1205,7 @@ def test_pex_cache_dir_and_pex_root():
         # When the options have conflicting values they should be rejected.
         run_pex_command(
             python=python,
-            args=["--cache-dir", cache_dir, "--pex-root", pex_root, "p537==1.0.4", "-o", pex_file],
+            args=["--cache-dir", cache_dir, "--pex-root", pex_root, "p537==1.0.5", "-o", pex_file],
         ).assert_failure()
 
         assert not os.path.exists(cache_dir)
@@ -1214,13 +1214,13 @@ def test_pex_cache_dir_and_pex_root():
 
 def test_disable_cache():
     # type: () -> None
-    python = ensure_python_interpreter(PY37)
+    python = ensure_python_interpreter(PY38)
     with temporary_dir() as td:
         pex_root = os.path.join(td, "pex_root")
         pex_file = os.path.join(td, "pex_file")
         run_pex_command(
             python=python,
-            args=["--disable-cache", "p537==1.0.4", "-o", pex_file],
+            args=["--disable-cache", "p537==1.0.5", "-o", pex_file],
             env=make_env(PEX_ROOT=pex_root),
         ).assert_success()
 

--- a/tests/integration/test_interpreter_selection.py
+++ b/tests/integration/test_interpreter_selection.py
@@ -11,7 +11,7 @@ from pex.pep_503 import ProjectName
 from pex.pex_info import PexInfo
 from pex.testing import (
     PY27,
-    PY37,
+    PY38,
     PY310,
     ensure_python_interpreter,
     make_env,
@@ -97,14 +97,14 @@ def test_interpreter_resolution_with_pex_python_path():
         with open(pexrc_path, "w") as pexrc:
             # set pex python path
             pex_python_path = os.pathsep.join(
-                [ensure_python_interpreter(PY27), ensure_python_interpreter(PY37)]
+                [ensure_python_interpreter(PY27), ensure_python_interpreter(PY38)]
             )
             pexrc.write("PEX_PYTHON_PATH=%s" % pex_python_path)
 
         # constraints to build pex cleanly; PPP + pex_bootstrapper.py
         # will use these constraints to override sys.executable on pex re-exec
         interpreter_constraint1 = ">3" if sys.version_info[0] == 3 else "<3"
-        interpreter_constraint2 = "<3.8" if sys.version_info[0] == 3 else ">=2.7"
+        interpreter_constraint2 = "<3.9" if sys.version_info[0] == 3 else ">=2.7"
 
         pex_out_path = os.path.join(td, "pex.pex")
         res = run_pex_command(
@@ -134,14 +134,14 @@ def test_interpreter_constraints_honored_without_ppp_or_pp(tmpdir):
     # Create a pex with interpreter constraints, but for not the default interpreter in the path.
 
     py310_path = ensure_python_interpreter(PY310)
-    py37_path = ensure_python_interpreter(PY37)
+    py38_path = ensure_python_interpreter(PY38)
 
     pex_out_path = os.path.join(str(tmpdir), "pex.pex")
     env = make_env(
         PEX_IGNORE_RCFILES="1",
         PATH=os.pathsep.join(
             [
-                os.path.dirname(py37_path),
+                os.path.dirname(py38_path),
                 os.path.dirname(py310_path),
             ]
         ),
@@ -171,7 +171,7 @@ def test_interpreter_resolution_pex_python_path_precedence_over_pex_python(tmpdi
     # type: (Any) -> None
 
     pexrc_path = os.path.join(str(tmpdir), ".pexrc")
-    ppp = os.pathsep.join(os.path.dirname(ensure_python_interpreter(py)) for py in (PY27, PY37))
+    ppp = os.pathsep.join(os.path.dirname(ensure_python_interpreter(py)) for py in (PY27, PY38))
     with open(pexrc_path, "w") as pexrc:
         # set both PPP and PP
         pexrc.write(
@@ -191,7 +191,7 @@ def test_interpreter_resolution_pex_python_path_precedence_over_pex_python(tmpdi
             "--disable-cache",
             "--rcfile",
             pexrc_path,
-            "--interpreter-constraint=>3,<3.8",
+            "--interpreter-constraint=>3,<3.9",
             "-o",
             pex_out_path,
         ]
@@ -222,7 +222,7 @@ def test_interpreter_resolution_pex_python_path_precedence_over_pex_python(tmpdi
         )
     stdout, rc = run_simple_pex(pex_out_path, print_python_version_command)
     assert rc == 0
-    assert b"3.7\n" == stdout
+    assert b"3.8\n" == stdout
 
 
 def test_plain_pex_exec_no_ppp_no_pp_no_constraints():
@@ -298,7 +298,7 @@ def test_pex_exec_with_pex_python_path_and_pex_python_but_no_constraints(tmpdir)
 def test_pex_python():
     # type: () -> None
     py2_path_interpreter = ensure_python_interpreter(PY27)
-    py3_path_interpreter = ensure_python_interpreter(PY37)
+    py3_path_interpreter = ensure_python_interpreter(PY38)
     path = os.pathsep.join(
         [os.path.dirname(py2_path_interpreter), os.path.dirname(py3_path_interpreter)]
     )
@@ -306,7 +306,7 @@ def test_pex_python():
     with temporary_dir() as td:
         pexrc_path = os.path.join(td, ".pexrc")
         with open(pexrc_path, "w") as pexrc:
-            pex_python = ensure_python_interpreter(PY37)
+            pex_python = ensure_python_interpreter(PY38)
             pexrc.write("PEX_PYTHON=%s" % pex_python)
 
         # test PEX_PYTHON with valid constraints
@@ -315,7 +315,7 @@ def test_pex_python():
             [
                 "--disable-cache",
                 "--rcfile=%s" % pexrc_path,
-                "--interpreter-constraint=>3,<3.8",
+                "--interpreter-constraint=>3,<3.9",
                 "-o",
                 pex_out_path,
             ],
@@ -340,7 +340,7 @@ def test_pex_python():
             [
                 "--disable-cache",
                 "--rcfile=%s" % pexrc_path,
-                "--interpreter-constraint=>3,<3.8",
+                "--interpreter-constraint=>3,<3.9",
                 "-o",
                 pex_out_path,
             ],

--- a/tests/integration/test_issue_1017.py
+++ b/tests/integration/test_issue_1017.py
@@ -1,14 +1,14 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pex.testing import PY37, ensure_python_interpreter, run_pex_command
+from pex.testing import PY38, ensure_python_interpreter, run_pex_command
 
 
 def test_resolve_python_requires_full_version():
     # type: () -> None
-    python37 = ensure_python_interpreter(PY37)
+    python38 = ensure_python_interpreter(PY38)
     result = run_pex_command(
-        python=python37,
+        python=python38,
         args=[
             "pandas==1.0.5",
             "--",

--- a/tests/integration/test_issue_1232.py
+++ b/tests/integration/test_issue_1232.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import subprocess
 
-from pex.testing import PY37, PY310, ensure_python_interpreter, make_env, run_pex_command
+from pex.testing import PY38, PY310, ensure_python_interpreter, make_env, run_pex_command
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -17,10 +17,10 @@ def test_isolated_pex_zip(tmpdir):
 
     pex_root = os.path.join(str(tmpdir), "pex_root")
 
-    python37 = ensure_python_interpreter(PY37)
+    python38 = ensure_python_interpreter(PY38)
     python310 = ensure_python_interpreter(PY310)
 
-    pex_env = make_env(PEX_PYTHON_PATH=os.pathsep.join((python37, python310)))
+    pex_env = make_env(PEX_PYTHON_PATH=os.pathsep.join((python38, python310)))
 
     def add_pex_args(*args):
         # type: (*str) -> List[str]
@@ -30,7 +30,7 @@ def test_isolated_pex_zip(tmpdir):
             "--runtime-pex-root",
             pex_root,
             "--interpreter-constraint",
-            "CPython=={version}".format(version=PY37),
+            "CPython=={version}".format(version=PY38),
         ]
 
     def tally_isolated_vendoreds():
@@ -60,7 +60,7 @@ def test_isolated_pex_zip(tmpdir):
     # ===
     current_pex_pex = os.path.join(str(tmpdir), "pex-current.pex")
     results = run_pex_command(
-        args=add_pex_args(".", "-c", "pex", "-o", current_pex_pex), env=pex_env, python=python37
+        args=add_pex_args(".", "-c", "pex", "-o", current_pex_pex), env=pex_env, python=python38
     )
     results.assert_success()
 

--- a/tests/integration/test_issue_1422.py
+++ b/tests/integration/test_issue_1422.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 import sys
 
-from pex.testing import PY27, PY37, PY310, ensure_python_interpreter, make_env, run_pex_command
+from pex.testing import PY27, PY38, PY310, ensure_python_interpreter, make_env, run_pex_command
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -57,12 +57,12 @@ def test_unconstrained_universal_venv_pex(tmpdir):
             assert "PEXWarning" not in stderr_text
 
     py27 = ensure_python_interpreter(PY27)
-    py37 = ensure_python_interpreter(PY37)
+    py38 = ensure_python_interpreter(PY38)
     py310 = ensure_python_interpreter(PY310)
 
     assert_uses_python(python=sys.executable, expected_version=sys.version_info[:2])
     assert_uses_python(python=py27, expected_version=(2, 7))
-    assert_uses_python(python=py37, expected_version=(3, 7))
+    assert_uses_python(python=py38, expected_version=(3, 8))
     assert_uses_python(python=py310, expected_version=(3, 10))
 
     # When PEX_PYTHON is imprecise, the final python should be chosen by the PEX runtime.
@@ -96,14 +96,14 @@ def test_unconstrained_universal_venv_pex(tmpdir):
 
     # When PEX_PYTHON is precise but not on PEX_PYTHON_PATH, the final python should also be chosen
     # by the PEX runtime and selection should fail.
-    _, _, returncode = execute_pex(python=py310, PEX_PYTHON=py37, PEX_PYTHON_PATH=py27_ppp)
+    _, _, returncode = execute_pex(python=py310, PEX_PYTHON=py38, PEX_PYTHON_PATH=py27_ppp)
     assert 0 != returncode
 
     # But when PEX_PYTHON is precise and on the PEX_PYTHON_PATH, the final python should be
     # PEX_PYTHON.
     assert_uses_python(
         python=py310,
-        expected_version=(3, 7),
-        PEX_PYTHON=py37,
-        PEX_PYTHON_PATH=os.pathsep.join(os.path.dirname(py) for py in (py27, py37)),
+        expected_version=(3, 8),
+        PEX_PYTHON=py38,
+        PEX_PYTHON_PATH=os.pathsep.join(os.path.dirname(py) for py in (py27, py38)),
     )

--- a/tests/integration/test_issue_1656.py
+++ b/tests/integration/test_issue_1656.py
@@ -106,7 +106,7 @@ def test_new_venv_tool_vs_old_pex(
 def test_mixed_pex_root(
     tmpdir,  # type: Any
     old_pex,  # type: str
-    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
 ):
     # type: (...) -> None
 
@@ -121,7 +121,7 @@ def test_mixed_pex_root(
         # just this and no more, proving out the particular bugged cases in #1656.
         return list(args) + [
             "--python",
-            py37.binary,
+            py38.binary,
             "--python",
             sys.executable,
             "--venv",
@@ -136,7 +136,7 @@ def test_mixed_pex_root(
 
     def greenlet_include_venv_path(venv_dir):
         # type: (str) -> str
-        return os.path.join(venv_dir, "include", "site", "python3.7", "greenlet", "greenlet.h")
+        return os.path.join(venv_dir, "include", "site", "python3.8", "greenlet", "greenlet.h")
 
     pex_app_old = os.path.join(str(tmpdir), "app.old.pex")
     subprocess.check_call(args=create_pex_args(old_pex, "-o", pex_app_old))
@@ -161,22 +161,22 @@ def test_mixed_pex_root(
         env=make_env(PEX_IGNORE_ERRORS=True),
     )
 
-    py37_venv_dir_old = PexInfo.from_pex(pex_app_new).runtime_venv_dir(pex_app_old, py37)
-    assert py37_venv_dir_old is not None
-    assert not os.path.exists(py37_venv_dir_old)
+    py38_venv_dir_old = PexInfo.from_pex(pex_app_new).runtime_venv_dir(pex_app_old, py38)
+    assert py38_venv_dir_old is not None
+    assert not os.path.exists(py38_venv_dir_old)
 
     subprocess.check_call(
-        args=[py37.binary, pex_app_old, "-c", "import greenlet"],
+        args=[py38.binary, pex_app_old, "-c", "import greenlet"],
         env=make_env(PEX_IGNORE_ERRORS=True),
     )
-    assert not os.path.exists(greenlet_include_venv_path(py37_venv_dir_old))
+    assert not os.path.exists(greenlet_include_venv_path(py38_venv_dir_old))
 
-    py37_venv_dir_new = PexInfo.from_pex(pex_app_new).runtime_venv_dir(pex_app_new, py37)
-    assert py37_venv_dir_new is not None
-    assert not os.path.exists(py37_venv_dir_new)
+    py38_venv_dir_new = PexInfo.from_pex(pex_app_new).runtime_venv_dir(pex_app_new, py38)
+    assert py38_venv_dir_new is not None
+    assert not os.path.exists(py38_venv_dir_new)
 
     subprocess.check_call(
-        args=[py37.binary, pex_app_new, "-c", "import greenlet"],
+        args=[py38.binary, pex_app_new, "-c", "import greenlet"],
         env=make_env(PEX_IGNORE_ERRORS=True),
     )
-    assert os.path.exists(greenlet_include_venv_path(py37_venv_dir_new))
+    assert os.path.exists(greenlet_include_venv_path(py38_venv_dir_new))

--- a/tests/integration/test_issue_1856.py
+++ b/tests/integration/test_issue_1856.py
@@ -6,7 +6,7 @@ import sys
 
 from pex.cli.testing import run_pex3
 from pex.resolve.lockfile import json_codec
-from pex.testing import PY37, ensure_python_interpreter, make_env
+from pex.testing import PY38, ensure_python_interpreter, make_env
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -49,7 +49,7 @@ def test_os_name_spoofing(tmpdir):
     # The above attempt to get pywinpty dependency metadata by building the sdist requires a
     # CPython>=3.7.5 on the PATH which we arrange for if not already present here.
     if sys.version_info[:3] < (3, 7, 5):
-        python_path = os.environ["PATH"].split(os.pathsep) + [ensure_python_interpreter(PY37)]
+        python_path = os.environ["PATH"].split(os.pathsep) + [ensure_python_interpreter(PY38)]
         create_lock_args.extend(["--python-path", os.pathsep.join(python_path)])
 
     run_pex3(*create_lock_args, env=env).assert_success()

--- a/tests/integration/test_issue_1872.py
+++ b/tests/integration/test_issue_1872.py
@@ -11,7 +11,7 @@ from pex.pep_503 import ProjectName
 from pex.resolve.locked_resolve import LocalProjectArtifact
 from pex.resolve.lockfile import json_codec
 from pex.resolve.resolved_requirement import Pin
-from pex.testing import PY37, ensure_python_interpreter, make_env
+from pex.testing import PY38, ensure_python_interpreter, make_env
 from pex.typing import TYPE_CHECKING
 from pex.version import __version__
 
@@ -26,7 +26,7 @@ def test_pep_518_venv_pex_env_scrubbing(
     # type: (...) -> None
 
     # N.B.: The package script requires Python 3.
-    python = sys.executable if PY3 else ensure_python_interpreter(PY37)
+    python = sys.executable if PY3 else ensure_python_interpreter(PY38)
 
     package_script = os.path.join(pex_project_dir, "scripts", "package.py")
     pex_pex = os.path.join(str(tmpdir), "pex")

--- a/tests/integration/test_lock_resolver.py
+++ b/tests/integration/test_lock_resolver.py
@@ -301,7 +301,7 @@ def requests_lock_universal(tmpdir_factory):
 def test_multiplatform(
     tmpdir,  # type: Any
     requests_lock_universal,  # type: str
-    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
     py310,  # type: PythonInterpreter
 ):
     # type: (...) -> None
@@ -310,7 +310,7 @@ def test_multiplatform(
     run_pex_command(
         args=[
             "--python",
-            py37.binary,
+            py38.binary,
             "--python",
             py310.binary,
             "--lock",
@@ -322,7 +322,7 @@ def test_multiplatform(
     ).assert_success()
 
     check_command = [pex_file, "-c", "import requests"]
-    py37.execute(check_command)
+    py38.execute(check_command)
     py310.execute(check_command)
 
 

--- a/tests/integration/test_pex_bootstrapper.py
+++ b/tests/integration/test_pex_bootstrapper.py
@@ -14,7 +14,7 @@ from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.pex_bootstrapper import ensure_venv
 from pex.pex_info import PexInfo
-from pex.testing import PY27, PY37, PY_VER, ensure_python_interpreter, make_env, run_pex_command
+from pex.testing import PY27, PY38, PY_VER, ensure_python_interpreter, make_env, run_pex_command
 from pex.typing import TYPE_CHECKING
 from pex.venv.pex import CollisionError
 from pex.venv.virtualenv import Virtualenv
@@ -292,7 +292,7 @@ def test_boot_compatible_issue_1020_no_ic(tmpdir):
     assert_boot(sys.executable)
 
     other_interpreter = (
-        ensure_python_interpreter(PY27) if PY_VER != (2, 7) else ensure_python_interpreter(PY37)
+        ensure_python_interpreter(PY27) if PY_VER != (2, 7) else ensure_python_interpreter(PY38)
     )
     assert_boot(other_interpreter)
 
@@ -300,7 +300,7 @@ def test_boot_compatible_issue_1020_no_ic(tmpdir):
 def test_boot_compatible_issue_1020_ic_min_compatible_build_time_hole(tmpdir):
     # type: (Any) -> None
     other_interpreter = PythonInterpreter.from_binary(
-        ensure_python_interpreter(PY27) if PY_VER != (2, 7) else ensure_python_interpreter(PY37)
+        ensure_python_interpreter(PY27) if PY_VER != (2, 7) else ensure_python_interpreter(PY38)
     )
     current_interpreter = PythonInterpreter.get()
 
@@ -362,13 +362,13 @@ def test_boot_compatible_issue_1020_ic_min_compatible_build_time_hole(tmpdir):
 def test_boot_resolve_fail(
     tmpdir,  # type: Any
     py27,  # type: PythonInterpreter
-    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
     py310,  # type: PythonInterpreter
 ):
     # type: (...) -> None
 
     pex = os.path.join(str(tmpdir), "pex")
-    run_pex_command(args=["--python", py37.binary, "psutil==5.9.0", "-o", pex]).assert_success()
+    run_pex_command(args=["--python", py38.binary, "psutil==5.9.0", "-o", pex]).assert_success()
 
     pex_python_path = os.pathsep.join((py27.binary, py310.binary))
     process = subprocess.Popen(

--- a/tests/integration/test_reproducible.py
+++ b/tests/integration/test_reproducible.py
@@ -14,7 +14,7 @@ from pex.compatibility import PY2
 from pex.testing import (
     IS_PYPY,
     PY27,
-    PY37,
+    PY38,
     PY310,
     PY_VER,
     create_pex_command,
@@ -82,12 +82,12 @@ def assert_reproducible_build(
 MAJOR_COMPATIBLE_PYTHONS = (
     (sys.executable, ensure_python_interpreter(PY27))
     if PY2
-    else (sys.executable, ensure_python_interpreter(PY37), ensure_python_interpreter(PY310))
+    else (sys.executable, ensure_python_interpreter(PY38), ensure_python_interpreter(PY310))
 )
 MIXED_MAJOR_PYTHONS = (
     sys.executable,
     ensure_python_interpreter(PY27),
-    ensure_python_interpreter(PY37),
+    ensure_python_interpreter(PY38),
     ensure_python_interpreter(PY310),
 )
 

--- a/tests/integration/tools/commands/test_venv.py
+++ b/tests/integration/tools/commands/test_venv.py
@@ -129,13 +129,15 @@ def test_collisions_mergeable_issue_1570(tmpdir):
             dedent(
                 """\
                 from __future__ import print_function
+                
+                import os
 
                 import opencensus
                 import opencensus.common
 
 
-                print(opencensus.__file__)
-                print(opencensus.common.__file__)
+                print(os.path.realpath(opencensus.__file__))
+                print(os.path.realpath(opencensus.common.__file__))
                 """
             ),
         ]

--- a/tests/integration/venv_ITs/test_issue_1630.py
+++ b/tests/integration/venv_ITs/test_issue_1630.py
@@ -9,7 +9,7 @@ from pex.dist_metadata import Distribution
 from pex.interpreter import PythonInterpreter
 from pex.pep_376 import InstalledWheel
 from pex.pex_info import PexInfo
-from pex.testing import PY37, ensure_python_venv, run_pex_command
+from pex.testing import PY38, ensure_python_venv, run_pex_command
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import Virtualenv
 
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 def test_data_files(tmpdir):
     # type: (Any) -> None
 
-    py37, pip = ensure_python_venv(PY37)
+    py38, pip = ensure_python_venv(PY38)
 
     pex_file = os.path.join(str(tmpdir), "pex.file")
     pex_root = os.path.join(str(tmpdir), "pex_root")
@@ -35,7 +35,7 @@ def test_data_files(tmpdir):
             "--runtime-pex-root",
             pex_root,
         ],
-        python=py37,
+        python=py38,
     ).assert_success()
 
     pex_info = PexInfo.from_pex(pex_file)
@@ -46,7 +46,7 @@ def test_data_files(tmpdir):
     )
 
     pex_venv = Virtualenv.create(
-        os.path.join(str(tmpdir), "pex.venv"), interpreter=PythonInterpreter.from_binary(py37)
+        os.path.join(str(tmpdir), "pex.venv"), interpreter=PythonInterpreter.from_binary(py38)
     )
     installed = list(InstalledWheel.load(nbconvert_dist.location).reinstall(pex_venv))
     assert installed
@@ -60,7 +60,7 @@ def test_data_files(tmpdir):
     # Pip.
     subprocess.check_call(args=[pip, "install", "--no-deps", "--no-compile", "nbconvert==6.4.2"])
     subprocess.check_call(args=[pip, "uninstall", "-y", "setuptools", "wheel", "pip"])
-    pip_venv = Virtualenv.enclosing(py37)
+    pip_venv = Virtualenv.enclosing(py38)
     assert pip_venv is not None
 
     def recursive_listing(venv):

--- a/tests/integration/venv_ITs/test_issue_1668.py
+++ b/tests/integration/venv_ITs/test_issue_1668.py
@@ -4,7 +4,7 @@
 import os.path
 import subprocess
 
-from pex.testing import PY37, ensure_python_interpreter, make_env, pex_project_dir, run_pex_command
+from pex.testing import PY38, ensure_python_interpreter, make_env, pex_project_dir, run_pex_command
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -23,12 +23,12 @@ def assert_venv_runtime_env_vars_ignored_during_create(
         args.append("--venv")
     run_pex_command(args=args).assert_success()
 
-    py37 = ensure_python_interpreter(PY37)
+    py38 = ensure_python_interpreter(PY38)
     pex_root = os.path.join(str(tmpdir), "pex_root")
     lock = os.path.join(str(tmpdir), "lock.json")
     subprocess.check_call(
         args=[
-            py37,
+            py38,
             pex_pex,
             "lock",
             "create",
@@ -43,7 +43,7 @@ def assert_venv_runtime_env_vars_ignored_during_create(
     ansicolors_path = (
         subprocess.check_output(
             args=[
-                py37,
+                py38,
                 pex_pex,
                 "--pex-root",
                 pex_root,

--- a/tests/resolve/lockfile/test_lockfile.py
+++ b/tests/resolve/lockfile/test_lockfile.py
@@ -10,7 +10,7 @@ import pytest
 from pex.interpreter import PythonInterpreter
 from pex.resolve.lockfile import json_codec
 from pex.targets import LocalInterpreter, Target
-from pex.testing import PY27, PY37, IntegResults, ensure_python_interpreter, run_pex_command
+from pex.testing import PY27, PY38, IntegResults, ensure_python_interpreter, run_pex_command
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -30,8 +30,8 @@ def py27():
 
 
 @pytest.fixture
-def py37():
-    return create_target(PY37)
+def py38():
+    return create_target(PY38)
 
 
 LOCK_STYLE_SOURCES = json_codec.loads(
@@ -91,7 +91,7 @@ LOCK_STYLE_SOURCES = json_codec.loads(
 
 def test_lockfile_style_sources(
     py27,  # type: Target
-    py37,  # type: Target
+    py38,  # type: Target
     tmpdir,  # type: Any
 ):
     # type: (...) -> None
@@ -107,7 +107,7 @@ def test_lockfile_style_sources(
             python=target.get_interpreter().binary,
         )
 
-    use_lock(py37).assert_success()
+    use_lock(py38).assert_success()
 
     # N.B.: We created a lock above that falsely advertises there is a solution for Python 2.7.
     # This is the devil's bargain with non-strict lock styles and the lock will fail only some time

--- a/tests/resolve/test_locked_resolve.py
+++ b/tests/resolve/test_locked_resolve.py
@@ -45,9 +45,9 @@ def current_target():
 
 
 @pytest.fixture
-def py37_target(py37):
+def py37_target(py38):
     # type: (PythonInterpreter) -> Target
-    return LocalInterpreter.create(py37)
+    return LocalInterpreter.create(py38)
 
 
 @pytest.fixture

--- a/tests/resolve/test_target_options.py
+++ b/tests/resolve/test_target_options.py
@@ -232,16 +232,16 @@ def path_for(*interpreters):
 def test_configure_interpreter_path(
     parser,  # type: ArgumentParser
     py27,  # type: PythonInterpreter
-    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
     py310,  # type: PythonInterpreter
 ):
     # type: (...) -> None
     target_options.register(parser)
 
-    with environment_as(PATH=path_for(py27, py37, py310)):
+    with environment_as(PATH=path_for(py27, py38, py310)):
         assert_interpreter(parser, ["--python", "python"], py27)
         assert_interpreter(parser, ["--python", "python2"], py27)
-        assert_interpreter(parser, ["--python", "python3"], py37)
+        assert_interpreter(parser, ["--python", "python3"], py38)
         assert_interpreter(parser, ["--python", "python3.10"], py310)
         with pytest.raises(pex.resolve.target_configuration.InterpreterNotFound):
             compute_target_configuration(parser, args=["--python", "python3.9"])
@@ -250,18 +250,18 @@ def test_configure_interpreter_path(
 def test_configure_interpreter_pex_python_path(
     parser,  # type: ArgumentParser
     py27,  # type: PythonInterpreter
-    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
     py310,  # type: PythonInterpreter
 ):
     # type: (...) -> None
     target_options.register(parser)
 
-    path_env_var = path_for(py27, py37, py310)
+    path_env_var = path_for(py27, py38, py310)
 
     with ENV.patch(PEX_PYTHON_PATH=path_env_var):
         assert_interpreter(parser, ["--python", "python"], py27)
         assert_interpreter(parser, ["--python", "python2"], py27)
-        assert_interpreter(parser, ["--python", "python3"], py37)
+        assert_interpreter(parser, ["--python", "python3"], py38)
         assert_interpreter(parser, ["--python", "python3.10"], py310)
         with pytest.raises(pex.resolve.target_configuration.InterpreterNotFound):
             compute_target_configuration(parser, args=["--python", "python3.9"])
@@ -269,20 +269,20 @@ def test_configure_interpreter_pex_python_path(
     with ENV.patch(PEX_PYTHON_PATH=py27.binary):
         assert_interpreter(parser, ["--python", "python2.7"], py27)
 
-    assert_interpreter(parser, ["--python-path", path_env_var, "--python", "python3"], py37)
+    assert_interpreter(parser, ["--python-path", path_env_var, "--python", "python3"], py38)
     assert_interpreter(parser, ["--python-path", py310.binary, "--python", "python3.10"], py310)
 
 
 def test_configure_interpreter_constraints(
     parser,  # type: ArgumentParser
     py27,  # type: PythonInterpreter
-    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
     py310,  # type: PythonInterpreter
 ):
     # type: (...) -> None
     target_options.register(parser)
 
-    path_env_var = path_for(py310, py27, py37)
+    path_env_var = path_for(py310, py27, py38)
 
     def interpreter_constraint_args(interpreter_constraints):
         # type: (Iterable[str]) -> List[str]
@@ -307,13 +307,13 @@ def test_configure_interpreter_constraints(
             *expected_interpreters
         )
 
-    assert_interpreter_constraint(["CPython"], [py310, py27, py37], expected_interpreter=py27)
-    assert_interpreter_constraint([">=2"], [py310, py27, py37], expected_interpreter=py27)
-    assert_interpreter_constraint([">=2,!=3.7.*"], [py310, py27], expected_interpreter=py27)
-    assert_interpreter_constraint(["==3.*"], [py310, py37], expected_interpreter=py37)
+    assert_interpreter_constraint(["CPython"], [py310, py27, py38], expected_interpreter=py27)
+    assert_interpreter_constraint([">=2"], [py310, py27, py38], expected_interpreter=py27)
+    assert_interpreter_constraint([">=2,!=3.8.*"], [py310, py27], expected_interpreter=py27)
+    assert_interpreter_constraint(["==3.*"], [py310, py38], expected_interpreter=py38)
     assert_interpreter_constraint(["==3.10.*"], [py310], expected_interpreter=py310)
-    assert_interpreter_constraint([">3"], [py310, py37], expected_interpreter=py37)
-    assert_interpreter_constraint([">=3.7,<3.8"], [py37], expected_interpreter=py37)
+    assert_interpreter_constraint([">3"], [py310, py38], expected_interpreter=py38)
+    assert_interpreter_constraint([">=3.8,<3.9"], [py38], expected_interpreter=py38)
     assert_interpreter_constraint(["==3.10.*", "==2.7.*"], [py310, py27], expected_interpreter=py27)
 
     def assert_interpreter_constraint_not_satisfied(interpreter_constraints):
@@ -331,13 +331,13 @@ def test_configure_interpreter_constraints(
 def test_configure_resolve_local_platforms(
     parser,  # type: ArgumentParser
     py27,  # type: PythonInterpreter
-    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
     py310,  # type: PythonInterpreter
 ):
     # type: (...) -> None
     target_options.register(parser)
 
-    path_env_var = path_for(py27, py37, py310)
+    path_env_var = path_for(py27, py38, py310)
 
     def assert_local_platforms(
         platforms,  # type: Iterable[str]
@@ -363,17 +363,17 @@ def test_configure_resolve_local_platforms(
     foreign_platform = "linux-x86_64-cp-37-m" if IS_MAC else "macosx-10.13-x86_64-cp-37-m"
 
     assert_local_platforms(
-        platforms=[foreign_platform, str(py37.platform)],
+        platforms=[foreign_platform, str(py38.platform)],
         expected_platforms=[foreign_platform],
-        expected_interpreter=py37,
+        expected_interpreter=py38,
     )
 
     assert_local_platforms(
-        platforms=[foreign_platform, str(py37.platform)],
+        platforms=[foreign_platform, str(py38.platform)],
         extra_args=["--interpreter-constraint", "CPython"],
         expected_platforms=[foreign_platform],
         expected_interpreter=py27,
-        expected_interpreters=(py27, py37, py310),
+        expected_interpreters=(py27, py38, py310),
     )
 
     assert_local_platforms(

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -26,7 +26,7 @@ from pex.targets import LocalInterpreter, Targets
 from pex.testing import (
     IS_LINUX,
     IS_PYPY3,
-    PY37,
+    PY38,
     WheelBuilder,
     ensure_python_interpreter,
     install_wheel,
@@ -202,24 +202,24 @@ def test_issues_598_explicit_missing_requirement():
 
 
 @pytest.fixture
-def python_37_interpreter():
+def python_38_interpreter():
     # type: () -> PythonInterpreter
     # Python 3.7 supports implicit namespace packages.
-    return PythonInterpreter.from_binary(ensure_python_interpreter(PY37))
+    return PythonInterpreter.from_binary(ensure_python_interpreter(PY38))
 
 
-def test_issues_598_implicit(python_37_interpreter):
+def test_issues_598_implicit(python_38_interpreter):
     # type: (PythonInterpreter) -> None
     assert_force_local_implicit_ns_packages_issues_598(
-        interpreter=python_37_interpreter, create_ns_packages=False
+        interpreter=python_38_interpreter, create_ns_packages=False
     )
 
 
-def test_issues_598_implicit_explicit_mixed(python_37_interpreter):
+def test_issues_598_implicit_explicit_mixed(python_38_interpreter):
     # type: (PythonInterpreter) -> None
     assert_force_local_implicit_ns_packages_issues_598(
-        interpreter=python_37_interpreter,
-        requirements=[get_setuptools_requirement(python_37_interpreter)],
+        interpreter=python_38_interpreter,
+        requirements=[get_setuptools_requirement(python_38_interpreter)],
         create_ns_packages=True,
     )
 
@@ -382,11 +382,11 @@ def create_dist(
 
 
 @pytest.fixture
-def cpython_37_environment(python_37_interpreter):
+def cpython_38_environment(python_38_interpreter):
     return PEXEnvironment(
         pex="",
         pex_info=PexInfo.default(),
-        target=LocalInterpreter.create(python_37_interpreter),
+        target=LocalInterpreter.create(python_38_interpreter),
     )
 
 
@@ -394,67 +394,65 @@ def cpython_37_environment(python_37_interpreter):
     ("wheel_distribution", "wheel_is_linux"),
     [
         pytest.param(
-            create_dist("llvmlite-0.29.0-cp37-cp37m-linux_x86_64.whl", "llvmlite", "0.29.0"),
+            create_dist("llvmlite-0.29.0-cp38-cp38-linux_x86_64.whl", "llvmlite", "0.29.0"),
             True,
             id="without_build_tag_linux",
         ),
         pytest.param(
-            create_dist("llvmlite-0.29.0-1-cp37-cp37m-linux_x86_64.whl", "llvmlite", "0.29.0"),
+            create_dist("llvmlite-0.29.0-1-cp38-cp38-linux_x86_64.whl", "llvmlite", "0.29.0"),
             True,
             id="with_build_tag_linux",
         ),
         pytest.param(
-            create_dist("llvmlite-0.29.0-cp37-cp37m-macosx_10.9_x86_64.whl", "llvmlite", "0.29.0"),
+            create_dist("llvmlite-0.29.0-cp38-cp38-macosx_10.9_x86_64.whl", "llvmlite", "0.29.0"),
             False,
             id="without_build_tag_osx",
         ),
         pytest.param(
-            create_dist(
-                "llvmlite-0.29.0-1-cp37-cp37m-macosx_10.9_x86_64.whl", "llvmlite", "0.29.0"
-            ),
+            create_dist("llvmlite-0.29.0-1-cp38-cp38-macosx_10.9_x86_64.whl", "llvmlite", "0.29.0"),
             False,
             id="with_build_tag_osx",
         ),
     ],
 )
 def test_can_add_handles_optional_build_tag_in_wheel(
-    cpython_37_environment, wheel_distribution, wheel_is_linux
+    cpython_38_environment, wheel_distribution, wheel_is_linux
 ):
     # type: (PEXEnvironment, FingerprintedDistribution, bool) -> None
     native_wheel = IS_LINUX and wheel_is_linux
-    added = isinstance(cpython_37_environment._can_add(wheel_distribution), _RankedDistribution)
+    added = isinstance(cpython_38_environment._can_add(wheel_distribution), _RankedDistribution)
     assert added is native_wheel
 
 
-def test_can_add_handles_invalid_wheel_filename(cpython_37_environment):
+def test_can_add_handles_invalid_wheel_filename(cpython_38_environment):
     # type: (PEXEnvironment) -> None
     dist = create_dist("pep427-invalid.whl")
-    assert _InvalidWheelName(dist, "pep427-invalid") == cpython_37_environment._can_add(dist)
+    assert _InvalidWheelName(dist, "pep427-invalid") == cpython_38_environment._can_add(dist)
 
 
 @pytest.fixture
-def assert_cpython_37_environment_can_add(cpython_37_environment):
+def assert_cpython_38_environment_can_add(cpython_38_environment):
     # type: (PEXEnvironment) -> Callable[[FingerprintedDistribution], _RankedDistribution]
     def assert_can_add(fingerprinted_dist):
         # type: (FingerprintedDistribution) -> _RankedDistribution
-        rank = cpython_37_environment._can_add(fingerprinted_dist)
+        rank = cpython_38_environment._can_add(fingerprinted_dist)
         assert isinstance(rank, _RankedDistribution)
         return rank
 
     return assert_can_add
 
 
-def test_can_add_ranking_platform_tag_more_specific(assert_cpython_37_environment_can_add):
+def test_can_add_ranking_platform_tag_more_specific(assert_cpython_38_environment_can_add):
     # type: (Callable[[FingerprintedDistribution], _RankedDistribution]) -> None
-    ranked_specific = assert_cpython_37_environment_can_add(
-        create_dist("foo-1.0.0-cp37-cp37m-macosx_10_9_x86_64.linux_x86_64.whl", "foo", "1.0.0")
+    ranked_specific = assert_cpython_38_environment_can_add(
+        create_dist("foo-1.0.0-cp38-cp38-macosx_10_9_x86_64.linux_x86_64.whl", "foo", "1.0.0")
     )
-    ranked_universal = assert_cpython_37_environment_can_add(
+    ranked_universal = assert_cpython_38_environment_can_add(
         create_dist("foo-2.0.0-py2.py3-none-any.whl", "foo", "2.0.0")
     )
     assert ranked_specific < ranked_universal
 
-    ranked_almost_py3universal = assert_cpython_37_environment_can_add(
+    ranked_almost_py3universal = assert_cpython_38_environment_can_add(
         create_dist("foo-2.0.0-py3-none-any.whl", "foo", "2.0.0")
     )
     assert ranked_universal.rank == ranked_almost_py3universal.rank, (
@@ -463,12 +461,12 @@ def test_can_add_ranking_platform_tag_more_specific(assert_cpython_37_environmen
     )
 
 
-def test_can_add_ranking_version_newer_tie_break(assert_cpython_37_environment_can_add):
+def test_can_add_ranking_version_newer_tie_break(assert_cpython_38_environment_can_add):
     # type: (Callable[[FingerprintedDistribution], _RankedDistribution]) -> None
-    ranked_v1 = assert_cpython_37_environment_can_add(
-        create_dist("foo-1.0.0-cp37-cp37m-macosx_10_9_x86_64.linux_x86_64.whl", "foo", "1.0.0")
+    ranked_v1 = assert_cpython_38_environment_can_add(
+        create_dist("foo-1.0.0-cp38-cp38-macosx_10_9_x86_64.linux_x86_64.whl", "foo", "1.0.0")
     )
-    ranked_v2 = assert_cpython_37_environment_can_add(
-        create_dist("foo-2.0.0-cp37-cp37m-macosx_10_9_x86_64.linux_x86_64.whl", "foo", "2.0.0")
+    ranked_v2 = assert_cpython_38_environment_can_add(
+        create_dist("foo-2.0.0-cp38-cp38-macosx_10_9_x86_64.linux_x86_64.whl", "foo", "2.0.0")
     )
     assert ranked_v2 < ranked_v1

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -23,7 +23,7 @@ from pex.pyenv import Pyenv
 from pex.testing import (
     ALL_PY_VERSIONS,
     PY27,
-    PY37,
+    PY38,
     PY310,
     PY_VER,
     ensure_python_distribution,
@@ -67,7 +67,7 @@ class TestPythonInterpreter(object):
     TEST_INTERPRETER1_VERSION = PY27
     TEST_INTERPRETER1_VERSION_TUPLE = tuple_from_version(TEST_INTERPRETER1_VERSION)
 
-    TEST_INTERPRETER2_VERSION = PY37
+    TEST_INTERPRETER2_VERSION = PY38
     TEST_INTERPRETER2_VERSION_TUPLE = tuple_from_version(TEST_INTERPRETER2_VERSION)
 
     @pytest.fixture
@@ -218,7 +218,7 @@ class TestPythonInterpreter(object):
 
     def test_pyenv_shims(self, tmpdir):
         # type: (Any) -> None
-        _, py37, _, run_pyenv = ensure_python_distribution(PY37)
+        _, py38, _, run_pyenv = ensure_python_distribution(PY38)
         py310 = ensure_python_interpreter(PY310)
 
         pyenv_root = str(run_pyenv(["root"]).strip())
@@ -265,49 +265,49 @@ class TestPythonInterpreter(object):
                 with pytest.raises(PythonInterpreter.IdentificationError):
                     interpreter_for_shim(shim_name)
 
-            pyenv_global(PY37, PY310)
-            assert_shim("python", py37)
-            assert_shim("python3", py37)
-            assert_shim("python3.7", py37)
+            pyenv_global(PY38, PY310)
+            assert_shim("python", py38)
+            assert_shim("python3", py38)
+            assert_shim("python3.8", py38)
             assert_shim("python3.10", py310)
 
-            pyenv_global(PY310, PY37)
+            pyenv_global(PY310, PY38)
             assert_shim("python", py310)
             assert_shim("python3", py310)
             assert_shim("python3.10", py310)
-            assert_shim("python3.7", py37)
+            assert_shim("python3.8", py38)
 
-            pyenv_local(PY37)
-            assert_shim("python", py37)
-            assert_shim("python3", py37)
-            assert_shim("python3.7", py37)
-            assert_shim_inactive("python3.8")
+            pyenv_local(PY38)
+            assert_shim("python", py38)
+            assert_shim("python3", py38)
+            assert_shim("python3.8", py38)
+            assert_shim_inactive("python3.7")
 
             with pyenv_shell(PY310):
                 assert_shim("python", py310)
                 assert_shim("python3", py310)
                 assert_shim("python3.10", py310)
-                assert_shim_inactive("python3.7")
+                assert_shim_inactive("python3.8")
 
-            with pyenv_shell(PY37, PY310):
-                assert_shim("python", py37)
-                assert_shim("python3", py37)
-                assert_shim("python3.7", py37)
+            with pyenv_shell(PY38, PY310):
+                assert_shim("python", py38)
+                assert_shim("python3", py38)
+                assert_shim("python3.8", py38)
                 assert_shim("python3.10", py310)
 
             # The shim pointer is now invalid since python3.7 was uninstalled and so
             # should be re-read and found invalid.
-            py37_version_dir = os.path.dirname(os.path.dirname(py37))
+            py37_version_dir = os.path.dirname(os.path.dirname(py38))
             py37_deleted = "{}.uninstalled".format(py37_version_dir)
             os.rename(py37_version_dir, py37_deleted)
             try:
                 assert_shim_inactive("python")
                 assert_shim_inactive("python3")
-                assert_shim_inactive("python3.7")
+                assert_shim_inactive("python3.8")
             finally:
                 os.rename(py37_deleted, py37_version_dir)
 
-            assert_shim("python", py37)
+            assert_shim("python", py38)
 
 
 def test_latest_release_of_min_compatible_version():
@@ -334,8 +334,8 @@ def test_latest_release_of_min_compatible_version():
 def test_detect_pyvenv(tmpdir):
     # type: (Any) -> None
     venv = str(tmpdir)
-    py37 = ensure_python_interpreter(PY37)
-    real_interpreter = PythonInterpreter.from_binary(py37)
+    py38 = ensure_python_interpreter(PY38)
+    real_interpreter = PythonInterpreter.from_binary(py38)
     real_interpreter.execute(["-m", "venv", venv])
     with pytest.raises(Executor.NonZeroExit):
         real_interpreter.execute(["-c", "import colors"])
@@ -354,7 +354,7 @@ def test_detect_pyvenv(tmpdir):
     ), "Expected exactly one canonical venv python, found: {}".format(canonical_to_python)
     canonical, pythons = canonical_to_python.popitem()
 
-    real_python = os.path.realpath(py37)
+    real_python = os.path.realpath(py38)
     assert canonical != real_python
     assert os.path.dirname(canonical) == venv_bin_dir
     assert os.path.realpath(canonical) == real_python
@@ -395,7 +395,7 @@ def check_resolve_venv(real_interpreter):
 
 def test_resolve_venv():
     # type: () -> None
-    real_interpreter = PythonInterpreter.from_binary(ensure_python_interpreter(PY37))
+    real_interpreter = PythonInterpreter.from_binary(ensure_python_interpreter(PY38))
     check_resolve_venv(real_interpreter)
 
 
@@ -411,13 +411,13 @@ def test_resolve_venv_ambient():
 def test_identify_cwd_isolation_issues_1231(tmpdir):
     # type: (Any) -> None
 
-    python37, pip = ensure_python_venv(PY37)
+    python38, pip = ensure_python_venv(PY38)
     polluted_cwd = os.path.join(str(tmpdir), "dir")
     subprocess.check_call(args=[pip, "install", "--target", polluted_cwd, "pex==2.1.16"])
 
     pex_root = os.path.join(str(tmpdir), "pex_root")
     with pushd(polluted_cwd), ENV.patch(PEX_ROOT=pex_root):
-        interp = PythonInterpreter.from_binary(python37)
+        interp = PythonInterpreter.from_binary(python38)
 
     interp_info_files = {
         os.path.join(root, f)

--- a/tests/test_pep_376.py
+++ b/tests/test_pep_376.py
@@ -54,7 +54,7 @@ def test_filter_path_relative():
 
 
 def test_installed_file_path_normalization_noop(
-    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
     py310,  # type: PythonInterpreter
 ):
     # type: (...) -> None
@@ -68,25 +68,25 @@ def test_installed_file_path_normalization_noop(
         assert "foo/bar" == InstalledFile.denormalized_path("foo/bar", interpreter=interpreter)
 
     assert_noop()
-    assert_noop(py37)
+    assert_noop(py38)
     assert_noop(py310)
 
 
 def test_installed_file_path_normalization_nominal(
-    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
     py310,  # type: PythonInterpreter
 ):
     # type: (...) -> None
 
     assert "foo/pythonX.Y/bar" == InstalledFile.normalized_path(
-        "foo/python3.7/bar", interpreter=py37
+        "foo/python3.8/bar", interpreter=py38
     )
     assert "foo/pythonX.Y/bar" == InstalledFile.normalized_path(
         "foo/python3.10/bar", interpreter=py310
     )
 
-    assert "foo/python3.7/bar" == InstalledFile.denormalized_path(
-        "foo/pythonX.Y/bar", interpreter=py37
+    assert "foo/python3.8/bar" == InstalledFile.denormalized_path(
+        "foo/pythonX.Y/bar", interpreter=py38
     )
     assert "foo/python3.10/bar" == InstalledFile.denormalized_path(
         "foo/pythonX.Y/bar", interpreter=py310

--- a/tests/test_pex_bootstrapper.py
+++ b/tests/test_pex_bootstrapper.py
@@ -20,7 +20,7 @@ from pex.pex_bootstrapper import (
     iter_compatible_interpreters,
 )
 from pex.pex_builder import PEXBuilder
-from pex.testing import PY27, PY37, PY310, ensure_python_interpreter
+from pex.testing import PY27, PY38, PY310, ensure_python_interpreter
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
 
@@ -54,15 +54,15 @@ def find_interpreters(
 def test_find_compatible_interpreters():
     # type: () -> None
     py27 = ensure_python_interpreter(PY27)
-    py37 = ensure_python_interpreter(PY37)
+    py38 = ensure_python_interpreter(PY38)
     py310 = ensure_python_interpreter(PY310)
-    path = [py27, py37, py310]
+    path = [py27, py38, py310]
 
-    assert [py37, py310] == find_interpreters(path, constraints=[">3"])
+    assert [py38, py310] == find_interpreters(path, constraints=[">3"])
     assert [py27] == find_interpreters(path, constraints=["<3"])
 
-    assert [py310] == find_interpreters(path, constraints=[">{}".format(PY37)])
-    assert [py37] == find_interpreters(path, constraints=[">{}, <{}".format(PY27, PY310)])
+    assert [py310] == find_interpreters(path, constraints=[">{}".format(PY38)])
+    assert [py38] == find_interpreters(path, constraints=[">{}, <{}".format(PY27, PY310)])
     assert [py310] == find_interpreters(path, constraints=[">=3.10"])
 
     with pytest.raises(UnsatisfiableInterpreterConstraintsError):
@@ -72,7 +72,7 @@ def test_find_compatible_interpreters():
         find_interpreters(path, constraints=[">4"])
 
     with pytest.raises(UnsatisfiableInterpreterConstraintsError):
-        find_interpreters(path, constraints=[">{}, <{}".format(PY27, PY37)])
+        find_interpreters(path, constraints=[">{}, <{}".format(PY27, PY38)])
 
     # All interpreters on PATH including whatever interpreter is currently running.
     all_known_interpreters = set(PythonInterpreter.all())
@@ -102,44 +102,44 @@ def test_find_compatible_interpreters_none():
 def test_find_compatible_interpreters_none_with_valid_basenames():
     # type: () -> None
     py27 = ensure_python_interpreter(PY27)
-    py37 = ensure_python_interpreter(PY37)
-    path = [py27, py37]
+    py38 = ensure_python_interpreter(PY38)
+    path = [py27, py38]
 
     with pytest.raises(UnsatisfiableInterpreterConstraintsError) as exec_info:
         find_interpreters(path, valid_basenames=["python3.6"])
 
     exception_message = str(exec_info.value)
     assert py27 not in exception_message
-    assert py37 not in exception_message
+    assert py38 not in exception_message
 
 
 def test_find_compatible_interpreters_none_with_constraints():
     # type: () -> None
     py27 = ensure_python_interpreter(PY27)
-    py37 = ensure_python_interpreter(PY37)
-    path = [py27, py37]
+    py38 = ensure_python_interpreter(PY38)
+    path = [py27, py38]
 
     with pytest.raises(UnsatisfiableInterpreterConstraintsError) as exec_info:
-        find_interpreters(path, constraints=[">=3.8"])
+        find_interpreters(path, constraints=[">=3.9"])
 
     exception_message = str(exec_info.value)
     assert py27 in exception_message
-    assert py37 in exception_message
-    assert ">=3.8" in exception_message
+    assert py38 in exception_message
+    assert ">=3.9" in exception_message
 
 
 def test_find_compatible_interpreters_none_with_valid_basenames_and_constraints():
     # type: () -> None
     py27 = ensure_python_interpreter(PY27)
-    py37 = ensure_python_interpreter(PY37)
-    path = [py27, py37]
+    py38 = ensure_python_interpreter(PY38)
+    path = [py27, py38]
 
     with pytest.raises(UnsatisfiableInterpreterConstraintsError) as exec_info:
         find_interpreters(path, valid_basenames=basenames(py27), constraints=[">=3.6"])
 
     exception_message = str(exec_info.value)
     assert py27 in exception_message
-    assert py37 not in exception_message
+    assert py38 not in exception_message
     assert os.path.basename(py27) in exception_message, exception_message
     assert ">=3.6" in exception_message
 
@@ -147,11 +147,11 @@ def test_find_compatible_interpreters_none_with_valid_basenames_and_constraints(
 def test_find_compatible_interpreters_with_valid_basenames():
     # type: () -> None
     py27 = ensure_python_interpreter(PY27)
-    py37 = ensure_python_interpreter(PY37)
+    py38 = ensure_python_interpreter(PY38)
     py310 = ensure_python_interpreter(PY310)
-    path = [py27, py37, py310]
+    path = [py27, py38, py310]
 
-    assert [py37] == find_interpreters(path, valid_basenames=basenames(py37))
+    assert [py38] == find_interpreters(path, valid_basenames=basenames(py38))
     assert [py27, py310] == find_interpreters(
         path, valid_basenames=basenames(*reversed([py27, py310]))
     )
@@ -160,12 +160,12 @@ def test_find_compatible_interpreters_with_valid_basenames():
 def test_find_compatible_interpreters_with_valid_basenames_and_constraints():
     # type: () -> None
     py27 = ensure_python_interpreter(PY27)
-    py37 = ensure_python_interpreter(PY37)
+    py38 = ensure_python_interpreter(PY38)
     py310 = ensure_python_interpreter(PY310)
-    path = [py27, py37, py310]
+    path = [py27, py38, py310]
 
-    assert [py37] == find_interpreters(
-        path, valid_basenames=basenames(py27, py37), constraints=[">=3"]
+    assert [py38] == find_interpreters(
+        path, valid_basenames=basenames(py27, py38), constraints=[">=3"]
     )
 
 
@@ -266,12 +266,12 @@ def test_pp_exact_on_ppp():
     # type: () -> None
 
     py27 = ensure_python_interpreter(PY27)
-    py37 = ensure_python_interpreter(PY37)
+    py38 = ensure_python_interpreter(PY38)
     py310 = ensure_python_interpreter(PY310)
 
     with ENV.patch(
         PEX_PYTHON=py310,
-        PEX_PYTHON_PATH=":".join(os.path.dirname(py) for py in (py27, py37, py310)),
+        PEX_PYTHON_PATH=":".join(os.path.dirname(py) for py in (py27, py38, py310)),
     ):
         assert PythonInterpreter.from_binary(py310) == find_compatible_interpreter()
 
@@ -314,11 +314,11 @@ def test_pp_exact_not_on_ppp():
     # type: () -> None
 
     py27 = ensure_python_interpreter(PY27)
-    py37 = ensure_python_interpreter(PY37)
+    py38 = ensure_python_interpreter(PY38)
     py310 = ensure_python_interpreter(PY310)
 
     with ENV.patch(
-        PEX_PYTHON=py310, PEX_PYTHON_PATH=":".join(os.path.dirname(py) for py in (py27, py37))
+        PEX_PYTHON=py310, PEX_PYTHON_PATH=":".join(os.path.dirname(py) for py in (py27, py38))
     ):
         with pytest.raises(
             UnsatisfiableInterpreterConstraintsError,

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -25,7 +25,7 @@ from pex.testing import (
     IS_LINUX,
     IS_PYPY,
     PY27,
-    PY37,
+    PY38,
     PY310,
     PY_VER,
     built_wheel,
@@ -267,7 +267,7 @@ def resolve_p537_wheel_names(
 ):
     # type: (...) -> List[str]
     with cache(cache_dir):
-        return resolve_wheel_names(requirements=["p537==1.0.4"], transitive=False, **kwargs)
+        return resolve_wheel_names(requirements=["p537==1.0.5"], transitive=False, **kwargs)
 
 
 @pytest.fixture(scope="module")
@@ -292,7 +292,7 @@ def test_resolve_current_platform(p537_resolve_cache):
             targets=Targets(platforms=current_platform, interpreters=tuple(interpreters)),
         )
 
-    other_python_version = PY310 if PY_VER == (3, 7) else PY37
+    other_python_version = PY310 if PY_VER == (3, 8) else PY38
     other_python = PythonInterpreter.from_binary(ensure_python_interpreter(other_python_version))
     current_python = PythonInterpreter.get()
 
@@ -315,7 +315,7 @@ def test_resolve_current_platform(p537_resolve_cache):
 )
 def test_resolve_current_and_foreign_platforms(p537_resolve_cache):
     # type: (str) -> None
-    foreign_platform = "macosx-10.13-x86_64-cp-37-m" if IS_LINUX else "manylinux1_x86_64-cp-37-m"
+    foreign_platform = "macosx-10.15-x86_64-cp-37-m" if IS_LINUX else "manylinux1_x86_64-cp-37-m"
 
     def resolve_current_and_foreign(interpreters=()):
         # type: (Iterable[PythonInterpreter]) -> List[str]
@@ -330,7 +330,7 @@ def test_resolve_current_and_foreign_platforms(p537_resolve_cache):
 
     assert 2 == len(resolve_current_and_foreign())
 
-    other_python_version = PY310 if PY_VER == (3, 7) else PY37
+    other_python_version = PY310 if PY_VER == (3, 8) else PY38
     other_python = PythonInterpreter.from_binary(ensure_python_interpreter(other_python_version))
     current_python = PythonInterpreter.get()
 
@@ -389,8 +389,8 @@ def test_resolve_foreign_abi3():
 
 def test_issues_851():
     # type: () -> None
-    # Previously, the PY37 resolve would fail post-resolution checks for configparser, pathlib2 and
-    # contextlib2 which are only required for python_version<3.
+    # Previously, the PY38 resolve would fail post-resolution checks for importlib-metadata,
+    # configparser, pathlib2 and contextlib2 which are only required for python_version<3.
 
     def resolve_pytest(python_version, pytest_version):
         interpreter = PythonInterpreter.from_binary(ensure_python_interpreter(python_version))
@@ -405,8 +405,8 @@ def test_issues_851():
         assert project_to_version["pytest"] == pytest_version
         return project_to_version
 
-    resolved_project_to_version = resolve_pytest(python_version=PY37, pytest_version="5.3.4")
-    assert "importlib-metadata" in resolved_project_to_version
+    resolved_project_to_version = resolve_pytest(python_version=PY38, pytest_version="5.3.4")
+    assert "importlib-metadata" not in resolved_project_to_version
     assert "configparser" not in resolved_project_to_version
     assert "pathlib2" not in resolved_project_to_version
     assert "contextlib2" not in resolved_project_to_version

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -53,7 +53,7 @@ def test_interpreter(
 
 def test_unique_targets(
     py27,  # type: PythonInterpreter
-    py37,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
     py310,  # type: PythonInterpreter
     current_interpreter,  # type: PythonInterpreter
     current_platform,  # type: Platform
@@ -82,8 +82,8 @@ def test_unique_targets(
     )
 
     assert (
-        OrderedSet(LocalInterpreter.create(i) for i in (py27, py37, py310))
-        == Targets(interpreters=(py27, py37, py310)).unique_targets()
+        OrderedSet(LocalInterpreter.create(i) for i in (py27, py38, py310))
+        == Targets(interpreters=(py27, py38, py310)).unique_targets()
     )
 
     complete_platform_current = CompletePlatform.from_interpreter(current_interpreter)

--- a/tests/tools/commands/test_interpreter_command.py
+++ b/tests/tools/commands/test_interpreter_command.py
@@ -11,7 +11,7 @@ import pytest
 from pex.common import safe_mkdtemp
 from pex.interpreter import PythonInterpreter
 from pex.pex_builder import PEXBuilder
-from pex.testing import PY37, PY310, ensure_python_interpreter
+from pex.testing import PY38, PY310, ensure_python_interpreter
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import Virtualenv
 
@@ -24,9 +24,9 @@ else:
 
 
 @pytest.fixture(scope="module")
-def python37():
+def python38():
     # type: () -> PythonInterpreter
-    return PythonInterpreter.from_binary(ensure_python_interpreter(PY37))
+    return PythonInterpreter.from_binary(ensure_python_interpreter(PY38))
 
 
 @pytest.fixture(scope="module")
@@ -82,11 +82,11 @@ class InterpreterTool(object):
 
 @pytest.fixture(scope="module")
 def interpreter_tool(
-    python37,  # type: PythonInterpreter
+    python38,  # type: PythonInterpreter
     python310,  # type: PythonInterpreter
 ):
     # type: (...) -> InterpreterTool
-    return InterpreterTool.create(python37, python310)
+    return InterpreterTool.create(python38, python310)
 
 
 def expected_basic(interpreter):
@@ -95,23 +95,23 @@ def expected_basic(interpreter):
 
 
 def test_basic(
-    python37,  # type: PythonInterpreter
+    python38,  # type: PythonInterpreter
     interpreter_tool,  # type: InterpreterTool
 ):
     # type: (...) -> None
     output = interpreter_tool.run()
-    assert expected_basic(python37) == output.strip()
+    assert expected_basic(python38) == output.strip()
 
 
 def test_basic_all(
-    python37,  # type: PythonInterpreter
+    python38,  # type: PythonInterpreter
     python310,  # type: PythonInterpreter
     interpreter_tool,  # type: InterpreterTool
 ):
     # type: (...) -> None
     output = interpreter_tool.run("-a")
     assert [
-        expected_basic(interpreter) for interpreter in (python37, python310)
+        expected_basic(interpreter) for interpreter in (python38, python310)
     ] == output.splitlines()
 
 
@@ -125,22 +125,22 @@ def expected_verbose(interpreter):
 
 
 def test_verbose(
-    python37,  # type: PythonInterpreter
+    python38,  # type: PythonInterpreter
     interpreter_tool,  # type: InterpreterTool
 ):
     # type: (...) -> None
     output = interpreter_tool.run("-v")
-    assert expected_verbose(python37) == json.loads(output)
+    assert expected_verbose(python38) == json.loads(output)
 
 
 def test_verbose_all(
-    python37,  # type: PythonInterpreter
+    python38,  # type: PythonInterpreter
     python310,  # type: PythonInterpreter
     interpreter_tool,  # type: InterpreterTool
 ):
     # type: (...) -> None
     output = interpreter_tool.run("-va")
-    assert [expected_verbose(interpreter) for interpreter in (python37, python310)] == [
+    assert [expected_verbose(interpreter) for interpreter in (python38, python310)] == [
         json.loads(line) for line in output.splitlines()
     ]
 
@@ -153,22 +153,22 @@ def expected_verbose_verbose(interpreter):
 
 
 def test_verbose_verbose(
-    python37,  # type: PythonInterpreter
+    python38,  # type: PythonInterpreter
     interpreter_tool,  # type: InterpreterTool
 ):
     # type: (...) -> None
     output = interpreter_tool.run("-vv")
-    assert expected_verbose_verbose(python37) == json.loads(output)
+    assert expected_verbose_verbose(python38) == json.loads(output)
 
 
 def test_verbose_verbose_verbose(
-    python37,  # type: PythonInterpreter
+    python38,  # type: PythonInterpreter
     interpreter_tool,  # type: InterpreterTool
 ):
     # type: (...) -> None
     output = interpreter_tool.run("-vvv")
-    expected = expected_verbose_verbose(python37)
-    expected.update(env_markers=python37.identity.env_markers.as_dict(), venv=False)
+    expected = expected_verbose_verbose(python38)
+    expected.update(env_markers=python38.identity.env_markers.as_dict(), venv=False)
     assert expected == json.loads(output)
 
 


### PR DESCRIPTION
Windows support via pyenv-win will floor out at 3.8 due to various issues surrounding long paths and symlink support in earlier Python versions. The reliance on the 2.7 pyenv in ITs will also need to be fixed, but this change just tackles the 3.7 case.