### PR TITLE
Migrate PY27 pyenv to PY39.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v3
+          key: ${{ runner.os }}-pyenv-root-v4
       - name: Run Unit Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -149,7 +149,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v3
+          key: ${{ runner.os }}-pyenv-root-v4
       - name: Run Unit Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -198,7 +198,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v3
+          key: ${{ runner.os }}-pyenv-root-v4
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -244,7 +244,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v3
+          key: ${{ runner.os }}-pyenv-root-v4
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -10,8 +10,11 @@ import platform
 import random
 import subprocess
 import sys
+from collections import OrderedDict
 from contextlib import contextmanager
 from textwrap import dedent
+
+import pytest
 
 from pex.common import (
     atomic_directory,
@@ -24,15 +27,18 @@ from pex.common import (
 )
 from pex.compatibility import to_unicode
 from pex.dist_metadata import Distribution
+from pex.enum import Enum
 from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
+from pex.orderedset import OrderedSet
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
 from pex.pip.installation import get_pip
 from pex.targets import LocalInterpreter
-from pex.typing import TYPE_CHECKING
+from pex.typing import TYPE_CHECKING, cast
 from pex.util import named_temporary_file
+from pex.venv.virtualenv import Virtualenv
 
 if TYPE_CHECKING:
     from typing import (
@@ -454,12 +460,14 @@ def bootstrap_python_installer(dest):
 # otherwise encountered when fetching and building too many on a cache miss. In the past we had
 # issues with the combination of 7 total unique interpreter versions and a Travis-CI timeout of 50
 # minutes for a shard.
-PY27 = "2.7.18"
+# N.B.: Make sure to stick to versions that have binary releases for all supported platforms to
+# support use of pyenv-win which does not build from source, just running released installers
+# robotically instead.
 PY38 = "3.8.10"
-PY310 = "3.10.1"
+PY39 = "3.9.13"
+PY310 = "3.10.7"
 
-ALL_PY_VERSIONS = (PY27, PY38, PY310)
-_ALL_PY3_VERSIONS = (PY38, PY310)
+ALL_PY_VERSIONS = (PY38, PY39, PY310)
 
 
 def ensure_python_distribution(version):
@@ -525,20 +533,18 @@ def ensure_python_distribution(version):
     return interpreter_location, python, pip, run_pyenv
 
 
-def ensure_python_venv(version, latest_pip=True, system_site_packages=False):
+def ensure_python_venv(
+    version,  # type: str
+    latest_pip=True,  # type: bool
+    system_site_packages=False,  # type: bool
+):
+    # type: (...) -> Tuple[str, str]
     _, python, pip, _ = ensure_python_distribution(version)
     venv = safe_mkdtemp()
-    if version in _ALL_PY3_VERSIONS:
-        args = [python, "-m", "venv", venv]
-        if system_site_packages:
-            args.append("--system-site-packages")
-        subprocess.check_call(args=args)
-    else:
-        subprocess.check_call(args=[pip, "install", "virtualenv==16.7.10"])
-        args = [python, "-m", "virtualenv", venv, "-q"]
-        if system_site_packages:
-            args.append("--system-site-packages")
-        subprocess.check_call(args=args)
+    args = [python, "-m", "venv", venv]
+    if system_site_packages:
+        args.append("--system-site-packages")
+    subprocess.check_call(args=args)
     python, pip = tuple(os.path.join(venv, "bin", exe) for exe in ("python", "pip"))
     if latest_pip:
         subprocess.check_call(args=[pip, "install", "-U", "pip<22.1"])
@@ -549,6 +555,122 @@ def ensure_python_interpreter(version):
     # type: (str) -> str
     _, python, _, _ = ensure_python_distribution(version)
     return python
+
+
+class InterpreterImplementation(Enum["InterpreterImplementation.Value"]):
+    class Value(Enum.Value):
+        pass
+
+    CPython = Value("CPython")
+    PyPy = Value("PyPy")
+
+
+def find_python_interpreter(
+    version=(),  # type: Tuple[int, ...]
+    implementation=InterpreterImplementation.CPython,  # type: InterpreterImplementation.Value
+):
+    # type: (...) -> Optional[str]
+    for interpreter in PythonInterpreter.iter():
+        if version != interpreter.version[: len(version)]:
+            continue
+        if implementation != InterpreterImplementation.for_value(interpreter.identity.interpreter):
+            continue
+        return interpreter.resolve_base_interpreter().binary
+    return None
+
+
+def skip_unless_python_interpreter(
+    version=(),  # type: Tuple[int, ...]
+    implementation=InterpreterImplementation.CPython,  # type: InterpreterImplementation.Value
+):
+    # type: (...) -> str
+    python = find_python_interpreter(version=version, implementation=implementation)
+    if python is not None:
+        return python
+    pytest.skip(
+        "Test requires a Python {version} on the PATH".format(version=".".join(map(str, version)))
+    )
+    raise AssertionError("Unreachable.")
+
+
+def python_venv(
+    python,  # type: str
+    system_site_packages=False,  # type: bool
+    venv_dir=None,  # type: Optional[str]
+):
+    # type: (...) -> Tuple[str, str]
+    venv = Virtualenv.create(
+        venv_dir=venv_dir or safe_mkdtemp(),
+        interpreter=PythonInterpreter.from_binary(python),
+        system_site_packages=system_site_packages,
+    )
+    venv.install_pip()
+    return venv.interpreter.binary, venv.bin_path("pip")
+
+
+def skip_unless_python_venv(
+    version=(),  # type: Tuple[int, ...]
+    implementation=InterpreterImplementation.CPython,  # type: InterpreterImplementation.Value
+    system_site_packages=False,  # type: bool
+    venv_dir=None,  # type: Optional[str]
+):
+    # type: (...) -> Tuple[str, str]
+    return python_venv(
+        skip_unless_python_interpreter(version=version, implementation=implementation),
+        system_site_packages=system_site_packages,
+        venv_dir=venv_dir,
+    )
+
+
+def all_pythons(additional_optional_versions=()):
+    # type: (Iterable[Tuple[int, ...]]) -> Tuple[str, ...]
+    pythons = OrderedSet()  # type: OrderedSet[str]
+    for version in ALL_PY_VERSIONS:
+        pythons.add(ensure_python_interpreter(version))
+    for optional_version in additional_optional_versions:
+        python = find_python_interpreter(optional_version)
+        if python:
+            pythons.add(python)
+    return tuple(pythons)
+
+
+@attr.s(frozen=True)
+class VenvFactory(object):
+    python_version = attr.ib()  # type: str
+    _factory = attr.ib()  # type: Callable[[], Tuple[str, str]]
+
+    def create_venv(self):
+        # type: () -> Tuple[str, str]
+        return self._factory()
+
+
+def all_python_venvs(
+    additional_optional_versions=(),  # type: Iterable[Tuple[int, ...]]
+    system_site_packages=False,  # type: bool
+):
+    # type: (...) -> Iterable[VenvFactory]
+    all_venv_factories = [
+        VenvFactory(
+            python_version=version,
+            factory=lambda: ensure_python_venv(version, system_site_packages=system_site_packages),
+        )
+        for version in ALL_PY_VERSIONS
+    ]
+    for optional_version in additional_optional_versions:
+        python = find_python_interpreter(optional_version)
+        if python is not None:
+            all_venv_factories.append(
+                VenvFactory(
+                    python_version=PythonInterpreter.from_binary(python).identity.version_str,
+                    factory=lambda: python_venv(
+                        # MyPy is not smart enough to track the None check above into the closure
+                        # capture.
+                        cast(str, python),
+                        system_site_packages=system_site_packages,
+                    ),
+                )
+            )
+    return all_venv_factories
 
 
 @contextmanager

--- a/pex/venv/virtualenv.py
+++ b/pex/venv/virtualenv.py
@@ -13,7 +13,7 @@ from contextlib import closing
 from fileinput import FileInput
 
 from pex.common import AtomicDirectory, atomic_directory, is_exe, safe_mkdir, safe_open
-from pex.compatibility import get_stdout_bytes_buffer
+from pex.compatibility import commonpath, get_stdout_bytes_buffer
 from pex.dist_metadata import Distribution, find_distributions
 from pex.executor import Executor
 from pex.fetcher import URLFetcher
@@ -91,7 +91,7 @@ def find_site_packages_dir(
     interpreter = interpreter or PythonInterpreter.get()
     for entry in interpreter.sys_path:
         real_entry_path = os.path.realpath(entry)
-        if os.path.commonprefix((real_venv_dir, real_entry_path)) != real_venv_dir:
+        if commonpath((real_venv_dir, real_entry_path)) != real_venv_dir:
             # This ignores system site packages when the venv is built with --system-site-packages.
             continue
         if "site-packages" == os.path.basename(real_entry_path) and os.path.isdir(real_entry_path):

--- a/pex/venv/virtualenv.py
+++ b/pex/venv/virtualenv.py
@@ -84,12 +84,19 @@ def find_site_packages_dir(
     interpreter=None,  # type: Optional[PythonInterpreter]
 ):
     # type: (...) -> str
+
+    real_venv_dir = os.path.realpath(venv_dir)
+    site_packages_dirs = OrderedSet()  # type: OrderedSet[str]
+
     interpreter = interpreter or PythonInterpreter.get()
-    site_packages_dirs = []
-    for path in OrderedSet(os.path.realpath(entry) for entry in interpreter.sys_path):
-        _, tail = os.path.split(path)
-        if "site-packages" == tail and os.path.isdir(path):
-            site_packages_dirs.append(path)
+    for entry in interpreter.sys_path:
+        real_entry_path = os.path.realpath(entry)
+        if os.path.commonprefix((real_venv_dir, real_entry_path)) != real_venv_dir:
+            # This ignores system site packages when the venv is built with --system-site-packages.
+            continue
+        if "site-packages" == os.path.basename(real_entry_path) and os.path.isdir(real_entry_path):
+            site_packages_dirs.add(real_entry_path)
+
     if not site_packages_dirs:
         raise InvalidVirtualenvError(
             "The virtualenv at {venv_dir} is not valid. No site-packages directory was found in "
@@ -104,7 +111,7 @@ def find_site_packages_dir(
                 venv_dir=venv_dir, site_packages="\n".join(site_packages_dirs)
             )
         )
-    return site_packages_dirs[0]
+    return site_packages_dirs.pop()
 
 
 class Virtualenv(object):
@@ -130,6 +137,7 @@ class Virtualenv(object):
         interpreter=None,  # type: Optional[PythonInterpreter]
         force=False,  # type: bool
         copies=False,  # type: bool
+        system_site_packages=False,  # type: bool
         prompt=None,  # type: Optional[str]
     ):
         # type: (...) -> Virtualenv
@@ -172,6 +180,8 @@ class Virtualenv(object):
                 args = [fp.name, "--no-pip", "--no-setuptools", "--no-wheel", venv_dir]
                 if copies:
                     args.append("--always-copy")
+                if system_site_packages:
+                    args.append("--system-site-packages")
                 if prompt:
                     args.extend(["--prompt", prompt])
                     custom_prompt = prompt
@@ -180,6 +190,8 @@ class Virtualenv(object):
             args = ["-m", "venv", "--without-pip", venv_dir]
             if copies:
                 args.append("--copies")
+            if system_site_packages:
+                args.append("--system-site-packages")
             if prompt and py_major_minor >= (3, 6):
                 args.extend(["--prompt", prompt])
                 custom_prompt = prompt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,8 @@ from pex.testing import (
     PY39,
     PY310,
     ensure_python_interpreter,
-    skip_unless_python_interpreter,
-    skip_unless_python_venv,
+    skip_unless_python27,
+    skip_unless_python27_venv,
 )
 
 
@@ -36,11 +36,10 @@ def current_platform(current_interpreter):
     return current_interpreter.platform
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def py27():
     # type: () -> PythonInterpreter
-    python, _ = skip_unless_python_venv(version=(2, 7))
-    return PythonInterpreter.from_binary(python)
+    return PythonInterpreter.from_binary(skip_unless_python27())
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,14 @@ import pytest
 from pex import testing
 from pex.interpreter import PythonInterpreter
 from pex.platforms import Platform
-from pex.testing import PY27, PY38, PY310, ensure_python_interpreter
+from pex.testing import (
+    PY38,
+    PY39,
+    PY310,
+    ensure_python_interpreter,
+    skip_unless_python_interpreter,
+    skip_unless_python_venv,
+)
 
 
 @pytest.fixture(scope="session")
@@ -29,16 +36,23 @@ def current_platform(current_interpreter):
     return current_interpreter.platform
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def py27():
     # type: () -> PythonInterpreter
-    return PythonInterpreter.from_binary(ensure_python_interpreter(PY27))
+    python, _ = skip_unless_python_venv(version=(2, 7))
+    return PythonInterpreter.from_binary(python)
 
 
 @pytest.fixture
 def py38():
     # type: () -> PythonInterpreter
     return PythonInterpreter.from_binary(ensure_python_interpreter(PY38))
+
+
+@pytest.fixture
+def py39():
+    # type: () -> PythonInterpreter
+    return PythonInterpreter.from_binary(ensure_python_interpreter(PY39))
 
 
 @pytest.fixture

--- a/tests/integration/cli/commands/test_issue_1734.py
+++ b/tests/integration/cli/commands/test_issue_1734.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+import re
 import subprocess
 
 from pex.cli.testing import run_pex3
@@ -90,21 +91,22 @@ def test_lock_create_universal_interpreter_constraint_unsatisfiable(
         "2",
     )
     result.assert_failure()
-    assert (
-        "When creating a universal lock with an --interpreter-constraint, an interpreter matching "
-        "the constraint must be found on the local system but none was: Could not find a "
-        "compatible interpreter.\n"
-        "\n"
-        "Examined the following interpreters:\n"
-        "1.) {py27_path} {py27_req}\n"
-        "2.) {py38_path} {py38_req}\n"
-        "\n"
-        "No interpreter compatible with the requested constraints was found:\n"
-        "\n"
-        "  Version matches CPython<3.11,>=3.9\n".format(
+    assert re.match(
+        r"^When creating a universal lock with an --interpreter-constraint, an interpreter "
+        r"matching the constraint must be found on the local system but none was: Could not find a "
+        r"compatible interpreter\.\n"
+        r"\n"
+        r"Examined the following interpreters:\n"
+        r"1\.\)\s+{py27_path} {py27_req}\n"
+        r"2\.\)\s+{py38_path} {py38_req}\n"
+        r"\n"
+        r"No interpreter compatible with the requested constraints was found:\n"
+        r"\n"
+        r"  Version matches CPython<3\.11,>=3\.9\n".format(
             py27_path=py27.binary,
             py27_req=py27.identity.requirement,
             py38_path=py38.binary,
             py38_req=py38.identity.requirement,
-        )
-    ) == result.error
+        ),
+        result.error,
+    )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -17,7 +17,7 @@ from textwrap import dedent
 import pytest
 
 from pex.common import safe_mkdir, safe_open, safe_rmtree, temporary_dir, touch
-from pex.compatibility import WINDOWS, to_bytes
+from pex.compatibility import WINDOWS
 from pex.dist_metadata import Distribution, Requirement
 from pex.fetcher import URLFetcher
 from pex.interpreter import PythonInterpreter
@@ -29,8 +29,8 @@ from pex.testing import (
     IS_MAC,
     NOT_CPYTHON27,
     NOT_CPYTHON27_OR_OSX,
-    PY27,
     PY38,
+    PY39,
     PY310,
     PY_VER,
     IntegResults,
@@ -41,6 +41,8 @@ from pex.testing import (
     run_pex_command,
     run_simple_pex,
     run_simple_pex_test,
+    skip_unless_python_interpreter,
+    skip_unless_python_venv,
     temporary_content,
 )
 from pex.typing import TYPE_CHECKING, cast
@@ -271,19 +273,19 @@ def test_entry_point_exit_code(tmpdir):
 def test_pex_multi_resolve():
     # type: () -> None
     """Tests multi-interpreter + multi-platform resolution."""
-    python27 = ensure_python_interpreter(PY27)
     python38 = ensure_python_interpreter(PY38)
+    python39 = ensure_python_interpreter(PY39)
     with temporary_dir() as output_dir:
         pex_path = os.path.join(output_dir, "pex.pex")
         results = run_pex_command(
             [
                 "--disable-cache",
-                "lxml==4.4.3",
+                "lxml==4.5.2",
                 "--no-build",
                 "--platform=linux-x86_64-cp-36-m",
                 "--platform=macosx-10.9-x86_64-cp-36-m",
-                "--python={}".format(python27),
                 "--python={}".format(python38),
+                "--python={}".format(python39),
                 "-o",
                 pex_path,
             ]
@@ -292,7 +294,7 @@ def test_pex_multi_resolve():
 
         included_dists = get_dep_dist_names_from_pex(pex_path, "lxml")
         assert len(included_dists) == 4
-        for dist_substr in ("-cp27-", "-cp36-", "-cp38-", "-manylinux1_x86_64", "-macosx_"):
+        for dist_substr in ("-cp36-", "-cp38-", "-cp39-", "-manylinux1_x86_64", "-macosx_"):
             assert any(dist_substr in f for f in included_dists)
 
 
@@ -872,7 +874,7 @@ def test_pex_interpreter_interact_custom_setuptools_useable():
 
 def test_setup_python():
     # type: () -> None
-    interpreter = ensure_python_interpreter(PY27)
+    interpreter = ensure_python_interpreter(PY39)
     with temporary_dir() as out:
         pex = os.path.join(out, "pex.pex")
         results = run_pex_command(
@@ -884,7 +886,7 @@ def test_setup_python():
 
 def test_setup_interpreter_constraint():
     # type: () -> None
-    interpreter = ensure_python_interpreter(PY27)
+    interpreter = ensure_python_interpreter(PY39)
     with temporary_dir() as out:
         pex = os.path.join(out, "pex.pex")
         env = make_env(
@@ -895,7 +897,7 @@ def test_setup_interpreter_constraint():
             [
                 "jsonschema==2.6.0",
                 "--disable-cache",
-                "--interpreter-constraint=CPython=={}".format(PY27),
+                "--interpreter-constraint=CPython=={}".format(PY39),
                 "-o",
                 pex,
             ],
@@ -910,8 +912,8 @@ def test_setup_interpreter_constraint():
 def test_setup_python_path():
     # type: () -> None
     """Check that `--python-path` is used rather than the default $PATH."""
-    py27_interpreter_dir = os.path.dirname(ensure_python_interpreter(PY27))
     py38_interpreter_dir = os.path.dirname(ensure_python_interpreter(PY38))
+    py39_interpreter_dir = os.path.dirname(ensure_python_interpreter(PY39))
     with temporary_dir() as out:
         pex = os.path.join(out, "pex.pex")
         # Even though we set $PATH="", we still expect for both interpreters to be used when
@@ -920,9 +922,9 @@ def test_setup_python_path():
             [
                 "more-itertools==5.0.0",
                 "--disable-cache",
-                "--interpreter-constraint=CPython>={},<={}".format(PY27, PY38),
+                "--interpreter-constraint=CPython>={},<={}".format(PY38, PY39),
                 "--python-path={}".format(
-                    os.pathsep.join([py27_interpreter_dir, py38_interpreter_dir])
+                    os.pathsep.join([py38_interpreter_dir, py39_interpreter_dir])
                 ),
                 "-o",
                 pex,
@@ -933,30 +935,30 @@ def test_setup_python_path():
 
         py310_interpreter = PythonInterpreter.from_binary(ensure_python_interpreter(PY310))
 
-        py27_env = make_env(PEX_IGNORE_RCFILES="1", PATH=py27_interpreter_dir)
+        py38_env = make_env(PEX_IGNORE_RCFILES="1", PATH=py38_interpreter_dir)
         stdout, rc = run_simple_pex(
             pex,
             interpreter=py310_interpreter,
-            env=py27_env,
-            stdin=b"import more_itertools, sys; print(sys.version_info[:2])",
-        )
-        assert rc == 0
-        assert b"(2, 7)" in stdout
-
-        py37_env = make_env(PEX_IGNORE_RCFILES="1", PATH=py38_interpreter_dir)
-        stdout, rc = run_simple_pex(
-            pex,
-            interpreter=py310_interpreter,
-            env=py37_env,
+            env=py38_env,
             stdin=b"import more_itertools, sys; print(sys.version_info[:2])",
         )
         assert rc == 0
         assert b"(3, 8)" in stdout
 
+        py39_env = make_env(PEX_IGNORE_RCFILES="1", PATH=py39_interpreter_dir)
+        stdout, rc = run_simple_pex(
+            pex,
+            interpreter=py310_interpreter,
+            env=py39_env,
+            stdin=b"import more_itertools, sys; print(sys.version_info[:2])",
+        )
+        assert rc == 0
+        assert b"(3, 9)" in stdout
+
 
 def test_setup_python_multiple_transitive_markers():
     # type: () -> None
-    py27_interpreter = ensure_python_interpreter(PY27)
+    py27_interpreter = skip_unless_python_interpreter(version=(2, 7))
     py310_interpreter = ensure_python_interpreter(PY310)
     with temporary_dir() as out:
         pex = os.path.join(out, "pex.pex")
@@ -979,19 +981,19 @@ def test_setup_python_multiple_transitive_markers():
             "import jsonschema, os, sys; print(os.path.realpath(sys.executable))"
         ]
 
-        py27_env = make_env(PATH=os.path.dirname(py27_interpreter))
-        subprocess.check_call(py2_only_program, env=py27_env)
+        subprocess.check_call([py27_interpreter] + py2_only_program)
 
-        stdout = subprocess.check_output(both_program, env=py27_env)
-        assert to_bytes(os.path.realpath(py27_interpreter)) == stdout.strip()
+        stdout = subprocess.check_output([py27_interpreter] + both_program)
+        assert os.path.realpath(py27_interpreter) == stdout.decode("utf-8").strip()
 
-        py310_env = make_env(PATH=os.path.dirname(py310_interpreter))
         with pytest.raises(subprocess.CalledProcessError) as err:
-            subprocess.check_output(py2_only_program, stderr=subprocess.STDOUT, env=py310_env)
+            subprocess.check_output(
+                [py310_interpreter] + py2_only_program, stderr=subprocess.STDOUT
+            )
         assert b"ModuleNotFoundError: No module named 'functools32'" in err.value.output
 
-        stdout = subprocess.check_output(both_program, env=py310_env)
-        assert to_bytes(os.path.realpath(py310_interpreter)) == stdout.strip()
+        stdout = subprocess.check_output([py310_interpreter] + both_program)
+        assert os.path.realpath(py310_interpreter) == stdout.decode("utf-8").strip()
 
 
 def test_setup_python_direct_markers():
@@ -1015,9 +1017,8 @@ def test_setup_python_direct_markers():
 
         with pytest.raises(subprocess.CalledProcessError) as err:
             subprocess.check_output(
-                py2_only_program,
+                [py310_interpreter] + py2_only_program,
                 stderr=subprocess.STDOUT,
-                env=make_env(PATH=os.path.dirname(py310_interpreter)),
             )
         assert b"ModuleNotFoundError: No module named 'subprocess32'" in err.value.output
 
@@ -1025,7 +1026,7 @@ def test_setup_python_direct_markers():
 def test_setup_python_multiple_direct_markers():
     # type: () -> None
     py310_interpreter = ensure_python_interpreter(PY310)
-    py27_interpreter = ensure_python_interpreter(PY27)
+    py27_interpreter = skip_unless_python_interpreter(version=(2, 7))
     with temporary_dir() as out:
         pex = os.path.join(out, "pex.pex")
         results = run_pex_command(
@@ -1045,18 +1046,15 @@ def test_setup_python_multiple_direct_markers():
 
         with pytest.raises(subprocess.CalledProcessError) as err:
             subprocess.check_output(
-                py2_only_program,
+                [py310_interpreter] + py2_only_program,
                 stderr=subprocess.STDOUT,
-                env=make_env(PATH=os.path.dirname(py310_interpreter)),
             )
         assert (
             re.search(b"ModuleNotFoundError: No module named 'subprocess32'", err.value.output)
             is not None
         )
 
-        subprocess.check_call(
-            py2_only_program, env=make_env(PATH=os.path.dirname(py27_interpreter))
-        )
+        subprocess.check_call([py27_interpreter] + py2_only_program)
 
 
 def build_and_execute_pex_with_warnings(*extra_build_args, **extra_runtime_env):
@@ -1099,7 +1097,7 @@ def test_no_emit_warnings_verbose_override():
 
 def test_trusted_host_handling():
     # type: () -> None
-    python = ensure_python_interpreter(PY27)
+    python = skip_unless_python_interpreter(version=(2, 7))
     # Since we explicitly ask Pex to find links at http://www.antlr3.org/download/Python, it should
     # implicitly trust the www.antlr3.org host.
     results = run_pex_command(
@@ -1405,7 +1403,7 @@ def test_venv_mode(
     isort_pex_args,  # type: Tuple[str, List[str]]
 ):
     # type: (...) -> None
-    other_interpreter_version = PY310 if sys.version_info[0] == 2 else PY27
+    other_interpreter_version = PY310 if sys.version_info[:2] == (3, 9) else PY39
     other_interpreter = ensure_python_interpreter(other_interpreter_version)
 
     pex_file, args = isort_pex_args

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -280,7 +280,7 @@ def test_pex_multi_resolve():
         results = run_pex_command(
             [
                 "--disable-cache",
-                "lxml==4.5.2",
+                "lxml==4.6.1",
                 "--no-build",
                 "--platform=linux-x86_64-cp-36-m",
                 "--platform=macosx-10.9-x86_64-cp-36-m",

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -41,8 +41,8 @@ from pex.testing import (
     run_pex_command,
     run_simple_pex,
     run_simple_pex_test,
-    skip_unless_python_interpreter,
-    skip_unless_python_venv,
+    skip_unless_python27,
+    skip_unless_python27_venv,
     temporary_content,
 )
 from pex.typing import TYPE_CHECKING, cast
@@ -958,7 +958,7 @@ def test_setup_python_path():
 
 def test_setup_python_multiple_transitive_markers():
     # type: () -> None
-    py27_interpreter = skip_unless_python_interpreter(version=(2, 7))
+    py27_interpreter = skip_unless_python27()
     py310_interpreter = ensure_python_interpreter(PY310)
     with temporary_dir() as out:
         pex = os.path.join(out, "pex.pex")
@@ -1026,7 +1026,7 @@ def test_setup_python_direct_markers():
 def test_setup_python_multiple_direct_markers():
     # type: () -> None
     py310_interpreter = ensure_python_interpreter(PY310)
-    py27_interpreter = skip_unless_python_interpreter(version=(2, 7))
+    py27_interpreter = skip_unless_python27()
     with temporary_dir() as out:
         pex = os.path.join(out, "pex.pex")
         results = run_pex_command(
@@ -1097,7 +1097,7 @@ def test_no_emit_warnings_verbose_override():
 
 def test_trusted_host_handling():
     # type: () -> None
-    python = skip_unless_python_interpreter(version=(2, 7))
+    python = skip_unless_python27()
     # Since we explicitly ask Pex to find links at http://www.antlr3.org/download/Python, it should
     # implicitly trust the www.antlr3.org host.
     results = run_pex_command(

--- a/tests/integration/test_interpreter_selection.py
+++ b/tests/integration/test_interpreter_selection.py
@@ -1,5 +1,6 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 import os
 import sys
 from textwrap import dedent
@@ -10,8 +11,8 @@ from pex.interpreter import PythonInterpreter
 from pex.pep_503 import ProjectName
 from pex.pex_info import PexInfo
 from pex.testing import (
-    PY27,
     PY38,
+    PY39,
     PY310,
     ensure_python_interpreter,
     make_env,
@@ -92,27 +93,25 @@ def test_interpreter_resolution_with_multiple_constraint_options():
 
 def test_interpreter_resolution_with_pex_python_path():
     # type: () -> None
+
+    py38 = ensure_python_interpreter(PY38)
+    py39 = ensure_python_interpreter(PY39)
+
     with temporary_dir() as td:
         pexrc_path = os.path.join(td, ".pexrc")
         with open(pexrc_path, "w") as pexrc:
-            # set pex python path
-            pex_python_path = os.pathsep.join(
-                [ensure_python_interpreter(PY27), ensure_python_interpreter(PY38)]
-            )
-            pexrc.write("PEX_PYTHON_PATH=%s" % pex_python_path)
+            pexrc.write("PEX_PYTHON_PATH={}".format(os.pathsep.join([py38, py39])))
 
         # constraints to build pex cleanly; PPP + pex_bootstrapper.py
         # will use these constraints to override sys.executable on pex re-exec
-        interpreter_constraint1 = ">3" if sys.version_info[0] == 3 else "<3"
-        interpreter_constraint2 = "<3.9" if sys.version_info[0] == 3 else ">=2.7"
+        interpreter_constraint = "==3.8.*" if sys.version_info[:2] == (3, 9) else "==3.9.*"
 
         pex_out_path = os.path.join(td, "pex.pex")
         res = run_pex_command(
             [
                 "--disable-cache",
-                "--rcfile=%s" % pexrc_path,
-                "--interpreter-constraint=%s,%s"
-                % (interpreter_constraint1, interpreter_constraint2),
+                "--rcfile={}".format(pexrc_path),
+                "--interpreter-constraint={}".format(interpreter_constraint),
                 "-o",
                 pex_out_path,
             ]
@@ -123,10 +122,10 @@ def test_interpreter_resolution_with_pex_python_path():
         stdout, rc = run_simple_pex(pex_out_path, stdin=stdin_payload)
 
         assert rc == 0
-        if sys.version_info[0] == 3:
-            assert str(pex_python_path.split(os.pathsep)[1]).encode() in stdout
+        if sys.version_info[:2] == (3, 9):
+            assert py38 in stdout.decode("utf-8")
         else:
-            assert str(pex_python_path.split(os.pathsep)[0]).encode() in stdout
+            assert py39 in stdout.decode("utf-8")
 
 
 def test_interpreter_constraints_honored_without_ppp_or_pp(tmpdir):
@@ -171,7 +170,7 @@ def test_interpreter_resolution_pex_python_path_precedence_over_pex_python(tmpdi
     # type: (Any) -> None
 
     pexrc_path = os.path.join(str(tmpdir), ".pexrc")
-    ppp = os.pathsep.join(os.path.dirname(ensure_python_interpreter(py)) for py in (PY27, PY38))
+    ppp = os.pathsep.join(os.path.dirname(ensure_python_interpreter(py)) for py in (PY38, PY39))
     with open(pexrc_path, "w") as pexrc:
         # set both PPP and PP
         pexrc.write(
@@ -191,7 +190,8 @@ def test_interpreter_resolution_pex_python_path_precedence_over_pex_python(tmpdi
             "--disable-cache",
             "--rcfile",
             pexrc_path,
-            "--interpreter-constraint=>3,<3.9",
+            "--interpreter-constraint",
+            ">=3.8,<3.10",
             "-o",
             pex_out_path,
         ]
@@ -243,25 +243,29 @@ def test_plain_pex_exec_no_ppp_no_pp_no_constraints():
 
 def test_pex_exec_with_pex_python_path_only():
     # type: () -> None
+
+    py39 = ensure_python_interpreter(PY39)
+
     with temporary_dir() as td:
         pexrc_path = os.path.join(td, ".pexrc")
         with open(pexrc_path, "w") as pexrc:
             # set pex python path
-            pex_python_path = os.pathsep.join(
-                [ensure_python_interpreter(PY27), ensure_python_interpreter(PY310)]
+            pexrc.write(
+                "PEX_PYTHON_PATH={}".format(
+                    os.pathsep.join([py39, ensure_python_interpreter(PY310)])
+                )
             )
-            pexrc.write("PEX_PYTHON_PATH=%s" % pex_python_path)
 
         pex_out_path = os.path.join(td, "pex.pex")
         res = run_pex_command(["--disable-cache", "--rcfile=%s" % pexrc_path, "-o", pex_out_path])
         res.assert_success()
 
-        # test that pex bootstrapper selects lowest version interpreter
-        # in pex python path (python2.7)
+        # test that pex bootstrapper selects the lowest version interpreter
+        # in pex python path (python3.9)
         stdin_payload = b"import sys; print(sys.executable); sys.exit(0)"
         stdout, rc = run_simple_pex(pex_out_path, stdin=stdin_payload)
         assert rc == 0
-        assert str(pex_python_path.split(os.pathsep)[0]).encode() in stdout
+        assert py39 in stdout.decode("utf-8")
 
 
 def test_pex_exec_with_pex_python_path_and_pex_python_but_no_constraints(tmpdir):
@@ -276,7 +280,7 @@ def test_pex_exec_with_pex_python_path_and_pex_python_but_no_constraints(tmpdir)
                 PEX_PYTHON=python
                 """.format(
                     os.pathsep.join(
-                        os.path.dirname(ensure_python_interpreter(py)) for py in (PY310, PY27)
+                        os.path.dirname(ensure_python_interpreter(py)) for py in (PY310, PY39)
                     )
                 )
             )
@@ -286,36 +290,34 @@ def test_pex_exec_with_pex_python_path_and_pex_python_but_no_constraints(tmpdir)
     res = run_pex_command(["--disable-cache", "--rcfile", pexrc_path, "-o", pex_out_path])
     res.assert_success()
 
-    # test that pex bootstrapper selects lowest version interpreter
-    # in pex python path (python2.7)
+    # test that pex bootstrapper selects the lowest version interpreter
+    # in pex python path (python3.9)
     stdout, rc = run_simple_pex(
         pex_out_path, args=["-c", "import sys; print('.'.join(map(str, sys.version_info[:2])))"]
     )
     assert rc == 0
-    assert b"2.7\n" == stdout
+    assert b"3.9\n" == stdout
 
 
 def test_pex_python():
     # type: () -> None
-    py2_path_interpreter = ensure_python_interpreter(PY27)
-    py3_path_interpreter = ensure_python_interpreter(PY38)
-    path = os.pathsep.join(
-        [os.path.dirname(py2_path_interpreter), os.path.dirname(py3_path_interpreter)]
-    )
-    env = make_env(PATH=path)
+    py38 = ensure_python_interpreter(PY38)
+    py39 = ensure_python_interpreter(PY39)
+    env = make_env(PATH=os.pathsep.join([os.path.dirname(py38), os.path.dirname(py39)]))
     with temporary_dir() as td:
         pexrc_path = os.path.join(td, ".pexrc")
         with open(pexrc_path, "w") as pexrc:
-            pex_python = ensure_python_interpreter(PY38)
-            pexrc.write("PEX_PYTHON=%s" % pex_python)
+            pexrc.write("PEX_PYTHON={}".format(py38))
 
         # test PEX_PYTHON with valid constraints
         pex_out_path = os.path.join(td, "pex.pex")
         res = run_pex_command(
             [
                 "--disable-cache",
-                "--rcfile=%s" % pexrc_path,
-                "--interpreter-constraint=>3,<3.9",
+                "--rcfile",
+                pexrc_path,
+                "--interpreter-constraint",
+                ">=3.8,<3.10",
                 "-o",
                 pex_out_path,
             ],
@@ -326,21 +328,22 @@ def test_pex_python():
         stdin_payload = b"import sys; print(sys.executable); sys.exit(0)"
         stdout, rc = run_simple_pex(pex_out_path, stdin=stdin_payload, env=env)
         assert rc == 0
-        correct_interpreter_path = pex_python.encode()
-        assert correct_interpreter_path in stdout
+        assert py38 in stdout.decode("utf-8")
 
         # test PEX_PYTHON with incompatible constraints
+        py310 = ensure_python_interpreter(PY310)
         pexrc_path = os.path.join(td, ".pexrc")
         with open(pexrc_path, "w") as pexrc:
-            pex_python = ensure_python_interpreter(PY27)
-            pexrc.write("PEX_PYTHON=%s" % pex_python)
+            pexrc.write("PEX_PYTHON={}".format(py310))
 
         pex_out_path = os.path.join(td, "pex2.pex")
         res = run_pex_command(
             [
                 "--disable-cache",
-                "--rcfile=%s" % pexrc_path,
-                "--interpreter-constraint=>3,<3.9",
+                "--rcfile",
+                pexrc_path,
+                "--interpreter-constraint",
+                ">=3.8,<3.10",
                 "-o",
                 pex_out_path,
             ],
@@ -351,21 +354,19 @@ def test_pex_python():
         stdin_payload = b"import sys; print(sys.executable); sys.exit(0)"
         stdout, rc = run_simple_pex(pex_out_path, stdin=stdin_payload, env=env)
         assert rc == 1
-        fail_str = ("Failed to find a compatible PEX_PYTHON={}.".format(pex_python)).encode()
-        assert fail_str in stdout
+        assert "Failed to find a compatible PEX_PYTHON={}.".format(py310) in stdout.decode("utf-8")
 
         # test PEX_PYTHON with no constraints
         pex_out_path = os.path.join(td, "pex3.pex")
         res = run_pex_command(
-            ["--disable-cache", "--rcfile=%s" % pexrc_path, "-o", pex_out_path], env=env
+            ["--disable-cache", "--rcfile", pexrc_path, "-o", pex_out_path], env=env
         )
         res.assert_success()
 
         stdin_payload = b"import sys; print(sys.executable); sys.exit(0)"
         stdout, rc = run_simple_pex(pex_out_path, stdin=stdin_payload, env=env)
         assert rc == 0
-        correct_interpreter_path = pex_python.encode()
-        assert correct_interpreter_path in stdout
+        assert py310 in stdout.decode("utf-8")
 
 
 def test_interpreter_selection_using_os_environ_for_bootstrap_reexec():
@@ -383,10 +384,10 @@ def test_interpreter_selection_using_os_environ_for_bootstrap_reexec():
         # The parent interpreter is the interpreter we expect the parent pex to
         # execute with. The child interpreter is the interpreter we expect the
         # child pex to execute with.
-        if sys.version_info[:2] == (3, 8):
+        if sys.version_info[:2] == (3, 10):
             child_pex_interpreter_version = PY310
         else:
-            child_pex_interpreter_version = PY27
+            child_pex_interpreter_version = PY39
 
         # Write parent pex's pexrc.
         with open(pexrc_path, "w") as pexrc:

--- a/tests/integration/test_issue_1031.py
+++ b/tests/integration/test_issue_1031.py
@@ -12,7 +12,7 @@ from pex.testing import (
     ensure_python_venv,
     make_env,
     run_pex_command,
-    skip_unless_python_venv,
+    skip_unless_python27_venv,
 )
 from pex.typing import TYPE_CHECKING
 
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
     "create_venv",
     [
         pytest.param(
-            lambda system_site_packages: skip_unless_python_venv(
-                version=(2, 7), system_site_packages=system_site_packages
+            lambda system_site_packages: skip_unless_python27_venv(
+                system_site_packages=system_site_packages
             )[0],
             id="virtualenv-16.7.10",
         ),

--- a/tests/integration/test_issue_1031.py
+++ b/tests/integration/test_issue_1031.py
@@ -7,38 +7,50 @@ import pytest
 
 from pex.interpreter import PythonInterpreter
 from pex.orderedset import OrderedSet
-from pex.testing import PY27, PY310, ensure_python_venv, make_env, run_pex_command
+from pex.testing import (
+    PY310,
+    ensure_python_venv,
+    make_env,
+    run_pex_command,
+    skip_unless_python_venv,
+)
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, MutableSet
+    from typing import Any, Callable, MutableSet
 
 
 @pytest.mark.parametrize(
-    "py_version",
+    "create_venv",
     [
-        pytest.param(PY27, id="virtualenv-16.7.10"),
-        pytest.param(PY310, id="pyvenv"),
+        pytest.param(
+            lambda system_site_packages: skip_unless_python_venv(
+                version=(2, 7), system_site_packages=system_site_packages
+            )[0],
+            id="virtualenv-16.7.10",
+        ),
+        pytest.param(
+            lambda system_site_packages: ensure_python_venv(
+                PY310, system_site_packages=system_site_packages
+            )[0],
+            id="pyvenv",
+        ),
     ],
 )
 def test_setuptools_isolation_with_system_site_packages(
-    tmpdir,  # type: Any
-    py_version,  # type: str
+    create_venv,  # type: Callable[[bool], str]
 ):
     # type: (...) -> None
-    system_site_packages_venv_python, _ = ensure_python_venv(
-        py_version, latest_pip=False, system_site_packages=True
-    )
-    standard_venv, _ = ensure_python_venv(py_version, latest_pip=False, system_site_packages=False)
+    system_site_packages_venv_python = create_venv(True)
+    standard_venv = create_venv(False)
 
     print_sys_path_code = "import os, sys; print('\\n'.join(map(os.path.realpath, sys.path)))"
 
     def get_sys_path(python):
         # type: (str) -> MutableSet[str]
-        _, stdout, _ = PythonInterpreter.from_binary(python).execute(
-            args=["-c", print_sys_path_code]
+        return OrderedSet(
+            os.path.realpath(entry) for entry in PythonInterpreter.from_binary(python).sys_path
         )
-        return OrderedSet(stdout.strip().splitlines())
 
     system_site_packages_venv_sys_path = get_sys_path(system_site_packages_venv_python)
     standard_venv_sys_path = get_sys_path(standard_venv)
@@ -52,7 +64,12 @@ def test_setuptools_isolation_with_system_site_packages(
     system_site_packages = {
         p
         for p in (system_site_packages_venv_sys_path - standard_venv_sys_path)
-        if not p.startswith((venv_dir(system_site_packages_venv_python), venv_dir(standard_venv)))
+        if (
+            "site-packages" == os.path.basename(p)
+            and not p.startswith(
+                (venv_dir(system_site_packages_venv_python), venv_dir(standard_venv))
+            )
+        )
     }
     assert len(system_site_packages) == 1, (
         "system_site_packages_venv_sys_path:\n"

--- a/tests/integration/test_issue_1202.py
+++ b/tests/integration/test_issue_1202.py
@@ -3,12 +3,13 @@
 
 import os.path
 import subprocess
+import sys
 
 import pytest
 
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
-from pex.testing import PY27, ensure_python_interpreter, run_pex_command
+from pex.testing import run_pex_command, skip_unless_python_interpreter
 from pex.third_party.packaging import tags
 from pex.typing import TYPE_CHECKING
 
@@ -16,33 +17,32 @@ if TYPE_CHECKING:
     from typing import Any
 
 
-PY27_BINARY = ensure_python_interpreter(PY27)
+@pytest.fixture
+def supported_py27():
+    # type: (...) -> str
 
-
-def supports_platform(
-    python,  # type: str
-    platform_tag,  # type: str
-):
-    # type: (...) -> bool
+    python = skip_unless_python_interpreter(version=(2, 7))
 
     # JPype1 version 0.7.0 has CPython 2.7 published wheels with tags:
     # + cp27-cp27m-manylinux2010_x86_64
     # + cp27-cp27mu-manylinux2010_x86_64
     python_identity = PythonInterpreter.from_binary(python).identity
-    tag = "{python}-{abi}-{platform}".format(
-        python=python_identity.python_tag, abi=python_identity.abi_tag, platform=platform_tag
+    tag = "{python}-{abi}-manylinux2010_x86_64".format(
+        python=python_identity.python_tag,
+        abi=python_identity.abi_tag,
     )
-    return len(python_identity.supported_tags.compatible_tags(tags.parse_tag(tag))) > 0
+    if len(python_identity.supported_tags.compatible_tags(tags.parse_tag(tag))) == 0:
+        pytest.skip("Test requires a manylinux2010 x86_64 compatible platform")
+    return python
 
 
-@pytest.mark.skipif(
-    not supports_platform(PY27_BINARY, "manylinux2010_x86_64"),
-    reason="Test requires a manylinux2010 x86_64 compatible platform",
-)
-def test_prefer_binary(tmpdir):
-    # type: (Any) -> None
+def test_prefer_binary(
+    tmpdir,  # type: Any
+    supported_py27,  # type: str
+):
+    # type: (...) -> None
 
-    result = run_pex_command(args=["JPype1"], python=PY27_BINARY)
+    result = run_pex_command(args=["JPype1"], python=supported_py27)
     result.assert_failure()
     assert "ImportError: No module named pathlib" in result.error, (
         "The latest versions of JPype1 do not support Python 2.7 and their setup.py use Python 3 "
@@ -52,12 +52,12 @@ def test_prefer_binary(tmpdir):
 
     pex = os.path.join(str(tmpdir), "pex")
     run_pex_command(
-        args=["--prefer-binary", "JPype1", "-o", pex], python=PY27_BINARY
+        args=["--prefer-binary", "JPype1", "-o", pex], python=supported_py27
     ).assert_success()
 
-    subprocess.check_call(args=[PY27_BINARY, pex, "-c", "import jpype"])
+    subprocess.check_call(args=[supported_py27, pex, "-c", "import jpype"])
     distributions = tuple(
-        PEX(pex, interpreter=PythonInterpreter.from_binary(PY27_BINARY)).resolve()
+        PEX(pex, interpreter=PythonInterpreter.from_binary(supported_py27)).resolve()
     )
     assert 1 == len(distributions)
     assert "JPype1" == distributions[0].project_name

--- a/tests/integration/test_issue_1202.py
+++ b/tests/integration/test_issue_1202.py
@@ -9,7 +9,7 @@ import pytest
 
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
-from pex.testing import run_pex_command, skip_unless_python_interpreter
+from pex.testing import run_pex_command, skip_unless_python27
 from pex.third_party.packaging import tags
 from pex.typing import TYPE_CHECKING
 
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 def supported_py27():
     # type: (...) -> str
 
-    python = skip_unless_python_interpreter(version=(2, 7))
+    python = skip_unless_python27()
 
     # JPype1 version 0.7.0 has CPython 2.7 published wheels with tags:
     # + cp27-cp27m-manylinux2010_x86_64

--- a/tests/integration/test_issue_1422.py
+++ b/tests/integration/test_issue_1422.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 import sys
 
-from pex.testing import PY27, PY38, PY310, ensure_python_interpreter, make_env, run_pex_command
+from pex.testing import PY38, PY39, PY310, ensure_python_interpreter, make_env, run_pex_command
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -56,25 +56,25 @@ def test_unconstrained_universal_venv_pex(tmpdir):
         else:
             assert "PEXWarning" not in stderr_text
 
-    py27 = ensure_python_interpreter(PY27)
     py38 = ensure_python_interpreter(PY38)
+    py39 = ensure_python_interpreter(PY39)
     py310 = ensure_python_interpreter(PY310)
 
     assert_uses_python(python=sys.executable, expected_version=sys.version_info[:2])
-    assert_uses_python(python=py27, expected_version=(2, 7))
     assert_uses_python(python=py38, expected_version=(3, 8))
+    assert_uses_python(python=py39, expected_version=(3, 9))
     assert_uses_python(python=py310, expected_version=(3, 10))
 
     # When PEX_PYTHON is imprecise, the final python should be chosen by the PEX runtime.
-    py27_ppp = os.path.dirname(py27)
+    py39_ppp = os.path.dirname(py39)
     assert_uses_python(
         python=py310,
-        expected_version=(2, 7),
+        expected_version=(3, 9),
         PEX_PYTHON="python3.7",
-        PEX_PYTHON_PATH=py27_ppp,
+        PEX_PYTHON_PATH=py39_ppp,
         expected_warnings=[
             r"Using a venv restricted by PEX_PYTHON_PATH={ppp} for {pex} at ".format(
-                ppp=py27_ppp, pex=setuptools_pex
+                ppp=py39_ppp, pex=setuptools_pex
             )
         ],
     )
@@ -83,20 +83,20 @@ def test_unconstrained_universal_venv_pex(tmpdir):
     # issued.
     assert_uses_python(
         python=py310,
-        expected_version=(2, 7),
+        expected_version=(3, 9),
         PEX_PYTHON="python3",
-        PEX_PYTHON_PATH=py27_ppp,
+        PEX_PYTHON_PATH=py39_ppp,
         expected_warnings=[
             r"Using a venv selected by PEX_PYTHON=python3 for {pex} at".format(pex=setuptools_pex),
             r"Using a venv restricted by PEX_PYTHON_PATH={ppp} for {pex} at ".format(
-                ppp=py27_ppp, pex=setuptools_pex
+                ppp=py39_ppp, pex=setuptools_pex
             ),
         ],
     )
 
     # When PEX_PYTHON is precise but not on PEX_PYTHON_PATH, the final python should also be chosen
     # by the PEX runtime and selection should fail.
-    _, _, returncode = execute_pex(python=py310, PEX_PYTHON=py38, PEX_PYTHON_PATH=py27_ppp)
+    _, _, returncode = execute_pex(python=py310, PEX_PYTHON=py38, PEX_PYTHON_PATH=py39_ppp)
     assert 0 != returncode
 
     # But when PEX_PYTHON is precise and on the PEX_PYTHON_PATH, the final python should be
@@ -105,5 +105,5 @@ def test_unconstrained_universal_venv_pex(tmpdir):
         python=py310,
         expected_version=(3, 8),
         PEX_PYTHON=py38,
-        PEX_PYTHON_PATH=os.pathsep.join(os.path.dirname(py) for py in (py27, py38)),
+        PEX_PYTHON_PATH=os.pathsep.join(os.path.dirname(py) for py in (py38, py39)),
     )

--- a/tests/integration/test_issue_1560.py
+++ b/tests/integration/test_issue_1560.py
@@ -30,7 +30,7 @@ else:
     "venv_factory",
     [
         pytest.param(venv_factory, id=venv_factory.python_version)
-        for venv_factory in all_python_venvs(additional_optional_versions=[(2, 7)])
+        for venv_factory in all_python_venvs()
     ],
 )
 def test_build_isolation(

--- a/tests/integration/test_issue_745.py
+++ b/tests/integration/test_issue_745.py
@@ -8,14 +8,14 @@ from textwrap import dedent
 import pytest
 
 from pex.common import safe_open, temporary_dir
-from pex.testing import PY27, ensure_python_venv, make_env, run_pex_command
+from pex.testing import make_env, run_pex_command, skip_unless_python_venv
 
 
 def test_extras_isolation():
     # type: () -> None
     # Here we ensure one of our extras, `subprocess32`, is properly isolated in the transition from
     # pex bootstrapping where it is imported by `pex.executor` to execution of user code.
-    python, pip = ensure_python_venv(PY27)
+    python, pip = skip_unless_python_venv(version=(2, 7))
     subprocess.check_call([pip, "install", "subprocess32"])
     with temporary_dir() as td:
         src_dir = os.path.join(td, "src")

--- a/tests/integration/test_issue_745.py
+++ b/tests/integration/test_issue_745.py
@@ -8,14 +8,14 @@ from textwrap import dedent
 import pytest
 
 from pex.common import safe_open, temporary_dir
-from pex.testing import make_env, run_pex_command, skip_unless_python_venv
+from pex.testing import make_env, run_pex_command, skip_unless_python27_venv
 
 
 def test_extras_isolation():
     # type: () -> None
     # Here we ensure one of our extras, `subprocess32`, is properly isolated in the transition from
     # pex bootstrapping where it is imported by `pex.executor` to execution of user code.
-    python, pip = skip_unless_python_venv(version=(2, 7))
+    python, pip = skip_unless_python27_venv()
     subprocess.check_call([pip, "install", "subprocess32"])
     with temporary_dir() as td:
         src_dir = os.path.join(td, "src")

--- a/tests/integration/test_issue_898.py
+++ b/tests/integration/test_issue_898.py
@@ -6,12 +6,18 @@ import subprocess
 from textwrap import dedent
 
 from pex.common import safe_open, temporary_dir
-from pex.testing import PY27, PY310, ensure_python_interpreter, make_env, run_pex_command
+from pex.testing import (
+    PY310,
+    ensure_python_interpreter,
+    make_env,
+    run_pex_command,
+    skip_unless_python_interpreter,
+)
 
 
 def test_top_level_requirements_requires_python_env_markers():
     # type: () -> None
-    python27 = ensure_python_interpreter(PY27)
+    python27 = skip_unless_python_interpreter(version=(2, 7))
     python310 = ensure_python_interpreter(PY310)
     with temporary_dir() as td:
         src_dir = os.path.join(td, "src")

--- a/tests/integration/test_issue_898.py
+++ b/tests/integration/test_issue_898.py
@@ -11,13 +11,13 @@ from pex.testing import (
     ensure_python_interpreter,
     make_env,
     run_pex_command,
-    skip_unless_python_interpreter,
+    skip_unless_python27,
 )
 
 
 def test_top_level_requirements_requires_python_env_markers():
     # type: () -> None
-    python27 = skip_unless_python_interpreter(version=(2, 7))
+    python27 = skip_unless_python27()
     python310 = ensure_python_interpreter(PY310)
     with temporary_dir() as td:
         src_dir = os.path.join(td, "src")

--- a/tests/integration/test_issue_899.py
+++ b/tests/integration/test_issue_899.py
@@ -11,7 +11,7 @@ from pex.testing import (
     ensure_python_interpreter,
     run_pex_command,
     run_simple_pex,
-    skip_unless_python_interpreter,
+    skip_unless_python27,
 )
 from pex.typing import TYPE_CHECKING
 
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 def test_top_level_environment_markers(tmpdir):
     # type: (Any) -> None
-    python27 = skip_unless_python_interpreter(version=(2, 7))
+    python27 = skip_unless_python27()
     python310 = ensure_python_interpreter(PY310)
 
     pex_file = os.path.join(str(tmpdir), "pex")

--- a/tests/integration/test_issue_899.py
+++ b/tests/integration/test_issue_899.py
@@ -6,7 +6,13 @@ import os
 from pex.dist_metadata import Requirement
 from pex.interpreter import PythonInterpreter
 from pex.pex_info import PexInfo
-from pex.testing import PY27, PY310, ensure_python_interpreter, run_pex_command, run_simple_pex
+from pex.testing import (
+    PY310,
+    ensure_python_interpreter,
+    run_pex_command,
+    run_simple_pex,
+    skip_unless_python_interpreter,
+)
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -15,7 +21,7 @@ if TYPE_CHECKING:
 
 def test_top_level_environment_markers(tmpdir):
     # type: (Any) -> None
-    python27 = ensure_python_interpreter(PY27)
+    python27 = skip_unless_python_interpreter(version=(2, 7))
     python310 = ensure_python_interpreter(PY310)
 
     pex_file = os.path.join(str(tmpdir), "pex")

--- a/tests/integration/test_issue_996.py
+++ b/tests/integration/test_issue_996.py
@@ -7,7 +7,7 @@ import os
 from pex.common import temporary_dir
 from pex.interpreter import PythonInterpreter
 from pex.testing import (
-    PY27,
+    PY39,
     PY310,
     IntegResults,
     ensure_python_interpreter,
@@ -23,31 +23,32 @@ if TYPE_CHECKING:
 
 def test_resolve_local_platform():
     # type: () -> None
-    python27 = ensure_python_interpreter(PY27)
+    python39 = ensure_python_interpreter(PY39)
     python310 = ensure_python_interpreter(PY310)
-    pex_python_path = os.pathsep.join((python27, python310))
+    pex_python_path = os.pathsep.join((python39, python310))
 
     def create_platform_pex(args):
         # type: (List[str]) -> IntegResults
         return run_pex_command(
             args=["--platform", str(PythonInterpreter.from_binary(python310).platform)] + args,
-            python=python27,
+            python=python39,
             env=make_env(PEX_PYTHON_PATH=pex_python_path),
         )
 
     with temporary_dir() as td:
         pex_file = os.path.join(td, "pex_file")
 
-        # N.B.: We use psutil since only an sdist is available for linux and osx and the distribution
-        # has no dependencies.
+        # N.B.: We use psutil since only an sdist is available for linux and osx and the
+        # distribution has no dependencies.
         args = ["psutil==5.7.0", "-o", pex_file]
 
-        # By default, no --platforms are resolved and so distributions must be available in binary form.
+        # By default, no --platforms are resolved and so distributions must be available in binary
+        # form.
         results = create_platform_pex(args)
         results.assert_failure()
 
-        # If --platform resolution is enabled however, we should be able to find a corresponding local
-        # interpreter to perform a full-featured resolve with.
+        # If --platform resolution is enabled however, we should be able to find a corresponding
+        # local interpreter to perform a full-featured resolve with.
         results = create_platform_pex(["--resolve-local-platforms"] + args)
         results.assert_success()
 

--- a/tests/integration/test_pex_bootstrapper.py
+++ b/tests/integration/test_pex_bootstrapper.py
@@ -14,7 +14,7 @@ from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.pex_bootstrapper import ensure_venv
 from pex.pex_info import PexInfo
-from pex.testing import PY27, PY38, PY_VER, ensure_python_interpreter, make_env, run_pex_command
+from pex.testing import PY38, PY39, PY_VER, ensure_python_interpreter, make_env, run_pex_command
 from pex.typing import TYPE_CHECKING
 from pex.venv.pex import CollisionError
 from pex.venv.virtualenv import Virtualenv
@@ -292,7 +292,7 @@ def test_boot_compatible_issue_1020_no_ic(tmpdir):
     assert_boot(sys.executable)
 
     other_interpreter = (
-        ensure_python_interpreter(PY27) if PY_VER != (2, 7) else ensure_python_interpreter(PY38)
+        ensure_python_interpreter(PY39) if PY_VER != (3, 9) else ensure_python_interpreter(PY38)
     )
     assert_boot(other_interpreter)
 
@@ -300,7 +300,7 @@ def test_boot_compatible_issue_1020_no_ic(tmpdir):
 def test_boot_compatible_issue_1020_ic_min_compatible_build_time_hole(tmpdir):
     # type: (Any) -> None
     other_interpreter = PythonInterpreter.from_binary(
-        ensure_python_interpreter(PY27) if PY_VER != (2, 7) else ensure_python_interpreter(PY38)
+        ensure_python_interpreter(PY39) if PY_VER != (3, 9) else ensure_python_interpreter(PY38)
     )
     current_interpreter = PythonInterpreter.get()
 
@@ -361,8 +361,8 @@ def test_boot_compatible_issue_1020_ic_min_compatible_build_time_hole(tmpdir):
 
 def test_boot_resolve_fail(
     tmpdir,  # type: Any
-    py27,  # type: PythonInterpreter
     py38,  # type: PythonInterpreter
+    py39,  # type: PythonInterpreter
     py310,  # type: PythonInterpreter
 ):
     # type: (...) -> None
@@ -370,9 +370,9 @@ def test_boot_resolve_fail(
     pex = os.path.join(str(tmpdir), "pex")
     run_pex_command(args=["--python", py38.binary, "psutil==5.9.0", "-o", pex]).assert_success()
 
-    pex_python_path = os.pathsep.join((py27.binary, py310.binary))
+    pex_python_path = os.pathsep.join((py39.binary, py310.binary))
     process = subprocess.Popen(
-        args=[py27.binary, pex, "-c", ""],
+        args=[py39.binary, pex, "-c", ""],
         env=make_env(PEX_PYTHON_PATH=pex_python_path),
         stderr=subprocess.PIPE,
     )
@@ -383,16 +383,16 @@ def test_boot_resolve_fail(
         r"^Failed to find compatible interpreter on path {pex_python_path}.\n"
         r"\n"
         r"Examined the following interpreters:\n"
-        r"1\.\)\s+{py27_exe} {py27_req}\n"
+        r"1\.\)\s+{py39_exe} {py39_req}\n"
         r"2\.\)\s+{py310_exe} {py310_req}\n"
         r"\n"
         r"No interpreter compatible with the requested constraints was found:\n"
         r"\n"
-        r"  A distribution for psutil could not be resolved for {py27_exe}.\n"
+        r"  A distribution for psutil could not be resolved for {py39_exe}.\n"
         r"  Found 1 distribution for psutil that do not apply:\n"
         r"  1\.\) The wheel tags for psutil 5\.9\.0 are .+ which do not match the supported tags "
-        r"of {py27_exe}:\n"
-        r"  cp27-cp27.+\n"
+        r"of {py39_exe}:\n"
+        r"  cp39-cp39-.+\n"
         r"  ... \d+ more ...\n"
         r"\n"
         r"  A distribution for psutil could not be resolved for {py310_exe}.\n"
@@ -402,8 +402,8 @@ def test_boot_resolve_fail(
         r"  cp310-cp310-.+\n"
         r"  ... \d+ more ...".format(
             pex_python_path=re.escape(pex_python_path),
-            py27_exe=py27.binary,
-            py27_req=py27.identity.requirement,
+            py39_exe=py39.binary,
+            py39_req=py39.identity.requirement,
             py310_exe=py310.binary,
             py310_req=py310.identity.requirement,
         ),

--- a/tests/integration/test_pex_import.py
+++ b/tests/integration/test_pex_import.py
@@ -11,7 +11,7 @@ import pytest
 
 from pex.common import safe_open
 from pex.layout import DEPS_DIR, Layout
-from pex.testing import IS_PYPY, PY27, PY_VER, ensure_python_interpreter, make_env, run_pex_command
+from pex.testing import make_env, run_pex_command
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -30,19 +30,6 @@ def test_import_from_pex(
     execution_mode_args,  # type: List[str]
 ):
     # type: (...) -> None
-
-    # For CPython 2.7 we work around bad virtualenvs created by tox that lead to the following
-    # error by using a pyenv CPython 2.7 interpreter instead:
-    #
-    # Traceback (most recent call last):
-    #   File "<string>", line 1, in <module>
-    #   File "/tmp/pytest-of-jsirois/pytest-10/popen-gw5/test_import_from_pex_UNZIPPED_0/importable.pex/.bootstrap/pex/third_party/__init__.py", line 39, in load_module
-    #   File "/home/jsirois/.pyenv/versions/2.7.18/lib/python2.7/importlib/__init__.py", line 37, in import_module
-    #     __import__(name)
-    #   File "/home/jsirois/dev/pantsbuild/jsirois-pex/.tox/py27-integration/lib/python2.7/site-packages/_virtualenv.py", line 112, in find_module
-    #     if fullname in _DISTUTILS_PATCH:
-    # TypeError: argument of type 'NoneType' is not iterable
-    python = ensure_python_interpreter(PY27) if (2, 7) == PY_VER and not IS_PYPY else sys.executable
 
     src = os.path.join(str(tmpdir), "src")
     with safe_open(os.path.join(src, "first_party.py"), "w") as fp:
@@ -77,13 +64,12 @@ def test_import_from_pex(
             layout.value,
         ]
         + execution_mode_args,
-        python=python,
     ).assert_success()
 
     def execute_with_pex_on_pythonpath(code):
         # type: (str) -> Text
         return (
-            subprocess.check_output(args=[python, "-c", code], env=make_env(PYTHONPATH=pex))
+            subprocess.check_output(args=[sys.executable, "-c", code], env=make_env(PYTHONPATH=pex))
             .decode("utf-8")
             .strip()
         )

--- a/tests/integration/test_reexec.py
+++ b/tests/integration/test_reexec.py
@@ -12,7 +12,7 @@ import pytest
 from pex.common import temporary_dir
 from pex.interpreter import PythonInterpreter
 from pex.testing import (
-    PY27,
+    PY39,
     PY310,
     ensure_python_interpreter,
     make_env,
@@ -130,11 +130,11 @@ def test_pex_reexec_constraints_match_current_pythonpath_present():
 
 def test_pex_reexec_constraints_dont_match_current_pex_python_path():
     # type: () -> None
+    py39_interpreter = ensure_python_interpreter(PY39)
     py310_interpreter = ensure_python_interpreter(PY310)
-    py27_interpreter = ensure_python_interpreter(PY27)
     _assert_exec_chain(
         exec_chain=[py310_interpreter],
-        pex_python_path=[py27_interpreter, py310_interpreter],
+        pex_python_path=[py39_interpreter, py310_interpreter],
         interpreter_constraints=["=={}".format(PY310)],
     )
 
@@ -142,15 +142,15 @@ def test_pex_reexec_constraints_dont_match_current_pex_python_path():
 def test_pex_reexec_constraints_dont_match_current_pex_python_path_min_py_version_selected():
     # type: () -> None
     py310_interpreter = ensure_python_interpreter(PY310)
-    py27_interpreter = ensure_python_interpreter(PY27)
+    py39_interpreter = ensure_python_interpreter(PY39)
     _assert_exec_chain(
-        exec_chain=[py27_interpreter], pex_python_path=[py310_interpreter, py27_interpreter]
+        exec_chain=[py39_interpreter], pex_python_path=[py310_interpreter, py39_interpreter]
     )
 
 
 def test_pex_reexec_constraints_dont_match_current_pex_python():
     # type: () -> None
-    version = PY27 if sys.version_info[:2] == (3, 8) else PY310
+    version = PY39 if sys.version_info[:2] == (3, 10) else PY310
     interpreter = ensure_python_interpreter(version)
     _assert_exec_chain(
         exec_chain=[interpreter],

--- a/tests/integration/test_reproducible.py
+++ b/tests/integration/test_reproducible.py
@@ -20,7 +20,7 @@ from pex.testing import (
     ensure_python_interpreter,
     run_command_with_jitter,
     run_commands_with_jitter,
-    skip_unless_python_interpreter,
+    skip_unless_python27,
     temporary_content,
 )
 from pex.typing import TYPE_CHECKING
@@ -83,7 +83,7 @@ def assert_reproducible_build(
 def major_compatible_pythons():
     # type: () -> Tuple[str, ...]
     return (
-        (sys.executable, skip_unless_python_interpreter(version=(2, 7)))
+        (sys.executable, skip_unless_python27())
         if PY2
         else (sys.executable, ensure_python_interpreter(PY38), ensure_python_interpreter(PY310))
     )
@@ -94,7 +94,7 @@ def mixed_major_pythons():
     # type: () -> Tuple[str, ...]
     return (
         sys.executable,
-        skip_unless_python_interpreter(version=(2, 7)),
+        skip_unless_python27(),
         ensure_python_interpreter(PY38),
         ensure_python_interpreter(PY310),
     )

--- a/tests/integration/test_reproducible.py
+++ b/tests/integration/test_reproducible.py
@@ -13,7 +13,6 @@ from pex.common import temporary_dir
 from pex.compatibility import PY2
 from pex.testing import (
     IS_PYPY,
-    PY27,
     PY38,
     PY310,
     PY_VER,
@@ -21,12 +20,13 @@ from pex.testing import (
     ensure_python_interpreter,
     run_command_with_jitter,
     run_commands_with_jitter,
+    skip_unless_python_interpreter,
     temporary_content,
 )
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Iterable, List, Optional
+    from typing import Iterable, List, Optional, Tuple
 
 
 def assert_reproducible_build(
@@ -79,22 +79,30 @@ def assert_reproducible_build(
             assert filecmp.cmp(pex1, pex2, shallow=False)
 
 
-MAJOR_COMPATIBLE_PYTHONS = (
-    (sys.executable, ensure_python_interpreter(PY27))
-    if PY2
-    else (sys.executable, ensure_python_interpreter(PY38), ensure_python_interpreter(PY310))
-)
-MIXED_MAJOR_PYTHONS = (
-    sys.executable,
-    ensure_python_interpreter(PY27),
-    ensure_python_interpreter(PY38),
-    ensure_python_interpreter(PY310),
-)
+@pytest.fixture(scope="module")
+def major_compatible_pythons():
+    # type: () -> Tuple[str, ...]
+    return (
+        (sys.executable, skip_unless_python_interpreter(version=(2, 7)))
+        if PY2
+        else (sys.executable, ensure_python_interpreter(PY38), ensure_python_interpreter(PY310))
+    )
 
 
-def test_reproducible_build_no_args():
-    # type: () -> None
-    assert_reproducible_build([], pythons=MIXED_MAJOR_PYTHONS)
+@pytest.fixture(scope="module")
+def mixed_major_pythons():
+    # type: () -> Tuple[str, ...]
+    return (
+        sys.executable,
+        skip_unless_python_interpreter(version=(2, 7)),
+        ensure_python_interpreter(PY38),
+        ensure_python_interpreter(PY310),
+    )
+
+
+def test_reproducible_build_no_args(mixed_major_pythons):
+    # type: (Tuple[str, ...]) -> None
+    assert_reproducible_build([], pythons=mixed_major_pythons)
 
 
 @pytest.mark.skipif(
@@ -118,20 +126,20 @@ def test_reproducible_build_bdist_requirements():
     )
 
 
-def test_reproducible_build_sdist_requirements():
-    # type: () -> None
+def test_reproducible_build_sdist_requirements(major_compatible_pythons):
+    # type: (Tuple[str, ...]) -> None
     # The python-crontab sdist will be built as py2-none-any or py3-none-any depending on the
     # Python major version since it is not marked as universal in the sdist.
-    assert_reproducible_build(["python-crontab==2.3.6"], pythons=MAJOR_COMPATIBLE_PYTHONS)
+    assert_reproducible_build(["python-crontab==2.3.6"], pythons=major_compatible_pythons)
 
 
-def test_reproducible_build_m_flag():
-    # type: () -> None
-    assert_reproducible_build(["-m", "pydoc"], pythons=MIXED_MAJOR_PYTHONS)
+def test_reproducible_build_m_flag(mixed_major_pythons):
+    # type: (Tuple[str, ...]) -> None
+    assert_reproducible_build(["-m", "pydoc"], pythons=mixed_major_pythons)
 
 
-def test_reproducible_build_c_flag_from_source():
-    # type: () -> None
+def test_reproducible_build_c_flag_from_source(major_compatible_pythons):
+    # type: (Tuple[str, ...]) -> None
     setup_cfg = dedent(
         """\
         [wheel]
@@ -161,22 +169,22 @@ def test_reproducible_build_c_flag_from_source():
             [project_dir, "-c", "my_app_function"],
             # Modern Pip / Setuptools produce different metadata for sdists than legacy Pip /
             # Setuptools; so we don't mix them.
-            pythons=MAJOR_COMPATIBLE_PYTHONS,
+            pythons=major_compatible_pythons,
         )
 
 
-def test_reproducible_build_c_flag_from_dependency():
-    # type: () -> None
+def test_reproducible_build_c_flag_from_dependency(major_compatible_pythons):
+    # type: (Tuple[str, ...]) -> None
     # The futurize script installed depends on the version of python being used; so we don't try
     # to mix Python 2 with Python 3 as in many other reproducibility tests.
     assert_reproducible_build(
-        ["future==0.17.1", "-c", "futurize"], pythons=MAJOR_COMPATIBLE_PYTHONS
+        ["future==0.17.1", "-c", "futurize"], pythons=major_compatible_pythons
     )
 
 
-def test_reproducible_build_python_flag():
-    # type: () -> None
-    assert_reproducible_build(["--python=python2.7"], pythons=MIXED_MAJOR_PYTHONS)
+def test_reproducible_build_python_flag(mixed_major_pythons):
+    # type: (Tuple[str, ...]) -> None
+    assert_reproducible_build(["--python=python2.7"], pythons=mixed_major_pythons)
 
 
 def test_reproducible_build_python_shebang_flag():

--- a/tests/integration/test_sh_boot.py
+++ b/tests/integration/test_sh_boot.py
@@ -108,7 +108,7 @@ def interpreters():
 
         yield entry(sys.executable)
 
-        for interpreter in all_pythons(additional_optional_versions=[(2, 7)]):
+        for interpreter in all_pythons():
             yield entry(interpreter)
 
         locations = (

--- a/tests/integration/test_sh_boot.py
+++ b/tests/integration/test_sh_boot.py
@@ -11,7 +11,13 @@ from typing import Text, Tuple
 import pytest
 
 from pex.common import safe_open
-from pex.testing import ALL_PY_VERSIONS, ensure_python_interpreter, make_env, run_pex_command
+from pex.testing import (
+    ALL_PY_VERSIONS,
+    all_pythons,
+    ensure_python_interpreter,
+    make_env,
+    run_pex_command,
+)
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -102,8 +108,7 @@ def interpreters():
 
         yield entry(sys.executable)
 
-        for version in ALL_PY_VERSIONS:
-            interpreter = ensure_python_interpreter(version)
+        for interpreter in all_pythons(additional_optional_versions=[(2, 7)]):
             yield entry(interpreter)
 
         locations = (

--- a/tests/integration/test_shebang_length_limit.py
+++ b/tests/integration/test_shebang_length_limit.py
@@ -58,7 +58,7 @@ def file_path_length_limit(tmpdir_factory):
             path = os.path.join(path, "directory")
             try:
                 os.mkdir(path)
-            except OSError as e:
+            except (IOError, OSError) as e:
                 if e.errno == errno.ENAMETOOLONG:
                     return True
                 elif e.errno != errno.EEXIST:
@@ -93,14 +93,14 @@ def shebang_length_limit(
             path = os.path.join(path, "directory")
             try:
                 os.mkdir(path)
-            except OSError as e:
+            except (IOError, OSError) as e:
                 if e.errno != errno.EEXIST:
                     raise e
 
         sh_path = os.path.join(path, "x" * (length - len("#!\n" + path + os.sep)))
         try:
             os.unlink(sh_path)
-        except OSError as e:
+        except (IOError, OSError) as e:
             if e.errno != errno.ENOENT:
                 raise e
         os.symlink("/bin/sh", sh_path)
@@ -112,7 +112,7 @@ def shebang_length_limit(
         chmod_plus_x(script)
         try:
             return 0 != subprocess.call(args=[script])
-        except OSError as e:
+        except (IOError, OSError) as e:
             if e.errno == errno.ENOEXEC:
                 return True
             raise e

--- a/tests/integration/venv_ITs/test_virtualenv.py
+++ b/tests/integration/venv_ITs/test_virtualenv.py
@@ -68,7 +68,7 @@ def test_iter_distributions_setuptools_not_leaked(tmpdir):
     "venv_factory",
     [
         pytest.param(venv_factory, id=venv_factory.python_version)
-        for venv_factory in all_python_venvs(additional_optional_versions=[(2, 7)])
+        for venv_factory in all_python_venvs()
     ],
 )
 def test_iter_distributions(venv_factory):

--- a/tests/integration/venv_ITs/test_virtualenv.py
+++ b/tests/integration/venv_ITs/test_virtualenv.py
@@ -8,13 +8,14 @@ import subprocess
 import pytest
 
 from pex.dist_metadata import Distribution
+from pex.interpreter import PythonInterpreter
 from pex.pep_503 import ProjectName
-from pex.testing import ALL_PY_VERSIONS, ensure_python_venv
+from pex.testing import ALL_PY_VERSIONS, VenvFactory, all_python_venvs, ensure_python_venv
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import InvalidVirtualenvError, Virtualenv
 
 if TYPE_CHECKING:
-    from typing import Any, Dict
+    from typing import Any, Callable, Dict, Tuple
 
 
 def test_invalid(tmpdir):
@@ -63,15 +64,17 @@ def test_iter_distributions_setuptools_not_leaked(tmpdir):
     assert ProjectName("setuptools") not in dists
 
 
-@pytest.mark.parametrize("py_version", ALL_PY_VERSIONS)
-def test_iter_distributions(
-    tmpdir,  # type: Any
-    py_version,  # type: str
-):
-    # type: (...) -> None
+@pytest.mark.parametrize(
+    "venv_factory",
+    [
+        pytest.param(venv_factory, id=venv_factory.python_version)
+        for venv_factory in all_python_venvs(additional_optional_versions=[(2, 7)])
+    ],
+)
+def test_iter_distributions(venv_factory):
+    # type: (VenvFactory) -> None
 
-    python, pip = ensure_python_venv(py_version)
-
+    python, pip = venv_factory.create_venv()
     venv = Virtualenv.enclosing(python)
     assert venv is not None
 

--- a/tests/resolve/lockfile/test_lockfile.py
+++ b/tests/resolve/lockfile/test_lockfile.py
@@ -10,28 +10,32 @@ import pytest
 from pex.interpreter import PythonInterpreter
 from pex.resolve.lockfile import json_codec
 from pex.targets import LocalInterpreter, Target
-from pex.testing import PY27, PY38, IntegResults, ensure_python_interpreter, run_pex_command
+from pex.testing import (
+    PY38,
+    IntegResults,
+    ensure_python_interpreter,
+    run_pex_command,
+    skip_unless_python_interpreter,
+)
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any
 
 
-def create_target(python_version):
+def create_target(python):
     # type: (str) -> Target
-    return LocalInterpreter.create(
-        PythonInterpreter.from_binary(ensure_python_interpreter(python_version))
-    )
+    return LocalInterpreter.create(PythonInterpreter.from_binary(python))
 
 
 @pytest.fixture
 def py27():
-    return create_target(PY27)
+    return create_target(skip_unless_python_interpreter(version=(2, 7)))
 
 
 @pytest.fixture
 def py38():
-    return create_target(PY38)
+    return create_target(ensure_python_interpreter(PY38))
 
 
 LOCK_STYLE_SOURCES = json_codec.loads(

--- a/tests/resolve/lockfile/test_lockfile.py
+++ b/tests/resolve/lockfile/test_lockfile.py
@@ -15,7 +15,7 @@ from pex.testing import (
     IntegResults,
     ensure_python_interpreter,
     run_pex_command,
-    skip_unless_python_interpreter,
+    skip_unless_python27,
 )
 from pex.typing import TYPE_CHECKING
 
@@ -30,7 +30,7 @@ def create_target(python):
 
 @pytest.fixture
 def py27():
-    return create_target(skip_unless_python_interpreter(version=(2, 7)))
+    return create_target(skip_unless_python27())
 
 
 @pytest.fixture

--- a/tests/resolve/test_pex_repository_resolver.py
+++ b/tests/resolve/test_pex_repository_resolver.py
@@ -16,7 +16,7 @@ from pex.resolve.pex_repository_resolver import resolve_from_pex
 from pex.resolve.resolvers import Unsatisfiable
 from pex.resolver import resolve
 from pex.targets import Targets
-from pex.testing import IS_LINUX, PY27, PY310, ensure_python_interpreter
+from pex.testing import IS_LINUX, PY310, ensure_python_interpreter, skip_unless_python_interpreter
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
@@ -62,7 +62,7 @@ def create_constraints_file(*requirements):
 @pytest.fixture(scope="module")
 def py27():
     # type: () -> PythonInterpreter
-    return PythonInterpreter.from_binary(ensure_python_interpreter(PY27))
+    return PythonInterpreter.from_binary(skip_unless_python_interpreter(version=(2, 7)))
 
 
 @pytest.fixture(scope="module")
@@ -102,9 +102,13 @@ def foreign_platform(
 def pex_repository(py27, py310, foreign_platform, manylinux):
     # type () -> str
 
-    # N.B.: requests 2.25.1 constrains urllib3 to <1.27,>=1.21.1 and pick 1.26.2 on its own as of
-    # this writing.
-    constraints_file = create_constraints_file("urllib3==1.26.1")
+    constraints_file = create_constraints_file(
+        # The 2.25.1 release of requests constrains urllib3 to <1.27,>=1.21.1 and picks 1.26.2 on
+        # its own as of this writing.
+        "urllib3==1.26.1",
+        # The 22.0.0 release of pyOpenSSL drops support for Python 2.7; so we pin lower.
+        "pyOpenSSL<22",
+    )
 
     return create_pex_repository(
         interpreters=[py27, py310],

--- a/tests/resolve/test_pex_repository_resolver.py
+++ b/tests/resolve/test_pex_repository_resolver.py
@@ -16,7 +16,7 @@ from pex.resolve.pex_repository_resolver import resolve_from_pex
 from pex.resolve.resolvers import Unsatisfiable
 from pex.resolver import resolve
 from pex.targets import Targets
-from pex.testing import IS_LINUX, PY310, ensure_python_interpreter, skip_unless_python_interpreter
+from pex.testing import IS_LINUX, PY310, ensure_python_interpreter, skip_unless_python27
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
@@ -62,7 +62,7 @@ def create_constraints_file(*requirements):
 @pytest.fixture(scope="module")
 def py27():
     # type: () -> PythonInterpreter
-    return PythonInterpreter.from_binary(skip_unless_python_interpreter(version=(2, 7)))
+    return PythonInterpreter.from_binary(skip_unless_python27())
 
 
 @pytest.fixture(scope="module")

--- a/tests/resolve/test_target_options.py
+++ b/tests/resolve/test_target_options.py
@@ -5,6 +5,7 @@ import itertools
 import json
 import os
 import re
+import sys
 from argparse import ArgumentParser, ArgumentTypeError
 
 import pytest

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -22,10 +22,11 @@ from pex.jobs import Job
 from pex.pyenv import Pyenv
 from pex.testing import (
     ALL_PY_VERSIONS,
-    PY27,
     PY38,
+    PY39,
     PY310,
     PY_VER,
+    all_pythons,
     ensure_python_distribution,
     ensure_python_interpreter,
     ensure_python_venv,
@@ -64,7 +65,7 @@ class TestPythonInterpreter(object):
                 reload(interpreter)
             PythonInterpreter.all()
 
-    TEST_INTERPRETER1_VERSION = PY27
+    TEST_INTERPRETER1_VERSION = PY39
     TEST_INTERPRETER1_VERSION_TUPLE = tuple_from_version(TEST_INTERPRETER1_VERSION)
 
     TEST_INTERPRETER2_VERSION = PY38
@@ -493,11 +494,17 @@ def test_issue_1494_iter_candidates(macos_monterey_interpeter):
     ] == list(PythonInterpreter.iter_candidates(paths=[sys.executable, macos_monterey_interpeter]))
 
 
-@pytest.mark.parametrize("py_version", ALL_PY_VERSIONS)
-def test_sys_path(py_version):
+@pytest.mark.parametrize(
+    "python",
+    [
+        pytest.param(python, id=str(PythonInterpreter.from_binary(python).identity))
+        for python in all_pythons(additional_optional_versions=[(2, 7)])
+    ],
+)
+def test_sys_path(python):
     # type: (str) -> None
 
-    interp = PythonInterpreter.from_binary(ensure_python_interpreter(py_version))
+    interp = PythonInterpreter.from_binary(python)
     _, stdout, _ = interp.execute(args=["-c", "import os, sys; print(os.linesep.join(sys.path))"])
     assert tuple(entry for entry in stdout.splitlines() if entry) == interp.sys_path, (
         'Its expected the sys_path matches the runtime sys.path with the exception of the PWD ("") '

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -498,7 +498,7 @@ def test_issue_1494_iter_candidates(macos_monterey_interpeter):
     "python",
     [
         pytest.param(python, id=str(PythonInterpreter.from_binary(python).identity))
-        for python in all_pythons(additional_optional_versions=[(2, 7)])
+        for python in all_pythons()
     ],
 )
 def test_sys_path(python):

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -22,8 +22,9 @@ from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
 from pex.testing import (
-    PY27,
+    PY39,
     PY310,
+    PY_VER,
     WheelBuilder,
     ensure_python_interpreter,
     environment_as,
@@ -559,7 +560,7 @@ def test_pex_verify_entry_point_module_should_fail():
 def test_activate_interpreter_different_from_current():
     # type: () -> None
     with temporary_dir() as pex_root:
-        interp_version = PY310 if PY2 else PY27
+        interp_version = PY310 if PY_VER == (3, 9) else PY39
         custom_interpreter = PythonInterpreter.from_binary(
             ensure_python_interpreter(interp_version)
         )

--- a/tests/test_pex_binary.py
+++ b/tests/test_pex_binary.py
@@ -19,7 +19,7 @@ from pex.compatibility import to_bytes
 from pex.interpreter import PythonInterpreter
 from pex.resolve import requirement_options, resolver_options, target_options
 from pex.testing import (
-    PY27,
+    PY39,
     built_wheel,
     ensure_python_interpreter,
     run_pex_command,
@@ -228,6 +228,6 @@ def test_run_pex():
         pex_args=["--platform={}".format(PythonInterpreter.get().platform)]
     )
 
-    py27 = ensure_python_interpreter(PY27)
-    stderr_lines = assert_run_pex(python=py27, pex_args=["--platform=macosx-10.13-x86_64-cp-37-m"])
+    py39 = ensure_python_interpreter(PY39)
+    stderr_lines = assert_run_pex(python=py39, pex_args=["--platform=macosx-10.13-x86_64-cp-37-m"])
     assert incompatible_platforms_warning_msg in stderr_lines

--- a/tests/test_pex_bootstrapper.py
+++ b/tests/test_pex_bootstrapper.py
@@ -20,7 +20,7 @@ from pex.pex_bootstrapper import (
     iter_compatible_interpreters,
 )
 from pex.pex_builder import PEXBuilder
-from pex.testing import PY27, PY38, PY310, ensure_python_interpreter
+from pex.testing import PY38, PY39, PY310, ensure_python_interpreter
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
 
@@ -53,26 +53,26 @@ def find_interpreters(
 
 def test_find_compatible_interpreters():
     # type: () -> None
-    py27 = ensure_python_interpreter(PY27)
     py38 = ensure_python_interpreter(PY38)
+    py39 = ensure_python_interpreter(PY39)
     py310 = ensure_python_interpreter(PY310)
-    path = [py27, py38, py310]
+    path = [py38, py39, py310]
 
-    assert [py38, py310] == find_interpreters(path, constraints=[">3"])
-    assert [py27] == find_interpreters(path, constraints=["<3"])
+    assert [py39, py310] == find_interpreters(path, constraints=[">3.9"])
+    assert [py38] == find_interpreters(path, constraints=["<3.9"])
 
-    assert [py310] == find_interpreters(path, constraints=[">{}".format(PY38)])
-    assert [py38] == find_interpreters(path, constraints=[">{}, <{}".format(PY27, PY310)])
+    assert [py310] == find_interpreters(path, constraints=[">{}".format(PY39)])
+    assert [py39] == find_interpreters(path, constraints=[">{}, <{}".format(PY38, PY310)])
     assert [py310] == find_interpreters(path, constraints=[">=3.10"])
 
     with pytest.raises(UnsatisfiableInterpreterConstraintsError):
-        find_interpreters(path, constraints=["<2"])
+        find_interpreters(path, constraints=["<3"])
 
     with pytest.raises(UnsatisfiableInterpreterConstraintsError):
         find_interpreters(path, constraints=[">4"])
 
     with pytest.raises(UnsatisfiableInterpreterConstraintsError):
-        find_interpreters(path, constraints=[">{}, <{}".format(PY27, PY38)])
+        find_interpreters(path, constraints=[">{}, <{}".format(PY38, PY39)])
 
     # All interpreters on PATH including whatever interpreter is currently running.
     all_known_interpreters = set(PythonInterpreter.all())
@@ -101,71 +101,71 @@ def test_find_compatible_interpreters_none():
 
 def test_find_compatible_interpreters_none_with_valid_basenames():
     # type: () -> None
-    py27 = ensure_python_interpreter(PY27)
     py38 = ensure_python_interpreter(PY38)
-    path = [py27, py38]
+    py39 = ensure_python_interpreter(PY39)
+    path = [py38, py39]
 
     with pytest.raises(UnsatisfiableInterpreterConstraintsError) as exec_info:
         find_interpreters(path, valid_basenames=["python3.6"])
 
     exception_message = str(exec_info.value)
-    assert py27 not in exception_message
     assert py38 not in exception_message
+    assert py39 not in exception_message
 
 
 def test_find_compatible_interpreters_none_with_constraints():
     # type: () -> None
-    py27 = ensure_python_interpreter(PY27)
     py38 = ensure_python_interpreter(PY38)
-    path = [py27, py38]
+    py39 = ensure_python_interpreter(PY39)
+    path = [py38, py39]
 
     with pytest.raises(UnsatisfiableInterpreterConstraintsError) as exec_info:
-        find_interpreters(path, constraints=[">=3.9"])
+        find_interpreters(path, constraints=[">=3.10"])
 
     exception_message = str(exec_info.value)
-    assert py27 in exception_message
     assert py38 in exception_message
-    assert ">=3.9" in exception_message
+    assert py39 in exception_message
+    assert ">=3.10" in exception_message
 
 
 def test_find_compatible_interpreters_none_with_valid_basenames_and_constraints():
     # type: () -> None
-    py27 = ensure_python_interpreter(PY27)
     py38 = ensure_python_interpreter(PY38)
-    path = [py27, py38]
+    py39 = ensure_python_interpreter(PY39)
+    path = [py39, py38]
 
     with pytest.raises(UnsatisfiableInterpreterConstraintsError) as exec_info:
-        find_interpreters(path, valid_basenames=basenames(py27), constraints=[">=3.6"])
+        find_interpreters(path, valid_basenames=basenames(py38), constraints=[">=3.9"])
 
     exception_message = str(exec_info.value)
-    assert py27 in exception_message
-    assert py38 not in exception_message
-    assert os.path.basename(py27) in exception_message, exception_message
-    assert ">=3.6" in exception_message
+    assert py38 in exception_message
+    assert os.path.basename(py38) in exception_message
+    assert py39 not in exception_message
+    assert ">=3.9" in exception_message
 
 
 def test_find_compatible_interpreters_with_valid_basenames():
     # type: () -> None
-    py27 = ensure_python_interpreter(PY27)
     py38 = ensure_python_interpreter(PY38)
+    py39 = ensure_python_interpreter(PY39)
     py310 = ensure_python_interpreter(PY310)
-    path = [py27, py38, py310]
+    path = [py38, py39, py310]
 
     assert [py38] == find_interpreters(path, valid_basenames=basenames(py38))
-    assert [py27, py310] == find_interpreters(
-        path, valid_basenames=basenames(*reversed([py27, py310]))
+    assert [py39, py310] == find_interpreters(
+        path, valid_basenames=basenames(*reversed([py39, py310]))
     )
 
 
 def test_find_compatible_interpreters_with_valid_basenames_and_constraints():
     # type: () -> None
-    py27 = ensure_python_interpreter(PY27)
     py38 = ensure_python_interpreter(PY38)
+    py39 = ensure_python_interpreter(PY39)
     py310 = ensure_python_interpreter(PY310)
-    path = [py27, py38, py310]
+    path = [py38, py39, py310]
 
-    assert [py38] == find_interpreters(
-        path, valid_basenames=basenames(py27, py38), constraints=[">=3"]
+    assert [py39] == find_interpreters(
+        path, valid_basenames=basenames(py38, py39), constraints=[">=3.9"]
     )
 
 
@@ -179,17 +179,17 @@ def test_find_compatible_interpreters_bias_current():
 
 def test_find_compatible_interpreters_siblings_of_current_issues_1109():
     # type: () -> None
-    py27 = ensure_python_interpreter(PY27)
+    py39 = ensure_python_interpreter(PY39)
     py310 = ensure_python_interpreter(PY310)
 
     with temporary_dir() as path_entry:
-        python27 = os.path.join(path_entry, "python2.7")
-        shutil.copy(py27, python27)
+        python39 = os.path.join(path_entry, "python3.9")
+        shutil.copy(py39, python39)
 
         python310 = os.path.join(path_entry, "python3.10")
         shutil.copy(py310, python310)
 
-        assert [os.path.realpath(p) for p in (python310, python27)] == find_interpreters(
+        assert [os.path.realpath(p) for p in (python310, python39)] == find_interpreters(
             path=[path_entry], preferred_interpreter=PythonInterpreter.from_binary(python310)
         )
 
@@ -265,13 +265,13 @@ def test_pp_exact():
 def test_pp_exact_on_ppp():
     # type: () -> None
 
-    py27 = ensure_python_interpreter(PY27)
     py38 = ensure_python_interpreter(PY38)
+    py39 = ensure_python_interpreter(PY39)
     py310 = ensure_python_interpreter(PY310)
 
     with ENV.patch(
         PEX_PYTHON=py310,
-        PEX_PYTHON_PATH=":".join(os.path.dirname(py) for py in (py27, py38, py310)),
+        PEX_PYTHON_PATH=":".join(os.path.dirname(py) for py in (py38, py39, py310)),
     ):
         assert PythonInterpreter.from_binary(py310) == find_compatible_interpreter()
 
@@ -313,12 +313,12 @@ def test_pp_exact_does_not_satisfy_constraints():
 def test_pp_exact_not_on_ppp():
     # type: () -> None
 
-    py27 = ensure_python_interpreter(PY27)
     py38 = ensure_python_interpreter(PY38)
+    py39 = ensure_python_interpreter(PY39)
     py310 = ensure_python_interpreter(PY310)
 
     with ENV.patch(
-        PEX_PYTHON=py310, PEX_PYTHON_PATH=":".join(os.path.dirname(py) for py in (py27, py38))
+        PEX_PYTHON=py310, PEX_PYTHON_PATH=":".join(os.path.dirname(py) for py in (py38, py39))
     ):
         with pytest.raises(
             UnsatisfiableInterpreterConstraintsError,

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -31,7 +31,7 @@ from pex.testing import (
     ensure_python_interpreter,
     make_project,
     make_source_dir,
-    skip_unless_python_interpreter,
+    skip_unless_python27,
 )
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
@@ -414,7 +414,7 @@ def test_issues_851():
     assert "contextlib2" not in resolved_project_to_version
 
     resolved_project_to_version = resolve_pytest(
-        python=skip_unless_python_interpreter(version=(2, 7)), pytest_version="4.6.9"
+        python=skip_unless_python27(), pytest_version="4.6.9"
     )
     assert "importlib-metadata" in resolved_project_to_version
     assert "configparser" in resolved_project_to_version
@@ -424,7 +424,7 @@ def test_issues_851():
 
 def test_issues_892():
     # type: () -> None
-    python27 = skip_unless_python_interpreter(version=(2, 7))
+    python27 = skip_unless_python27()
     program = dedent(
         """\
         from __future__ import print_function


### PR DESCRIPTION
This brings the set of canned pyenv interpreters to 2.7 and 3.{8,9,10},
paving the way for pyenv-win. PY27 use is minimized and made explicit
and lazy such that appropriate `pytest.skip()`s can be added in the
Windows port to skip over the handful of ramining integration tests that
truly mean to test against a Python 2.7 interpreter.