### PR TITLE
Unquote path component of parsed url requirements

### DIFF
--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -8,7 +8,7 @@ import re
 from contextlib import contextmanager
 
 from pex import attrs, dist_metadata, pex_warnings
-from pex.compatibility import urlparse
+from pex.compatibility import unquote, urlparse
 from pex.dist_metadata import (
     MetadataError,
     ProjectNameAndVersion,
@@ -297,7 +297,7 @@ def parse_scheme(scheme):
             )
             |
             (?P<vcs_type>
-                # VCSs: https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support       
+                # VCSs: https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support
                   bzr
                 | git
                 | hg
@@ -481,7 +481,7 @@ def _parse_requirement_line(
         specifier = None  # type: Optional[SpecifierSet]
         if not project_name:
             project_name_and_specifier = _try_parse_project_name_and_specifier_from_path(
-                parsed_url.path
+                unquote(parsed_url.path)
             )
             if project_name_and_specifier is not None:
                 project_name = project_name_and_specifier.project_name

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -286,6 +286,9 @@ def test_parse_requirements_stress(chroot):
                 Django@ git+https://github.com/django/django.git\\
                     @fd209f62f1d83233cc634443cfac5ee4328d98b8
                 Django @ file:projects/django-2.3.zip; python_version >= "3.10"
+
+                # Wheel with local version
+                http://download.pytorch.org/whl/cpu/torch-1.12.1%2Bcpu-cp310-cp310-linux_x86_64.whl
                 """
             )
         )
@@ -432,6 +435,11 @@ def test_parse_requirements_stress(chroot):
             url=os.path.realpath("extra/projects/django-2.3.zip"),
             specifier="==2.3",
             marker="python_version>='3.10'",
+        ),
+        url_req(
+            project_name="torch",
+            url="http://download.pytorch.org/whl/cpu/torch-1.12.1%2Bcpu-cp310-cp310-linux_x86_64.whl",
+            specifier="==1.12.1+cpu",
         ),
         url_req(
             project_name="numpy",


### PR DESCRIPTION
`urlparse` components are not unquoted. Without unquoting local version specifiers like `+cpu` are parsed as `%2Bcpu`.

Fixes #1919