### PR TITLE
Fix locks for git+ssh with credentials.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,13 @@ jobs:
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v4
+      - name: Setup SSH Agent
+        uses: webfactory/ssh-agent@v0.5.4
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        if: env.SSH_PRIVATE_KEY != ''
+        with:
+          ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -245,6 +252,13 @@ jobs:
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v4
+      - name: Setup SSH Agent
+        uses: webfactory/ssh-agent@v0.5.4
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        if: env.SSH_PRIVATE_KEY != ''
+        with:
+          ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,10 +199,6 @@ jobs:
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v4
-      - name: Setup SSH Agent
-        uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -249,10 +245,6 @@ jobs:
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v4
-      - name: Setup SSH Agent
-        uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
     name: (${{ matrix.os }}) Pip ${{ matrix.pip-version }} TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-integration
     needs: org-check
     runs-on: ${{ matrix.os }}
+    environment: CI
     strategy:
       matrix:
         python-version: [[2, 7], [3, 10], [3, 11, "0-rc.2"]]
@@ -199,6 +200,10 @@ jobs:
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v4
+      - name: Setup SSH Agent
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:
@@ -207,6 +212,7 @@ jobs:
     name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}-integration
     needs: org-check
     runs-on: ubuntu-20.04
+    environment: CI
     strategy:
       matrix:
         pypy-version: [[2, 7], [3, 9]]
@@ -245,6 +251,10 @@ jobs:
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v4
+      - name: Setup SSH Agent
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,6 @@ jobs:
     name: (${{ matrix.os }}) Pip ${{ matrix.pip-version }} TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-integration
     needs: org-check
     runs-on: ${{ matrix.os }}
-    environment: CI
     strategy:
       matrix:
         python-version: [[2, 7], [3, 10], [3, 11, "0-rc.2"]]
@@ -212,7 +211,6 @@ jobs:
     name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}-integration
     needs: org-check
     runs-on: ubuntu-20.04
-    environment: CI
     strategy:
       matrix:
         pypy-version: [[2, 7], [3, 9]]

--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -695,15 +695,20 @@ def parse_requirement_file(
             yield req_info
 
 
+def parse_requirement_string(requirement):
+    # type: (Text) -> ParsedRequirement
+    return _parse_requirement_line(
+        LogicalLine(
+            raw_text=requirement,
+            processed_text=requirement.strip(),
+            source="<string>",
+            start_line=1,
+            end_line=1,
+        )
+    )
+
+
 def parse_requirement_strings(requirements):
     # type: (Iterable[Text]) -> Iterator[ParsedRequirement]
     for requirement in requirements:
-        yield _parse_requirement_line(
-            LogicalLine(
-                raw_text=requirement,
-                processed_text=requirement.strip(),
-                source="<string>",
-                start_line=1,
-                end_line=1,
-            )
-        )
+        yield parse_requirement_string(requirement)

--- a/pex/resolve/downloads.py
+++ b/pex/resolve/downloads.py
@@ -11,6 +11,7 @@ from pex.hashing import Sha256
 from pex.jobs import Job, Raise, SpawnedJob, execute_parallel
 from pex.pip.installation import get_pip
 from pex.pip.tool import PackageIndexConfiguration, Pip
+from pex.requirements import parse_requirement_string
 from pex.resolve import locker
 from pex.resolve.locked_resolve import Artifact, FileArtifact, LockConfiguration, LockStyle
 from pex.resolve.pep_691.fingerprint_service import FingerprintService
@@ -109,6 +110,7 @@ class ArtifactDownloader(object):
         # observer does just this for universal locks with no target system or requires python
         # restrictions.
         download_observer = locker.patch(
+            root_requirements=[parse_requirement_string(url)],
             pip_version=self.package_index_configuration.pip_version,
             resolver=self.resolver,
             lock_configuration=LockConfiguration(style=LockStyle.UNIVERSAL),

--- a/pex/resolve/lockfile/create.py
+++ b/pex/resolve/lockfile/create.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
     import attr  # vendor:skip
 
     from pex.hashing import HintedDigest
+    from pex.requirements import ParsedRequirement
 else:
     from pex.third_party import attr
 
@@ -129,6 +130,7 @@ class _LockAnalysis(object):
 
 @attr.s(frozen=True)
 class LockObserver(ResolveObserver):
+    root_requirements = attr.ib()  # type: Tuple[ParsedRequirement, ...]
     lock_configuration = attr.ib()  # type: LockConfiguration
     resolver = attr.ib()  # type: Resolver
     wheel_builder = attr.ib()  # type: WheelBuilder
@@ -143,6 +145,7 @@ class LockObserver(ResolveObserver):
     ):
         # type: (...) -> DownloadObserver
         patch = locker.patch(
+            root_requirements=self.root_requirements,
             pip_version=self.package_index_configuration.pip_version,
             resolver=self.resolver,
             lock_configuration=self.lock_configuration,
@@ -253,6 +256,7 @@ def create(
 
     configured_resolver = ConfiguredResolver(pip_configuration=pip_configuration)
     lock_observer = LockObserver(
+        root_requirements=parsed_requirements,
         lock_configuration=lock_configuration,
         resolver=configured_resolver,
         wheel_builder=WheelBuilder(

--- a/tests/integration/resolve/test_issue_1918.py
+++ b/tests/integration/resolve/test_issue_1918.py
@@ -1,0 +1,107 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import itertools
+import os.path
+
+import pytest
+
+from pex.cli.testing import run_pex3
+from pex.compatibility import commonpath
+from pex.dist_metadata import Requirement
+from pex.pip.version import PipVersion, PipVersionValue
+from pex.requirements import VCS
+from pex.resolve.locked_resolve import VCSArtifact
+from pex.resolve.lockfile import json_codec
+from pex.resolve.resolver_configuration import ResolverVersion
+from pex.sorted_tuple import SortedTuple
+from pex.testing import run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+VCS_URL = (
+    "git+ssh://git@github.com/jonathaneunice/colors.git@c965f5b9103c5bd32a1572adb8024ebe83278fb0"
+)
+
+
+@pytest.mark.parametrize(
+    ["requirement", "expected_url"],
+    [
+        pytest.param(
+            "ansicolors @ {vcs_url}".format(vcs_url=VCS_URL), VCS_URL, id="direct-reference"
+        ),
+        pytest.param(
+            *itertools.repeat("{vcs_url}#egg=ansicolors".format(vcs_url=VCS_URL), 2),
+            id="pip-proprietary"
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "pip_version",
+    [pytest.param(pip_version, id=pip_version.value) for pip_version in PipVersion.values()],
+)
+@pytest.mark.parametrize(
+    "resolver_version",
+    [
+        pytest.param(resolver_version, id=resolver_version.value)
+        for resolver_version in ResolverVersion.values()
+    ],
+)
+def test_redacted_requirement_handling(
+    tmpdir,  # type: Any
+    requirement,  # type: str
+    expected_url,  # type: str
+    pip_version,  # type: PipVersionValue
+    resolver_version,  # type: ResolverVersion.Value
+):
+    # type: (...) -> None
+
+    lock = os.path.join(str(tmpdir), "lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--pip-version",
+        str(pip_version),
+        "--resolver-version",
+        str(resolver_version),
+        requirement,
+        "-o",
+        lock,
+        "--indent",
+        "2",
+    ).assert_success()
+    lockfile = json_codec.load(lock)
+    assert SortedTuple([Requirement.parse("ansicolors")]) == lockfile.requirements
+
+    assert 1 == len(lockfile.locked_resolves)
+    locked_resolve = lockfile.locked_resolves[0]
+
+    assert 1 == len(locked_resolve.locked_requirements)
+    locked_requirement = locked_resolve.locked_requirements[0]
+
+    artifacts = list(locked_requirement.iter_artifacts())
+    assert 1 == len(artifacts)
+    artifact = artifacts[0]
+
+    assert isinstance(artifact, VCSArtifact)
+    assert VCS.Git is artifact.vcs
+    assert expected_url == artifact.url
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    result = run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--lock",
+            lock,
+            "--",
+            "-c",
+            "import colors; print(colors.__file__)",
+        ]
+    )
+    result.assert_success()
+    assert pex_root == commonpath([pex_root, result.output.strip()])

--- a/tests/integration/resolve/test_issue_1918.py
+++ b/tests/integration/resolve/test_issue_1918.py
@@ -1,7 +1,9 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 import itertools
 import os.path
+import subprocess
 
 import pytest
 
@@ -26,8 +28,27 @@ VCS_URL = (
 )
 
 
+def has_ssh_access():
+    # type: () -> bool
+    process = subprocess.Popen(
+        args=[
+            "ssh",
+            "-T",
+            "-o",
+            "PasswordAuthentication=no",
+            "-o",
+            "NumberOfPasswordPrompts=0",
+            "git@github.com",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    output, _ = process.communicate()
+    return "You've successfully authenticated" in output.decode()
+
+
 @pytest.mark.skipif(
-    not os.environ.get("SSH_AUTH_SOCK"), reason="An ssh agent must be up and running for this test."
+    not has_ssh_access(), reason="Password-less ssh to git@github.com is required for this test."
 )
 @pytest.mark.parametrize(
     ["requirement", "expected_url"],

--- a/tests/integration/resolve/test_issue_1918.py
+++ b/tests/integration/resolve/test_issue_1918.py
@@ -27,8 +27,7 @@ VCS_URL = (
 
 
 @pytest.mark.skipif(
-    not os.environ.get("SSH_AUTH_SOCK"),
-    reason="An ssh agent must be up and running for this test."
+    not os.environ.get("SSH_AUTH_SOCK"), reason="An ssh agent must be up and running for this test."
 )
 @pytest.mark.parametrize(
     ["requirement", "expected_url"],

--- a/tests/integration/resolve/test_issue_1918.py
+++ b/tests/integration/resolve/test_issue_1918.py
@@ -26,6 +26,10 @@ VCS_URL = (
 )
 
 
+@pytest.mark.skipif(
+    not os.environ.get("SSH_AUTH_SOCK"),
+    reason="An ssh agent must be up and running for this test."
+)
 @pytest.mark.parametrize(
     ["requirement", "expected_url"],
     [

--- a/tests/integration/test_locked_resolve.py
+++ b/tests/integration/test_locked_resolve.py
@@ -50,6 +50,7 @@ def create_lock_observer(lock_configuration):
         network_configuration=pip_configuration.network_configuration,
     )
     return LockObserver(
+        root_requirements=(),
         lock_configuration=lock_configuration,
         resolver=ConfiguredResolver(pip_configuration=pip_configuration),
         wheel_builder=WheelBuilder(

--- a/tests/resolve/test_locker.py
+++ b/tests/resolve/test_locker.py
@@ -1,0 +1,85 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pex.resolve.locker import CredentialedURL, Credentials, Netloc
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+
+def test_credentials_redacted():
+    # type: () -> None
+
+    assert not Credentials("git").are_redacted()
+    assert not Credentials("git", "").are_redacted()
+    assert not Credentials("joe", "bob").are_redacted()
+
+    assert Credentials("****").are_redacted()
+    assert Credentials("joe", "****").are_redacted()
+
+
+def test_basic_auth_rendering():
+    # type: () -> None
+
+    assert "git" == Credentials("git").render_basic_auth()
+    assert "git:" == Credentials("git", "").render_basic_auth()
+    assert "joe:bob" == Credentials("joe", "bob").render_basic_auth()
+
+
+def test_host_port_rendering():
+    # type: () -> None
+
+    assert "example.com" == Netloc("example.com").render_host_port()
+    assert "example.com:80" == Netloc("example.com", 80).render_host_port()
+
+
+def test_strip_credentials():
+    # type: () -> None
+
+    def strip_credentials(
+        url,  # type: str
+        expected_credentials=None,  # type: Optional[Credentials]
+    ):
+        # type: (...) -> str
+        credentialed_url = CredentialedURL.parse(url)
+        assert expected_credentials == credentialed_url.credentials
+        return str(credentialed_url.strip_credentials())
+
+    assert "file:///a/file" == strip_credentials("file:///a/file")
+    assert "http://example.com" == strip_credentials("http://example.com")
+    assert "http://example.com:80" == strip_credentials("http://example.com:80")
+    assert "http://example.com" == strip_credentials("http://joe@example.com", Credentials("joe"))
+    assert "https://example.com:443" == strip_credentials(
+        "https://joe@example.com:443", Credentials("joe")
+    )
+    assert "http://example.com" == strip_credentials(
+        "http://joe:bob@example.com", Credentials("joe", "bob")
+    )
+    assert "phys://example.com:1137" == strip_credentials(
+        "phys://joe:bob@example.com:1137", Credentials("joe", "bob")
+    )
+    assert "git://example.org" == strip_credentials("git://git@example.org", Credentials("git"))
+    assert "git://example.org" == strip_credentials("git://****@example.org", Credentials("****"))
+
+
+def test_inject_credentials():
+    # type: () -> None
+
+    def inject_credentials(
+        url,  # type: str
+        credentials,  # type: Optional[Credentials]
+    ):
+        # type: (...) -> str
+        return str(CredentialedURL.parse(url).inject_credentials(credentials))
+
+    assert "git://git@example.org" == inject_credentials("git://example.org", Credentials("git"))
+    assert "git://git@example.org" == inject_credentials(
+        "git://****@example.org", Credentials("git")
+    )
+    assert "http://joe:bob@example.org" == inject_credentials(
+        "http://example.org", Credentials("joe", "bob")
+    )
+    assert "http://joe:bob@example.org" == inject_credentials(
+        "http://joe:****@example.org", Credentials("joe", "bob")
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,8 @@ passenv =
     PATHEXT
     USER
     USERNAME
+    # Needed for tests of git+ssh://...
+    SSH_AUTH_SOCK
 setenv =
     pip20: _PEX_PIP_VERSION=20.3.4-patched
     pip22: _PEX_PIP_VERSION=22.2.2


### PR DESCRIPTION
Previously redacted credentials from the Pip download log were embedded
in locked artifact URLs rendering the lock unusable. Now credentials are
fixed up before the lock file is written.

Fixes #1918