### PR TITLE
Fix slow PEX boot time when there are many extras.

### DIFF
--- a/pex/dist_metadata.py
+++ b/pex/dist_metadata.py
@@ -508,7 +508,9 @@ class Requirement(object):
         return self._str
 
 
-@attr.s(frozen=True)
+# N.B.: DistributionMetadata can have an expensive hash when a distribution has many requirements;
+# so we cache the hash. See: https://github.com/pantsbuild/pex/issues/1928
+@attr.s(frozen=True, cache_hash=True)
 class DistMetadata(object):
     @classmethod
     def load(cls, location):

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -123,9 +123,13 @@ class PythonIdentity(object):
         )
 
         # Pex identifies interpreters using a bit of Pex code injected via an extraction of that
-        # code under the `PEX_ROOT` adjoined to `sys.path` via `PYTHONPATH`. We ignore such adjoined
-        # `sys.path` entries to discover the true base interpreter `sys.path`.
-        pythonpath = frozenset(os.environ.get("PYTHONPATH", "").split(os.pathsep))
+        # code under the `PEX_ROOT` adjoined to `sys.path` via `PYTHONPATH`. Pex also exposes the
+        # vendored attrs distribution so that its `cache_hash=True` feature can work (see the
+        # bottom of pex/third_party/__init__.py where the vendor importer is installed). We ignore
+        # such adjoined `sys.path` entries to discover the true base interpreter `sys.path`.
+        pythonpath = frozenset(
+            os.environ.get("PYTHONPATH", "").split(os.pathsep) + list(third_party.exposed())
+        )
         sys_path = [item for item in sys.path if item and item not in pythonpath]
 
         return cls(


### PR DESCRIPTION
Large extras sets lead to an exponentially scaled collection of
fingerprinted distribution objects that need to be de-duped. The hash
codes calculated in doing so are expensive when the distribution
metadata contains a large number of requirements. Cache these hash codes
to improve boot time by two orders of magnitude.

In order to enable ergonomic caching of hash codes via attrs built in
feature for doing this, some new plumbing is added to the third party
vendored importer plumbing.

Fixes #1928