### PR TITLE
Extract an InterpreterConstraints type.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -25,6 +25,7 @@ from pex.commands.command import (
 from pex.common import die, safe_mkdtemp
 from pex.enum import Enum
 from pex.inherit_path import InheritPath
+from pex.interpreter_constraints import InterpreterConstraints
 from pex.layout import Layout, maybe_install
 from pex.orderedset import OrderedSet
 from pex.pex import PEX
@@ -547,6 +548,7 @@ def configure_clp():
 def build_pex(
     requirement_configuration,  # type: RequirementConfiguration
     resolver_configuration,  # type: ResolverConfiguration
+    interpreter_constraints,  # type: InterpreterConstraints
     targets,  # type: Targets
     options,  # type: Namespace
 ):
@@ -612,10 +614,7 @@ def build_pex(
     pex_info.inherit_path = options.inherit_path
     pex_info.pex_root = options.runtime_pex_root
     pex_info.strip_pex_env = options.strip_pex_env
-
-    if options.interpreter_constraint:
-        for ic in options.interpreter_constraint:
-            pex_builder.add_interpreter_constraint(ic)
+    pex_info.interpreter_constraints = interpreter_constraints
 
     for requirements_pex in options.requirements_pexes:
         pex_builder.add_from_requirements_pex(requirements_pex)
@@ -771,8 +770,9 @@ def main(args=None):
             except resolver_options.InvalidConfigurationError as e:
                 die(str(e))
 
+            target_config = target_options.configure(options)
             try:
-                targets = target_options.configure(options).resolve_targets()
+                targets = target_config.resolve_targets()
             except target_configuration.InterpreterNotFound as e:
                 die(str(e))
             except target_configuration.InterpreterConstraintsNotSatisfied as e:
@@ -788,6 +788,7 @@ def main(args=None):
                     options=options,
                     requirement_configuration=requirement_configuration,
                     resolver_configuration=resolver_configuration,
+                    interpreter_constraints=target_config.interpreter_constraints,
                     targets=targets,
                     cmdline=cmdline,
                     env=env,
@@ -801,6 +802,7 @@ def do_main(
     options,  # type: Namespace
     requirement_configuration,  # type: RequirementConfiguration
     resolver_configuration,  # type: ResolverConfiguration
+    interpreter_constraints,  # type: InterpreterConstraints
     targets,  # type: Targets
     cmdline,  # type: List[str]
     env,  # type: Dict[str, str]
@@ -809,6 +811,7 @@ def do_main(
         pex_builder = build_pex(
             requirement_configuration=requirement_configuration,
             resolver_configuration=resolver_configuration,
+            interpreter_constraints=interpreter_constraints,
             targets=targets,
             options=options,
         )

--- a/pex/cli/commands/interpreter.py
+++ b/pex/cli/commands/interpreter.py
@@ -9,6 +9,7 @@ from argparse import ArgumentParser, _ActionsContainer
 from pex.cli.command import BuildTimeCommand
 from pex.commands.command import JsonMixin, OutputMixin
 from pex.interpreter import PythonInterpreter
+from pex.interpreter_constraints import InterpreterConstraint
 from pex.resolve import target_options
 from pex.resolve.target_configuration import InterpreterConstraintsNotSatisfied, InterpreterNotFound
 from pex.result import Error, Ok, Result
@@ -123,7 +124,7 @@ class Interpreter(OutputMixin, JsonMixin, BuildTimeCommand):
                     if self.options.verbose:
                         interpreter_info.update(
                             version=interpreter.identity.version_str,
-                            requirement=str(interpreter.identity.requirement),
+                            requirement=str(InterpreterConstraint.exact_version(interpreter)),
                             platform=str(interpreter.platform),
                             venv=interpreter.is_venv,
                         )

--- a/pex/cli/commands/lock.py
+++ b/pex/cli/commands/lock.py
@@ -398,7 +398,7 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
             lock_configuration = LockConfiguration(
                 style=LockStyle.UNIVERSAL,
                 requires_python=tuple(
-                    str(interpreter_constraint.specifier)
+                    str(interpreter_constraint.requires_python)
                     for interpreter_constraint in target_configuration.interpreter_constraints
                 ),
                 target_systems=tuple(self.options.target_systems),

--- a/pex/dist_metadata.py
+++ b/pex/dist_metadata.py
@@ -476,7 +476,7 @@ class Requirement(object):
         return self.project_name.normalized
 
     def __contains__(self, item):
-        # type: (Union[str, Version, Distribution]) -> bool
+        # type: (Union[str, Version, Distribution, ProjectNameAndVersion]) -> bool
 
         # We emulate pkg_resources.Requirement.__contains__ pre-release behavior here since the
         # codebase expects it.
@@ -484,14 +484,18 @@ class Requirement(object):
 
     def contains(
         self,
-        item,  # type: Union[str, Version, Distribution]
+        item,  # type: Union[str, Version, Distribution, ProjectNameAndVersion]
         prereleases=None,  # type: Optional[bool]
     ):
         # type: (...) -> bool
-        if isinstance(item, Distribution):
+        if isinstance(item, ProjectNameAndVersion):
+            if item.canonicalized_project_name != self.project_name:
+                return False
+            version = item.canonicalized_version.parsed_version  # type: Union[ParsedVersion, str]
+        elif isinstance(item, Distribution):
             if item.key != self.key:
                 return False
-            version = item.metadata.version.parsed_version  # type: Union[ParsedVersion, str]
+            version = item.metadata.version.parsed_version
         elif isinstance(item, Version):
             version = item.parsed_version
         else:

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -3,7 +3,7 @@
 
 """pex support for interacting with interpreters."""
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import
 
 import hashlib
 import json

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -3,7 +3,7 @@
 
 """pex support for interacting with interpreters."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import hashlib
 import json
@@ -17,15 +17,11 @@ from collections import OrderedDict
 from textwrap import dedent
 
 from pex import third_party
-from pex.common import is_exe, safe_mkdtemp, safe_rmtree
-from pex.compatibility import string
-from pex.dist_metadata import DistMetadata, Distribution, Requirement, RequirementParseError
+from pex.common import is_exe, safe_mkdtemp, safe_open, safe_rmtree
 from pex.executor import Executor
 from pex.jobs import Job, Retain, SpawnedJob, execute_parallel
 from pex.orderedset import OrderedSet
 from pex.pep_425 import CompatibilityTags
-from pex.pep_440 import Version
-from pex.pep_503 import ProjectName
 from pex.pep_508 import MarkerEnvironment
 from pex.platforms import Platform
 from pex.pyenv import Pyenv
@@ -299,21 +295,6 @@ class PythonIdentity(object):
     def interpreter(self):
         return self._interpreter_name
 
-    @property
-    def requirement(self):
-        # type: () -> Requirement
-        return self.distribution.as_requirement()
-
-    @property
-    def distribution(self):
-        # type: () -> Distribution
-        return Distribution(
-            location=self.binary,
-            metadata=DistMetadata(
-                project_name=ProjectName(self.interpreter), version=Version(self.version_str)
-            ),
-        )
-
     def iter_supported_platforms(self):
         # type: () -> Iterator[Platform]
         """All platforms supported by the associated interpreter ordered from most specific to
@@ -327,35 +308,6 @@ class PythonIdentity(object):
         )
         for tag in self._supported_tags:
             yield Platform.from_tag(tag)
-
-    @classmethod
-    def parse_requirement(
-        cls,
-        requirement,  # type: Union[Requirement, str]
-        default_interpreter="CPython",  # type: str
-    ):
-        # type: (...) -> Requirement
-        if isinstance(requirement, Requirement):
-            return requirement
-        elif isinstance(requirement, string):
-            try:
-                requirement = Requirement.parse(requirement)
-            except RequirementParseError:
-                try:
-                    requirement = Requirement.parse("%s%s" % (default_interpreter, requirement))
-                except RequirementParseError:
-                    raise ValueError("Unknown requirement string: %s" % requirement)
-            return requirement
-        else:
-            raise ValueError("Unknown requirement type: %r" % (requirement,))
-
-    def matches(self, requirement):
-        """Given a Requirement, check if this interpreter matches."""
-        try:
-            requirement = self.parse_requirement(requirement, self._interpreter_name)
-        except ValueError as e:
-            raise self.UnknownRequirement(str(e))
-        return self.distribution in requirement
 
     def binary_name(self, version_components=2):
         # type: (int) -> str

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -301,14 +301,6 @@ class PEXBuilder(object):
         self._ensure_unfrozen("Adding a requirement")
         self._pex_info.add_requirement(req)
 
-    def add_interpreter_constraint(self, ic):
-        """Add an interpreter constraint to the PEX environment.
-
-        :param ic: A version constraint on the interpreter used to build and run this PEX environment.
-        """
-        self._ensure_unfrozen("Adding an interpreter constraint")
-        self._pex_info.add_interpreter_constraint(ic)
-
     def add_from_requirements_pex(self, pex):
         """Add requirements from an existing pex.
 

--- a/pex/resolve/resolver_configuration.py
+++ b/pex/resolve/resolver_configuration.py
@@ -9,7 +9,6 @@ import os
 from pex.auth import PasswordEntry
 from pex.enum import Enum
 from pex.jobs import DEFAULT_MAX_JOBS
-from pex.layout import PEX_INFO_PATH
 from pex.network_configuration import NetworkConfiguration
 from pex.pip.version import PipVersion, PipVersionValue
 from pex.typing import TYPE_CHECKING

--- a/pex/resolve/target_configuration.py
+++ b/pex/resolve/target_configuration.py
@@ -6,9 +6,11 @@ from __future__ import absolute_import
 import os
 from collections import OrderedDict
 
-from pex.dist_metadata import Requirement
 from pex.interpreter import PythonInterpreter
-from pex.interpreter_constraints import UnsatisfiableInterpreterConstraintsError
+from pex.interpreter_constraints import (
+    InterpreterConstraints,
+    UnsatisfiableInterpreterConstraintsError,
+)
 from pex.orderedset import OrderedSet
 from pex.pex_bootstrapper import iter_compatible_interpreters, normalize_path
 from pex.platforms import Platform
@@ -29,7 +31,9 @@ else:
 class InterpreterConfiguration(object):
     _python_path = attr.ib(default=None)  # type: Optional[Tuple[str, ...]]
     pythons = attr.ib(default=())  # type: Tuple[str, ...]
-    interpreter_constraints = attr.ib(default=())  # type: Tuple[Requirement, ...]
+    interpreter_constraints = attr.ib(
+        default=InterpreterConstraints()
+    )  # type: InterpreterConstraints
 
     @property
     def python_path(self):
@@ -109,7 +113,7 @@ class TargetConfiguration(object):
 
     @property
     def interpreter_constraints(self):
-        # type: () -> Tuple[Requirement, ...]
+        # type: () -> InterpreterConstraints
         return self.interpreter_configuration.interpreter_constraints
 
     complete_platforms = attr.ib(default=())  # type: Tuple[CompletePlatform, ...]

--- a/pex/resolve/target_options.py
+++ b/pex/resolve/target_options.py
@@ -9,7 +9,8 @@ import sys
 from argparse import ArgumentTypeError, Namespace, _ActionsContainer
 
 from pex.argparse import HandleBoolAction
-from pex.interpreter import PythonIdentity, PythonInterpreter
+from pex.interpreter import PythonInterpreter
+from pex.interpreter_constraints import InterpreterConstraints
 from pex.orderedset import OrderedSet
 from pex.pep_425 import CompatibilityTags
 from pex.pep_508 import MarkerEnvironment
@@ -190,12 +191,7 @@ def configure_interpreters(options):
     :param options: The interpreter configuration options.
     """
     try:
-        interpreter_constraints = tuple(
-            OrderedSet(
-                PythonIdentity.parse_requirement(interpreter_constraint)
-                for interpreter_constraint in options.interpreter_constraint
-            )
-        )
+        interpreter_constraints = InterpreterConstraints.parse(*options.interpreter_constraint)
     except ValueError as e:
         raise ArgumentTypeError(str(e))
 

--- a/pex/sh_boot.py
+++ b/pex/sh_boot.py
@@ -10,8 +10,8 @@ from textwrap import dedent
 
 from pex import dist_metadata, variables
 from pex.dist_metadata import Distribution
-from pex.interpreter import PythonIdentity, PythonInterpreter, calculate_binary_name
-from pex.interpreter_constraints import iter_compatible_versions
+from pex.interpreter import PythonInterpreter, calculate_binary_name
+from pex.interpreter_constraints import InterpreterConstraints, iter_compatible_versions
 from pex.orderedset import OrderedSet
 from pex.pep_440 import Version
 from pex.pex_info import PexInfo
@@ -41,7 +41,7 @@ class PythonBinaryName(object):
 
 def _calculate_applicable_binary_names(
     targets,  # type: Targets
-    interpreter_constraints,  # type: Iterable[str]
+    interpreter_constraints,  # type: InterpreterConstraints
 ):
     # type: (...) -> Iterable[str]
 
@@ -50,15 +50,14 @@ def _calculate_applicable_binary_names(
     # those.
 
     ic_majors_minors = OrderedSet()  # type: OrderedSet[PythonBinaryName]
-    python_requirements = tuple(
-        PythonIdentity.parse_requirement(ic) for ic in interpreter_constraints
-    )
-    if python_requirements:
+    if interpreter_constraints:
         ic_majors_minors.update(
-            PythonBinaryName(name=calculate_binary_name(python_requirement.name), version=version)
-            for python_requirement in python_requirements
+            PythonBinaryName(
+                name=calculate_binary_name(interpreter_constraint.requirement.name), version=version
+            )
+            for interpreter_constraint in interpreter_constraints
             for version in iter_compatible_versions(
-                requires_python=[str(python_requirement.specifier)]
+                requires_python=[str(interpreter_constraint.requires_python)]
             )
         )
     # If we get targets from ICs, we only want explicitly specified local interpreter targets;

--- a/pex/tools/commands/graph.py
+++ b/pex/tools/commands/graph.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 from pex.commands.command import OutputMixin, try_open_file, try_run_program
 from pex.common import safe_mkdir
 from pex.dist_metadata import requires_dists
+from pex.interpreter_constraints import InterpreterConstraint
 from pex.pex import PEX
 from pex.result import Ok, Result
 from pex.tools.command import PEXCommand
@@ -37,7 +38,9 @@ class Graph(OutputMixin, PEXCommand):
             fontsize="14",
             labelloc="t",
             label="Dependency graph of {} for interpreter {} ({})".format(
-                pex.path(), pex.interpreter.binary, pex.interpreter.identity.requirement
+                pex.path(),
+                pex.interpreter.binary,
+                InterpreterConstraint.exact_version(pex.interpreter),
             ),
         )
         marker_environment = pex.interpreter.identity.env_markers.as_dict()

--- a/pex/tools/commands/interpreter.py
+++ b/pex/tools/commands/interpreter.py
@@ -9,7 +9,11 @@ from argparse import ArgumentParser
 from pex import pex_bootstrapper
 from pex.commands.command import JsonMixin, OutputMixin
 from pex.interpreter import PythonInterpreter
-from pex.interpreter_constraints import UnsatisfiableInterpreterConstraintsError
+from pex.interpreter_constraints import (
+    InterpreterConstraint,
+    InterpreterConstraints,
+    UnsatisfiableInterpreterConstraintsError,
+)
 from pex.pex import PEX
 from pex.pex_bootstrapper import InterpreterTest
 from pex.result import Error, Ok, Result
@@ -85,7 +89,7 @@ class Interpreter(JsonMixin, OutputMixin, PEXCommand):
                     if self.options.verbose:
                         interpreter_info = {
                             "path": interpreter.binary,
-                            "requirement": str(interpreter.identity.requirement),
+                            "requirement": str(InterpreterConstraint.exact_version(interpreter)),
                             "platform": str(interpreter.platform),
                         }  # type: Dict[str, Any]
                         if self.options.verbose >= 2:

--- a/pex/tools/commands/repository.py
+++ b/pex/tools/commands/repository.py
@@ -26,7 +26,8 @@ from pex.common import (
 from pex.compatibility import Queue
 from pex.dist_metadata import Distribution
 from pex.environment import PEXEnvironment
-from pex.interpreter import PythonIdentity, PythonInterpreter, spawn_python_job
+from pex.interpreter import PythonInterpreter, spawn_python_job
+from pex.interpreter_constraints import InterpreterConstraint
 from pex.jobs import Retain, SpawnedJob, execute_parallel
 from pex.pex import PEX
 from pex.result import Error, Ok, Result
@@ -342,9 +343,7 @@ class Repository(JsonMixin, OutputMixin, PEXCommand):
 
         python_requires = None
         if len(pex_info.interpreter_constraints) == 1:
-            python_requires = str(
-                PythonIdentity.parse_requirement(pex_info.interpreter_constraints[0]).specifier
-            )
+            python_requires = str(pex_info.interpreter_constraints[0].requires_python)
         elif pex_info.interpreter_constraints:
             logger.warning(
                 "Omitting `python_requires` for {name} sdist since {pex} has multiple "

--- a/tests/bin/test_sh_boot.py
+++ b/tests/bin/test_sh_boot.py
@@ -3,6 +3,7 @@
 
 from pex import sh_boot
 from pex.interpreter import PythonInterpreter
+from pex.interpreter_constraints import InterpreterConstraints
 from pex.orderedset import OrderedSet
 from pex.pep_425 import CompatibilityTags
 from pex.pep_508 import MarkerEnvironment
@@ -22,7 +23,7 @@ def calculate_binary_names(
     return list(
         sh_boot._calculate_applicable_binary_names(
             targets=targets,
-            interpreter_constraints=interpreter_constraints,
+            interpreter_constraints=InterpreterConstraints.parse(*interpreter_constraints),
         )
     )
 

--- a/tests/integration/cli/commands/test_issue_1734.py
+++ b/tests/integration/cli/commands/test_issue_1734.py
@@ -7,6 +7,7 @@ import subprocess
 
 from pex.cli.testing import run_pex3
 from pex.interpreter import PythonInterpreter
+from pex.interpreter_constraints import InterpreterConstraint
 from pex.testing import run_pex_command
 from pex.typing import TYPE_CHECKING
 
@@ -104,9 +105,9 @@ def test_lock_create_universal_interpreter_constraint_unsatisfiable(
         r"\n"
         r"  Version matches CPython<3\.11,>=3\.9\n".format(
             py27_path=py27.binary,
-            py27_req=py27.identity.requirement,
+            py27_req=InterpreterConstraint.exact_version(py27),
             py38_path=py38.binary,
-            py38_req=py38.identity.requirement,
+            py38_req=InterpreterConstraint.exact_version(py38),
         ),
         result.error,
     )

--- a/tests/integration/test_interpreter_selection.py
+++ b/tests/integration/test_interpreter_selection.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 from pex.common import temporary_dir
 from pex.dist_metadata import find_distribution
 from pex.interpreter import PythonInterpreter
+from pex.interpreter_constraints import InterpreterConstraints
 from pex.pep_503 import ProjectName
 from pex.pex_info import PexInfo
 from pex.testing import (
@@ -41,7 +42,7 @@ def test_interpreter_constraints_to_pex_info_py2():
         )
         res.assert_success()
         pex_info = PexInfo.from_pex(pex_out_path)
-        assert {">=2.7,<3", ">=3.5"} == set(pex_info.interpreter_constraints)
+        assert InterpreterConstraints.parse(">=2.7,<3", ">=3.5") == pex_info.interpreter_constraints
 
 
 def test_interpreter_constraints_to_pex_info_py3():
@@ -56,7 +57,7 @@ def test_interpreter_constraints_to_pex_info_py3():
         )
         res.assert_success()
         pex_info = PexInfo.from_pex(pex_out_path)
-        assert [">3"] == pex_info.interpreter_constraints
+        assert InterpreterConstraints.parse(">3") == pex_info.interpreter_constraints
 
 
 def test_interpreter_resolution_with_constraint_option():
@@ -68,7 +69,7 @@ def test_interpreter_resolution_with_constraint_option():
         )
         res.assert_success()
         pex_info = PexInfo.from_pex(pex_out_path)
-        assert [">=2.7,<3"] == pex_info.interpreter_constraints
+        assert InterpreterConstraints.parse(">=2.7,<3") == pex_info.interpreter_constraints
 
 
 def test_interpreter_resolution_with_multiple_constraint_options():
@@ -88,7 +89,7 @@ def test_interpreter_resolution_with_multiple_constraint_options():
         )
         res.assert_success()
         pex_info = PexInfo.from_pex(pex_out_path)
-        assert {">=2.7,<3", ">=500"} == set(pex_info.interpreter_constraints)
+        assert InterpreterConstraints.parse(">=2.7,<3", ">=500") == pex_info.interpreter_constraints
 
 
 def test_interpreter_resolution_with_pex_python_path():

--- a/tests/integration/test_pex_bootstrapper.py
+++ b/tests/integration/test_pex_bootstrapper.py
@@ -12,6 +12,7 @@ import pytest
 from pex.common import safe_open
 from pex.compatibility import commonpath
 from pex.interpreter import PythonInterpreter
+from pex.interpreter_constraints import InterpreterConstraint
 from pex.pex import PEX
 from pex.pex_bootstrapper import ensure_venv
 from pex.pex_info import PexInfo
@@ -404,9 +405,9 @@ def test_boot_resolve_fail(
         r"  ... \d+ more ...".format(
             pex_python_path=re.escape(pex_python_path),
             py39_exe=py39.binary,
-            py39_req=py39.identity.requirement,
+            py39_req=InterpreterConstraint.exact_version(py39),
             py310_exe=py310.binary,
-            py310_req=py310.identity.requirement,
+            py310_req=InterpreterConstraint.exact_version(py310),
         ),
     )
     assert pattern.match(error), "Got error:\n{error}\n\nExpected pattern\n{pattern}".format(

--- a/tests/integration/test_reexec.py
+++ b/tests/integration/test_reexec.py
@@ -11,6 +11,7 @@ import pytest
 
 from pex.common import temporary_dir
 from pex.interpreter import PythonInterpreter
+from pex.interpreter_constraints import InterpreterConstraint
 from pex.testing import (
     PY39,
     PY310,
@@ -116,7 +117,7 @@ def test_pex_reexec_no_constraints_pythonpath_present():
 
 def test_pex_no_reexec_constraints_match_current():
     # type: () -> None
-    _assert_exec_chain(interpreter_constraints=[str(PythonInterpreter.get().identity.requirement)])
+    _assert_exec_chain(interpreter_constraints=[str(InterpreterConstraint.exact_version())])
 
 
 def test_pex_reexec_constraints_match_current_pythonpath_present():
@@ -124,7 +125,7 @@ def test_pex_reexec_constraints_match_current_pythonpath_present():
     _assert_exec_chain(
         exec_chain=[sys.executable],
         pythonpath=["."],
-        interpreter_constraints=[str(PythonInterpreter.get().identity.requirement)],
+        interpreter_constraints=[str(InterpreterConstraint.exact_version())],
     )
 
 

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -21,7 +21,6 @@ from pex.interpreter import PythonInterpreter
 from pex.jobs import Job
 from pex.pyenv import Pyenv
 from pex.testing import (
-    ALL_PY_VERSIONS,
     PY38,
     PY39,
     PY310,

--- a/tests/test_pex_binary.py
+++ b/tests/test_pex_binary.py
@@ -76,10 +76,12 @@ def test_clp_preamble_file():
 
         requirement_configuration = requirement_options.configure(options)
         resolver_configuration = resolver_options.configure(options)
-        targets = target_options.configure(options).resolve_targets()
+        target_config = target_options.configure(options)
+        targets = target_config.resolve_targets()
         pex_builder = build_pex(
             requirement_configuration=requirement_configuration,
             resolver_configuration=resolver_configuration,
+            interpreter_constraints=target_config.interpreter_constraints,
             targets=targets,
             options=options,
         )
@@ -130,10 +132,12 @@ def test_clp_prereleases_resolver():
         assert not options.allow_prereleases
 
         with pytest.raises(SystemExit):
+            target_config = target_options.configure(options)
             build_pex(
                 requirement_configuration=requirement_options.configure(options),
                 resolver_configuration=resolver_options.configure(options),
-                targets=target_options.configure(options).resolve_targets(),
+                interpreter_constraints=target_config.interpreter_constraints,
+                targets=target_config.resolve_targets(),
                 options=options,
             )
 
@@ -162,10 +166,12 @@ def test_clp_prereleases_resolver():
         #     dep==1.2.3b1, dep
         #
         # With a correct behavior the assert line is reached and pex_builder object created.
+        target_config = target_options.configure(options)
         pex_builder = build_pex(
             requirement_configuration=requirement_options.configure(options),
             resolver_configuration=resolver_options.configure(options),
-            targets=target_options.configure(options).resolve_targets(),
+            interpreter_constraints=target_config.interpreter_constraints,
+            targets=target_config.resolve_targets(),
             options=options,
         )
         assert pex_builder is not None

--- a/tests/test_pex_info.py
+++ b/tests/test_pex_info.py
@@ -8,6 +8,7 @@ import pytest
 
 from pex.common import temporary_dir
 from pex.inherit_path import InheritPath
+from pex.interpreter_constraints import InterpreterConstraints
 from pex.orderedset import OrderedSet
 from pex.pex_info import PexInfo
 from pex.pex_warnings import PEXWarning
@@ -129,13 +130,15 @@ def test_copy():
     info.add_requirement("baz==2")
     info.add_distribution("bar.whl", "bar-sha")
     info.add_distribution("baz.whl", "baz-sha")
-    info.add_interpreter_constraint(">=2.7.18")
-    info.add_interpreter_constraint("CPython==2.7.9")
+    info.interpreter_constraints = InterpreterConstraints.parse(">=2.7.18", "CPython==2.7.9")
     info_copy = info.copy()
 
     assert "foo" == info_copy.code_hash
     assert InheritPath.FALLBACK == info_copy.inherit_path
     assert OrderedSet(["bar==1", "baz==2"]) == info_copy.requirements
     assert {"bar.whl": "bar-sha", "baz.whl": "baz-sha"} == info_copy.distributions
-    assert {">=2.7.18", "CPython==2.7.9"} == set(info_copy.interpreter_constraints)
+    assert (
+        InterpreterConstraints.parse(">=2.7.18", "CPython==2.7.9")
+        == info_copy.interpreter_constraints
+    )
     assert info.dump() == info_copy.dump()

--- a/tests/tools/commands/test_interpreter_command.py
+++ b/tests/tools/commands/test_interpreter_command.py
@@ -10,6 +10,7 @@ import pytest
 
 from pex.common import safe_mkdtemp
 from pex.interpreter import PythonInterpreter
+from pex.interpreter_constraints import InterpreterConstraint
 from pex.pex_builder import PEXBuilder
 from pex.testing import PY38, PY310, ensure_python_interpreter
 from pex.typing import TYPE_CHECKING
@@ -120,7 +121,7 @@ def expected_verbose(interpreter):
     return {
         "path": interpreter.binary,
         "platform": str(interpreter.platform),
-        "requirement": str(interpreter.identity.requirement),
+        "requirement": str(InterpreterConstraint.exact_version(interpreter)),
     }
 
 


### PR DESCRIPTION
This work was initiated trying to fix #1928 when it appeared attrs 
cached_hash use was triggering a circular import. That turned out not to
be the case, but this work is still useful since it centralizes IC
behavior (OR semantics) and is needed to eventually fix #1580.