### PR TITLE
Prepare the 2.1.108 release.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+2.1.108
+-------
+
+This release fixes a latent PEX boot performance bug triggered by
+requirements with large extras sets.
+
+* Fix slow PEX boot time when there are many extras. (#1929)
+  `PR #1929 <https://github.com/pantsbuild/pex/pull/1929>`_
+
 2.1.107
 -------
 

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.1.107"
+__version__ = "2.1.108"


### PR DESCRIPTION
Closes #1924