### PR TITLE
Don't treat `PEX_PATH=` as `.` like other PATHS.

### DIFF
--- a/pex/variables.py
+++ b/pex/variables.py
@@ -301,10 +301,16 @@ class Variables(object):
                 % (variable, self._environ[variable])
             )
 
-    def _maybe_get_path_tuple(self, variable):
-        # type: (str) -> Optional[Tuple[str, ...]]
+    def _maybe_get_path_tuple(
+        self,
+        variable,  # type: str
+        empty_string_is_cwd=True,  # type: bool
+    ):
+        # type: (...) -> Optional[Tuple[str, ...]]
         value = self._maybe_get_string(variable)
         if value is None:
+            return None
+        if not value and not empty_string_is_cwd:
             return None
         return tuple(
             OrderedSet(os.path.normpath(os.path.expanduser(p)) for p in value.split(os.pathsep))
@@ -600,7 +606,7 @@ class Variables(object):
 
         See also PEX_EXTRA_SYS_PATH for how to add arbitrary entries to the sys.path.
         """
-        return self._maybe_get_path_tuple("PEX_PATH") or ()
+        return self._maybe_get_path_tuple("PEX_PATH", empty_string_is_cwd=False) or ()
 
     @property
     def PEX_SCRIPT(self):

--- a/tests/integration/test_issue_1936.py
+++ b/tests/integration/test_issue_1936.py
@@ -1,0 +1,38 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+import subprocess
+
+from pex.testing import make_env, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_empty_pex_path(tmpdir):
+    # type: (Any) -> None
+
+    empty_pex = os.path.join(str(tmpdir), "empty.pex")
+    run_pex_command(args=["-o", empty_pex]).assert_success()
+
+    # The previously failing case.
+    subprocess.check_call(args=[empty_pex, "-c", ""], env=make_env(PEX_PATH=""))
+
+    colors_pex = os.path.join(str(tmpdir), "colors.pex")
+    run_pex_command(
+        args=["ansicolors==1.1.8", "-o", colors_pex, "--layout", "packed"]
+    ).assert_success()
+
+    assert 0 != subprocess.call(
+        args=[empty_pex, "-c", "import colors"]
+    ), "Expected a PEX_PATH including colors.pex to be needed in order to import colors."
+    subprocess.check_call(
+        args=[empty_pex, "-c", "import colors"], env=make_env(PEX_PATH=colors_pex)
+    )
+    # Demonstrate that . can be used instead of the empty string to trigger a CWD PEX_PATH if that
+    # is what is intended.
+    subprocess.check_call(
+        args=[empty_pex, "-c", "import colors"], env=make_env(PEX_PATH="."), cwd=colors_pex
+    )

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -258,3 +258,11 @@ def test_warnings():
             for env_var in ("PEX_ALWAYS_CACHE", "PEX_FORCE_LOCAL", "PEX_UNZIP")
         )
     ) == tuple(sorted(warning_by_message_first_sentence))
+
+
+def test_empty_pex_path_issue_1936():
+    # type: () -> None
+
+    assert () == Variables(environ={}).PEX_PATH
+    assert () == Variables(environ={"PEX_PATH": ""}).PEX_PATH
+    assert (".",) == Variables(environ={"PEX_PATH": "."}).PEX_PATH


### PR DESCRIPTION
This fixes a regression reading the `PEX_PATH` variable introduced by
changes in #1902 that ended up attempting to add CWD as a PEX when 
`PEX_PATH` was set to the empty string in the environment.

Since `PEX_PATH` is closest in spirit to a `PATH` of files instead of a
`PATH` of directories like `PATH` and `PYTHONPATH`, the old relied-upon
behavior makes sense generally.

Fixes #1936