### PR TITLE
Fix `sys.path` scrubbing.

### DIFF
--- a/pex/bootstrap.py
+++ b/pex/bootstrap.py
@@ -12,6 +12,7 @@ class Bootstrap(object):
 
     @classmethod
     def locate(cls):
+        # type: () -> Bootstrap
         """Locates the active PEX bootstrap.
 
         :rtype: :class:`Bootstrap`
@@ -30,8 +31,14 @@ class Bootstrap(object):
         return cls._INSTANCE
 
     def __init__(self, sys_path_entry):
+        # type: (str) -> None
         self._sys_path_entry = sys_path_entry
         self._realpath = os.path.realpath(self._sys_path_entry)
+
+    @property
+    def path(self):
+        # type: () -> str
+        return self._sys_path_entry
 
     def demote(self):
         """Demote the bootstrap code to the end of the `sys.path` so it is found last.

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import sysconfig
 from collections import OrderedDict
+from contextlib import contextmanager
 from textwrap import dedent
 
 from pex import third_party
@@ -24,6 +25,7 @@ from pex.orderedset import OrderedSet
 from pex.pep_425 import CompatibilityTags
 from pex.pep_508 import MarkerEnvironment
 from pex.platforms import Platform
+from pex.pth import iter_pth_paths
 from pex.pyenv import Pyenv
 from pex.third_party.packaging import __version__ as packaging_version
 from pex.third_party.packaging import tags
@@ -98,6 +100,49 @@ class PythonIdentity(object):
             return None
         return str(value)
 
+    @staticmethod
+    def _iter_site_packages():
+        # type: () -> Iterator[str]
+
+        try:
+            from site import getsitepackages
+
+            for path in getsitepackages():
+                yield path
+        except ImportError as e:
+            # The site.py provided by old virtualenv (which we use to create some venvs) does not
+            # include a getsitepackages function.
+            TRACER.log("The site module does not define getsitepackages: {err}".format(err=e))
+
+        try:
+            from distutils.sysconfig import get_python_lib
+
+            yield get_python_lib(plat_specific=False)
+            yield get_python_lib(plat_specific=True)
+        except ImportError as e:
+            # The distutils.sysconfig module is deprecated in Python 3.10 but still around.
+            # Eventually it will go away with replacements in sysconfig that we'll add at that time
+            # as another site packages source.
+            TRACER.log(
+                "The distutils.sysconfig module does not define get_python_lib: {err}".format(err=e)
+            )
+
+    @staticmethod
+    def _iter_extras_paths(site_packages):
+        # type: (Iterable[str]) -> Iterator[str]
+
+        # Handle .pth injected paths as extras.
+        for dir_path in site_packages:
+            if not os.path.isdir(dir_path):
+                continue
+            for file in os.listdir(dir_path):
+                if not file.endswith(".pth"):
+                    continue
+                pth_path = os.path.join(dir_path, file)
+                TRACER.log("Found .pth file: {pth_file}".format(pth_file=pth_path), V=3)
+                for extras_path in iter_pth_paths(pth_path):
+                    yield extras_path
+
     @classmethod
     def get(cls, binary=None):
         # type: (Optional[str]) -> PythonIdentity
@@ -127,7 +172,18 @@ class PythonIdentity(object):
         pythonpath = frozenset(
             os.environ.get("PYTHONPATH", "").split(os.pathsep) + list(third_party.exposed())
         )
-        sys_path = [item for item in sys.path if item and item not in pythonpath]
+        sys_path = OrderedSet(item for item in sys.path if item and item not in pythonpath)
+
+        site_packages = OrderedSet(
+            path
+            for path in cls._iter_site_packages()
+            # On Windows getsitepackages() includes sys.prefix as a historical vestige. In PEP-250
+            # Windows got a proper dedicated directory for this which is what is used in the Pythons
+            # we support. See: https://peps.python.org/pep-0250/
+            if path != sys.prefix
+        )
+
+        extras_paths = OrderedSet(cls._iter_extras_paths(site_packages=site_packages))
 
         return cls(
             binary=binary or sys.executable,
@@ -140,6 +196,8 @@ class PythonIdentity(object):
                 or cast(str, getattr(sys, "base_prefix", sys.prefix))
             ),
             sys_path=sys_path,
+            site_packages=site_packages,
+            extras_paths=extras_paths,
             packaging_version=packaging_version,
             python_tag=preferred_tag.interpreter,
             abi_tag=preferred_tag.abi,
@@ -154,7 +212,7 @@ class PythonIdentity(object):
     def decode(cls, encoded):
         TRACER.log("creating PythonIdentity from encoded: %s" % encoded, V=9)
         values = json.loads(encoded)
-        if len(values) != 12:
+        if len(values) != 14:
             raise cls.InvalidError("Invalid interpreter identity: %s" % encoded)
 
         supported_tags = values.pop("supported_tags")
@@ -190,6 +248,8 @@ class PythonIdentity(object):
         prefix,  # type: str
         base_prefix,  # type: str
         sys_path,  # type: Iterable[str]
+        site_packages,  # type: Iterable[str]
+        extras_paths,  # type: Iterable[str]
         packaging_version,  # type: str
         python_tag,  # type: str
         abi_tag,  # type: str
@@ -208,6 +268,8 @@ class PythonIdentity(object):
         self._prefix = prefix
         self._base_prefix = base_prefix
         self._sys_path = tuple(sys_path)
+        self._site_packages = tuple(site_packages)
+        self._extras_paths = tuple(extras_paths)
         self._packaging_version = packaging_version
         self._python_tag = python_tag
         self._abi_tag = abi_tag
@@ -223,6 +285,8 @@ class PythonIdentity(object):
             prefix=self._prefix,
             base_prefix=self._base_prefix,
             sys_path=self._sys_path,
+            site_packages=self._site_packages,
+            extras_paths=self._extras_paths,
             packaging_version=self._packaging_version,
             python_tag=self._python_tag,
             abi_tag=self._abi_tag,
@@ -254,6 +318,16 @@ class PythonIdentity(object):
     def sys_path(self):
         # type: () -> Tuple[str, ...]
         return self._sys_path
+
+    @property
+    def site_packages(self):
+        # type: () -> Tuple[str, ...]
+        return self._site_packages
+
+    @property
+    def extras_paths(self):
+        # type: () -> Tuple[str, ...]
+        return self._extras_paths
 
     @property
     def python_tag(self):
@@ -405,6 +479,19 @@ class PythonInterpreter(object):
     )
 
     _PYTHON_INTERPRETER_BY_NORMALIZED_PATH = {}  # type: Dict
+
+    @classmethod
+    @contextmanager
+    def _cleared_memory_cache(cls):
+        # type: () -> Iterator[None]
+        # Intended for test use.
+
+        _cache = cls._PYTHON_INTERPRETER_BY_NORMALIZED_PATH.copy()
+        cls._PYTHON_INTERPRETER_BY_NORMALIZED_PATH = {}
+        try:
+            yield
+        finally:
+            cls._PYTHON_INTERPRETER_BY_NORMALIZED_PATH = _cache
 
     @staticmethod
     def _get_pyvenv_cfg(path):
@@ -610,9 +697,6 @@ class PythonInterpreter(object):
         cmd = [binary]
 
         # Don't add the user site directory to `sys.path`.
-        #
-        # Additionally, it would be nice to pass `-S` to disable adding site-packages but unfortunately
-        # some python distributions include portions of the standard library there.
         cmd.append("-s")
 
         env = cls._sanitized_environment(env=env)
@@ -1007,6 +1091,18 @@ class PythonInterpreter(object):
         with no adornments.
         """
         return self._identity.sys_path
+
+    @property
+    def site_packages(self):
+        # type: () -> Tuple[str, ...]
+        """Return the interpreter's site packages directories."""
+        return self.identity.site_packages
+
+    @property
+    def extras_paths(self):
+        # type: () -> Tuple[str, ...]
+        """Return any extra paths adjoined to the `sys.path` via the .pth mechanism."""
+        return self.identity.extras_paths
 
     class BaseInterpreterResolutionError(Exception):
         """Indicates the base interpreter for a virtual environment could not be resolved."""

--- a/pex/pth.py
+++ b/pex/pth.py
@@ -1,0 +1,74 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os
+import sys
+
+from pex.compatibility import PY2, exec_function
+from pex.tracer import TRACER
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Iterator
+
+
+def iter_pth_paths(filename):
+    # type: (str) -> Iterator[str]
+    """Given a .pth file, extract and yield all inner paths without honoring imports.
+
+    This shadows Python's site.py behavior, which is invoked at interpreter startup.
+    """
+    try:
+        f = open(filename, "rU" if PY2 else "r")  # noqa
+    except IOError:
+        return
+
+    seen = set()
+    with f:
+        for i, line in enumerate(f, start=1):
+            line = line.rstrip()
+            if not line or line.startswith("#"):
+                continue
+            elif line.startswith(("import ", "import\t")):
+                # One important side effect of executing import lines can be alteration of the
+                # sys.path directly or indirectly as a programmatic way to add sys.path entries
+                # in contrast to the standard .pth mechanism of including fixed paths as
+                # individual lines in the file. Here we capture all such programmatic attempts
+                # to expand the sys.path and report the additions.
+                original_sys_path = sys.path[:]
+                try:
+                    # N.B.: Setting sys.path to empty is ok since all the .pth files we find and
+                    # execute have already been found and executed by our ambient sys.executable
+                    # when it started up before running this PEX file. As such, all symbols imported
+                    # by the .pth files then will still be available now as cached in sys.modules.
+                    sys.path = []
+                    exec_function(line, globals_map={})
+                    for path in sys.path:
+                        norm_path = os.path.normcase(path)
+                        if norm_path not in seen:
+                            yield path
+                            seen.add(norm_path)
+                except Exception as e:
+                    # NB: import lines are routinely abused with extra code appended using `;` so
+                    # the class of exceptions that might be raised in broader than ImportError. As
+                    # such we catch broadly here.
+                    TRACER.log(
+                        "Error executing line {linenumber} of {pth_file} with content:\n"
+                        "{content}\n"
+                        "Error was:\n"
+                        "{error}".format(linenumber=i, pth_file=filename, content=line, error=e),
+                        V=9,
+                    )
+
+                    # Defer error handling to the higher level site.py logic invoked at startup.
+                    return
+                finally:
+                    sys.path = original_sys_path
+            else:
+                extras_dir = os.path.abspath(os.path.join(os.path.dirname(filename), line))
+                norm_extras_dir = os.path.normcase(extras_dir)
+                if norm_extras_dir not in seen and os.path.exists(extras_dir):
+                    yield extras_dir
+                    seen.add(norm_extras_dir)

--- a/pex/util.py
+++ b/pex/util.py
@@ -8,7 +8,6 @@ import hashlib
 import importlib
 import os
 import shutil
-import sys
 import tempfile
 from hashlib import sha1
 from site import makepath  # type: ignore[attr-defined]
@@ -20,7 +19,6 @@ from pex.compatibility import (  # type: ignore[attr-defined]  # `exec_function`
     exec_function,
 )
 from pex.orderedset import OrderedSet
-from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -140,61 +138,3 @@ def named_temporary_file(**kwargs):
             yield fp
     finally:
         os.remove(fp.name)
-
-
-def iter_pth_paths(filename):
-    # type: (str) -> Iterator[str]
-    """Given a .pth file, extract and yield all inner paths without honoring imports.
-
-    This shadows Python's site.py behavior, which is invoked at interpreter startup.
-    """
-    try:
-        f = open(filename, "rU" if PY2 else "r")  # noqa
-    except IOError:
-        return
-
-    dirname = os.path.dirname(filename)
-    known_paths = set()
-
-    with f:
-        for i, line in enumerate(f, start=1):
-            line = line.rstrip()
-            if not line or line.startswith("#"):
-                continue
-            elif line.startswith(("import ", "import\t")):
-                # One important side effect of executing import lines can be alteration of the
-                # sys.path directly or indirectly as a programmatic way to add sys.path entries
-                # in contrast to the standard .pth mechanism of including fixed paths as
-                # individual lines in the file. Here we capture all such programmatic attempts
-                # to expand the sys.path and report the additions.
-                original_sys_path = sys.path[:]
-                try:
-                    # N.B.: Setting sys.path to empty is ok since all the .pth files we find and
-                    # execute have already been found and executed by our ambient sys.executable
-                    # when it started up before running this PEX file. As such, all symbols imported
-                    # by the .pth files then will still be available now as cached in sys.modules.
-                    sys.path = []
-                    exec_function(line, globals_map={})
-                    for path in sys.path:
-                        yield path
-                except Exception as e:
-                    # NB: import lines are routinely abused with extra code appended using `;` so
-                    # the class of exceptions that might be raised in broader than ImportError. As
-                    # such we catch broadly here.
-                    TRACER.log(
-                        "Error executing line {linenumber} of {pth_file} with content:\n"
-                        "{content}\n"
-                        "Error was:\n"
-                        "{error}".format(linenumber=i, pth_file=filename, content=line, error=e),
-                        V=9,
-                    )
-
-                    # Defer error handling to the higher level site.py logic invoked at startup.
-                    return
-                finally:
-                    sys.path = original_sys_path
-            else:
-                extras_dir, extras_dir_case_insensitive = makepath(dirname, line)
-                if extras_dir_case_insensitive not in known_paths and os.path.exists(extras_dir):
-                    yield extras_dir
-                    known_paths.add(extras_dir_case_insensitive)

--- a/tests/integration/test_pex_import.py
+++ b/tests/integration/test_pex_import.py
@@ -1,6 +1,6 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-import json
+
 import os.path
 import subprocess
 import sys

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -13,9 +13,7 @@ from textwrap import dedent
 
 import pytest
 
-from pex import interpreter
 from pex.common import chmod_plus_x, safe_mkdir, safe_mkdtemp, temporary_dir, touch
-from pex.compatibility import PY3
 from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
 from pex.jobs import Job

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -55,13 +55,7 @@ class TestPythonInterpreter(object):
     def test_all_does_not_raise_with_empty_path_envvar(self):
         # type: () -> None
         """additionally, tests that the module does not raise at import."""
-        with patch.dict(os.environ, clear=True):
-            if PY3:
-                import importlib
-
-                importlib.reload(interpreter)
-            else:
-                reload(interpreter)
+        with patch.dict(os.environ, clear=True), PythonInterpreter._cleared_memory_cache():
             PythonInterpreter.all()
 
     TEST_INTERPRETER1_VERSION = PY39
@@ -416,7 +410,9 @@ def test_identify_cwd_isolation_issues_1231(tmpdir):
     subprocess.check_call(args=[pip, "install", "--target", polluted_cwd, "pex==2.1.16"])
 
     pex_root = os.path.join(str(tmpdir), "pex_root")
-    with pushd(polluted_cwd), ENV.patch(PEX_ROOT=pex_root):
+    with pushd(polluted_cwd), ENV.patch(
+        PEX_ROOT=pex_root
+    ), PythonInterpreter._cleared_memory_cache():
         interp = PythonInterpreter.from_binary(python38)
 
     interp_info_files = {

--- a/tests/test_pth.py
+++ b/tests/test_pth.py
@@ -1,0 +1,46 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+from typing import Any, Dict, List
+from unittest import mock
+
+from pex.common import temporary_dir
+from pex.compatibility import to_bytes
+from pex.pth import iter_pth_paths
+
+
+@mock.patch("os.path.exists", autospec=True, spec_set=True)
+def test_iter_pth_paths(mock_exists):
+    # type: (Any) -> None
+    # Ensure path checking always returns True for dummy paths.
+    mock_exists.return_value = True
+
+    with temporary_dir() as tmpdir:
+        in_tmp = lambda f: os.path.join(tmpdir, f)
+
+        PTH_TEST_MAPPING = {
+            # A mapping of .pth file content -> expected paths.
+            "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python\n": [
+                "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python"
+            ],
+            "relative_path\nrelative_path2\n\nrelative_path3": [
+                in_tmp("relative_path"),
+                in_tmp("relative_path2"),
+                in_tmp("relative_path3"),
+            ],
+            "duplicate_path\nduplicate_path": [in_tmp("duplicate_path")],
+            "randompath\nimport nosuchmodule\n": [in_tmp("randompath")],
+            "import sys\nfoo\n/bar/baz": [in_tmp("foo"), "/bar/baz"],
+            "import nosuchmodule\nfoo": [],
+            "import nosuchmodule\n": [],
+            "import bad)syntax\n": [],
+        }  # type: Dict[str, List[str]]
+
+        for i, pth_content in enumerate(PTH_TEST_MAPPING):
+            pth_tmp_path = os.path.abspath(os.path.join(tmpdir, "test%s.pth" % i))
+            with open(pth_tmp_path, "wb") as f:
+                f.write(to_bytes(pth_content))
+            assert sorted(PTH_TEST_MAPPING[pth_content]) == sorted(
+                list(iter_pth_paths(pth_tmp_path))
+            )

--- a/tests/test_pth.py
+++ b/tests/test_pth.py
@@ -2,12 +2,19 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-from typing import Any, Dict, List
-from unittest import mock
 
 from pex.common import temporary_dir
 from pex.compatibility import to_bytes
 from pex.pth import iter_pth_paths
+from pex.typing import TYPE_CHECKING
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock  # type: ignore[no-redef,import]
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, List
 
 
 @mock.patch("os.path.exists", autospec=True, spec_set=True)


### PR DESCRIPTION
All the calculations needed to support classification of `sys.path` entries as belonging to site-packages, extras paths or the stdlib are now completed during interpreter identification. This is both more efficient (5-10ms savings on zipapp PEX boot time), since several calculations now become cached for the lifetime of the interpreter installation on a machine, and more correct, since the interpreter identification is done in fresh Python subprocess executed with `-s`. This hardens `sys.path` from additions by external code calling into the PEX using the old pex_bootstrapper bootstrap_pex_env API or using a PEX as a `sys.path` entry as afforded by the `__pex__` import hook.

Fixes #1944