### PR TITLE
Prepare the 2.1.110 release.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 Release Notes
 =============
 
+2.1.110
+-------
+
+This release fixes Pex runtime ``sys.path`` scrubbing for cases where
+Pex is not the main entry point. An important example of this is in
+Lambdex where the AWS Lambda Python runtime packages (``boto3`` and
+``botocore``) are leaked into the PEX runtime ``sys.path``.
+
+* Fix ``sys.path`` scrubbing. (#1946)
+  `PR #1946 <https://github.com/pantsbuild/pex/pull/1946>`_
+
 2.1.109
 -------
 

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.1.109"
+__version__ = "2.1.110"


### PR DESCRIPTION
Closes #1934