### PR TITLE
Fix lock resolution to handle arbitrary equality.

### DIFF
--- a/pex/resolve/locked_resolve.py
+++ b/pex/resolve/locked_resolve.py
@@ -605,8 +605,8 @@ class LockedResolve(object):
                     # https://peps.python.org/pep-0440/#handling-of-pre-releases during the lock
                     # resolve; so we trust that resolve's conclusion about prereleases and are
                     # permissive here.
-                    if not resolve_request.requirement.specifier.contains(
-                        str(locked_requirement.pin.version), prereleases=True
+                    if not resolve_request.requirement.contains(
+                        locked_requirement.pin.version, prereleases=True
                     ):
                         version_mismatches.append(
                             "{specifier} ({via})".format(

--- a/pex/resolve/lockfile/json_codec.py
+++ b/pex/resolve/lockfile/json_codec.py
@@ -368,7 +368,10 @@ def as_json_data(
                 "locked_requirements": [
                     {
                         "project_name": str(req.pin.project_name),
-                        "version": str(req.pin.version),
+                        # N.B.: We store the raw version so that `===` can work as intended against
+                        # the un-normalized form of versions that are non-legacy and thus
+                        # normalizable.
+                        "version": req.pin.version.raw,
                         "requires_dists": [
                             path_mappings.maybe_canonicalize(str(dependency))
                             for dependency in req.requires_dists

--- a/tests/integration/test_issue_1949.py
+++ b/tests/integration/test_issue_1949.py
@@ -1,0 +1,107 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import os.path
+
+import pytest
+
+from pex.cli.testing import run_pex3
+from pex.compatibility import commonpath
+from pex.testing import IntegResults, built_wheel, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Iterator
+
+
+@pytest.fixture
+def wheel():
+    # type: () -> Iterator[str]
+    with built_wheel(name="not_boto", version="2.49.0a1") as whl:
+        yield whl
+
+
+def test_resolve_arbitrary_equality(
+    tmpdir,  # type: Any
+    wheel,  # type: str
+):
+    # type: (...) -> None
+
+    lock = os.path.join(str(tmpdir), "lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--no-pypi",
+        "--find-links",
+        os.path.dirname(wheel),
+        "not_boto===2.49.0a1",
+        "--indent",
+        "2",
+        "-o",
+        lock,
+    ).assert_success()
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+
+    def create_pex_from_lock(*additional_args):
+        # type: (*str) -> IntegResults
+        return run_pex_command(
+            args=[
+                "--pex-root",
+                pex_root,
+                "--runtime-pex-root",
+                pex_root,
+                "--lock",
+                lock,
+            ]
+            + list(additional_args)
+            + ["--", "-c", "import not_boto; print(not_boto.__file__)"]
+        )
+
+    result = create_pex_from_lock()
+    result.assert_success()
+    assert pex_root == commonpath((pex_root, result.output.strip()))
+
+    result = create_pex_from_lock("not_boto===2.49.0a1")
+    result.assert_success()
+    assert pex_root == commonpath((pex_root, result.output.strip()))
+
+    result = create_pex_from_lock("not_boto===2.49a1")
+    result.assert_failure()
+
+    pex_repository = os.path.join(str(tmpdir), "pex_repository")
+    run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--lock",
+            lock,
+            "-o",
+            pex_repository,
+        ]
+    ).assert_success()
+
+    def create_pex_from_pex_repository(requirement):
+        # type: (str) -> IntegResults
+        return run_pex_command(
+            args=[
+                "--pex-root",
+                pex_root,
+                "--runtime-pex-root",
+                pex_root,
+                "--pex-repository",
+                pex_repository,
+                requirement,
+                "--",
+                "-c",
+                "import not_boto; print(not_boto.__file__)",
+            ]
+        )
+
+    result = create_pex_from_pex_repository("not_boto===2.49.0a1")
+    result.assert_success()
+    assert pex_root == commonpath((pex_root, result.output.strip()))
+
+    result = create_pex_from_pex_repository("not_boto===2.49a1")
+    result.assert_failure()


### PR DESCRIPTION
Previously, arbitrary equality could not be used in requirements when resolving against a lockfile when the project being resolved had a PEP-440 compatible version that was normalized.

Fixes #1949