### PR TITLE
Migrate from `::set-output` to `$GITHUB_OUTPUT`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           # We need to keep Python 3.8 for consistent vendoring with tox.
           python-version: "3.8"
       - name: Check Formatting, Types, Vendoring and Packaging
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           tox-env: format-check,typecheck,vendor-check,package -- --additional-format sdist --additional-format wheel
   cpython-unit-tests:
@@ -88,7 +88,7 @@ jobs:
         with:
           python-version: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
+        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Cache Pyenv Interpreters
@@ -97,7 +97,7 @@ jobs:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v4
       - name: Run Unit Tests
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}
   pypy-unit-tests:
@@ -131,7 +131,7 @@ jobs:
         with:
           python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
+        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Cache Pyenv Interpreters
@@ -140,7 +140,7 @@ jobs:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v4
       - name: Run Unit Tests
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           tox-env: pypy${{ join(matrix.pypy-version, '') }}-pip${{ matrix.pip-version }}
   cpython-integration-tests:
@@ -196,7 +196,7 @@ jobs:
         with:
           python-version: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
+        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Cache Pyenv Interpreters
@@ -212,7 +212,7 @@ jobs:
         with:
           ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
       - name: Run Integration Tests
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}-integration
   pypy-integration-tests:
@@ -249,7 +249,7 @@ jobs:
         with:
           python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
+        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Install Packages
@@ -269,7 +269,7 @@ jobs:
         with:
           ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
       - name: Run Integration Tests
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           tox-env: pypy${{ join(matrix.pypy-version, '') }}-pip${{ matrix.pip-version }}-integration
   final-status:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           if [[ "$(uname -s)" == "Linux" ]]; then
             skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
           fi
-          echo "::set-output name=skip::${skip}"
+          echo "skip=${skip}" >> $GITHUB_OUTPUT
       - name: Checkout Pex
         uses: actions/checkout@v2
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
@@ -123,7 +123,7 @@ jobs:
           if [[ "$(uname -s)" == "Linux" ]]; then
             skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
           fi
-          echo "::set-output name=skip::${skip}"
+          echo "skip=${skip}" >> $GITHUB_OUTPUT
       - name: Checkout Pex
         uses: actions/checkout@v2
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
@@ -185,7 +185,7 @@ jobs:
           if [[ "$(uname -s)" == "Linux" ]]; then
             skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
           fi
-          echo "::set-output name=skip::${skip}"
+          echo "skip=${skip}" >> $GITHUB_OUTPUT
       - name: Checkout Pex
         uses: actions/checkout@v2
         with:
@@ -238,7 +238,7 @@ jobs:
           if [[ "$(uname -s)" == "Linux" ]]; then
             skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
           fi
-          echo "::set-output name=skip::${skip}"
+          echo "skip=${skip}" >> $GITHUB_OUTPUT
       - name: Checkout Pex
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Pex
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # We need branches and tags since package leans on `git describe`. Passing 0 gets us
           # complete history.
@@ -82,7 +82,7 @@ jobs:
           fi
           echo "skip=${skip}" >> $GITHUB_OUTPUT
       - name: Checkout Pex
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
         uses: actions/setup-python@v4
         with:
@@ -92,7 +92,7 @@ jobs:
         with:
           skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Cache Pyenv Interpreters
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v4
@@ -125,7 +125,7 @@ jobs:
           fi
           echo "skip=${skip}" >> $GITHUB_OUTPUT
       - name: Checkout Pex
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
         uses: actions/setup-python@v4
         with:
@@ -135,7 +135,7 @@ jobs:
         with:
           skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Cache Pyenv Interpreters
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v4
@@ -187,7 +187,7 @@ jobs:
           fi
           echo "skip=${skip}" >> $GITHUB_OUTPUT
       - name: Checkout Pex
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # We need branches and tags for some ITs.
           fetch-depth: 0
@@ -200,7 +200,7 @@ jobs:
         with:
           skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Cache Pyenv Interpreters
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v4
@@ -240,7 +240,7 @@ jobs:
           fi
           echo "skip=${skip}" >> $GITHUB_OUTPUT
       - name: Checkout Pex
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # We need branches and tags for some ITs.
           fetch-depth: 0
@@ -257,7 +257,7 @@ jobs:
           # This is needed for `test_requirement_file_from_url` for building `lxml`.
           sudo apt install --yes libxslt-dev
       - name: Cache Pyenv Interpreters
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           # complete history.
           fetch-depth: 0
       - name: Setup Python 3.8
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           # We need to keep Python 3.8 for consistent vendoring with tox.
           python-version: "3.8"
@@ -84,7 +84,7 @@ jobs:
       - name: Checkout Pex
         uses: actions/checkout@v2
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
@@ -127,7 +127,7 @@ jobs:
       - name: Checkout Pex
         uses: actions/checkout@v2
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
       - name: Expose Pythons
@@ -192,7 +192,7 @@ jobs:
           # We need branches and tags for some ITs.
           fetch-depth: 0
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
@@ -245,7 +245,7 @@ jobs:
           # We need branches and tags for some ITs.
           fetch-depth: 0
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
       - name: Expose Pythons

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
             RELEASE_TAG=${GITHUB_REF#refs/tags/}
           fi
           if [[ "${RELEASE_TAG}" =~ ^v[0-9]+.[0-9]+.[0-9]+$ ]]; then
-            echo "::set-output name=release-tag::${RELEASE_TAG}"
-            echo "::set-output name=release-version::${RELEASE_TAG#v}"
+            echo "release-tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
+            echo "release-version=${RELEASE_TAG#v}" >> $GITHUB_OUTPUT
           else
             echo "::error::Release tag '${RELEASE_TAG}' must match 'v\d+.\d+.\d+'."
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           ref: ${{ needs.determine-tag.outputs.release-tag }}
       - name: Setup Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: Publish Pex ${{ needs.determine-tag.outputs.release-tag }}
@@ -73,7 +73,7 @@ jobs:
           # This ensures we get all branches and tags which is needed for `tox -e package`.
           fetch-depth: 0
       - name: Setup Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: Package Pex ${{ needs.determine-tag.outputs.release-tag }} PEX

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     environment: Release
     steps:
       - name: Checkout Pex ${{ needs.determine-tag.outputs.release-tag }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ needs.determine-tag.outputs.release-tag }}
       - name: Setup Python 3.10
@@ -67,7 +67,7 @@ jobs:
     environment: Release
     steps:
       - name: Checkout Pex ${{ needs.determine-tag.outputs.release-tag }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ needs.determine-tag.outputs.release-tag }}
           # This ensures we get all branches and tags which is needed for `tox -e package`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Publish Pex ${{ needs.determine-tag.outputs.release-tag }}
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         env:
           FLIT_USERNAME: ${{ secrets.PYPI_USERNAME }}
           FLIT_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
@@ -77,7 +77,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Package Pex ${{ needs.determine-tag.outputs.release-tag }} PEX
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           tox-env: package
       - name: Create ${{ needs.determine-tag.outputs.release-tag }} Release


### PR DESCRIPTION
This gets ahead of the deprecation announced here:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/