### PR TITLE
Map pex python path interpreter to realpath when creating venv dir hash.

### DIFF
--- a/pex/variables.py
+++ b/pex/variables.py
@@ -773,7 +773,15 @@ def venv_dir(
     if interpreter_path:
         venv_contents["interpreter"] = os.path.realpath(interpreter_path)
 
-    print("VENV CONTENTS with PEX_PYTHON_PATH={}: {}".format(ENV.PEX_PYTHON_PATH, json.dumps(venv_contents, sort_keys=True)))
+    real_stdout = sys.stdout
+    sys.stdout = sys.stderr
+    print(
+        "VENV CONTENTS with PEX_PYTHON_PATH={}: {}".format(
+            ENV.PEX_PYTHON_PATH, json.dumps(venv_contents, sort_keys=True)
+        ),
+    )
+    sys.stdout = real_stdout
+
     venv_contents_hash = hashlib.sha1(
         json.dumps(venv_contents, sort_keys=True).encode("utf-8")
     ).hexdigest()

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -773,15 +773,6 @@ def venv_dir(
     if interpreter_path:
         venv_contents["interpreter"] = os.path.realpath(interpreter_path)
 
-    real_stdout = sys.stdout
-    sys.stdout = sys.stderr
-    print(
-        "VENV CONTENTS with PEX_PYTHON_PATH={}: {}".format(
-            ENV.PEX_PYTHON_PATH, json.dumps(venv_contents, sort_keys=True)
-        ),
-    )
-    sys.stdout = real_stdout
-
     venv_contents_hash = hashlib.sha1(
         json.dumps(venv_contents, sort_keys=True).encode("utf-8")
     ).hexdigest()

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -773,6 +773,7 @@ def venv_dir(
     if interpreter_path:
         venv_contents["interpreter"] = os.path.realpath(interpreter_path)
 
+    print("VENV CONTENTS with PEX_PYTHON_PATH={}: {}".format(ENV.PEX_PYTHON_PATH, json.dumps(venv_contents, sort_keys=True)))
     venv_contents_hash = hashlib.sha1(
         json.dumps(venv_contents, sort_keys=True).encode("utf-8")
     ).hexdigest()

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -765,7 +765,9 @@ def venv_dir(
         if (
             not ENV.PEX_PYTHON_PATH
             or interpreter_binary.startswith(ENV.PEX_PYTHON_PATH)
-            or os.path.realpath(interpreter_binary).startswith(ENV.PEX_PYTHON_PATH)
+            or os.path.realpath(interpreter_binary).startswith(
+                tuple(os.path.realpath(p) for p in ENV.PEX_PYTHON_PATH)
+            )
         ):
             interpreter_path = interpreter_binary
     if interpreter_path:

--- a/pex/vendor/_vendored/attrs/attrs-21.5.0.dev0.dist-info/WHEEL
+++ b/pex/vendor/_vendored/attrs/attrs-21.5.0.dev0.dist-info/WHEEL
@@ -1,5 +1,5 @@
 Wheel-Version: 1.0
-Generator: bdist_wheel (0.37.1)
+Generator: bdist_wheel (0.38.3)
 Root-Is-Purelib: true
 Tag: py2-none-any
 Tag: py3-none-any

--- a/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/WHEEL
+++ b/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/WHEEL
@@ -1,5 +1,5 @@
 Wheel-Version: 1.0
-Generator: bdist_wheel (0.37.1)
+Generator: bdist_wheel (0.38.3)
 Root-Is-Purelib: true
 Tag: py2-none-any
 Tag: py3-none-any

--- a/pex/vendor/_vendored/setuptools/setuptools-44.0.0+3acb925dd708430aeaf197ea53ac8a752f7c1863.dist-info/WHEEL
+++ b/pex/vendor/_vendored/setuptools/setuptools-44.0.0+3acb925dd708430aeaf197ea53ac8a752f7c1863.dist-info/WHEEL
@@ -1,5 +1,5 @@
 Wheel-Version: 1.0
-Generator: bdist_wheel (0.38.2)
+Generator: bdist_wheel (0.38.3)
 Root-Is-Purelib: true
 Tag: py2-none-any
 Tag: py3-none-any

--- a/pex/vendor/_vendored/setuptools/setuptools-44.0.0+3acb925dd708430aeaf197ea53ac8a752f7c1863.dist-info/WHEEL
+++ b/pex/vendor/_vendored/setuptools/setuptools-44.0.0+3acb925dd708430aeaf197ea53ac8a752f7c1863.dist-info/WHEEL
@@ -1,5 +1,5 @@
 Wheel-Version: 1.0
-Generator: bdist_wheel (0.37.1)
+Generator: bdist_wheel (0.38.2)
 Root-Is-Purelib: true
 Tag: py2-none-any
 Tag: py3-none-any

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -317,6 +317,7 @@ def test_pip_pex_interpreter_venv_hash_issue_1885(
     binary_link = os.path.join(str(tmpdir), "python")
     os.symlink(binary, binary_link)
     pip_w_linked_ppp = create_pip(current_interpreter, PEX_PYTHON_PATH=binary_link)
+    print("binary link real path resolves to: {}".format(os.path.realpath(binary_link)))
     venv_contents_hash = hashlib.sha1(
         json.dumps(
             {

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -4,6 +4,8 @@
 from __future__ import absolute_import
 
 import glob
+import hashlib
+import json
 import os
 import warnings
 
@@ -13,7 +15,7 @@ from pex import targets
 from pex.common import safe_rmtree
 from pex.interpreter import PythonInterpreter
 from pex.jobs import Job
-from pex.pip.installation import get_pip
+from pex.pip.installation import _PIP, PipInstallation, get_pip
 from pex.pip.tool import PackageIndexConfiguration, Pip
 from pex.pip.version import PipVersion, PipVersionValue
 from pex.platforms import Platform
@@ -294,3 +296,35 @@ def test_create_confounding_env_vars_issue_1668(
         requirements=["ansicolors==1.1.8"], download_dir=download_dir
     ).wait()
     assert ["ansicolors-1.1.8-py2.py3-none-any.whl"] == os.listdir(download_dir)
+
+
+def test_pip_pex_interpreter_venv_hash_issue_1885(
+    create_pip,  # type: CreatePip
+    current_interpreter,  # type: PythonInterpreter
+    tmpdir,  # type: Any
+):
+    # type: (...) -> None
+    """This test is under the test_pip module because the resolver
+    doesn't allow the user to control the pip.pex interpreter constraints, so those intperpreter
+    constraints can't feed into the venv_dir hash. Therefore if
+    PEX_PYTHON_PATH is present and contains symlinks that aren't resolved the wrong pip pex venv
+    may end up being invoked by resolver.resolve because the pip.pex venv dir collisions.
+
+    This tests that that doesn't happen.
+    """
+
+    binary = current_interpreter.binary
+    binary_link = os.path.join(tmpdir, "python")
+    os.symlink(binary, binary_link)
+    pip_w_linked_ppp = create_pip(current_interpreter, PEX_PYTHON_PATH=binary_link)
+    venv_contents_hash = hashlib.sha1(
+        json.dumps(
+            {
+                "pex_path": {},
+                "PEX_PYTHON_PATH": (binary_link,),
+                "interpreter": os.path.realpath(binary_link),
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
+    assert venv_contents_hash in pip_w_linked_ppp._pip_pex.venv_dir

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -15,7 +15,7 @@ from pex import targets
 from pex.common import safe_rmtree
 from pex.interpreter import PythonInterpreter
 from pex.jobs import Job
-from pex.pip.installation import get_pip
+from pex.pip.installation import _PIP, PipInstallation, get_pip
 from pex.pip.tool import PackageIndexConfiguration, Pip
 from pex.pip.version import PipVersion, PipVersionValue
 from pex.platforms import Platform
@@ -312,7 +312,12 @@ def test_pip_pex_interpreter_venv_hash_issue_1885(
 
     This tests that that doesn't happen.
     """
-
+    # Remove any existing pip.pex which may exist as a result of other test suites.
+    installation = PipInstallation(
+        interpreter=current_interpreter,
+        version=PipVersion.VENDORED,
+    )
+    del _PIP[installation]
     binary = current_interpreter.binary
     binary_link = os.path.join(str(tmpdir), "python")
     os.symlink(binary, binary_link)

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -15,7 +15,7 @@ from pex import targets
 from pex.common import safe_rmtree
 from pex.interpreter import PythonInterpreter
 from pex.jobs import Job
-from pex.pip.installation import _PIP, PipInstallation, get_pip
+from pex.pip.installation import get_pip
 from pex.pip.tool import PackageIndexConfiguration, Pip
 from pex.pip.version import PipVersion, PipVersionValue
 from pex.platforms import Platform

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -314,7 +314,7 @@ def test_pip_pex_interpreter_venv_hash_issue_1885(
     """
 
     binary = current_interpreter.binary
-    binary_link = os.path.join(tmpdir, "python")
+    binary_link = os.path.join(str(tmpdir), "python")
     os.symlink(binary, binary_link)
     pip_w_linked_ppp = create_pip(current_interpreter, PEX_PYTHON_PATH=binary_link)
     venv_contents_hash = hashlib.sha1(


### PR DESCRIPTION
fixes #1885 

Problem:
When the PEX_PYTHON_PATH contains paths to allowed interpreters that are symlinks to the real interpreter the venv_dir hash value doesn't end up including a valid interpreter. The is a particular problem for the pip.pex venvs that are created by `resolver.resolve` because those pip.pex have no interpreter constraints. they rely on the venv interpreter being the correct one matching the resolve target. If an existing pip.pex venv exists with the wrong venv interpterer the venv_dir paths can collide resulting in the `ensure_venv` returning a path to a pip.pex with the incorrect interpreter, and thus with different resolve behavior.

Solution:
Make sure that when computing the venv_dir if the PEX_PYTHON_PATH contains symlinks to interpreters those are resolved down to their realpath ensuring that the venv_dir path doesn't collide between different interpreters on the PEX_PYTHON_PATH.
