### PR TITLE
Fix vendoring wheel dependency drift.

### DIFF
--- a/pex/vendor/__main__.py
+++ b/pex/vendor/__main__.py
@@ -229,13 +229,15 @@ def vendorize(root_dir, vendor_specs, prefix, update):
         # Setting --no-build-isolation means that versions of setuptools and wheel must be provided
         # in the environment in which we run the pip command, which is the environment in which we
         # run pex.vendor. Since we document that pex.vendor should be run via tox, that environment
-        # will contain pinned versions of setuptools and wheel. As a result, vendoring (at least via
-        # tox) is hermetic.
+        # will contain pinned versions of setuptools and wheel. We further set `--no-cache-dir` so
+        # that Pip finds no newer versions of wheel in its cache. As a result, vendoring (at least
+        # via tox) is hermetic.
         requirement = vendor_spec.prepare()
         cmd = [
             "pip",
             "install",
             "--no-build-isolation",
+            "--no-cache-dir",
             "--no-compile",
             "--prefix",
             prefix_dir_by_vendor_spec[vendor_spec],

--- a/pex/vendor/__main__.py
+++ b/pex/vendor/__main__.py
@@ -220,21 +220,22 @@ def vendorize(root_dir, vendor_specs, prefix, update):
         # NB: We set --no-build-isolation to prevent pip from installing the requirements listed in
         # its [build-system] config in its pyproject.toml.
         #
-        # Those requirements are (currently) the unpinned ["setuptools", "wheel"], which will cause pip
-        # to use the latest version of those packages.  This is a hermeticity problem: re-vendoring a
-        # package at a later time may yield a different result.  At the very least the result will
-        # differ in the version embedded in the WHEEL metadata file, which causes issues with our
-        # tests.
+        # Those requirements are (currently) the unpinned ["setuptools", "wheel"], which will cause
+        # pip to use the latest version of those packages.  This is a hermeticity problem:
+        # re-vendoring a package at a later time may yield a different result.  At the very least
+        # the result will differ in the version embedded in the WHEEL metadata file, which causes
+        # issues with our tests.
         #
         # Setting --no-build-isolation means that versions of setuptools and wheel must be provided
-        # in the environment in which we run the pip command, which is the environment in which we run
-        # pex.vendor. Since we document that pex.vendor should be run via tox, that environment will
-        # contain pinned versions of setuptools and wheel. As a result, vendoring (at least via tox)
-        # is hermetic.
+        # in the environment in which we run the pip command, which is the environment in which we
+        # run pex.vendor. Since we document that pex.vendor should be run via tox, that environment
+        # will contain pinned versions of setuptools and wheel. As a result, vendoring (at least via
+        # tox) is hermetic.
         requirement = vendor_spec.prepare()
         cmd = [
             "pip",
             "install",
+            "--no-build-isolation",
             "--no-compile",
             "--prefix",
             prefix_dir_by_vendor_spec[vendor_spec],

--- a/pex/vendor/_vendored/attrs/attrs-21.5.0.dev0.dist-info/METADATA
+++ b/pex/vendor/_vendored/attrs/attrs-21.5.0.dev0.dist-info/METADATA
@@ -16,6 +16,7 @@ Project-URL: Funding, https://github.com/sponsors/hynek
 Project-URL: Tidelift, https://tidelift.com/subscription/pkg/pypi-attrs?utm_source=pypi-attrs&utm_medium=pypi
 Project-URL: Ko-fi, https://ko-fi.com/the_hynek
 Keywords: class,attribute,boilerplate
+Platform: UNKNOWN
 Classifier: Development Status :: 5 - Production/Stable
 Classifier: Intended Audience :: Developers
 Classifier: Natural Language :: English
@@ -36,8 +37,6 @@ Classifier: Programming Language :: Python :: Implementation :: PyPy
 Classifier: Topic :: Software Development :: Libraries :: Python Modules
 Requires-Python: >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 Description-Content-Type: text/x-rst
-License-File: LICENSE
-License-File: AUTHORS.rst
 Provides-Extra: dev
 Requires-Dist: coverage[toml] (>=5.0.2) ; extra == 'dev'
 Requires-Dist: hypothesis ; extra == 'dev'
@@ -227,3 +226,5 @@ A full list of contributors can be found in `GitHub's overview <https://github.c
 
 It’s the spiritual successor of `characteristic <https://characteristic.readthedocs.io/>`_ and aspires to fix some of it clunkiness and unfortunate decisions.
 Both were inspired by Twisted’s `FancyEqMixin <https://twistedmatrix.com/documents/current/api/twisted.python.util.FancyEqMixin.html>`_ but both are implemented using class decorators because `subclassing is bad for you <https://www.youtube.com/watch?v=3MNVP9-hglc>`_, m’kay?
+
+

--- a/pex/vendor/_vendored/attrs/attrs-21.5.0.dev0.dist-info/WHEEL
+++ b/pex/vendor/_vendored/attrs/attrs-21.5.0.dev0.dist-info/WHEEL
@@ -1,5 +1,5 @@
 Wheel-Version: 1.0
-Generator: bdist_wheel (0.37.1)
+Generator: bdist_wheel (0.35.1)
 Root-Is-Purelib: true
 Tag: py2-none-any
 Tag: py3-none-any

--- a/pex/vendor/_vendored/attrs/attrs-21.5.0.dev0.dist-info/WHEEL
+++ b/pex/vendor/_vendored/attrs/attrs-21.5.0.dev0.dist-info/WHEEL
@@ -1,5 +1,5 @@
 Wheel-Version: 1.0
-Generator: bdist_wheel (0.38.3)
+Generator: bdist_wheel (0.37.1)
 Root-Is-Purelib: true
 Tag: py2-none-any
 Tag: py3-none-any

--- a/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/METADATA
+++ b/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/METADATA
@@ -10,6 +10,7 @@ Project-URL: Documentation, https://pip.pypa.io
 Project-URL: Source, https://github.com/pypa/pip
 Project-URL: Changelog, https://pip.pypa.io/en/stable/news/
 Keywords: distutils easy_install egg setuptools wheel virtualenv
+Platform: UNKNOWN
 Classifier: Development Status :: 5 - Production/Stable
 Classifier: Intended Audience :: Developers
 Classifier: License :: OSI Approved :: MIT License
@@ -26,7 +27,6 @@ Classifier: Programming Language :: Python :: 3.9
 Classifier: Programming Language :: Python :: Implementation :: CPython
 Classifier: Programming Language :: Python :: Implementation :: PyPy
 Requires-Python: >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*
-License-File: LICENSE.txt
 
 pip - The Python Package Installer
 ==================================
@@ -90,3 +90,5 @@ rooms, and mailing lists is expected to follow the `PSF Code of Conduct`_.
 .. _User IRC: https://webchat.freenode.net/?channels=%23pypa
 .. _Development IRC: https://webchat.freenode.net/?channels=%23pypa-dev
 .. _PSF Code of Conduct: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
+
+

--- a/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/WHEEL
+++ b/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/WHEEL
@@ -1,5 +1,5 @@
 Wheel-Version: 1.0
-Generator: bdist_wheel (0.37.1)
+Generator: bdist_wheel (0.35.1)
 Root-Is-Purelib: true
 Tag: py2-none-any
 Tag: py3-none-any

--- a/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/WHEEL
+++ b/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/WHEEL
@@ -1,5 +1,5 @@
 Wheel-Version: 1.0
-Generator: bdist_wheel (0.38.3)
+Generator: bdist_wheel (0.37.1)
 Root-Is-Purelib: true
 Tag: py2-none-any
 Tag: py3-none-any

--- a/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/entry_points.txt
+++ b/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/entry_points.txt
@@ -2,3 +2,4 @@
 pip = pip._internal.cli.main:main
 pip3 = pip._internal.cli.main:main
 pip3.8 = pip._internal.cli.main:main
+

--- a/pex/vendor/_vendored/setuptools/setuptools-44.0.0+3acb925dd708430aeaf197ea53ac8a752f7c1863.dist-info/WHEEL
+++ b/pex/vendor/_vendored/setuptools/setuptools-44.0.0+3acb925dd708430aeaf197ea53ac8a752f7c1863.dist-info/WHEEL
@@ -1,5 +1,5 @@
 Wheel-Version: 1.0
-Generator: bdist_wheel (0.38.3)
+Generator: bdist_wheel (0.35.1)
 Root-Is-Purelib: true
 Tag: py2-none-any
 Tag: py3-none-any


### PR DESCRIPTION
This was all accounted for with `--no-build-isolation` and tox venv
pinning with an extensive comment about all this to boot. For some
reason unclear to me, I undid `--no-build-isolation` in
https://github.com/pantsbuild/pex/pull/1661 though.

This just re-instates that flag and re-runs vendoring to get back to
stable wheel versions.