### PR TITLE
Only insert `""` to head of `sys.path` if a venv PEX runs in interpreter mode

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -628,6 +628,7 @@ class PEX(object):  # noqa: T000
         # type: () -> Any
 
         # A Python interpreter always inserts the CWD at the head of the sys.path.
+        # See https://docs.python.org/3/library/sys.html#sys.path
         sys.path.insert(0, "")
 
         args = sys.argv[1:]

--- a/pex/venv/pex.py
+++ b/pex/venv/pex.py
@@ -489,18 +489,18 @@ def _populate_sources(
                 os.execv(script_path, [script_path] + sys.argv[1:])
 
             pex_interpreter = pex_overrides.get("PEX_INTERPRETER", "").lower() in ("1", "true")
-
-            if pex_interpreter:
-                # A Python interpreter always inserts the CWD at the head of the sys.path.
-                # See https://docs.python.org/3/library/sys.html#sys.path
-                sys.path.insert(0, "")
-
             PEX_INTERPRETER_ENTRYPOINT = "code:interact"
             entry_point = (
                 PEX_INTERPRETER_ENTRYPOINT
                 if pex_interpreter
                 else pex_overrides.get("PEX_MODULE", {entry_point!r} or PEX_INTERPRETER_ENTRYPOINT)
             )
+
+            if entry_point == PEX_INTERPRETER_ENTRYPOINT:
+                # A Python interpreter always inserts the CWD at the head of the sys.path.
+                # See https://docs.python.org/3/library/sys.html#sys.path
+                sys.path.insert(0, "")
+
             if entry_point == PEX_INTERPRETER_ENTRYPOINT and len(sys.argv) > 1:
                 args = sys.argv[1:]
 

--- a/pex/venv/pex.py
+++ b/pex/venv/pex.py
@@ -489,6 +489,12 @@ def _populate_sources(
                 os.execv(script_path, [script_path] + sys.argv[1:])
 
             pex_interpreter = pex_overrides.get("PEX_INTERPRETER", "").lower() in ("1", "true")
+
+            if pex_interpreter:
+                # A Python interpreter always inserts the CWD at the head of the sys.path.
+                # See https://docs.python.org/3/library/sys.html#sys.path
+                sys.path.insert(0, "")
+
             PEX_INTERPRETER_ENTRYPOINT = "code:interact"
             entry_point = (
                 PEX_INTERPRETER_ENTRYPOINT

--- a/pex/venv/pex.py
+++ b/pex/venv/pex.py
@@ -440,9 +440,6 @@ def _populate_sources(
 
             os.environ["VIRTUAL_ENV"] = venv_dir
 
-            # A Python interpreter always inserts the CWD at the head of the sys.path.
-            sys.path.insert(0, "")
-
             bin_path = os.environ.get("PEX_VENV_BIN_PATH", {bin_path!r})
             if bin_path != "false":
                 PATH = os.environ.get("PATH", "").split(os.pathsep)


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pex/issues/1983.

Note that this PR doesn't revert the code to use the prior code (`sys.path.extend(os.environ.get("PEX_EXTRA_SYS_PATH", "").split(os.pathsep))`) as that might still add `""` when `PEX_EXTRA_SYS_PATH` is not in the environment.

Also note that this doesn't change anything related to https://github.com/pantsbuild/pex/issues/1982 (whose outcome might be that `""` is in `sys.path`, but for other reasons and in unrelated cases).