### PR TITLE
Fix CI break.

### DIFF
--- a/tests/integration/test_issue_729.py
+++ b/tests/integration/test_issue_729.py
@@ -41,6 +41,7 @@ def test_undeclared_setuptools_import_on_pex_path(tmpdir):
     constraints = os.path.join(str(tmpdir), "constraints.txt")
     with open(constraints, "w") as fp:
         print("google-api-core==1.32.0", file=fp)
+        print("googleapis-common-protos==1.56.4", file=fp)
         print("google-crc32c==1.1.2", file=fp)
         print("protobuf<=3.17.3", file=fp)
 

--- a/tests/integration/test_issue_729.py
+++ b/tests/integration/test_issue_729.py
@@ -41,7 +41,7 @@ def test_undeclared_setuptools_import_on_pex_path(tmpdir):
     constraints = os.path.join(str(tmpdir), "constraints.txt")
     with open(constraints, "w") as fp:
         print("google-api-core==1.32.0", file=fp)
-        print("googleapis-common-protos==1.56.4", file=fp)
+        print("googleapis-common-protos<=1.56.4", file=fp)
         print("google-crc32c==1.1.2", file=fp)
         print("protobuf<=3.17.3", file=fp)
 


### PR DESCRIPTION
The googleapis-common-protos 1.57.0 release on 11/15 breaks the test_issue_729 test_undeclared_setuptools_import_on_pex_path test. Pin behind that release to fix CI on main.