### PR TITLE
Use raw version when exporting

### DIFF
--- a/pex/cli/commands/lock.py
+++ b/pex/cli/commands/lock.py
@@ -545,7 +545,7 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
                     "{project_name}=={version} \\\n"
                     "  {hashes}\n".format(
                         project_name=pin.project_name,
-                        version=pin.version,
+                        version=pin.version.raw,
                         hashes=" \\\n  ".join(
                             "--hash={algorithm}:{hash}".format(
                                 algorithm=fingerprint.algorithm, hash=fingerprint.hash

--- a/tests/integration/cli/commands/test_export.py
+++ b/tests/integration/cli/commands/test_export.py
@@ -117,6 +117,50 @@ def test_export_single_artifact(tmpdir):
         == export(tmpdir, attr.evolve(UNIVERSAL_ANSICOLORS, allow_wheels=False))
     )
 
+def test_export_normalizes_name_but_not_version(tmpdir):
+    # type: (Any) -> None
+
+    assert (
+        dedent(
+            """\
+             twitter-common-decorators==1.3.0 \\
+               --hash=md5:abcd1234 \\
+               --hash=sha1:ef567890
+            """
+        )
+        == export(
+            tmpdir,
+            attr.evolve(
+                UNIVERSAL_ANSICOLORS,
+                requirements=SortedTuple([Requirement.parse("twitter.common.decorators")]),
+                locked_resolves=SortedTuple(
+                    [
+                        LockedResolve(
+                            locked_requirements=SortedTuple(
+                                [
+                                    LockedRequirement(
+                                        pin=Pin(ProjectName("twitter.common.decorators"), Version("1.3.0")),
+                                        artifact=Artifact.from_url(
+                                            url="http://localhost:9999/twitter.common.decorators-1.3.0-py2.py3-none-any.whl",
+                                            fingerprint=Fingerprint(algorithm="md5", hash="abcd1234"),
+                                        ),
+                                        additional_artifacts=SortedTuple(
+                                            [
+                                                Artifact.from_url(
+                                                    url="http://localhost:9999/twitter.common.decorators-1.3.0.tar.gz",
+                                                    fingerprint=Fingerprint(algorithm="sha1", hash="ef567890"),
+                                                )
+                                            ]
+                                        ),
+                                    )
+                                ],
+                            ),
+                        )
+                    ]
+                ),
+            )
+        )
+    )
 
 def test_export_respects_target(tmpdir):
     # type: (Any) -> None

--- a/tests/integration/cli/commands/test_export.py
+++ b/tests/integration/cli/commands/test_export.py
@@ -121,53 +121,48 @@ def test_export_single_artifact(tmpdir):
 def test_export_normalizes_name_but_not_version(tmpdir):
     # type: (Any) -> None
 
-    assert (
-        dedent(
-            """\
+    assert dedent(
+        """\
              twitter-common-decorators==1.3.0 \\
                --hash=md5:abcd1234 \\
                --hash=sha1:ef567890
             """
-        )
-        == export(
-            tmpdir,
-            attr.evolve(
-                UNIVERSAL_ANSICOLORS,
-                requirements=SortedTuple([Requirement.parse("twitter.common.decorators")]),
-                locked_resolves=SortedTuple(
-                    [
-                        LockedResolve(
-                            locked_requirements=SortedTuple(
-                                [
-                                    LockedRequirement(
-                                        pin=Pin(
-                                            ProjectName("twitter.common.decorators"),
-                                            Version("1.3.0"),
-                                        ),
-                                        artifact=Artifact.from_url(
-                                            url="http://localhost:9999/twitter.common.decorators-1.3.0-py2.py3-none-any.whl",
-                                            fingerprint=Fingerprint(
-                                                algorithm="md5", hash="abcd1234"
-                                            ),
-                                        ),
-                                        additional_artifacts=SortedTuple(
-                                            [
-                                                Artifact.from_url(
-                                                    url="http://localhost:9999/twitter.common.decorators-1.3.0.tar.gz",
-                                                    fingerprint=Fingerprint(
-                                                        algorithm="sha1", hash="ef567890"
-                                                    ),
-                                                )
-                                            ]
-                                        ),
-                                    )
-                                ],
-                            ),
-                        )
-                    ]
-                ),
+    ) == export(
+        tmpdir,
+        attr.evolve(
+            UNIVERSAL_ANSICOLORS,
+            requirements=SortedTuple([Requirement.parse("twitter.common.decorators")]),
+            locked_resolves=SortedTuple(
+                [
+                    LockedResolve(
+                        locked_requirements=SortedTuple(
+                            [
+                                LockedRequirement(
+                                    pin=Pin(
+                                        ProjectName("twitter.common.decorators"),
+                                        Version("1.3.0"),
+                                    ),
+                                    artifact=Artifact.from_url(
+                                        url="http://localhost:9999/twitter.common.decorators-1.3.0-py2.py3-none-any.whl",
+                                        fingerprint=Fingerprint(algorithm="md5", hash="abcd1234"),
+                                    ),
+                                    additional_artifacts=SortedTuple(
+                                        [
+                                            Artifact.from_url(
+                                                url="http://localhost:9999/twitter.common.decorators-1.3.0.tar.gz",
+                                                fingerprint=Fingerprint(
+                                                    algorithm="sha1", hash="ef567890"
+                                                ),
+                                            )
+                                        ]
+                                    ),
+                                )
+                            ],
+                        ),
+                    )
+                ]
             ),
-        )
+        ),
     )
 
 

--- a/tests/integration/cli/commands/test_export.py
+++ b/tests/integration/cli/commands/test_export.py
@@ -117,6 +117,7 @@ def test_export_single_artifact(tmpdir):
         == export(tmpdir, attr.evolve(UNIVERSAL_ANSICOLORS, allow_wheels=False))
     )
 
+
 def test_export_normalizes_name_but_not_version(tmpdir):
     # type: (Any) -> None
 
@@ -139,16 +140,23 @@ def test_export_normalizes_name_but_not_version(tmpdir):
                             locked_requirements=SortedTuple(
                                 [
                                     LockedRequirement(
-                                        pin=Pin(ProjectName("twitter.common.decorators"), Version("1.3.0")),
+                                        pin=Pin(
+                                            ProjectName("twitter.common.decorators"),
+                                            Version("1.3.0"),
+                                        ),
                                         artifact=Artifact.from_url(
                                             url="http://localhost:9999/twitter.common.decorators-1.3.0-py2.py3-none-any.whl",
-                                            fingerprint=Fingerprint(algorithm="md5", hash="abcd1234"),
+                                            fingerprint=Fingerprint(
+                                                algorithm="md5", hash="abcd1234"
+                                            ),
                                         ),
                                         additional_artifacts=SortedTuple(
                                             [
                                                 Artifact.from_url(
                                                     url="http://localhost:9999/twitter.common.decorators-1.3.0.tar.gz",
-                                                    fingerprint=Fingerprint(algorithm="sha1", hash="ef567890"),
+                                                    fingerprint=Fingerprint(
+                                                        algorithm="sha1", hash="ef567890"
+                                                    ),
                                                 )
                                             ]
                                         ),
@@ -158,9 +166,10 @@ def test_export_normalizes_name_but_not_version(tmpdir):
                         )
                     ]
                 ),
-            )
+            ),
         )
     )
+
 
 def test_export_respects_target(tmpdir):
     # type: (Any) -> None


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pex/issues/1989 and matches `pip-compile`'s behavior.

Test fails before change, passes after.