### PR TITLE
Check for --complete-platforms match when --resolve-local-platforms

### DIFF
--- a/pex/resolve/target_configuration.py
+++ b/pex/resolve/target_configuration.py
@@ -20,7 +20,7 @@ from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
 
 if TYPE_CHECKING:
-    from typing import Iterator, Optional, Tuple
+    from typing import FrozenSet, Iterator, Optional, Set, Tuple
 
     import attr  # vendor:skip
 else:
@@ -104,11 +104,11 @@ def _interpreter_compatible_platforms(
     all_platforms,  # type: OrderedDict[Optional[Platform], Optional[CompletePlatform]]
     candidate_interpreter,  # type: PythonInterpreter
 ):
-    # type: (...) -> frozenset[Platform]
+    # type: (...) -> FrozenSet[Platform]
     resolved_platforms = candidate_interpreter.supported_platforms.intersection(
         all_platforms
-    )  # type: frozenset[Platform]
-    incompatible_platforms = set()  # type: set[Platform]
+    )  # type: FrozenSet[Platform]
+    incompatible_platforms = set()  # type: Set[Platform]
 
     for resolved_platform in resolved_platforms:
         requested_complete = all_platforms[resolved_platform]

--- a/pex/resolve/target_configuration.py
+++ b/pex/resolve/target_configuration.py
@@ -100,6 +100,73 @@ class InterpreterConstraintsNotSatisfied(TargetConfigurationError):
     """Indicates no interpreter meeting the requested constraints could be found."""
 
 
+def _interpreter_compatible_platforms(
+    all_platforms,  # type: OrderedDict[Optional[Platform], Optional[CompletePlatform]]
+    candidate_interpreter,  # type: PythonInterpreter
+):
+    # type: (...) -> frozenset[Platform]
+    resolved_platforms = candidate_interpreter.supported_platforms.intersection(
+        all_platforms
+    )  # type: frozenset[Platform]
+    incompatible_platforms = set()  # type: set[Platform]
+
+    for resolved_platform in resolved_platforms:
+        requested_complete = all_platforms[resolved_platform]
+        if requested_complete is not None:
+            # if there was an explicit complete platform specified, only use the local interpreter
+            # when the interpreter's tags are a subset of the complete platform's: tags supported by
+            # the interpreter but not the complete platform may result in incompatible wheels being
+            # chosen, if the interpreter was used directly
+            candidate_complete = CompletePlatform.from_interpreter(candidate_interpreter)
+            requested_tags = set(requested_complete.supported_tags)
+            missing_tags = OrderedSet(
+                t for t in candidate_complete.supported_tags if t not in requested_tags
+            )
+            if missing_tags:
+                TRACER.log(
+                    "Rejected resolution of {} for platform {} due to supporting {} extra tags".format(
+                        candidate_interpreter,
+                        resolved_platform,
+                        len(missing_tags),
+                    ),
+                    V=3,
+                )
+                TRACER.log(
+                    "Extra tags supported by {} for platform {} but not supported by specified complete platform: {}".format(
+                        candidate_interpreter,
+                        resolved_platform,
+                        ", ".join(map(str, missing_tags)),
+                    ),
+                    V=9,
+                )
+                # keep iterating to give information about each of the relevant platforms
+                incompatible_platforms.add(resolved_platform)
+                continue
+
+        TRACER.log(
+            "Provisionally accepted resolution of {} for platform {} due to matching {}".format(
+                candidate_interpreter,
+                resolved_platform,
+                "tags"
+                if requested_complete is not None
+                else "platform (no complete platform and thus no tags to check)",
+            ),
+            V=3,
+        )
+
+    if incompatible_platforms:
+        TRACER.log(
+            "Rejected interpreter {} due to being incompatible with {}: {}".format(
+                candidate_interpreter,
+                "a platform" if len(incompatible_platforms) == 1 else "some platforms",
+                ", ".join(sorted(map(str, incompatible_platforms))),
+            )
+        )
+        return frozenset()
+
+    return resolved_platforms
+
+
 @attr.s(frozen=True)
 class TargetConfiguration(object):
     interpreter_configuration = attr.ib(
@@ -151,30 +218,11 @@ class TargetConfiguration(object):
                 )  # type: OrderedSet[PythonInterpreter]
                 candidate_interpreters.add(PythonInterpreter.get())
                 for candidate_interpreter in candidate_interpreters:
-                    resolved_platforms = candidate_interpreter.supported_platforms.intersection(
-                        all_platforms
+                    resolved_platforms = _interpreter_compatible_platforms(
+                        all_platforms, candidate_interpreter
                     )
                     if resolved_platforms:
                         for resolved_platform in resolved_platforms:
-                            # if there was an explicit complete platform specified, only use the
-                            # local interpreter if it exactly matches, or else incorrect wheels may
-                            # be chosen
-                            requested_complete = all_platforms[resolved_platform]
-                            candidate_complete = CompletePlatform.from_interpreter(
-                                candidate_interpreter
-                            )
-                            if (
-                                requested_complete is not None
-                                and requested_complete != candidate_complete
-                            ):
-                                TRACER.log(
-                                    "Rejected resolution of {} for platform {} due to different complete platforms".format(
-                                        candidate_interpreter, resolved_platform
-                                    ),
-                                    V=3,
-                                )
-                                continue
-
                             TRACER.log(
                                 "Resolved {} for platform {}".format(
                                     candidate_interpreter, resolved_platform

--- a/pex/resolve/target_configuration.py
+++ b/pex/resolve/target_configuration.py
@@ -156,6 +156,25 @@ class TargetConfiguration(object):
                     )
                     if resolved_platforms:
                         for resolved_platform in resolved_platforms:
+                            # if there was an explicit complete platform specified, only use the
+                            # local interpreter if it exactly matches, or else incorrect wheels may
+                            # be chosen
+                            requested_complete = all_platforms[resolved_platform]
+                            candidate_complete = CompletePlatform.from_interpreter(
+                                candidate_interpreter
+                            )
+                            if (
+                                requested_complete is not None
+                                and requested_complete != candidate_complete
+                            ):
+                                TRACER.log(
+                                    "Rejected resolution of {} for platform {} due to different complete platforms".format(
+                                        candidate_interpreter, resolved_platform
+                                    ),
+                                    V=3,
+                                )
+                                continue
+
                             TRACER.log(
                                 "Resolved {} for platform {}".format(
                                     candidate_interpreter, resolved_platform

--- a/tests/resolve/test_target_options.py
+++ b/tests/resolve/test_target_options.py
@@ -22,7 +22,7 @@ from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
 
 if TYPE_CHECKING:
-    from typing import Any, Iterable, List, Optional, Tuple
+    from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
 def compute_target_configuration(
@@ -400,8 +400,8 @@ def test_configure_resolve_local_platforms_with_complete_platforms(
 
     def dump_complete_platform(
         name,  # type: str
-        marker_environment,  # type: dict[str, str]
-        compatible_tags,  # type: list[str]
+        marker_environment,  # type: Dict[str, str]
+        compatible_tags,  # type: List[str]
         **extra_fields  # type: Any
     ):
         # type: (...) -> str
@@ -456,15 +456,16 @@ def test_configure_resolve_local_platforms_with_complete_platforms(
         py310.identity.env_markers.as_dict(),
         py310.identity.supported_tags.to_string_list(),
     )
+    py39999_env_markers = py310.identity.env_markers.as_dict()
+    py39999_env_markers.update(
+        implementation_version="3.9999.0",
+        python_full_version="3.9999.0",
+        python_version="3.9999",
+        sys_platform="linux",
+    )
     py39999_complete = dump_complete_platform(
         "other",
-        {
-            **py310.identity.env_markers.as_dict(),
-            "implementation_version": "3.9999.0",
-            "python_full_version": "3.9999.0",
-            "python_version": "3.9999",
-            "sys_platform": "linux",
-        },
+        py39999_env_markers,
         [
             "py39999-none-any",
             "py3-none-any",


### PR DESCRIPTION
This makes --resolve-local-platforms work better with --complete-platforms: if there's an external complete platform specified for a platform that matches a local interpreter, the local interpreter's complete platform is checked against that external complete platform. If the local interpreter supports any additional tags, the local interpreter is not used.

If the local interpreter/environment is newer (supports more tags), the old behaviour would risk including wheels that aren't compatible with the external complete platform. That is, execution will fail, see https://github.com/pantsbuild/pants/issues/17621 for an example.

Fixes #1899 
