### PR TITLE
Fix interpreter constraint parsing.

### DIFF
--- a/pex/sh_boot.py
+++ b/pex/sh_boot.py
@@ -53,11 +53,16 @@ def _calculate_applicable_binary_names(
     if interpreter_constraints:
         ic_majors_minors.update(
             PythonBinaryName(
-                name=calculate_binary_name(interpreter_constraint.requirement.name), version=version
+                name=calculate_binary_name(platform_python_implementation=name), version=version
             )
             for interpreter_constraint in interpreter_constraints
             for version in iter_compatible_versions(
                 requires_python=[str(interpreter_constraint.requires_python)]
+            )
+            for name in (
+                (interpreter_constraint.name,)
+                if interpreter_constraint.name
+                else ("CPython", "PyPy")
             )
         )
     # If we get targets from ICs, we only want explicitly specified local interpreter targets;

--- a/tests/bin/test_sh_boot.py
+++ b/tests/bin/test_sh_boot.py
@@ -136,11 +136,14 @@ def test_calculate_no_targets_ics():
     assert (
         expected(
             PythonBinaryName(name="python", version=(3, 7)),
-            PythonBinaryName(name="python", version=(3, 8)),
-            PythonBinaryName(name="python", version=(3, 9)),
             PythonBinaryName(name="pypy", version=(3, 7)),
+            PythonBinaryName(name="python", version=(3, 8)),
+            PythonBinaryName(name="pypy", version=(3, 8)),
+            PythonBinaryName(name="python", version=(3, 9)),
+            PythonBinaryName(name="pypy", version=(3, 9)),
+            PythonBinaryName(name="pypy", version=(3, 6)),
         )
-        == calculate_binary_names(interpreter_constraints=[">=3.7,<3.10", "PyPy==3.7.*"])
+        == calculate_binary_names(interpreter_constraints=[">=3.7,<3.10", "PyPy==3.6.*"])
     )
 
 

--- a/tests/integration/test_issue_1995.py
+++ b/tests/integration/test_issue_1995.py
@@ -5,7 +5,7 @@ import os.path
 import subprocess
 import sys
 
-from pex.testing import make_env, run_pex_command
+from pex.testing import PY38, ensure_python_interpreter, make_env, run_pex_command
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -28,9 +28,13 @@ def test_packaging(
             "-v",
             "--pex-output-file",
             pex,
-        ]
+        ],
+        # The package script requires Python 3.
+        python=sys.executable if sys.version_info[0] >= 3 else ensure_python_interpreter(PY38),
     ).assert_success()
     assert os.path.exists(pex), "Expected {pex} to be created by {package_script}.".format(
         pex=pex, package_script=package_script
     )
+    # The packaged Pex PEX should work with all Pythons we support, including the current test
+    # interpreter.
     subprocess.check_call(args=[sys.executable, pex, "-V"], env=make_env(PEX_PYTHON=sys.executable))

--- a/tests/integration/test_issue_1995.py
+++ b/tests/integration/test_issue_1995.py
@@ -5,7 +5,7 @@ import os.path
 import subprocess
 import sys
 
-from pex.testing import make_env
+from pex.testing import make_env, run_pex_command
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -18,18 +18,19 @@ def test_packaging(
 ):
     # type: (...) -> None
     pex = os.path.join(str(tmpdir), "pex.pex")
-    subprocess.check_call(
+    package_script = os.path.join(pex_project_dir, "scripts", "package.py")
+    run_pex_command(
         args=[
-            "tox",
-            "-c",
-            os.path.join(pex_project_dir, "tox.ini"),
-            "-e",
-            "package",
+            "toml",
+            pex_project_dir,
             "--",
+            package_script,
             "-v",
             "--pex-output-file",
             pex,
         ]
+    ).assert_success()
+    assert os.path.exists(pex), "Expected {pex} to be created by {package_script}.".format(
+        pex=pex, package_script=package_script
     )
-    assert os.path.exists(pex), "Expected {pex} to be created by tox -epackage.".format(pex=pex)
     subprocess.check_call(args=[sys.executable, pex, "-V"], env=make_env(PEX_PYTHON=sys.executable))

--- a/tests/integration/test_issue_1995.py
+++ b/tests/integration/test_issue_1995.py
@@ -12,8 +12,23 @@ if TYPE_CHECKING:
     from typing import Any
 
 
-def test_packaging(tmpdir):
-    # type: (Any) -> None
+def test_packaging(
+    tmpdir,  # type: Any
+    pex_project_dir,  # type: str
+):
+    # type: (...) -> None
     pex = os.path.join(str(tmpdir), "pex.pex")
-    subprocess.check_call(args=["tox", "-e", "package", "--", "--pex-output-file", pex])
+    subprocess.check_call(
+        args=[
+            "tox",
+            "-c",
+            os.path.join(pex_project_dir, "tox.ini"),
+            "-e",
+            "package",
+            "--",
+            "--pex-output-file",
+            pex,
+        ]
+    )
+    assert os.path.exists(pex), "Expected {pex} to be created by tox -epackage.".format(pex=pex)
     subprocess.check_call(args=[sys.executable, pex, "-V"], env=make_env(PEX_PYTHON=sys.executable))

--- a/tests/integration/test_issue_1995.py
+++ b/tests/integration/test_issue_1995.py
@@ -1,0 +1,19 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+import subprocess
+import sys
+
+from pex.testing import make_env
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_packaging(tmpdir):
+    # type: (Any) -> None
+    pex = os.path.join(str(tmpdir), "pex.pex")
+    subprocess.check_call(args=["tox", "-e", "package", "--", "--pex-output-file", pex])
+    subprocess.check_call(args=[sys.executable, pex, "-V"], env=make_env(PEX_PYTHON=sys.executable))

--- a/tests/integration/test_issue_1995.py
+++ b/tests/integration/test_issue_1995.py
@@ -26,6 +26,7 @@ def test_packaging(
             "-e",
             "package",
             "--",
+            "-v",
             "--pex-output-file",
             pex,
         ]

--- a/tests/test_interpreter_constraints.py
+++ b/tests/test_interpreter_constraints.py
@@ -5,11 +5,23 @@ import itertools
 import sys
 
 from pex import interpreter_constraints
-from pex.interpreter_constraints import COMPATIBLE_PYTHON_VERSIONS, Lifecycle
+from pex.interpreter import PythonInterpreter
+from pex.interpreter_constraints import COMPATIBLE_PYTHON_VERSIONS, InterpreterConstraint, Lifecycle
+from pex.testing import PY27, PY38, PY310, ensure_python_interpreter
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import List, Tuple
+
+
+def test_parse():
+    py38 = PythonInterpreter.from_binary(ensure_python_interpreter(PY38))
+
+    assert py38 in InterpreterConstraint.parse("==3.8.*")
+    assert py38 in InterpreterConstraint.parse("CPython==3.8.*")
+    assert py38 in InterpreterConstraint.parse("==3.8.*", default_interpreter="CPython")
+    assert py38 not in InterpreterConstraint.parse("==3.8.*", default_interpreter="PyPy")
+    assert py38 not in InterpreterConstraint.parse("PyPy==3.8.*")
 
 
 def iter_compatible_versions(*requires_python):


### PR DESCRIPTION
Previously a bare specifier assumed CPython; now it does not.

Fixes #1995