### PR TITLE
Add `--non-hermetic-scripts` option to `venv` tool.

### DIFF
--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -164,6 +164,16 @@ class Venv(PEXCommand):
                 )
             ),
         )
+        parser.add_argument(
+            "--non-hermetic",
+            dest="hermetic",
+            action="store_false",
+            default=True,
+            help=(
+                "Don't rewrite console script shebangs in the venv to pass `-sE` to the interpreter; "
+                "for example, to enable running venv scripts with a custom `PYTHONPATH`."
+            ),
+        )
         cls.register_global_arguments(parser, include_verbosity=False)
 
     def run(self, pex):
@@ -196,6 +206,7 @@ class Venv(PEXCommand):
             collisions_ok=self.options.collisions_ok,
             symlink=False,
             scope=self.options.scope,
+            hermetic=self.options.hermetic,
         )
         if self.options.pip:
             try:

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -165,8 +165,8 @@ class Venv(PEXCommand):
             ),
         )
         parser.add_argument(
-            "--non-hermetic",
-            dest="hermetic",
+            "--non-hermetic-scripts",
+            dest="hermetic_scripts",
             action="store_false",
             default=True,
             help=(
@@ -206,7 +206,7 @@ class Venv(PEXCommand):
             collisions_ok=self.options.collisions_ok,
             symlink=False,
             scope=self.options.scope,
-            hermetic=self.options.hermetic,
+            hermetic_scripts=self.options.hermetic_scripts,
         )
         if self.options.pip:
             try:

--- a/pex/venv/pex.py
+++ b/pex/venv/pex.py
@@ -103,7 +103,7 @@ def populate_venv(
     collisions_ok=True,  # type: bool
     symlink=False,  # type: bool
     scope=InstallScope.ALL,  # type: InstallScope.Value
-    hermetic=True,  # type: bool
+    hermetic_scripts=True,  # type: bool
 ):
     # type: (...) -> str
 
@@ -118,7 +118,7 @@ def populate_venv(
             provenance[dst].append(src)
 
     if scope in (InstallScope.ALL, InstallScope.DEPS_ONLY):
-        record_provenance(_populate_deps(venv, pex, venv_python, symlink, hermetic))
+        record_provenance(_populate_deps(venv, pex, venv_python, symlink, hermetic_scripts))
 
     if scope in (InstallScope.ALL, InstallScope.SOURCE_ONLY):
         record_provenance(_populate_sources(venv, pex, shebang, venv_python, bin_path))
@@ -196,7 +196,7 @@ def _populate_deps(
     pex,  # type: PEX
     venv_python,  # type: str
     symlink=False,  # type: bool
-    hermetic=True,  # type: bool
+    hermetic_scripts=True,  # type: bool
 ):
     # type: (...) -> Iterator[Tuple[str, str]]
 
@@ -276,7 +276,7 @@ def _populate_deps(
                     print(rel_extra_path, file=fp)
 
     # 3. Re-write any (console) scripts to use the venv Python.
-    script_python_args = "-sE" if hermetic else None
+    script_python_args = "-sE" if hermetic_scripts else None
     for script in venv.rewrite_scripts(python=venv_python, python_args=script_python_args):
         TRACER.log("Re-writing {}".format(script))
 

--- a/pex/venv/pex.py
+++ b/pex/venv/pex.py
@@ -103,6 +103,7 @@ def populate_venv(
     collisions_ok=True,  # type: bool
     symlink=False,  # type: bool
     scope=InstallScope.ALL,  # type: InstallScope.Value
+    hermetic=True,  # type: bool
 ):
     # type: (...) -> str
 
@@ -117,7 +118,7 @@ def populate_venv(
             provenance[dst].append(src)
 
     if scope in (InstallScope.ALL, InstallScope.DEPS_ONLY):
-        record_provenance(_populate_deps(venv, pex, venv_python, symlink))
+        record_provenance(_populate_deps(venv, pex, venv_python, symlink, hermetic))
 
     if scope in (InstallScope.ALL, InstallScope.SOURCE_ONLY):
         record_provenance(_populate_sources(venv, pex, shebang, venv_python, bin_path))
@@ -195,6 +196,7 @@ def _populate_deps(
     pex,  # type: PEX
     venv_python,  # type: str
     symlink=False,  # type: bool
+    hermetic=True,  # type: bool
 ):
     # type: (...) -> Iterator[Tuple[str, str]]
 
@@ -274,7 +276,8 @@ def _populate_deps(
                     print(rel_extra_path, file=fp)
 
     # 3. Re-write any (console) scripts to use the venv Python.
-    for script in venv.rewrite_scripts(python=venv_python, python_args="-sE"):
+    script_python_args = "-sE" if hermetic else None
+    for script in venv.rewrite_scripts(python=venv_python, python_args=script_python_args):
         TRACER.log("Re-writing {}".format(script))
 
 

--- a/tests/integration/tools/commands/test_venv.py
+++ b/tests/integration/tools/commands/test_venv.py
@@ -329,7 +329,7 @@ def test_non_hermetic_issue_2004(
     non_hermetic_venv = os.path.join(str(tmpdir), "non-hermetic")
 
     run_pex_tools(check_pex, "venv", hermetic_venv).assert_success()
-    run_pex_tools(check_pex, "venv", "--non-hermetic", non_hermetic_venv).assert_success()
+    run_pex_tools(check_pex, "venv", "--non-hermetic-scripts", non_hermetic_venv).assert_success()
 
     hermetic_check = subprocess.check_output(
         args=[os.path.join(hermetic_venv, "bin", "check-hermetic")],


### PR DESCRIPTION
Closes #2004 

When the option is set, console scripts in the generated virtualenv will not pass `-sE` to `python` in their shebangs. This is needed to allow customization of `PYTHONPATH` when running tools like `pylint`.