### PR TITLE
Support REPL command history.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,125 +21,125 @@ jobs:
     steps:
       - name: Noop
         run: "true"
-#  checks:
-#    name:  TOXENV=format-check,typecheck,vendor-check,package -- --additional-format sdist --additional-format wheel
-#    needs: org-check
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Checkout Pex
-#        uses: actions/checkout@v3
-#        with:
-#          # We need branches and tags since package leans on `git describe`. Passing 0 gets us
-#          # complete history.
-#          fetch-depth: 0
-#      - name: Setup Python 3.8
-#        uses: actions/setup-python@v4
-#        with:
-#          # We need to keep Python 3.8 for consistent vendoring with tox.
-#          python-version: "3.8"
-#      - name: Check Formatting, Types, Vendoring and Packaging
-#        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-#        with:
-#          tox-env: format-check,typecheck,vendor-check,package -- --additional-format sdist --additional-format wheel
-#  cpython-unit-tests:
-#    name: (${{ matrix.os }}) Pip ${{ matrix.pip-version }} TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}
-#    needs: org-check
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      matrix:
-#        include:
-#          - os: macos-11
-#            python-version: [ 2, 7 ]
-#            pip-version: 20
-#          - os: ubuntu-20.04
-#            python-version: [ 2, 7 ]
-#            pip-version: 20
-#          - os: ubuntu-20.04
-#            python-version: [ 3, 5 ]
-#            pip-version: 20
-#          - os: macos-11
-#            python-version: [ 3, 11 ]
-#            pip-version: 20
-#          - os: ubuntu-20.04
-#            python-version: [ 3, 11 ]
-#            pip-version: 20
-#          - os: ubuntu-20.04
-#            python-version: [ 3, 11 ]
-#            pip-version: 22_2
-#          - os: ubuntu-20.04
-#            python-version: [ 3, 11 ]
-#            pip-version: 22_3
-#    steps:
-#      - name: Calculate Pythons to Expose
-#        id: calculate-pythons-to-expose
-#        run: |
-#          skip=""
-#          if [[ "$(uname -s)" == "Linux" ]]; then
-#            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
-#          fi
-#          echo "skip=${skip}" >> $GITHUB_OUTPUT
-#      - name: Checkout Pex
-#        uses: actions/checkout@v3
-#      - name: Setup Python ${{ join(matrix.python-version, '.') }}
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: "${{ join(matrix.python-version, '.') }}"
-#      - name: Expose Pythons
-#        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-#        with:
-#          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
-#      - name: Cache Pyenv Interpreters
-#        uses: actions/cache@v3
-#        with:
-#          path: ${{ env._PEX_TEST_PYENV_ROOT }}
-#          key: ${{ runner.os }}-pyenv-root-v9
-#      - name: Run Unit Tests
-#        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-#        with:
-#          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}
-#  pypy-unit-tests:
-#    name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}
-#    needs: org-check
-#    runs-on: ubuntu-20.04
-#    strategy:
-#      matrix:
-#        include:
-#          - pypy-version: [ 2, 7 ]
-#            pip-version: 20
-#          - pypy-version: [ 3, 9 ]
-#            pip-version: 20
-#          - pypy-version: [ 3, 9 ]
-#            pip-version: 22_2
-#          - pypy-version: [ 3, 9 ]
-#            pip-version: 22_3
-#    steps:
-#      - name: Calculate Pythons to Expose
-#        id: calculate-pythons-to-expose
-#        run: |
-#          skip=""
-#          if [[ "$(uname -s)" == "Linux" ]]; then
-#            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
-#          fi
-#          echo "skip=${skip}" >> $GITHUB_OUTPUT
-#      - name: Checkout Pex
-#        uses: actions/checkout@v3
-#      - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
-#      - name: Expose Pythons
-#        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-#        with:
-#          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
-#      - name: Cache Pyenv Interpreters
-#        uses: actions/cache@v3
-#        with:
-#          path: ${{ env._PEX_TEST_PYENV_ROOT }}
-#          key: ${{ runner.os }}-pyenv-root-v9
-#      - name: Run Unit Tests
-#        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-#        with:
-#          tox-env: pypy${{ join(matrix.pypy-version, '') }}-pip${{ matrix.pip-version }}
+  checks:
+    name:  TOXENV=format-check,typecheck,vendor-check,package -- --additional-format sdist --additional-format wheel
+    needs: org-check
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Pex
+        uses: actions/checkout@v3
+        with:
+          # We need branches and tags since package leans on `git describe`. Passing 0 gets us
+          # complete history.
+          fetch-depth: 0
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          # We need to keep Python 3.8 for consistent vendoring with tox.
+          python-version: "3.8"
+      - name: Check Formatting, Types, Vendoring and Packaging
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+        with:
+          tox-env: format-check,typecheck,vendor-check,package -- --additional-format sdist --additional-format wheel
+  cpython-unit-tests:
+    name: (${{ matrix.os }}) Pip ${{ matrix.pip-version }} TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}
+    needs: org-check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-11
+            python-version: [ 2, 7 ]
+            pip-version: 20
+          - os: ubuntu-20.04
+            python-version: [ 2, 7 ]
+            pip-version: 20
+          - os: ubuntu-20.04
+            python-version: [ 3, 5 ]
+            pip-version: 20
+          - os: macos-11
+            python-version: [ 3, 11 ]
+            pip-version: 20
+          - os: ubuntu-20.04
+            python-version: [ 3, 11 ]
+            pip-version: 20
+          - os: ubuntu-20.04
+            python-version: [ 3, 11 ]
+            pip-version: 22_2
+          - os: ubuntu-20.04
+            python-version: [ 3, 11 ]
+            pip-version: 22_3
+    steps:
+      - name: Calculate Pythons to Expose
+        id: calculate-pythons-to-expose
+        run: |
+          skip=""
+          if [[ "$(uname -s)" == "Linux" ]]; then
+            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
+          fi
+          echo "skip=${skip}" >> $GITHUB_OUTPUT
+      - name: Checkout Pex
+        uses: actions/checkout@v3
+      - name: Setup Python ${{ join(matrix.python-version, '.') }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: "${{ join(matrix.python-version, '.') }}"
+      - name: Expose Pythons
+        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+        with:
+          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
+      - name: Cache Pyenv Interpreters
+        uses: actions/cache@v3
+        with:
+          path: ${{ env._PEX_TEST_PYENV_ROOT }}
+          key: ${{ runner.os }}-pyenv-root-v9
+      - name: Run Unit Tests
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+        with:
+          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}
+  pypy-unit-tests:
+    name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}
+    needs: org-check
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - pypy-version: [ 2, 7 ]
+            pip-version: 20
+          - pypy-version: [ 3, 9 ]
+            pip-version: 20
+          - pypy-version: [ 3, 9 ]
+            pip-version: 22_2
+          - pypy-version: [ 3, 9 ]
+            pip-version: 22_3
+    steps:
+      - name: Calculate Pythons to Expose
+        id: calculate-pythons-to-expose
+        run: |
+          skip=""
+          if [[ "$(uname -s)" == "Linux" ]]; then
+            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
+          fi
+          echo "skip=${skip}" >> $GITHUB_OUTPUT
+      - name: Checkout Pex
+        uses: actions/checkout@v3
+      - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
+      - name: Expose Pythons
+        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+        with:
+          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
+      - name: Cache Pyenv Interpreters
+        uses: actions/cache@v3
+        with:
+          path: ${{ env._PEX_TEST_PYENV_ROOT }}
+          key: ${{ runner.os }}-pyenv-root-v9
+      - name: Run Unit Tests
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+        with:
+          tox-env: pypy${{ join(matrix.pypy-version, '') }}-pip${{ matrix.pip-version }}
   cpython-integration-tests:
     name: (${{ matrix.os }}) Pip ${{ matrix.pip-version }} TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-integration
     needs: org-check
@@ -147,30 +147,30 @@ jobs:
     strategy:
       matrix:
         include:
-#          - os: macos-11
-#            python-version: [ 2, 7 ]
-#            pip-version: 20
-#          - os: ubuntu-20.04
-#            python-version: [ 2, 7 ]
-#            pip-version: 20
-#          - os: ubuntu-20.04
-#            python-version: [ 3, 7 ]
-#            pip-version: 22_2
-#          - os: ubuntu-20.04
-#            python-version: [ 3, 7 ]
-#            pip-version: 22_3
+          - os: macos-11
+            python-version: [ 2, 7 ]
+            pip-version: 20
+          - os: ubuntu-20.04
+            python-version: [ 2, 7 ]
+            pip-version: 20
+          - os: ubuntu-20.04
+            python-version: [ 3, 7 ]
+            pip-version: 22_2
+          - os: ubuntu-20.04
+            python-version: [ 3, 7 ]
+            pip-version: 22_3
           - os: macos-11
             python-version: [ 3, 11 ]
             pip-version: 20
-#          - os: ubuntu-20.04
-#            python-version: [ 3, 11 ]
-#            pip-version: 20
-#          - os: ubuntu-20.04
-#            python-version: [ 3, 11 ]
-#            pip-version: 22_2
-#          - os: ubuntu-20.04
-#            python-version: [ 3, 11 ]
-#            pip-version: 22_3
+          - os: ubuntu-20.04
+            python-version: [ 3, 11 ]
+            pip-version: 20
+          - os: ubuntu-20.04
+            python-version: [ 3, 11 ]
+            pip-version: 22_2
+          - os: ubuntu-20.04
+            python-version: [ 3, 11 ]
+            pip-version: 22_3
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -205,84 +205,82 @@ jobs:
         if: env.SSH_PRIVATE_KEY != ''
         with:
           ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-#      - name: Run Integration Tests
-#        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-#        with:
-#          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}-integration
-#  pypy-integration-tests:
-#    name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}-integration
-#    needs: org-check
-#    runs-on: ubuntu-20.04
-#    strategy:
-#      matrix:
-#        include:
-#          - pypy-version: [ 2, 7 ]
-#            pip-version: 20
-#          - pypy-version: [ 3, 9 ]
-#            pip-version: 20
-#          - pypy-version: [ 3, 9 ]
-#            pip-version: 22_2
-#          - pypy-version: [ 3, 9 ]
-#            pip-version: 22_3
-#    steps:
-#      - name: Calculate Pythons to Expose
-#        id: calculate-pythons-to-expose
-#        run: |
-#          skip=""
-#          if [[ "$(uname -s)" == "Linux" ]]; then
-#            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
-#          fi
-#          echo "skip=${skip}" >> $GITHUB_OUTPUT
-#      - name: Checkout Pex
-#        uses: actions/checkout@v3
-#        with:
-#          # We need branches and tags for some ITs.
-#          fetch-depth: 0
-#      - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
-#      - name: Expose Pythons
-#        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-#        with:
-#          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
-#      - name: Install Packages
-#        run: |
-#          # This is needed for `test_requirement_file_from_url` for building `lxml`.
-#          sudo apt install --yes libxslt-dev
-#      - name: Cache Pyenv Interpreters
-#        uses: actions/cache@v3
-#        with:
-#          path: ${{ env._PEX_TEST_PYENV_ROOT }}
-#          key: ${{ runner.os }}-pyenv-root-v9
-#      - name: Setup SSH Agent
-#        uses: webfactory/ssh-agent@v0.5.4
-#        env:
-#          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-#        if: env.SSH_PRIVATE_KEY != ''
-#        with:
-#          ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
-#      - name: Run Integration Tests
-#        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-#        with:
-#          tox-env: pypy${{ join(matrix.pypy-version, '') }}-pip${{ matrix.pip-version }}-integration
-#  final-status:
-#    name: Gather Final Status
-#    needs:
-#      - checks
-#      - cpython-unit-tests
-#      - pypy-unit-tests
-#      - cpython-integration-tests
-#      - pypy-integration-tests
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Check Non-Success
-#        if: |
-#          contains(needs.*.result, 'cancelled') ||
-#          contains(needs.*.result, 'failure') ||
-#          contains(needs.*.result, 'skipped')
-#        run: "false"
-#      - name: Success
-#        run: "true"
+      - name: Run Integration Tests
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+        with:
+          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}-integration
+  pypy-integration-tests:
+    name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}-integration
+    needs: org-check
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - pypy-version: [ 2, 7 ]
+            pip-version: 20
+          - pypy-version: [ 3, 9 ]
+            pip-version: 20
+          - pypy-version: [ 3, 9 ]
+            pip-version: 22_2
+          - pypy-version: [ 3, 9 ]
+            pip-version: 22_3
+    steps:
+      - name: Calculate Pythons to Expose
+        id: calculate-pythons-to-expose
+        run: |
+          skip=""
+          if [[ "$(uname -s)" == "Linux" ]]; then
+            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
+          fi
+          echo "skip=${skip}" >> $GITHUB_OUTPUT
+      - name: Checkout Pex
+        uses: actions/checkout@v3
+        with:
+          # We need branches and tags for some ITs.
+          fetch-depth: 0
+      - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
+      - name: Expose Pythons
+        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+        with:
+          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
+      - name: Install Packages
+        run: |
+          # This is needed for `test_requirement_file_from_url` for building `lxml`.
+          sudo apt install --yes libxslt-dev
+      - name: Cache Pyenv Interpreters
+        uses: actions/cache@v3
+        with:
+          path: ${{ env._PEX_TEST_PYENV_ROOT }}
+          key: ${{ runner.os }}-pyenv-root-v9
+      - name: Setup SSH Agent
+        uses: webfactory/ssh-agent@v0.5.4
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        if: env.SSH_PRIVATE_KEY != ''
+        with:
+          ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
+      - name: Run Integration Tests
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+        with:
+          tox-env: pypy${{ join(matrix.pypy-version, '') }}-pip${{ matrix.pip-version }}-integration
+  final-status:
+    name: Gather Final Status
+    needs:
+      - checks
+      - cpython-unit-tests
+      - pypy-unit-tests
+      - cpython-integration-tests
+      - pypy-integration-tests
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check Non-Success
+        if: |
+          contains(needs.*.result, 'cancelled') ||
+          contains(needs.*.result, 'failure') ||
+          contains(needs.*.result, 'skipped')
+        run: "false"
+      - name: Success
+        run: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,125 +21,125 @@ jobs:
     steps:
       - name: Noop
         run: "true"
-  checks:
-    name:  TOXENV=format-check,typecheck,vendor-check,package -- --additional-format sdist --additional-format wheel
-    needs: org-check
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout Pex
-        uses: actions/checkout@v3
-        with:
-          # We need branches and tags since package leans on `git describe`. Passing 0 gets us
-          # complete history.
-          fetch-depth: 0
-      - name: Setup Python 3.8
-        uses: actions/setup-python@v4
-        with:
-          # We need to keep Python 3.8 for consistent vendoring with tox.
-          python-version: "3.8"
-      - name: Check Formatting, Types, Vendoring and Packaging
-        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        with:
-          tox-env: format-check,typecheck,vendor-check,package -- --additional-format sdist --additional-format wheel
-  cpython-unit-tests:
-    name: (${{ matrix.os }}) Pip ${{ matrix.pip-version }} TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}
-    needs: org-check
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: macos-11
-            python-version: [ 2, 7 ]
-            pip-version: 20
-          - os: ubuntu-20.04
-            python-version: [ 2, 7 ]
-            pip-version: 20
-          - os: ubuntu-20.04
-            python-version: [ 3, 5 ]
-            pip-version: 20
-          - os: macos-11
-            python-version: [ 3, 11 ]
-            pip-version: 20
-          - os: ubuntu-20.04
-            python-version: [ 3, 11 ]
-            pip-version: 20
-          - os: ubuntu-20.04
-            python-version: [ 3, 11 ]
-            pip-version: 22_2
-          - os: ubuntu-20.04
-            python-version: [ 3, 11 ]
-            pip-version: 22_3
-    steps:
-      - name: Calculate Pythons to Expose
-        id: calculate-pythons-to-expose
-        run: |
-          skip=""
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
-          fi
-          echo "skip=${skip}" >> $GITHUB_OUTPUT
-      - name: Checkout Pex
-        uses: actions/checkout@v3
-      - name: Setup Python ${{ join(matrix.python-version, '.') }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: "${{ join(matrix.python-version, '.') }}"
-      - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        with:
-          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
-      - name: Cache Pyenv Interpreters
-        uses: actions/cache@v3
-        with:
-          path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v9
-      - name: Run Unit Tests
-        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        with:
-          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}
-  pypy-unit-tests:
-    name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}
-    needs: org-check
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        include:
-          - pypy-version: [ 2, 7 ]
-            pip-version: 20
-          - pypy-version: [ 3, 9 ]
-            pip-version: 20
-          - pypy-version: [ 3, 9 ]
-            pip-version: 22_2
-          - pypy-version: [ 3, 9 ]
-            pip-version: 22_3
-    steps:
-      - name: Calculate Pythons to Expose
-        id: calculate-pythons-to-expose
-        run: |
-          skip=""
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
-          fi
-          echo "skip=${skip}" >> $GITHUB_OUTPUT
-      - name: Checkout Pex
-        uses: actions/checkout@v3
-      - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
-      - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        with:
-          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
-      - name: Cache Pyenv Interpreters
-        uses: actions/cache@v3
-        with:
-          path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v9
-      - name: Run Unit Tests
-        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        with:
-          tox-env: pypy${{ join(matrix.pypy-version, '') }}-pip${{ matrix.pip-version }}
+#  checks:
+#    name:  TOXENV=format-check,typecheck,vendor-check,package -- --additional-format sdist --additional-format wheel
+#    needs: org-check
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Checkout Pex
+#        uses: actions/checkout@v3
+#        with:
+#          # We need branches and tags since package leans on `git describe`. Passing 0 gets us
+#          # complete history.
+#          fetch-depth: 0
+#      - name: Setup Python 3.8
+#        uses: actions/setup-python@v4
+#        with:
+#          # We need to keep Python 3.8 for consistent vendoring with tox.
+#          python-version: "3.8"
+#      - name: Check Formatting, Types, Vendoring and Packaging
+#        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+#        with:
+#          tox-env: format-check,typecheck,vendor-check,package -- --additional-format sdist --additional-format wheel
+#  cpython-unit-tests:
+#    name: (${{ matrix.os }}) Pip ${{ matrix.pip-version }} TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}
+#    needs: org-check
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      matrix:
+#        include:
+#          - os: macos-11
+#            python-version: [ 2, 7 ]
+#            pip-version: 20
+#          - os: ubuntu-20.04
+#            python-version: [ 2, 7 ]
+#            pip-version: 20
+#          - os: ubuntu-20.04
+#            python-version: [ 3, 5 ]
+#            pip-version: 20
+#          - os: macos-11
+#            python-version: [ 3, 11 ]
+#            pip-version: 20
+#          - os: ubuntu-20.04
+#            python-version: [ 3, 11 ]
+#            pip-version: 20
+#          - os: ubuntu-20.04
+#            python-version: [ 3, 11 ]
+#            pip-version: 22_2
+#          - os: ubuntu-20.04
+#            python-version: [ 3, 11 ]
+#            pip-version: 22_3
+#    steps:
+#      - name: Calculate Pythons to Expose
+#        id: calculate-pythons-to-expose
+#        run: |
+#          skip=""
+#          if [[ "$(uname -s)" == "Linux" ]]; then
+#            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
+#          fi
+#          echo "skip=${skip}" >> $GITHUB_OUTPUT
+#      - name: Checkout Pex
+#        uses: actions/checkout@v3
+#      - name: Setup Python ${{ join(matrix.python-version, '.') }}
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: "${{ join(matrix.python-version, '.') }}"
+#      - name: Expose Pythons
+#        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+#        with:
+#          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
+#      - name: Cache Pyenv Interpreters
+#        uses: actions/cache@v3
+#        with:
+#          path: ${{ env._PEX_TEST_PYENV_ROOT }}
+#          key: ${{ runner.os }}-pyenv-root-v9
+#      - name: Run Unit Tests
+#        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+#        with:
+#          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}
+#  pypy-unit-tests:
+#    name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}
+#    needs: org-check
+#    runs-on: ubuntu-20.04
+#    strategy:
+#      matrix:
+#        include:
+#          - pypy-version: [ 2, 7 ]
+#            pip-version: 20
+#          - pypy-version: [ 3, 9 ]
+#            pip-version: 20
+#          - pypy-version: [ 3, 9 ]
+#            pip-version: 22_2
+#          - pypy-version: [ 3, 9 ]
+#            pip-version: 22_3
+#    steps:
+#      - name: Calculate Pythons to Expose
+#        id: calculate-pythons-to-expose
+#        run: |
+#          skip=""
+#          if [[ "$(uname -s)" == "Linux" ]]; then
+#            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
+#          fi
+#          echo "skip=${skip}" >> $GITHUB_OUTPUT
+#      - name: Checkout Pex
+#        uses: actions/checkout@v3
+#      - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
+#      - name: Expose Pythons
+#        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+#        with:
+#          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
+#      - name: Cache Pyenv Interpreters
+#        uses: actions/cache@v3
+#        with:
+#          path: ${{ env._PEX_TEST_PYENV_ROOT }}
+#          key: ${{ runner.os }}-pyenv-root-v9
+#      - name: Run Unit Tests
+#        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+#        with:
+#          tox-env: pypy${{ join(matrix.pypy-version, '') }}-pip${{ matrix.pip-version }}
   cpython-integration-tests:
     name: (${{ matrix.os }}) Pip ${{ matrix.pip-version }} TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-integration
     needs: org-check
@@ -147,30 +147,30 @@ jobs:
     strategy:
       matrix:
         include:
+#          - os: macos-11
+#            python-version: [ 2, 7 ]
+#            pip-version: 20
+#          - os: ubuntu-20.04
+#            python-version: [ 2, 7 ]
+#            pip-version: 20
+#          - os: ubuntu-20.04
+#            python-version: [ 3, 7 ]
+#            pip-version: 22_2
+#          - os: ubuntu-20.04
+#            python-version: [ 3, 7 ]
+#            pip-version: 22_3
           - os: macos-11
-            python-version: [ 2, 7 ]
-            pip-version: 20
-          - os: ubuntu-20.04
-            python-version: [ 2, 7 ]
-            pip-version: 20
-          - os: ubuntu-20.04
-            python-version: [ 3, 7 ]
-            pip-version: 22_2
-          - os: ubuntu-20.04
-            python-version: [ 3, 7 ]
-            pip-version: 22_3
-          - os: macos-11
             python-version: [ 3, 11 ]
             pip-version: 20
-          - os: ubuntu-20.04
-            python-version: [ 3, 11 ]
-            pip-version: 20
-          - os: ubuntu-20.04
-            python-version: [ 3, 11 ]
-            pip-version: 22_2
-          - os: ubuntu-20.04
-            python-version: [ 3, 11 ]
-            pip-version: 22_3
+#          - os: ubuntu-20.04
+#            python-version: [ 3, 11 ]
+#            pip-version: 20
+#          - os: ubuntu-20.04
+#            python-version: [ 3, 11 ]
+#            pip-version: 22_2
+#          - os: ubuntu-20.04
+#            python-version: [ 3, 11 ]
+#            pip-version: 22_3
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -205,82 +205,84 @@ jobs:
         if: env.SSH_PRIVATE_KEY != ''
         with:
           ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
-      - name: Run Integration Tests
-        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        with:
-          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}-integration
-  pypy-integration-tests:
-    name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}-integration
-    needs: org-check
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        include:
-          - pypy-version: [ 2, 7 ]
-            pip-version: 20
-          - pypy-version: [ 3, 9 ]
-            pip-version: 20
-          - pypy-version: [ 3, 9 ]
-            pip-version: 22_2
-          - pypy-version: [ 3, 9 ]
-            pip-version: 22_3
-    steps:
-      - name: Calculate Pythons to Expose
-        id: calculate-pythons-to-expose
-        run: |
-          skip=""
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
-          fi
-          echo "skip=${skip}" >> $GITHUB_OUTPUT
-      - name: Checkout Pex
-        uses: actions/checkout@v3
-        with:
-          # We need branches and tags for some ITs.
-          fetch-depth: 0
-      - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
-      - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        with:
-          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
-      - name: Install Packages
-        run: |
-          # This is needed for `test_requirement_file_from_url` for building `lxml`.
-          sudo apt install --yes libxslt-dev
-      - name: Cache Pyenv Interpreters
-        uses: actions/cache@v3
-        with:
-          path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v9
-      - name: Setup SSH Agent
-        uses: webfactory/ssh-agent@v0.5.4
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-        if: env.SSH_PRIVATE_KEY != ''
-        with:
-          ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
-      - name: Run Integration Tests
-        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        with:
-          tox-env: pypy${{ join(matrix.pypy-version, '') }}-pip${{ matrix.pip-version }}-integration
-  final-status:
-    name: Gather Final Status
-    needs:
-      - checks
-      - cpython-unit-tests
-      - pypy-unit-tests
-      - cpython-integration-tests
-      - pypy-integration-tests
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check Non-Success
-        if: |
-          contains(needs.*.result, 'cancelled') ||
-          contains(needs.*.result, 'failure') ||
-          contains(needs.*.result, 'skipped')
-        run: "false"
-      - name: Success
-        run: "true"
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+#      - name: Run Integration Tests
+#        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+#        with:
+#          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}-integration
+#  pypy-integration-tests:
+#    name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}-integration
+#    needs: org-check
+#    runs-on: ubuntu-20.04
+#    strategy:
+#      matrix:
+#        include:
+#          - pypy-version: [ 2, 7 ]
+#            pip-version: 20
+#          - pypy-version: [ 3, 9 ]
+#            pip-version: 20
+#          - pypy-version: [ 3, 9 ]
+#            pip-version: 22_2
+#          - pypy-version: [ 3, 9 ]
+#            pip-version: 22_3
+#    steps:
+#      - name: Calculate Pythons to Expose
+#        id: calculate-pythons-to-expose
+#        run: |
+#          skip=""
+#          if [[ "$(uname -s)" == "Linux" ]]; then
+#            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
+#          fi
+#          echo "skip=${skip}" >> $GITHUB_OUTPUT
+#      - name: Checkout Pex
+#        uses: actions/checkout@v3
+#        with:
+#          # We need branches and tags for some ITs.
+#          fetch-depth: 0
+#      - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
+#      - name: Expose Pythons
+#        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+#        with:
+#          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
+#      - name: Install Packages
+#        run: |
+#          # This is needed for `test_requirement_file_from_url` for building `lxml`.
+#          sudo apt install --yes libxslt-dev
+#      - name: Cache Pyenv Interpreters
+#        uses: actions/cache@v3
+#        with:
+#          path: ${{ env._PEX_TEST_PYENV_ROOT }}
+#          key: ${{ runner.os }}-pyenv-root-v9
+#      - name: Setup SSH Agent
+#        uses: webfactory/ssh-agent@v0.5.4
+#        env:
+#          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+#        if: env.SSH_PRIVATE_KEY != ''
+#        with:
+#          ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
+#      - name: Run Integration Tests
+#        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+#        with:
+#          tox-env: pypy${{ join(matrix.pypy-version, '') }}-pip${{ matrix.pip-version }}-integration
+#  final-status:
+#    name: Gather Final Status
+#    needs:
+#      - checks
+#      - cpython-unit-tests
+#      - pypy-unit-tests
+#      - cpython-integration-tests
+#      - pypy-integration-tests
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Check Non-Success
+#        if: |
+#          contains(needs.*.result, 'cancelled') ||
+#          contains(needs.*.result, 'failure') ||
+#          contains(needs.*.result, 'skipped')
+#        run: "false"
+#      - name: Success
+#        run: "true"

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -681,7 +681,7 @@ class PEX(object):  # noqa: T000
                 try:
                     readline.read_history_file(histfile)
                     readline.set_history_length(1000)
-                except FileNotFoundError:
+                except OSError:
                     pass
 
                 atexit.register(readline.write_history_file, histfile)

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -673,6 +673,19 @@ class PEX(object):  # noqa: T000
         else:
             self.demote_bootstrap()
 
+            if self._vars.PEX_INTERPRETER_HISTORY:
+                import atexit
+                import readline
+
+                histfile = os.path.expanduser(self._vars.PEX_INTERPRETER_HISTORY_FILE)
+                try:
+                    readline.read_history_file(histfile)
+                    readline.set_history_length(1000)
+                except FileNotFoundError:
+                    pass
+
+                atexit.register(readline.write_history_file, histfile)
+
             import code
 
             code.interact()

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -671,8 +671,6 @@ class PEX(object):  # noqa: T000
                 sys.argv = args
                 return self.execute_content(arg, content)
         else:
-            self.demote_bootstrap()
-
             if self._vars.PEX_INTERPRETER_HISTORY:
                 import atexit
                 import readline
@@ -685,6 +683,8 @@ class PEX(object):  # noqa: T000
                     pass
 
                 atexit.register(readline.write_history_file, histfile)
+
+            self.demote_bootstrap()
 
             import code
 

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -679,8 +679,10 @@ class PEX(object):  # noqa: T000
                 try:
                     readline.read_history_file(histfile)
                     readline.set_history_length(1000)
-                except OSError:
-                    pass
+                except OSError as e:
+                    sys.stderr.write(
+                        "Failed to read history file at {} due to: {}".format(histfile, e)
+                    )
 
                 atexit.register(readline.write_history_file, histfile)
 

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -528,6 +528,8 @@ class Variables(object):
         IF PEX_INTERPRETER is true, use a command history file for REPL user convenience.
         The location of the history file is determined by PEX_INTERPRETER_HISTORY_FILE.
 
+        Note: Only supported on CPython interpreters.
+
         Default: false.
         """
         return self._get_bool("PEX_INTERPRETER_HISTORY")
@@ -538,7 +540,7 @@ class Variables(object):
         """File.
 
         IF PEX_INTERPRETER_HISTORY is true, use this history file.
-        The default is the standard Python interpreter history location.
+        The default is the standard CPython interpreter history location.
 
         Default: ~/.python_history.
         """

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -189,8 +189,8 @@ class Variables(object):
         """
         ret_vars = {}  # type: Dict[str, str]
         rc_locations = [
-            "/etc/pexrc",
-            "~/.pexrc",
+            os.path.join(os.sep, "etc", "pexrc"),
+            os.path.join("~", ".pexrc"),
             os.path.join(os.path.dirname(sys.argv[0]), ".pexrc"),
         ]
         if rc:
@@ -520,6 +520,30 @@ class Variables(object):
         """
         return self._get_bool("PEX_INTERPRETER")
 
+    @defaulted_property(default=False)
+    def PEX_INTERPRETER_HISTORY(self):
+        # type: () -> bool
+        """Boolean.
+
+        IF PEX_INTERPRETER is true, use a command history file for REPL user convenience.
+        The location of the history file is determined by PEX_INTERPRETER_HISTORY_FILE.
+
+        Default: false.
+        """
+        return self._get_bool("PEX_INTERPRETER_HISTORY")
+
+    @defaulted_property(default=os.path.join("~", ".python_history"))
+    def PEX_INTERPRETER_HISTORY_FILE(self):
+        # type: () -> str
+        """File.
+
+        IF PEX_INTERPRETER_HISTORY is true, use this history file.
+        The default is the standard Python interpreter history location.
+
+        Default: ~/.python_history.
+        """
+        return self._get_string("PEX_INTERPRETER_HISTORY_FILE")
+
     @property
     def PEX_MODULE(self):
         # type: () -> Optional[str]
@@ -607,7 +631,7 @@ class Variables(object):
         )
         return self._maybe_get_path_tuple("PEX_EXTRA_SYS_PATH") or ()
 
-    @defaulted_property(default="~/.pex")
+    @defaulted_property(default=os.path.join("~", ".pex"))
     def PEX_ROOT(self):
         # type: () -> str
         """Directory.

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -229,15 +229,18 @@ def test_pex_repl_built():
 
 
 @pytest.mark.skipif(IS_PYPY, reason="REPL history is only supported on CPython.")
-def test_pex_repl_history():
-    # type: () -> None
+@pytest.mark.parametrize("venv_pex", [False, True])
+def test_pex_repl_history(venv_pex):
+    # type: (...) -> None
     """Tests enabling REPL command history."""
     stdin_payload = b"import sys; import readline; print(readline.get_history_item(1)); sys.exit(3)"
 
     with temporary_dir() as output_dir:
         # Create a dummy temporary pex with no entrypoint.
         pex_path = os.path.join(output_dir, "dummy.pex")
-        results = run_pex_command(["--disable-cache", "-o", pex_path])
+        results = run_pex_command(
+            ["--disable-cache", "-o", pex_path] + (["--venv"] if venv_pex else [])
+        )
         results.assert_success()
 
         history_file = os.path.join(output_dir, ".python_history")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -28,6 +28,7 @@ from pex.pex_info import PexInfo
 from pex.requirements import LogicalLine, PyPIRequirement, parse_requirement_file
 from pex.testing import (
     IS_MAC,
+    IS_PYPY,
     NOT_CPYTHON27,
     NOT_CPYTHON27_OR_OSX,
     PY38,
@@ -227,6 +228,7 @@ def test_pex_repl_built():
         assert b">>>" in stdout
 
 
+@pytest.mark.skipif(IS_PYPY, reason="REPL history is only supported on CPython.")
 def test_pex_repl_history():
     # type: () -> None
     """Tests enabling REPL command history."""
@@ -245,7 +247,7 @@ def test_pex_repl_history():
         # Test that the REPL can see the history.
         env = {"PEX_INTERPRETER_HISTORY": "1", "PEX_INTERPRETER_HISTORY_FILE": history_file}
         stdout, rc = run_simple_pex(pex_path, stdin=stdin_payload, env=env)
-        assert rc == 3
+        assert rc == 3, "Failed with: {}".format(stdout)
         assert b">>>" in stdout
         assert b"2 + 2" in stdout
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -228,7 +228,13 @@ def test_pex_repl_built():
         assert b">>>" in stdout
 
 
-@pytest.mark.skipif(IS_PYPY, reason="REPL history is only supported on CPython.")
+@pytest.mark.skipif(
+    IS_PYPY or IS_MAC,
+    reason="REPL history is only supported on CPython. It works on macOS in an interactive "
+    "terminal, but this test fails in CI on macOS with `Inappropriate ioctl for device`, "
+    "because readline.read_history_file expects a tty on stdout. The linux tests will have "
+    "to suffice for now.",
+)
 @pytest.mark.parametrize("venv_pex", [False, True])
 def test_pex_repl_history(venv_pex):
     # type: (...) -> None

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -250,7 +250,7 @@ def test_pex_repl_history(venv_pex):
         # Test that the REPL can see the history.
         env = {"PEX_INTERPRETER_HISTORY": "1", "PEX_INTERPRETER_HISTORY_FILE": history_file}
         stdout, rc = run_simple_pex(pex_path, stdin=stdin_payload, env=env)
-        assert rc == 3, "Failed with: {}".format(stdout)
+        assert rc == 3, "Failed with: {}".format(stdout.decode("utf-8"))
         assert b">>>" in stdout
         assert b"2 + 2" in stdout
 


### PR DESCRIPTION
When running a REPL via Pex (e.g., with Pants's repl goal), it can be useful to support command history.

Python normally sets up command history by default when the interpreter imports `site`, but Pex bypasses that. So this change re-introduces the suggested idiom for loading and saving history, per https://docs.python.org/3/library/readline.html#example

Also replace a few hardcoded forward-slashed paths with os.path.sep.