### PR TITLE
Allow safe_copy to overwrite on windows

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -100,7 +100,8 @@ def safe_copy(source, dest, overwrite=False):
         # type: () -> None
         temp_dest = dest + uuid4().hex
         shutil.copy(source, temp_dest)
-        os.rename(temp_dest, dest)
+        replace = getattr(os, 'replace', None) or os.rename
+        replace(temp_dest, dest)
 
     # If the platform supports hard-linking, use that and fall back to copying.
     # Windows does not support hard-linking.


### PR DESCRIPTION
`os.rename` will throw FileExistsError on Windows, but not other operating systems. `os.replace` is the portable function that will overwrite, and should be used if available.

Obviously this will still fail on python 2.7. Alternative approaches would be testing for existence and removing the destination before trying the copy (an approach used in other portions of the codebase).