### PR TITLE
Log all pip invocations

### DIFF
--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -259,3 +259,9 @@ else:
         if not prefix:
             return ""
         return os.path.join(*prefix)
+
+
+if PY3:
+    from shlex import quote as quote
+else:
+    from pipes import quote as quote

--- a/pex/pip/tool.py
+++ b/pex/pip/tool.py
@@ -14,7 +14,7 @@ from tempfile import mkdtemp
 from pex import dist_metadata, targets
 from pex.auth import PasswordEntry
 from pex.common import safe_mkdir, safe_mkdtemp
-from pex.compatibility import get_stderr_bytes_buffer, urlparse
+from pex.compatibility import get_stderr_bytes_buffer, quote, urlparse
 from pex.interpreter import PythonInterpreter
 from pex.jobs import Job
 from pex.network_configuration import NetworkConfiguration
@@ -361,6 +361,11 @@ class Pip(object):
             popen_kwargs.update(stderr=subprocess.PIPE)
 
             args = self._pip_pex.execute_args(*command)
+
+            rendered_env = " ".join("{}={}".format(key, quote(value)) for key, value in env.items())
+            rendered_args = " ".join(quote(s) for s in args)
+            TRACER.log("Executing: {} {}".format(rendered_env, rendered_args), V=3)
+
             return args, subprocess.Popen(args=args, env=env, **popen_kwargs)
 
     def _spawn_pip_isolated_job(


### PR DESCRIPTION
This adds logging for `pip` invocations, to make it easier to understand how pex is calling `pip`, such as when a single invocation is taking a long time (https://github.com/pantsbuild/pex/issues/2036).

This mirrors similar logging for Python invocations: https://github.com/pantsbuild/pex/blob/1f8e25a714e52c45a50a6d6ab2ee7cb9e21a92bb/pex/interpreter.py#L713-L716