### PR TITLE
Fix `execute_parallel` "leaking" a thread.

### DIFF
--- a/tests/integration/test_issue_1336.py
+++ b/tests/integration/test_issue_1336.py
@@ -4,6 +4,7 @@
 import os
 import subprocess
 
+from pex.compatibility import commonpath
 from pex.testing import PY310, ensure_python_interpreter, run_pex_command
 from pex.typing import TYPE_CHECKING
 
@@ -16,4 +17,24 @@ def test_pip_leak(tmpdir):
     python = ensure_python_interpreter(PY310)
     pip = os.path.join(os.path.dirname(python), "pip")
     subprocess.check_call(args=[pip, "install", "setuptools_scm==6.0.1"])
-    run_pex_command(args=["--python", python, "bitstring==3.1.7"], python=python).assert_success()
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    result = run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--python",
+            python,
+            "bitstring==3.1.7",
+            "--",
+            "-c",
+            "import bitstring, os; print(os.path.realpath(bitstring.__file__))",
+        ],
+        python=python,
+    )
+    result.assert_success()
+    assert os.path.realpath(pex_root) == commonpath(
+        [os.path.realpath(pex_root), result.output.strip()]
+    )


### PR DESCRIPTION
Although the thread was not leaked per-se, it could run after `execute_parallel` returned which could cause parallel atomic_directory posix locks to fail.

Fixes one case in #1969.