### PR TITLE
Lock sdists with `prepare-metadata-for-build-wheel`.

### DIFF
--- a/pex/build_system/pep_517.py
+++ b/pex/build_system/pep_517.py
@@ -5,23 +5,25 @@ from __future__ import absolute_import
 
 import os
 import subprocess
-from subprocess import CalledProcessError
+import sys
 from textwrap import dedent
 
 from pex import third_party
 from pex.build_system.pep_518 import BuildSystem, load_build_system
-from pex.dist_metadata import Distribution
+from pex.common import safe_mkdtemp
+from pex.dist_metadata import DistMetadata, Distribution
+from pex.jobs import Job, SpawnedJob
 from pex.pip.version import PipVersion, PipVersionValue
 from pex.resolve.resolvers import Resolver
-from pex.result import Error
+from pex.result import Error, try_
 from pex.tracer import TRACER
-from pex.typing import TYPE_CHECKING, cast
+from pex.typing import TYPE_CHECKING
 from pex.util import named_temporary_file
 
 if TYPE_CHECKING:
-    from typing import Dict, Union
+    from typing import Any, Dict, Iterable, Mapping, Optional, Text, Tuple, Union
 
-_DEFAULT_BUILD_BACKEND = "setuptools.build_meta:__legacy__"
+_DEFAULT_BUILD_BACKEND = "setuptools.build_meta"
 _DEFAULT_BUILD_SYSTEMS = {}  # type: Dict[PipVersionValue, BuildSystem]
 
 
@@ -40,14 +42,14 @@ def _default_build_system(
         ):
             extra_env = {}  # type: Dict[str, str]
             if pip_version is PipVersion.VENDORED:
-                requires = ["setuptools"]
+                requires = ["setuptools", "wheel"]
                 resolved = tuple(
                     Distribution.load(dist_location)
                     for dist_location in third_party.expose(requires)
                 )
                 extra_env.update(__PEX_UNVENDORED__="1")
             else:
-                requires = [pip_version.setuptools_requirement]
+                requires = [pip_version.setuptools_requirement, pip_version.wheel_requirement]
                 resolved = tuple(
                     installed_distribution.fingerprinted_distribution.distribution
                     for installed_distribution in resolver.resolve_requirements(
@@ -58,6 +60,7 @@ def _default_build_system(
                 requires=requires,
                 resolved=resolved,
                 build_backend=_DEFAULT_BUILD_BACKEND,
+                backend_path=(),
                 **extra_env
             )
             _DEFAULT_BUILD_SYSTEMS[pip_version] = build_system
@@ -76,13 +79,28 @@ def _get_build_system(
     return _default_build_system(pip_version=pip_version, resolver=resolver)
 
 
-def build_sdist(
+# Exit code 75 is EX_TEMPFAIL defined in /usr/include/sysexits.h
+# this seems an appropriate signal of DNE vs execute and fail.
+_HOOK_UNAVAILABLE_EXIT_CODE = 75
+
+
+def is_hook_unavailable_error(error):
+    # type: (Job.Error) -> bool
+    return error.exitcode == _HOOK_UNAVAILABLE_EXIT_CODE
+
+
+def _invoke_build_hook(
     project_directory,  # type: str
-    dist_dir,  # type: str
     pip_version,  # type: PipVersionValue
     resolver,  # type: Resolver
+    hook_method,  # type: str
+    hook_args,  # type: Iterable[Any]
+    hook_kwargs=None,  # type: Optional[Mapping[str, Any]]
+    stdout=None,  # type: Optional[int]
+    stderr=None,  # type: Optional[int]
 ):
-    # type: (...) -> Union[str, Error]
+    # type: (...) -> Union[SpawnedJob[Text], Error]
+
     if not os.path.exists(project_directory):
         return Error(
             "Project directory {project_directory} does not exist.".format(
@@ -101,7 +119,7 @@ def build_sdist(
         return build_system_or_error
     build_system = build_system_or_error
 
-    # The interface is spec'd here: https://peps.python.org/pep-0517/#build-sdist
+    # The interfaces are spec'd here: https://peps.python.org/pep-0517
     build_backend_module, _, _ = build_system.build_backend.partition(":")
     build_backend_object = build_system.build_backend.replace(":", ".")
     with named_temporary_file(mode="r") as fp:
@@ -109,28 +127,80 @@ def build_sdist(
             "-c",
             dedent(
                 """\
+                import sys
+
                 import {build_backend_module}
 
 
-                sdist_relpath = {build_backend_object}.build_sdist({dist_dir!r})
+                if not hasattr({build_backend_object}, {hook_method!r}):
+                    sys.exit({hook_unavailable_exit_code})
+
+                result = {build_backend_object}.{hook_method}(*{hook_args!r}, **{hook_kwargs!r})
                 with open({result_file!r}, "w") as fp:
-                    fp.write(sdist_relpath)
+                    fp.write(result)
                 """
             ).format(
                 build_backend_module=build_backend_module,
                 build_backend_object=build_backend_object,
-                dist_dir=dist_dir,
+                hook_method=hook_method,
+                hook_args=tuple(hook_args),
+                hook_kwargs=dict(hook_kwargs) if hook_kwargs else {},
+                hook_unavailable_exit_code=_HOOK_UNAVAILABLE_EXIT_CODE,
                 result_file=fp.name,
             ),
         )
-        try:
-            subprocess.check_output(
-                args=args, env=build_system.env, cwd=project_directory, stderr=subprocess.STDOUT
-            )
-        except CalledProcessError as e:
-            return Error(
-                "Failed to build sdist for local project {project_directory}: {err}\n"
-                "{stderr}".format(project_directory=project_directory, err=e, stderr=e.output)
-            )
-        sdist_relpath = cast(str, fp.read()).strip()
+        process = subprocess.Popen(
+            args=args,
+            env=build_system.env,
+            cwd=project_directory,
+            stdout=stdout if stdout is not None else sys.stderr.fileno(),
+            stderr=stderr if stderr is not None else sys.stderr.fileno(),
+        )
+        return SpawnedJob.file(
+            Job(command=args, process=process),
+            output_file=fp.name,
+            result_func=lambda file_content: file_content.decode("utf-8"),
+        )
+
+
+def build_sdist(
+    project_directory,  # type: str
+    dist_dir,  # type: str
+    pip_version,  # type: PipVersionValue
+    resolver,  # type: Resolver
+):
+    # type: (...) -> Union[Text, Error]
+
+    spawned_job_or_error = _invoke_build_hook(
+        project_directory, pip_version, resolver, hook_method="build_sdist", hook_args=[dist_dir]
+    )
+    if isinstance(spawned_job_or_error, Error):
+        return spawned_job_or_error
+    try:
+        sdist_relpath = spawned_job_or_error.await_result()
+    except Job.Error as e:
+        return Error(
+            "Failed to build sdist for local project {project_directory}: {err}\n"
+            "{stderr}".format(project_directory=project_directory, err=e, stderr=e.stderr)
+        )
     return os.path.join(dist_dir, sdist_relpath)
+
+
+def spawn_prepare_metadata(
+    project_directory,  # type: str
+    pip_version,  # type: PipVersionValue
+    resolver,  # type: Resolver
+):
+    # type: (...) -> SpawnedJob[DistMetadata]
+    build_dir = os.path.join(safe_mkdtemp(), "build")
+    os.mkdir(build_dir)
+    spawned_job = try_(
+        _invoke_build_hook(
+            project_directory,
+            pip_version,
+            resolver,
+            hook_method="prepare_metadata_for_build_wheel",
+            hook_args=[build_dir],
+        )
+    )
+    return spawned_job.map(lambda _: DistMetadata.load(build_dir))

--- a/pex/build_system/testing.py
+++ b/pex/build_system/testing.py
@@ -49,7 +49,7 @@ def assert_build_sdist(
     assert not isinstance(location, Error), location
     assert sdist_dir == os.path.dirname(location)
 
-    sdist = Distribution.load(location)
+    sdist = Distribution.load(str(location))
     assert_expected_dist(sdist)
 
     # Verify the sdist is valid such that we can build a wheel from it.

--- a/pex/dist_metadata.py
+++ b/pex/dist_metadata.py
@@ -518,7 +518,7 @@ class Requirement(object):
 class DistMetadata(object):
     @classmethod
     def load(cls, location):
-        # type: (Union[str, Message]) -> DistMetadata
+        # type: (Union[Text, Message]) -> DistMetadata
 
         project_name_and_ver = project_name_and_version(location)
         if not project_name_and_ver:

--- a/pex/jobs.py
+++ b/pex/jobs.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     _I = TypeVar("_I")
     _O = TypeVar("_O")
     _T = TypeVar("_T")
+    _S = TypeVar("_S")
     _SE = TypeVar("_SE")
     _JE = TypeVar("_JE")
 else:
@@ -324,6 +325,24 @@ class SpawnedJob(Generic["_T"]):
         # type: () -> None
         """Terminates the spawned job if it's not already complete."""
         raise NotImplementedError()
+
+    def map(self, func):
+        # type: (Callable[[_T], _S]) -> SpawnedJob[_S]
+
+        class Map(SpawnedJob):
+            def await_result(me):
+                # type: () -> _S
+                return func(self.await_result())
+
+            def kill(me):
+                # type: () -> None
+                self.kill()
+
+            def __repr__(me):
+                # type: () -> str
+                return "{job}.map({func})".format(job=self, func=func)
+
+        return Map()
 
 
 # If `cpu_count` fails, we default to 2. This is relatively arbitrary, based on what seems to be

--- a/tests/integration/cli/commands/test_issue_2050.py
+++ b/tests/integration/cli/commands/test_issue_2050.py
@@ -1,0 +1,221 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from textwrap import dedent
+from typing import Callable
+
+import pytest
+
+from pex.build_system import pep_517
+from pex.cli.testing import run_pex3
+from pex.common import safe_open
+from pex.pip.version import PipVersion
+from pex.resolve.configured_resolver import ConfiguredResolver
+from pex.result import try_
+from pex.testing import IS_LINUX, PY39, PY310, ensure_python_interpreter, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class Repo(object):
+    find_links = attr.ib()  # type: str
+    path_mapping = attr.ib()  # type: str
+
+
+@pytest.fixture
+def build_sdist(tmpdir):
+    # type: (Any) -> Callable[[str], Repo]
+
+    def func(project_directory):
+        find_links = os.path.join(tmpdir, "find-links")
+        path_mapping = "FL|{}".format(find_links)
+        os.makedirs(find_links)
+        try_(
+            pep_517.build_sdist(
+                project_directory=project_directory,
+                dist_dir=find_links,
+                pip_version=PipVersion.VENDORED,
+                resolver=ConfiguredResolver.default(),
+            )
+        )
+        return Repo(find_links=find_links, path_mapping=path_mapping)
+
+    return func
+
+
+def test_lock_uncompilable_sdist(
+    tmpdir,  # type: Any
+    build_sdist,  # type: Callable[[str], Repo]
+):
+    # type: (...) -> None
+
+    project = os.path.join(str(tmpdir), "project")
+    os.mkdir(project)
+    with open(os.path.join(project, "bad.c"), "w") as fp:
+        fp.write("This is not valid C code.")
+
+    with open(os.path.join(project, "README"), "w") as fp:
+        fp.write("This is a Python C-extension project that does not compile.")
+
+    with open(os.path.join(project, "setup.py"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                from setuptools import setup, Extension
+
+
+                setup(
+                    name="bad",
+                    version="0.1.0",
+                    author="John Sirois",
+                    author_email="js@example.com",
+                    url="http://example.com/bad",
+                    ext_modules=[Extension('bad',  sources=['bad.c'])],
+                )
+                """
+            )
+        )
+
+    repo = build_sdist(project)
+
+    lock = os.path.join(str(tmpdir), "lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "-f",
+        repo.find_links,
+        "bad",
+        "--no-pypi",
+        "--path-mapping",
+        repo.path_mapping,
+        "--indent",
+        "2",
+        "-o",
+        lock,
+    ).assert_success()
+
+    result = run_pex_command(args=["--lock", lock, "--path-mapping", repo.path_mapping])
+    result.assert_failure()
+    assert "bad-0.1.0.tar.gz" in result.error, result.error
+    assert "ERROR: Failed to build one or more wheels" in result.error, result.error
+
+
+@pytest.mark.skipif(not IS_LINUX, reason="The evdev project requires Linux.")
+def test_pep_517_prepare_metadata_for_build_wheel_fallback(
+    tmpdir,  # type: Any
+    build_sdist,  # type: Callable[[str], Repo]
+):
+    # type: (...) -> None
+
+    python = ensure_python_interpreter(PY310)
+
+    evdev = os.path.join(str(tmpdir), "python-evdev")
+    os.mkdir(evdev)
+    subprocess.check_call(args=["git", "init"], cwd=evdev)
+    evdev_1_6_1_sha = "2dd6ce6364bb67eedb209f6aa0bace0c18a3a40a"
+    subprocess.check_call(
+        args=[
+            "git",
+            "fetch",
+            "--depth",
+            "1",
+            "https://github.com/gvalkov/python-evdev",
+            evdev_1_6_1_sha,
+        ],
+        cwd=evdev,
+    )
+    subprocess.check_call(args=["git", "reset", "--hard", evdev_1_6_1_sha], cwd=evdev)
+    with tempfile.NamedTemporaryFile() as fp:
+        fp.write(
+            dedent(
+                """\
+                diff --git a/builder/delegate_to_setuptools.py b/builder/delegate_to_setuptools.py
+                new file mode 100644
+                index 0000000..9a4d93d
+                --- /dev/null
+                +++ b/builder/delegate_to_setuptools.py
+                @@ -0,0 +1,6 @@
+                +from setuptools import build_meta
+                +
+                +
+                +build_sdist = build_meta.build_sdist
+                +build_wheel = build_meta.build_wheel
+                +
+                diff --git a/pyproject.toml b/pyproject.toml
+                new file mode 100644
+                index 0000000..7c52595
+                --- /dev/null
+                +++ b/pyproject.toml
+                @@ -0,0 +1,5 @@
+                +[build-system]
+                +requires = ["setuptools==67.2.0", "wheel==0.38.4"]
+                +backend-path = ["builder"]
+                +build-backend = "delegate_to_setuptools"
+                +
+                diff --git a/setup.py b/setup.py
+                index 73ba1f5..c19fa76 100755
+                --- a/setup.py
+                +++ b/setup.py
+                @@ -41,7 +41,7 @@ ecodes_c = Extension('evdev._ecodes', sources=['evdev/ecodes.c'], extra_compile_
+                 #-----------------------------------------------------------------------------
+                 kw = {
+                     'name':                 'evdev',
+                -    'version':              '1.6.1',
+                +    'version':              '1.6.1+test',
+
+                     'description':          'Bindings to the Linux input handling subsystem',
+                     'long_description':     (curdir / 'README.rst').read_text(),
+                @@ -53,7 +53,7 @@ kw = {
+                     'url':                  'https://github.com/gvalkov/python-evdev',
+                     'classifiers':          classifiers,
+
+                -    'packages':             ['evdev'],
+                +    'packages':             ['evdev', 'builder'],
+                     'ext_modules':          [input_c, uinput_c, ecodes_c],
+                     'include_package_data': False,
+                     'zip_safe':             True,
+                """
+            ).encode("utf-8")
+        )
+        fp.flush()
+        subprocess.check_call(args=["git", "apply", fp.name], cwd=evdev)
+
+    repo = build_sdist(evdev)
+
+    lock = os.path.join(str(tmpdir), "lock.json")
+    result = run_pex3(
+        "lock",
+        "create",
+        "-vvv",
+        "--python",
+        python,
+        "-f",
+        repo.find_links,
+        "evdev==1.6.1+test",
+        "--path-mapping",
+        repo.path_mapping,
+        "--indent",
+        "2",
+        "-o",
+        lock,
+    )
+    result.assert_success()
+
+    assert re.search(
+        r"Failed to prepare metadata for .+{}, trying to build a wheel instead: ".format(
+            re.escape("evdev-1.6.1+test.tar.gz")
+        ),
+        result.error,
+    ), result.error

--- a/tests/integration/cli/commands/test_issue_2050.py
+++ b/tests/integration/cli/commands/test_issue_2050.py
@@ -57,7 +57,7 @@ def build_sdist(tmpdir):
 
 @pytest.mark.skipif(
     sys.version_info[0] < 3,
-    reason="Encoding of setup.py files for Python 2 is tricky and not worth the trouble."
+    reason="Encoding of setup.py files for Python 2 is tricky and not worth the trouble.",
 )
 def test_lock_uncompilable_sdist(
     tmpdir,  # type: Any
@@ -121,7 +121,7 @@ def test_lock_uncompilable_sdist(
     reason=(
         "The evdev project requires Linux and Python 3 and we use a setuptools in our in-tree "
         "build backend that requires Python 3.7+."
-    )
+    ),
 )
 def test_pep_517_prepare_metadata_for_build_wheel_fallback(
     tmpdir,  # type: Any


### PR DESCRIPTION
PEP-517 specifies an optional `prepare-metadata-for-build-wheel` hook.
This can be used to extract metadata from an sdist without actually
building a wheel from the sdist when supported by the PEP-517 build
backend. Augment the Pex lock creation code to 1st try this and only
fall back to building a wheel when the optional hook is not present.

This allows locking sdist-only platform-specific projects that are
not compilable on the current platform by avoiding compiling them.

Fixes #2050