### PR TITLE
Handle locking all direct reference URL forms.

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -213,8 +213,9 @@ class PermPreservingZipFile(zipfile.ZipFile, object):
         # This magic works to extract perm bits from the 32 bit external file attributes field for
         # unix-created zip files, for the layout, see:
         #   https://www.forensicswiki.org/wiki/ZIP#External_file_attributes
-        attr = info.external_attr >> 16
-        os.chmod(path, attr)
+        if info.external_attr > 0xFFFF:
+            attr = info.external_attr >> 16
+            os.chmod(path, attr)
 
 
 @contextlib.contextmanager

--- a/pex/dist_metadata.py
+++ b/pex/dist_metadata.py
@@ -291,8 +291,10 @@ class ProjectNameAndVersion(object):
         # characters and dashes.
         fname = _strip_sdist_path(path)
         if fname is not None:
-            project_name, version = fname.rsplit("-", 1)
-            return cls(project_name=project_name, version=version)
+            components = fname.rsplit("-", 1)
+            if len(components) == 2:
+                project_name, version = components
+                return cls(project_name=project_name, version=version)
 
         raise UnrecognizedDistributionFormat(
             "The distribution at path {!r} does not have a file name matching known sdist or wheel "

--- a/pex/pip/download_observer.py
+++ b/pex/pip/download_observer.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import
 
 from pex.pip.log_analyzer import LogAnalyzer
-from pex.typing import TYPE_CHECKING, Generic
+from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Iterable, Mapping, Optional, Text
@@ -21,28 +21,7 @@ class Patch(object):
     env = attr.ib(factory=dict)  # type: Mapping[str, str]
 
 
-if TYPE_CHECKING:
-    from typing import TypeVar
-
-    _L = TypeVar("_L", bound=LogAnalyzer)
-
-
-class DownloadObserver(Generic["_L"]):
-    def __init__(
-        self,
-        analyzer,  # type: _L
-        patch=Patch(),  # type: Patch
-    ):
-        # type: (...) -> None
-        self._analyzer = analyzer
-        self._patch = patch
-
-    @property
-    def analyzer(self):
-        # type: () -> _L
-        return self._analyzer
-
-    @property
-    def patch(self):
-        # type: () -> Patch
-        return self._patch
+@attr.s(frozen=True)
+class DownloadObserver(object):
+    analyzer = attr.ib()  # type: Optional[LogAnalyzer]
+    patch = attr.ib()  # type: Patch

--- a/pex/pip/tool.py
+++ b/pex/pip/tool.py
@@ -475,7 +475,8 @@ class Pip(object):
         code = None  # type: Optional[Text]
         for obs in (foreign_platform_observer, observer):
             if obs:
-                log_analyzers.append(obs.analyzer)
+                if obs.analyzer:
+                    log_analyzers.append(obs.analyzer)
                 download_cmd.extend(obs.patch.args)
                 extra_env.update(obs.patch.env)
                 code = code or obs.patch.code

--- a/pex/pip/vcs.py
+++ b/pex/pip/vcs.py
@@ -3,12 +3,12 @@
 
 from __future__ import absolute_import
 
-import hashlib
 import os
 import re
 
 from pex import hashing
 from pex.common import filter_pyc_dirs, filter_pyc_files, open_zip, temporary_dir
+from pex.hashing import Sha256
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.requirements import VCS
@@ -18,7 +18,7 @@ from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Union
+    from typing import Tuple, Union
 
     from pex.hashing import HintedDigest
 
@@ -61,16 +61,16 @@ def fingerprint_downloaded_vcs_archive(
     version,  # type: str
     vcs,  # type: VCS.Value
 ):
-    # type: (...) -> Fingerprint
+    # type: (...) -> Tuple[Fingerprint, str]
 
     archive_path = try_(
         _find_built_source_dist(
             build_dir=download_dir, project_name=ProjectName(project_name), version=Version(version)
         )
     )
-    digest = hashlib.sha256()
+    digest = Sha256()
     digest_vcs_archive(archive_path=archive_path, vcs=vcs, digest=digest)
-    return Fingerprint(algorithm=digest.name, hash=digest.hexdigest())
+    return Fingerprint.from_digest(digest), archive_path
 
 
 def digest_vcs_archive(

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -66,9 +66,7 @@ class FileArtifactDownloadManager(DownloadManager[FileArtifact]):
         digest,  # type: HintedDigest
     ):
         # type: (...) -> Union[str, Error]
-        return self._downloader.download(
-            artifact=artifact, project_name=project_name, dest_dir=dest_dir, digest=digest
-        )
+        return self._downloader.download(artifact=artifact, dest_dir=dest_dir, digest=digest)
 
 
 class VCSArtifactDownloadManager(DownloadManager[VCSArtifact]):

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -66,7 +66,9 @@ class FileArtifactDownloadManager(DownloadManager[FileArtifact]):
         digest,  # type: HintedDigest
     ):
         # type: (...) -> Union[str, Error]
-        return self._downloader.download(artifact=artifact, dest_dir=dest_dir, digest=digest)
+        return self._downloader.download(
+            artifact=artifact, project_name=project_name, dest_dir=dest_dir, digest=digest
+        )
 
 
 class VCSArtifactDownloadManager(DownloadManager[VCSArtifact]):

--- a/pex/resolve/pep_691/fingerprint_service.py
+++ b/pex/resolve/pep_691/fingerprint_service.py
@@ -150,7 +150,7 @@ class FingerprintService(object):
             if artifact.fingerprint:
                 yield artifact
             else:
-                artifacts_to_fingerprint[artifact.url] = artifact
+                artifacts_to_fingerprint[artifact.url.normalized_url] = artifact
 
         if not artifacts_to_fingerprint:
             return

--- a/tests/integration/cli/commands/test_issue_2057.py
+++ b/tests/integration/cli/commands/test_issue_2057.py
@@ -174,9 +174,11 @@ def test_lock_create_local_project_direct_reference(tmpdir):
             1. ansicolors 1.1.8 from file://{clone_dir}
                 Expected sha256 hash of {expected} when downloading ansicolors but hashed to
             """
-        ).format(
+        )
+        .format(
             clone_dir=clone_dir,
             expected=locked_requirement.artifact.fingerprint.hash,
-        ).strip()
+        )
+        .strip()
         in result.error
     ), result.error

--- a/tests/integration/cli/commands/test_issue_2057.py
+++ b/tests/integration/cli/commands/test_issue_2057.py
@@ -1,0 +1,183 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+import shutil
+import subprocess
+import tempfile
+from textwrap import dedent
+
+import colors
+
+from pex.cli.testing import run_pex3
+from pex.testing import run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_pex_archive_direct_reference(tmpdir):
+    # type: (Any) -> None
+
+    result = run_pex_command(
+        args=[
+            "cowsay @ https://github.com/VaasuDevanS/cowsay-python/archive/v5.0.zip",
+            "-c",
+            "cowsay",
+            "--",
+            "Moo!",
+        ]
+    )
+    result.assert_success()
+    assert "Moo!" in result.output
+
+
+def test_lock_create_archive_direct_reference(tmpdir):
+    # type: (Any) -> None
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    lock = os.path.join(str(tmpdir), "lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--pex-root",
+        pex_root,
+        "cowsay @ https://github.com/VaasuDevanS/cowsay-python/archive/v5.0.zip",
+        "--indent",
+        "2",
+        "-o",
+        lock,
+    ).assert_success()
+
+    def assert_create_and_run_pex_from_lock():
+        # type: () -> None
+        result = run_pex_command(
+            args=[
+                "--pex-root",
+                pex_root,
+                "--runtime-pex-root",
+                pex_root,
+                "--lock",
+                lock,
+                "-c",
+                "cowsay",
+                "--",
+                "Moo!",
+            ]
+        )
+        result.assert_success()
+        assert "Moo!" in result.output
+
+    assert_create_and_run_pex_from_lock()
+    shutil.rmtree(pex_root)
+    assert_create_and_run_pex_from_lock()
+
+
+def test_lock_create_local_project_direct_reference(tmpdir):
+    # type: (Any) -> None
+
+    clone_dir = os.path.join(str(tmpdir), "ansicolors")
+    subprocess.check_call(args=["git", "init", clone_dir])
+
+    ansicolors_1_1_8_sha = "c965f5b9103c5bd32a1572adb8024ebe83278fb0"
+    subprocess.check_call(
+        args=[
+            "git",
+            "fetch",
+            "--depth",
+            "1",
+            "https://github.com/jonathaneunice/colors",
+            ansicolors_1_1_8_sha,
+        ],
+        cwd=clone_dir,
+    )
+    subprocess.check_call(args=["git", "reset", "--hard", ansicolors_1_1_8_sha], cwd=clone_dir)
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    lock = os.path.join(str(tmpdir), "lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--pex-root",
+        pex_root,
+        "ansicolors @ file://{}".format(clone_dir),
+        "--indent",
+        "2",
+        "-o",
+        lock,
+    ).assert_success()
+
+    def assert_create_and_run_pex_from_lock():
+        # type: () -> None
+        result = run_pex_command(
+            args=[
+                "--pex-root",
+                pex_root,
+                "--runtime-pex-root",
+                pex_root,
+                "--lock",
+                lock,
+                "--",
+                "-c",
+                "import colors; print(colors.yellow('Vogon Constructor Fleet!'))",
+            ]
+        )
+        result.assert_success()
+        assert colors.yellow("Vogon Constructor Fleet!") == result.output.strip()
+
+    assert_create_and_run_pex_from_lock()
+    shutil.rmtree(pex_root)
+    assert_create_and_run_pex_from_lock()
+
+    with tempfile.NamedTemporaryFile() as fp:
+        fp.write(
+            dedent(
+                """\
+                diff --git a/setup.py b/setup.py
+                index 0b58889..bdb7c90 100755
+                --- a/setup.py
+                +++ b/setup.py
+                @@ -42,3 +42,4 @@ setup(
+                         'Topic :: Software Development :: Libraries :: Python Modules'
+                     ]
+                 )
+                +# Changed
+                """
+            ).encode("utf-8")
+        )
+        fp.flush()
+        subprocess.check_call(args=["git", "apply", fp.name], cwd=clone_dir)
+
+    # We patched the source but have a cached wheel built from it before the patch in
+    # ~/.pex/installed_wheels; so no "download" is performed.
+    assert_create_and_run_pex_from_lock()
+
+    # But now we do need to "download" the project, build a wheel and install it. The hash check
+    # should fail.
+    shutil.rmtree(pex_root)
+    result = run_pex_command(
+        args=["--pex-root", pex_root, "--runtime-pex-root", pex_root, "--lock", lock]
+    )
+    result.assert_failure()
+    assert "There was 1 error downloading required artifacts:" in result.error, result.error
+    assert "1. ansicolors 1.1.8 from file://{}".format(clone_dir) in result.error, result.error
+    assert (
+        "Expected sha256 hash of fca533d24ea5fc1b0fc8bc10ee146535bddda1c40c85510544c5766cef4d10b6 "
+        "when downloading ansicolors but hashed to "
+        "3dc7cf307bf04a3c93f0958d296dd2278cabca393023b7c1dfd7409c7eaacb7e."
+    ) in result.error, result.error
+    assert (
+        dedent(
+            """\
+            There was 1 error downloading required artifacts:
+            1. ansicolors 1.1.8 from file://{clone_dir}
+                Expected sha256 hash of {expect} when downloading ansicolors but hashed to {actual}.
+            """
+        ).format(
+            clone_dir=clone_dir,
+            expect="fca533d24ea5fc1b0fc8bc10ee146535bddda1c40c85510544c5766cef4d10b6",
+            actual="3dc7cf307bf04a3c93f0958d296dd2278cabca393023b7c1dfd7409c7eaacb7e",
+        )
+        in result.error
+    ), result.error

--- a/tests/integration/test_downloads.py
+++ b/tests/integration/test_downloads.py
@@ -52,8 +52,6 @@ MAC_ARTIFACT = file_artifact(
     sha256="c7be9d7f5b0d206f0bbc3794b8e16fb7dbc53ec9e40bbe8787c6f2d38efcf6c9",
 )
 
-PROJECT_NAME = ProjectName("psutil")
-
 
 @pytest.fixture
 def downloader():
@@ -71,7 +69,7 @@ def test_issue_1849_download_foreign_artifact(
 
     dest_dir = os.path.join(str(tmpdir), "dest_dir")
     assert foreign_artifact.filename == downloader.download(
-        foreign_artifact, project_name=PROJECT_NAME, dest_dir=dest_dir, digest=hashlib.sha256()
+        foreign_artifact, dest_dir=dest_dir, digest=hashlib.sha256()
     )
 
 

--- a/tests/integration/test_downloads.py
+++ b/tests/integration/test_downloads.py
@@ -5,6 +5,7 @@ import os.path
 
 import pytest
 
+from pex.pep_503 import ProjectName
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.downloads import ArtifactDownloader
 from pex.resolve.locked_resolve import Artifact, FileArtifact
@@ -51,6 +52,8 @@ MAC_ARTIFACT = file_artifact(
     sha256="c7be9d7f5b0d206f0bbc3794b8e16fb7dbc53ec9e40bbe8787c6f2d38efcf6c9",
 )
 
+PROJECT_NAME = ProjectName("psutil")
+
 
 @pytest.fixture
 def downloader():
@@ -68,7 +71,7 @@ def test_issue_1849_download_foreign_artifact(
 
     dest_dir = os.path.join(str(tmpdir), "dest_dir")
     assert foreign_artifact.filename == downloader.download(
-        foreign_artifact, dest_dir=dest_dir, digest=hashlib.sha256()
+        foreign_artifact, project_name=PROJECT_NAME, dest_dir=dest_dir, digest=hashlib.sha256()
     )
 
 


### PR DESCRIPTION
Previously, it was assumed that direct reference URLs were either VCS
URLs or else wheel or sdist URLs. This neglected two remaining cases,
both of which failed to lock with better or worse error messages. The
two missed cases were:
1. URLs of source archives not conforming to the sdist quasi-standard
   naming convention of `<project name>-<version>.{.tar.gz,.zip}`.
2. Local `file://` URLs pointing at project directories.

A notable case of the 1st are project archives provided by GitHub.
A notable need for the 2nd case comes from Pants where Pip proprietary
requirement strings are not handled (e.g.: `/path/to/project`) and a
direct reference URL must be used instead (e.g.: `projectname @
file:///path/to/project`).

Fixes #2057