### PR TITLE
Fix python tag handling in IC locks.

### DIFF
--- a/tests/integration/cli/commands/test_issue_2059.py
+++ b/tests/integration/cli/commands/test_issue_2059.py
@@ -34,6 +34,7 @@ def test_pypy_impl_tag_handling(tmpdir):
         "--indent",
         "2",
     ).assert_success()
+
     python = sys.executable if sys.version_info[:2] >= (3, 7) else ensure_python_interpreter(PY310)
     result = run_pex_command(
         args=[

--- a/tests/integration/cli/commands/test_issue_2059.py
+++ b/tests/integration/cli/commands/test_issue_2059.py
@@ -1,0 +1,53 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import os.path
+import sys
+
+from pex.cli.testing import run_pex3
+from pex.compatibility import commonpath
+from pex.testing import PY310, ensure_python_interpreter, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_pypy_impl_tag_handling(tmpdir):
+    # type: (Any) -> None
+
+    pex_root = os.path.realpath(os.path.join(str(tmpdir), "pex_root"))
+    lock = os.path.join(str(tmpdir), "lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--pex-root",
+        pex_root,
+        "lexid",
+        "--style",
+        "universal",
+        "--resolver-version",
+        "pip-2020-resolver",
+        "--interpreter-constraint",
+        ">=3.7,<4",
+        "-o",
+        lock,
+        "--indent",
+        "2",
+    ).assert_success()
+    python = sys.executable if sys.version_info[:2] >= (3, 7) else ensure_python_interpreter(PY310)
+    result = run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--lock",
+            lock,
+            "--",
+            "-c",
+            "import lexid; print(lexid.__file__)",
+        ],
+        python=python,
+    )
+    result.assert_success()
+    assert pex_root == commonpath([pex_root, os.path.realpath(result.output.strip())])


### PR DESCRIPTION
Previously, the non-standard but compliant `pypy` tag was not accounted
for. Re-work python tag parsing to account for the spec by including
acceptance of `cpython` and `pypy` implementation names as well as
versions with trailing `_` portion (which is ignored).

Fixes #2059