### PR TITLE
Handle `[build-system]` with no build-backend.

### DIFF
--- a/pex/build_system/__init__.py
+++ b/pex/build_system/__init__.py
@@ -1,2 +1,12 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+# The split of PEP-517 / PEP-518 is quite awkward. PEP-518 doesn't really work without also
+# specifying a build backend or knowing a default value for one, but the concept is not defined
+# until PEP-517. As such, we break this historical? strange division and define the default outside
+# both PEPs.
+#
+# See: https://peps.python.org/pep-0517/#source-trees
+DEFAULT_BUILD_BACKEND = "setuptools.build_meta:__legacy__"

--- a/pex/build_system/pep_517.py
+++ b/pex/build_system/pep_517.py
@@ -9,6 +9,7 @@ import sys
 from textwrap import dedent
 
 from pex import third_party
+from pex.build_system import DEFAULT_BUILD_BACKEND
 from pex.build_system.pep_518 import BuildSystem, load_build_system
 from pex.common import safe_mkdtemp
 from pex.dist_metadata import DistMetadata, Distribution
@@ -21,9 +22,8 @@ from pex.typing import TYPE_CHECKING
 from pex.util import named_temporary_file
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Iterable, Mapping, Optional, Text, Tuple, Union
+    from typing import Any, Dict, Iterable, Mapping, Optional, Text, Union
 
-_DEFAULT_BUILD_BACKEND = "setuptools.build_meta"
 _DEFAULT_BUILD_SYSTEMS = {}  # type: Dict[PipVersionValue, BuildSystem]
 
 
@@ -36,9 +36,7 @@ def _default_build_system(
     build_system = _DEFAULT_BUILD_SYSTEMS.get(pip_version)
     if build_system is None:
         with TRACER.timed(
-            "Building {build_backend} build_backend PEX".format(
-                build_backend=_DEFAULT_BUILD_BACKEND
-            )
+            "Building {build_backend} build_backend PEX".format(build_backend=DEFAULT_BUILD_BACKEND)
         ):
             extra_env = {}  # type: Dict[str, str]
             if pip_version is PipVersion.VENDORED:
@@ -59,7 +57,7 @@ def _default_build_system(
             build_system = BuildSystem.create(
                 requires=requires,
                 resolved=resolved,
-                build_backend=_DEFAULT_BUILD_BACKEND,
+                build_backend=DEFAULT_BUILD_BACKEND,
                 backend_path=(),
                 **extra_env
             )

--- a/pex/build_system/pep_518.py
+++ b/pex/build_system/pep_518.py
@@ -4,8 +4,8 @@
 from __future__ import absolute_import
 
 import os.path
-import sys
 
+from pex.build_system import DEFAULT_BUILD_BACKEND
 from pex.dist_metadata import Distribution
 from pex.pex import PEX
 from pex.pex_bootstrapper import VenvPex, ensure_venv
@@ -29,7 +29,7 @@ else:
 @attr.s(frozen=True)
 class BuildSystemTable(object):
     requires = attr.ib()  # type: Tuple[str, ...]
-    build_backend = attr.ib()  # type: str
+    build_backend = attr.ib(default=DEFAULT_BUILD_BACKEND)  # type: str
     backend_path = attr.ib(default=())  # type: Tuple[str, ...]
 
 
@@ -57,7 +57,7 @@ def _read_build_system_table(
 
     return BuildSystemTable(
         requires=tuple(requires),
-        build_backend=build_system["build-backend"],
+        build_backend=build_system.get("build-backend", DEFAULT_BUILD_BACKEND),
         backend_path=tuple(
             os.path.join(os.path.dirname(pyproject_toml), entry)
             for entry in build_system.get("backend-path", ())

--- a/tests/integration/build_system/test_issue_2063.py
+++ b/tests/integration/build_system/test_issue_2063.py
@@ -1,0 +1,22 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import sys
+
+import pytest
+
+from pex.cli.testing import run_pex3
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+@pytest.mark.skipif(
+    sys.version_info[:2] < (3, 5),
+    reason="The tested distribution is only compatible with Python >= 3.5",
+)
+def test_build_system_no_build_backend(tmpdir):
+    # type: (Any) -> None
+
+    run_pex3("lock", "create", "xmlsec==1.3.13").assert_success()


### PR DESCRIPTION
PEP-518 only requires `requires` and PEP-517 mandates falling back to
the default introduced here.

Fixes #2063