### PR TITLE
Add support for Pip 23.0.1.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
             pip-version: 22_3_1
           - os: ubuntu-20.04
             python-version: [ 3, 11 ]
-            pip-version: 23_0
+            pip-version: 23_0_1
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -111,7 +111,7 @@ jobs:
           - pypy-version: [ 3, 9 ]
             pip-version: 22_3_1
           - pypy-version: [ 3, 9 ]
-            pip-version: 23_0
+            pip-version: 23_0_1
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -158,7 +158,7 @@ jobs:
             pip-version: 22_3_1
           - os: ubuntu-20.04
             python-version: [ 3, 7 ]
-            pip-version: 23_0
+            pip-version: 23_0_1
           - os: macos-11
             python-version: [ 3, 11 ]
             pip-version: 20
@@ -170,7 +170,7 @@ jobs:
             pip-version: 22_3_1
           - os: ubuntu-20.04
             python-version: [ 3, 11 ]
-            pip-version: 23_0
+            pip-version: 23_0_1
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -223,7 +223,7 @@ jobs:
           - pypy-version: [ 3, 9 ]
             pip-version: 22_3_1
           - pypy-version: [ 3, 9 ]
-            pip-version: 23_0
+            pip-version: 23_0_1
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose

--- a/pex/pip/version.py
+++ b/pex/pip/version.py
@@ -106,4 +106,11 @@ class PipVersion(Enum["PipVersionValue"]):
         requires_python=">=3.7",
     )
 
+    v23_0_1 = PipVersionValue(
+        version="23.0.1",
+        setuptools_version="67.4.0",
+        wheel_version="0.38.4",
+        requires_python=">=3.7",
+    )
+
     VENDORED = v20_3_4_patched

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,7 @@ setenv =
     pip22_3: _PEX_PIP_VERSION=22.3
     pip22_3_1: _PEX_PIP_VERSION=22.3.1
     pip23_0: _PEX_PIP_VERSION=23.0
+    pip23_0_1: _PEX_PIP_VERSION=23.0.1
     # Python 3 (until a fix here in 3.9: https://bugs.python.org/issue13601) switched from stderr
     # being unbuffered to stderr being buffered by default. This can lead to tests checking stderr
     # failing to see what they expect if the stderr buffer block has not been flushed. Force stderr
@@ -64,7 +65,7 @@ whitelist_externals =
     bash
     git
 
-[testenv:py{py27-subprocess,py27,py35,py36,py37,py38,py39,27,35,36,37,38,39,310,311}-{,pip20-,pip22_2-,pip22_3-,pip22_3_1-,pip23_0-}integration]
+[testenv:py{py27-subprocess,py27,py35,py36,py37,py38,py39,27,35,36,37,38,39,310,311}-{,pip20-,pip22_2-,pip22_3-,pip22_3_1-,pip23_0-,pip23_0_1-}integration]
 deps =
     pytest-xdist==1.34.0
     {[testenv]deps}


### PR DESCRIPTION
The release notes are here:
+ https://pip.pypa.io/en/stable/news/#v23-0-1
+ https://setuptools.pypa.io/en/stable/history.html#v67-4-0