### PR TITLE
Fix regression in venv symlinking.

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -171,7 +171,7 @@ class PEX(object):  # noqa: T000
     def layout(self):
         # type: () -> Layout.Value
         if self._layout is None:
-            self._layout = Layout.identify(self._pex)
+            self._layout = Layout.identify_original(self._pex)
         return self._layout
 
     def pex_info(self, include_env_overrides=True):

--- a/pex/venv/pex.py
+++ b/pex/venv/pex.py
@@ -10,7 +10,7 @@ import shutil
 from collections import Counter, defaultdict
 from textwrap import dedent
 
-from pex import pex_warnings
+from pex import layout, pex_warnings
 from pex.common import chmod_plus_x, pluralize, safe_mkdir
 from pex.compatibility import is_valid_python_identifier
 from pex.dist_metadata import Distribution
@@ -313,11 +313,12 @@ def _populate_sources(
         src=PEXEnvironment.mount(pex.path()).path,
         dst=venv.site_packages_dir,
         exclude=(
-            pex_info.internal_cache,
-            pex_info.bootstrap,
             "__main__.py",
             "__pycache__",
-            pex_info.PATH,
+            layout.BOOTSTRAP_DIR,
+            layout.DEPS_DIR,
+            layout.PEX_INFO_PATH,
+            layout.PEX_LAYOUT_PATH,
         ),
         symlink=False,
     ):

--- a/tests/integration/test_issue_2088.py
+++ b/tests/integration/test_issue_2088.py
@@ -1,0 +1,90 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import os.path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+from pex.common import safe_rmtree
+from pex.compatibility import commonpath
+from pex.layout import Layout
+from pex.testing import run_pex_command
+from pex.typing import TYPE_CHECKING
+from pex.venv.virtualenv import Virtualenv
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+@pytest.mark.parametrize(
+    "layout", [pytest.param(layout, id=layout.value) for layout in Layout.values()]
+)
+@pytest.mark.parametrize(
+    "symlink_site_packages",
+    [
+        pytest.param(True, id="--no-venv-site-packages-copies"),
+        pytest.param(False, id="--venv-site-packages-copies"),
+    ],
+)
+def test_venv_symlink_site_packages(
+    tmpdir,  # type: Any
+    layout,  # type: Layout.Value
+    symlink_site_packages,  # type: bool
+):
+    # type: (...) -> None
+
+    pex = os.path.join(str(tmpdir), "pex")
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    venv_site_packages_copies_arg = (
+        "--no-venv-site-packages-copies" if symlink_site_packages else "--venv-site-packages-copies"
+    )
+    result = run_pex_command(
+        args=[
+            "ansicolors==1.1.8",
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--venv",
+            venv_site_packages_copies_arg,
+            "--layout",
+            layout.value,
+            "--seed",
+            "-o",
+            pex,
+        ]
+    )
+    result.assert_success()
+    venv_pex_path = str(result.output.strip())
+
+    safe_rmtree(pex_root)
+    colors_module_realpath = os.path.realpath(
+        subprocess.check_output(
+            args=[sys.executable, pex, "-c", "import colors; print(colors.__file__)"]
+        )
+        .decode("utf-8")
+        .strip()
+    )
+
+    venv_dir = os.path.dirname(venv_pex_path)
+    virtualenv = Virtualenv(venv_dir)
+    site_packages_dir = os.path.realpath(virtualenv.site_packages_dir)
+
+    ansicolors_venv_package_dir_realpath = os.path.join(site_packages_dir, "colors")
+    assert os.path.isdir(ansicolors_venv_package_dir_realpath)
+
+    symlinks_expected = symlink_site_packages and layout != Layout.LOOSE
+    assert os.path.islink(ansicolors_venv_package_dir_realpath) == symlinks_expected
+
+    if symlinks_expected:
+        installed_wheels_dir_realpath = os.path.realpath(os.path.join(pex_root, "installed_wheels"))
+        assert installed_wheels_dir_realpath == commonpath(
+            (installed_wheels_dir_realpath, colors_module_realpath)
+        )
+    else:
+        assert (
+            os.path.join(ansicolors_venv_package_dir_realpath, "__init__.py")
+            == colors_module_realpath
+        )


### PR DESCRIPTION
The change in #2033 that safeguarded loose `--venv` PEXes such that they
could be executed, moved and continue to execute properly from their new
location, silently broke zipapp and packed layout `--venv` PEX
symlinking. Although `--venv` PEXes for those layouts continued to work,
they used copying to build their venvs instead of symlinking even when
symlinking (the default for `--venv` PEXes) was the intended style.

Fixes #2088