### PR TITLE
Fix VCS & local project locks to respect target.

### DIFF
--- a/pex/build_system/testing.py
+++ b/pex/build_system/testing.py
@@ -15,6 +15,7 @@ from pex.pip.version import PipVersion
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.resolver_configuration import PipConfiguration
 from pex.result import Error
+from pex.targets import LocalInterpreter
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -44,6 +45,7 @@ def assert_build_sdist(
         project_dir,
         sdist_dir,
         pip_version,
+        LocalInterpreter.create(),
         ConfiguredResolver(PipConfiguration(version=pip_version)),
     )
     assert not isinstance(location, Error), location

--- a/pex/pip/local_project.py
+++ b/pex/pip/local_project.py
@@ -9,10 +9,10 @@ import tarfile
 from pex import hashing
 from pex.build_system import pep_517
 from pex.common import temporary_dir
-from pex.hashing import Fingerprint, Sha256
 from pex.pip.version import PipVersionValue
 from pex.resolve.resolvers import Resolver
-from pex.result import Error, try_
+from pex.result import Error
+from pex.targets import Target
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 
@@ -22,21 +22,11 @@ if TYPE_CHECKING:
     from pex.hashing import HintedDigest
 
 
-def fingerprint_local_project(
-    directory,  # type: str
-    pip_version,  # type: PipVersionValue
-    resolver,  # type: Resolver
-):
-    # type: (...) -> Fingerprint
-    digest = Sha256()
-    try_(digest_local_project(directory, digest, pip_version, resolver))
-    return digest.hexdigest()
-
-
 def digest_local_project(
     directory,  # type: str
     digest,  # type: HintedDigest
     pip_version,  # type: PipVersionValue
+    target,  # type: Target
     resolver,  # type: Resolver
     dest_dir=None,  # type: Optional[str]
 ):
@@ -47,6 +37,7 @@ def digest_local_project(
                 project_directory=directory,
                 dist_dir=os.path.join(td, "dists"),
                 pip_version=pip_version,
+                target=target,
                 resolver=resolver,
             )
             if isinstance(sdist_or_error, Error):

--- a/pex/resolve/locker.py
+++ b/pex/resolve/locker.py
@@ -34,6 +34,7 @@ from pex.resolve.resolved_requirement import (
     ResolvedRequirement,
 )
 from pex.resolve.resolvers import Resolver
+from pex.targets import Target
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -247,6 +248,7 @@ class ArtifactBuildObserver(object):
 class Locker(LogAnalyzer):
     def __init__(
         self,
+        target,  # type: Target
         root_requirements,  # type: Iterable[ParsedRequirement]
         pip_version,  # type: PipVersionValue
         resolver,  # type: Resolver
@@ -256,6 +258,7 @@ class Locker(LogAnalyzer):
     ):
         # type: (...) -> None
 
+        self._target = target
         self._vcs_url_manager = VCSURLManager.create(root_requirements)
         self._pip_version = pip_version
         self._resolver = resolver
@@ -377,6 +380,7 @@ class Locker(LogAnalyzer):
                             directory=artifact_url.path,
                             digest=digest,
                             pip_version=self._pip_version,
+                            target=self._target,
                             resolver=self._resolver,
                         )
                         self._local_projects.add(artifact_url.path)

--- a/pex/targets.py
+++ b/pex/targets.py
@@ -282,6 +282,16 @@ class CompletePlatform(Target):
 
 @attr.s(frozen=True)
 class Targets(object):
+    @classmethod
+    def from_target(cls, target):
+        # type: (Target) -> Targets
+        if isinstance(target, AbbreviatedPlatform):
+            return cls(platforms=(target.platform,), assume_manylinux=target.manylinux)
+        elif isinstance(target, CompletePlatform):
+            return cls(complete_platforms=(target,))
+        else:
+            return cls(interpreters=(target.get_interpreter(),))
+
     interpreters = attr.ib(default=())  # type: Tuple[PythonInterpreter, ...]
     complete_platforms = attr.ib(default=())  # type: Tuple[CompletePlatform, ...]
     platforms = attr.ib(default=())  # type: Tuple[Optional[Platform], ...]

--- a/tests/build_system/test_pep_517.py
+++ b/tests/build_system/test_pep_517.py
@@ -9,6 +9,7 @@ from pex.common import touch
 from pex.pip.version import PipVersion
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.result import Error
+from pex.targets import LocalInterpreter
 from pex.testing import make_project
 from pex.typing import TYPE_CHECKING
 from pex.version import __version__
@@ -22,7 +23,13 @@ def test_build_sdist_project_directory_dne(tmpdir):
 
     project_dir = os.path.join(str(tmpdir), "project_dir")
     dist_dir = os.path.join(str(tmpdir), "dists")
-    result = build_sdist(project_dir, dist_dir, PipVersion.VENDORED, ConfiguredResolver.default())
+    result = build_sdist(
+        project_dir,
+        dist_dir,
+        PipVersion.VENDORED,
+        LocalInterpreter.create(),
+        ConfiguredResolver.default(),
+    )
     assert isinstance(result, Error)
     assert str(result).startswith(
         "Project directory {project_dir} does not exist.".format(project_dir=project_dir)
@@ -35,7 +42,13 @@ def test_build_sdist_project_directory_is_file(tmpdir):
     project_dir = os.path.join(str(tmpdir), "project_dir")
     touch(project_dir)
     dist_dir = os.path.join(str(tmpdir), "dists")
-    result = build_sdist(project_dir, dist_dir, PipVersion.VENDORED, ConfiguredResolver.default())
+    result = build_sdist(
+        project_dir,
+        dist_dir,
+        PipVersion.VENDORED,
+        LocalInterpreter.create(),
+        ConfiguredResolver.default(),
+    )
     assert isinstance(result, Error)
     assert str(result).startswith(
         "Project directory {project_dir} is not a directory.".format(project_dir=project_dir)

--- a/tests/build_system/test_pep_518.py
+++ b/tests/build_system/test_pep_518.py
@@ -14,6 +14,7 @@ from pex.pip.version import PipVersion
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.resolver_configuration import PipConfiguration
 from pex.result import Error
+from pex.targets import LocalInterpreter
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
 
@@ -24,7 +25,9 @@ if TYPE_CHECKING:
 def load_build_system(project_directory):
     # type: (...) -> Union[Optional[BuildSystem], Error]
     return pep_518.load_build_system(
-        ConfiguredResolver(PipConfiguration(version=PipVersion.VENDORED)), project_directory
+        LocalInterpreter.create(),
+        ConfiguredResolver(PipConfiguration(version=PipVersion.VENDORED)),
+        project_directory,
     )
 
 

--- a/tests/integration/build_system/test_pep_518.py
+++ b/tests/integration/build_system/test_pep_518.py
@@ -22,12 +22,14 @@ def test_load_build_system_pyproject_custom_repos(
 ):
     # type: (...) -> None
 
+    current_target = LocalInterpreter.create()
     pip_version = (
         PipVersion.v22_2_2
-        if PipVersion.v22_2_2.requires_python_applies(LocalInterpreter.create())
+        if PipVersion.v22_2_2.requires_python_applies(current_target)
         else PipVersion.VENDORED
     )
     build_system = load_build_system(
+        current_target,
         ConfiguredResolver(PipConfiguration(version=pip_version)),
         pex_project_dir,
     )
@@ -50,7 +52,7 @@ def test_load_build_system_pyproject_custom_repos(
     custom_resolver = ConfiguredResolver(
         PipConfiguration(repos_configuration=repos_configuration, version=pip_version)
     )
-    build_system = load_build_system(custom_resolver, pex_project_dir)
+    build_system = load_build_system(current_target, custom_resolver, pex_project_dir)
     assert isinstance(build_system, BuildSystem)
     subprocess.check_call(
         args=[build_system.venv_pex.pex, "-c", "import {}".format(build_system.build_backend)]

--- a/tests/integration/cli/commands/test_issue_2050.py
+++ b/tests/integration/cli/commands/test_issue_2050.py
@@ -22,6 +22,7 @@ from pex.resolve.lockfile import json_codec
 from pex.resolve.path_mappings import PathMapping, PathMappings
 from pex.result import try_
 from pex.sorted_tuple import SortedTuple
+from pex.targets import LocalInterpreter
 from pex.testing import (
     IS_LINUX,
     PY310,
@@ -71,6 +72,7 @@ def build_sdist(tmpdir):
                 project_directory=project_directory,
                 dist_dir=find_links,
                 pip_version=PipVersion.VENDORED,
+                target=LocalInterpreter.create(),
                 resolver=ConfiguredResolver.default(),
             )
         )

--- a/tests/integration/resolve/test_issue_2092.py
+++ b/tests/integration/resolve/test_issue_2092.py
@@ -42,6 +42,8 @@ def test_vcs_respects_target(
         "linux",
         "--target-system",
         "mac",
+        "--python-path",
+        os.pathsep.join((py38.binary, py39.binary)),
         "--interpreter-constraint",
         "==3.9.*",
         vcs_requirement,

--- a/tests/integration/resolve/test_issue_2092.py
+++ b/tests/integration/resolve/test_issue_2092.py
@@ -1,0 +1,80 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import os.path
+import sys
+
+import pytest
+
+from pex.cli.testing import run_pex3
+from pex.compatibility import commonpath
+from pex.interpreter import PythonInterpreter
+from pex.pex_info import PexInfo
+from pex.testing import run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_vcs_respects_target(
+    tmpdir,  # type: Any
+    py38,  # type: PythonInterpreter
+    py39,  # type: PythonInterpreter
+):
+    # type: (...) -> None
+
+    lock = os.path.join(str(tmpdir), "lock.json")
+    vcs_requirement = (
+        "emote-rl[torch]@ "
+        "git+https://github.com/EmbarkStudios/emote"
+        "@4c5b31753e7a497fa57ab59e13344468510c920c"
+        "#egg=emote-rl"
+    )
+
+    run_pex3(
+        "lock",
+        "create",
+        "--style",
+        "universal",
+        "--resolver-version",
+        "pip-2020-resolver",
+        "--target-system",
+        "linux",
+        "--target-system",
+        "mac",
+        "--interpreter-constraint",
+        "==3.9.*",
+        vcs_requirement,
+        "-o",
+        lock,
+        "--indent",
+        "2",
+    ).assert_success()
+
+    pex = os.path.join(str(tmpdir), "pex")
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--lock",
+            lock,
+            "--python-path",
+            os.pathsep.join((py38.binary, py39.binary)),
+            "--interpreter-constraint",
+            "==3.9.*",
+            "--intransitive",
+            vcs_requirement,
+            "-o",
+            pex,
+        ],
+        python=py38.binary,
+    ).assert_success()
+
+    assert {
+        "emote_rl-23.0.0-py3-none-any.whl": (
+            "e136042e61a0a4f6875cbfa06e4e3fada1f23f095364daf84c18d124fc4e462a"
+        )
+    } == PexInfo.from_pex(pex).distributions

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -29,12 +29,6 @@ if TYPE_CHECKING:
     from typing import Optional
 
 
-@pytest.fixture
-def current_interpreter():
-    # type: () -> PythonInterpreter
-    return PythonInterpreter.get()
-
-
 def test_current(current_interpreter):
     # type: (PythonInterpreter) -> None
     assert LocalInterpreter.create() == targets.current()
@@ -235,3 +229,35 @@ def test_requires_python_invalid_target():
         ),
     ):
         invalid_target.requires_python_applies(requires_python=requires_python, source=source)
+
+
+def test_from_target_local_interpreter():
+    # type: () -> None
+
+    local_interpreter = LocalInterpreter.create()
+    tgts = Targets.from_target(local_interpreter)
+    assert local_interpreter.interpreter == tgts.interpreter
+    assert OrderedSet([local_interpreter]) == tgts.unique_targets(only_explicit=False)
+    assert OrderedSet([local_interpreter]) == tgts.unique_targets(only_explicit=True)
+
+
+def test_from_target_abbreviated_platform(current_platform):
+    # type: (Platform) -> None
+
+    abbreviated_platform = AbbreviatedPlatform.create(
+        platform=current_platform, manylinux="manylinux1"
+    )
+    tgts = Targets.from_target(abbreviated_platform)
+    assert tgts.interpreter is None
+    assert OrderedSet([abbreviated_platform]) == tgts.unique_targets(only_explicit=False)
+    assert OrderedSet([abbreviated_platform]) == tgts.unique_targets(only_explicit=True)
+
+
+def test_from_target_complete_platform(current_interpreter):
+    # type: (PythonInterpreter) -> None
+
+    complete_platform = CompletePlatform.from_interpreter(current_interpreter)
+    tgts = Targets.from_target(complete_platform)
+    assert tgts.interpreter is None
+    assert OrderedSet([complete_platform]) == tgts.unique_targets(only_explicit=False)
+    assert OrderedSet([complete_platform]) == tgts.unique_targets(only_explicit=True)


### PR DESCRIPTION
Previously the ambient Pex interpreter was used to perform VCS downloads
and perform PEP-517 builds instead of the target interpreter(s) selected
by `--python`, `--python-path` and `--interpreter-constraint`.

Fixes #2092