### PR TITLE
Support --pip overrides via PEX deps.

### DIFF
--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -10,7 +10,6 @@ import subprocess
 from argparse import ArgumentParser
 from collections import OrderedDict
 from subprocess import CalledProcessError
-from typing import Iterable, Union
 
 from pex import pex_warnings
 from pex.common import safe_delete, safe_rmtree
@@ -30,7 +29,7 @@ from pex.venv.pex import populate_venv
 from pex.venv.virtualenv import PipUnavailableError, Virtualenv
 
 if TYPE_CHECKING:
-    from typing import Optional
+    from typing import Iterable, Optional, Union
 
     import attr  # vendor:skip
 else:
@@ -154,10 +153,14 @@ def ensure_pip_installed(
         ),
     )
     if not collisions_ok:
-        return Error("{message}.\nConsider re-running without --pip.".format(message=message))
+        return Error(
+            "{message}\nConsider re-running either without --pip or with --collisions-ok.".format(
+                message=message
+            )
+        )
 
     pex_warnings.warn(
-        "{message}.\nUninstalling venv versions and using versions from the PEX.".format(
+        "{message}\nUninstalling venv versions and using versions from the PEX.".format(
             message=message
         )
     )

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -6,15 +6,23 @@ from __future__ import absolute_import
 import errno
 import logging
 import os
+import subprocess
 from argparse import ArgumentParser
+from collections import OrderedDict
+from subprocess import CalledProcessError
+from typing import Iterable, Union
 
 from pex import pex_warnings
 from pex.common import safe_delete, safe_rmtree
+from pex.dist_metadata import Distribution
 from pex.enum import Enum
 from pex.executor import Executor
+from pex.pep_440 import Version
+from pex.pep_503 import ProjectName
 from pex.pex import PEX
-from pex.result import Error, Ok, Result
+from pex.result import Error, Ok, Result, try_
 from pex.tools.command import PEXCommand
+from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 from pex.venv.bin_path import BinPath
 from pex.venv.install_scope import InstallScope
@@ -71,6 +79,100 @@ class InstallScopeState(object):
             install_scope = InstallScope.ALL
         with open(self._state_file, "w") as fp:
             fp.write(str(install_scope))
+
+
+def find_dist(
+    project_name,  # type: ProjectName
+    dists,  # type: Iterable[Distribution]
+):
+    # type: (...) -> Optional[Version]
+    for dist in dists:
+        if project_name == dist.metadata.project_name:
+            return dist.metadata.version
+    return None
+
+
+_PIP = ProjectName("pip")
+_SETUPTOOLS = ProjectName("setuptools")
+
+
+def ensure_pip_installed(
+    venv,  # type: Virtualenv
+    pex,  # type: PEX
+    scope,  # type: InstallScope.Value
+    collisions_ok,  # type: bool
+):
+    # type: (...) -> Union[Version, Error]
+
+    venv_pip_version = find_dist(_PIP, venv.iter_distributions())
+    if venv_pip_version:
+        TRACER.log(
+            "The venv at {venv_dir} already has Pip {version} installed.".format(
+                venv_dir=venv.venv_dir, version=venv_pip_version
+            )
+        )
+    else:
+        try:
+            venv.install_pip()
+        except PipUnavailableError as e:
+            return Error(
+                "The virtual environment was successfully created, but Pip was not "
+                "installed:\n{}".format(e)
+            )
+        venv_pip_version = find_dist(_PIP, venv.iter_distributions())
+        if not venv_pip_version:
+            return Error(
+                "Failed to install pip into venv at {venv_dir}".format(venv_dir=venv.venv_dir)
+            )
+
+    if InstallScope.SOURCE_ONLY == scope:
+        return venv_pip_version
+
+    uninstall = OrderedDict()
+    pex_pip_version = find_dist(_PIP, pex.resolve())
+    if pex_pip_version and pex_pip_version != venv_pip_version:
+        uninstall[_PIP] = pex_pip_version
+
+    venv_setuptools_version = find_dist(_SETUPTOOLS, venv.iter_distributions())
+    if venv_setuptools_version:
+        pex_setuptools_version = find_dist(_SETUPTOOLS, pex.resolve())
+        if pex_setuptools_version and venv_setuptools_version != pex_setuptools_version:
+            uninstall[_SETUPTOOLS] = pex_setuptools_version
+
+    if not uninstall:
+        return venv_pip_version
+
+    message = (
+        "You asked for --pip to be installed in the venv at {venv_dir},\n"
+        "but the PEX at {pex} already contains:\n{distributions}"
+    ).format(
+        venv_dir=venv.venv_dir,
+        pex=pex.path(),
+        distributions="\n".join(
+            "{project_name} {version}".format(project_name=project_name, version=version)
+            for project_name, version in uninstall.items()
+        ),
+    )
+    if not collisions_ok:
+        return Error("{message}.\nConsider re-running without --pip.".format(message=message))
+
+    pex_warnings.warn(
+        "{message}.\nUninstalling venv versions and using versions from the PEX.".format(
+            message=message
+        )
+    )
+    projects_to_uninstall = sorted(str(project_name) for project_name in uninstall)
+    try:
+        subprocess.check_call(
+            args=[venv.interpreter.binary, "-m", "pip", "uninstall", "-y"] + projects_to_uninstall
+        )
+    except CalledProcessError as e:
+        return Error(
+            "Failed to uninstall venv versions of {projects}: {err}".format(
+                projects=" and ".join(projects_to_uninstall), err=e
+            )
+        )
+    return pex_pip_version or venv_pip_version
 
 
 class Venv(PEXCommand):
@@ -133,7 +235,12 @@ class Venv(PEXCommand):
             "--pip",
             action="store_true",
             default=False,
-            help="Add pip to the venv.",
+            help=(
+                "Add pip (and setuptools) to the venv. If the PEX already contains its own "
+                "conflicting versions pip (or setuptools), the command will error and you must "
+                "pass --collisions-ok to have the PEX versions over-ride the natural venv versions "
+                "installed by --pip."
+            ),
         )
         parser.add_argument(
             "--copies",
@@ -195,6 +302,13 @@ class Venv(PEXCommand):
                 prompt=self.options.prompt,
             )
 
+        if self.options.pip:
+            try_(
+                ensure_pip_installed(
+                    venv, pex, scope=self.options.scope, collisions_ok=self.options.collisions_ok
+                )
+            )
+
         if self.options.prompt != venv.custom_prompt:
             logger.warning(
                 "Unable to apply custom --prompt {prompt!r} in {python} venv; continuing with the "
@@ -211,14 +325,7 @@ class Venv(PEXCommand):
             scope=self.options.scope,
             hermetic_scripts=self.options.hermetic_scripts,
         )
-        if self.options.pip:
-            try:
-                venv.install_pip()
-            except PipUnavailableError as e:
-                return Error(
-                    "The virtual environment was successfully created, but Pip was not "
-                    "installed:\n{}".format(e)
-                )
+
         if self.options.compile:
             try:
                 pex.interpreter.execute(["-m", "compileall", venv_dir])

--- a/pex/venv/virtualenv.py
+++ b/pex/venv/virtualenv.py
@@ -375,5 +375,5 @@ class Virtualenv(object):
                         os.path.join(atomic_dir.work_dir, os.path.basename(get_pip)), "wb"
                     ) as dst_fp:
                         shutil.copyfileobj(src_fp, dst_fp)
-            self._interpreter.execute(args=[get_pip])
+            self._interpreter.execute(args=[get_pip, "--no-wheel"])
         return self.bin_path("pip")

--- a/tests/integration/tools/commands/test_issue_2105.py
+++ b/tests/integration/tools/commands/test_issue_2105.py
@@ -165,10 +165,10 @@ def assert_venv_dists_conflicts(
     expected_message_prefix = (
         dedent(
             """\
-        You asked for --pip to be installed in the venv at {venv_dir},
-        but the PEX at {pex} already contains:
-        {conflicts}
-        """
+            You asked for --pip to be installed in the venv at {venv_dir},
+            but the PEX at {pex} already contains:
+            {conflicts}
+            """
         )
         .format(venv_dir=venv_dir, pex=pex, conflicts=os.linesep.join(expected_conflicts))
         .strip()

--- a/tests/integration/tools/commands/test_issue_2105.py
+++ b/tests/integration/tools/commands/test_issue_2105.py
@@ -1,0 +1,294 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+import subprocess
+from textwrap import dedent
+
+import pytest
+
+from pex.dist_metadata import Distribution
+from pex.pep_440 import Version
+from pex.pep_503 import ProjectName
+from pex.pex import PEX
+from pex.testing import make_env, run_pex_command
+from pex.typing import TYPE_CHECKING
+from pex.venv.virtualenv import Virtualenv
+
+if TYPE_CHECKING:
+    from typing import Any, Iterable, Mapping
+
+
+@pytest.fixture(scope="module")
+def td(tmpdir_factory):
+    # type: (Any) -> Any
+    return tmpdir_factory.mktemp("td")
+
+
+PIP_PROJECT_NAME = ProjectName("pip")
+SETUPTOOLS_PROJECT_NAME = ProjectName("setuptools")
+
+
+def index_distributions(dists):
+    # type: (Iterable[Distribution]) -> Mapping[ProjectName, Version]
+    return {dist.metadata.project_name: dist.metadata.version for dist in dists}
+
+
+@pytest.fixture(scope="module")
+def baseline_venv_with_pip(td):
+    # type: (Any) -> Mapping[ProjectName, Version]
+    baseline_venv = Virtualenv.create(venv_dir=str(td.join("baseline.venv")))
+    baseline_venv.install_pip()
+    baseline_venv_distributions = index_distributions(baseline_venv.iter_distributions())
+    assert {PIP_PROJECT_NAME, SETUPTOOLS_PROJECT_NAME} == set(baseline_venv_distributions)
+    return baseline_venv_distributions
+
+
+@pytest.fixture(scope="module")
+def baseline_venv_pip_version(baseline_venv_with_pip):
+    # type: (Mapping[ProjectName, Version]) -> Version
+    return baseline_venv_with_pip[PIP_PROJECT_NAME]
+
+
+@pytest.fixture(scope="module")
+def baseline_venv_setuptools_version(baseline_venv_with_pip):
+    # type: (Mapping[ProjectName, Version]) -> Version
+    return baseline_venv_with_pip[SETUPTOOLS_PROJECT_NAME]
+
+
+def assert_venv_dists(
+    venv_dir,  # type: str
+    expected_pip_version,  # type: Version
+    expected_setuptools_version,  # type: Version
+):
+    virtualenv = Virtualenv(venv_dir)
+    dists = index_distributions(virtualenv.iter_distributions())
+    assert expected_pip_version == dists[PIP_PROJECT_NAME]
+    assert expected_setuptools_version == dists[SETUPTOOLS_PROJECT_NAME]
+
+    def reported_version(module):
+        # type: (str) -> Version
+        return Version(
+            subprocess.check_output(
+                args=[
+                    virtualenv.interpreter.binary,
+                    "-c",
+                    "import {module}; print({module}.__version__)".format(module=module),
+                ]
+            ).decode("utf-8")
+        )
+
+    assert expected_pip_version == reported_version("pip")
+    assert expected_setuptools_version == reported_version("setuptools")
+
+
+def assert_venv_dists_no_conflicts(
+    tmpdir,  # type: Any
+    pex,  # type: str
+    expected_pip_version,  # type: Version
+    expected_setuptools_version,  # type: Version
+):
+    # type: (...) -> None
+    venv_dir = os.path.join(str(tmpdir), "venv_dir")
+    subprocess.check_call(args=[pex, "venv", "--pip", venv_dir], env=make_env(PEX_TOOLS=1))
+    assert_venv_dists(venv_dir, expected_pip_version, expected_setuptools_version)
+
+
+def test_pip_empty_pex(
+    tmpdir,  # type: Any
+    baseline_venv_pip_version,  # type: Version
+    baseline_venv_setuptools_version,  # type: Version
+):
+    # type: (...) -> None
+
+    pex = os.path.join(str(tmpdir), "pex")
+    run_pex_command(args=["-o", pex, "--include-tools"]).assert_success()
+
+    assert_venv_dists_no_conflicts(
+        tmpdir,
+        pex,
+        expected_pip_version=baseline_venv_pip_version,
+        expected_setuptools_version=baseline_venv_setuptools_version,
+    )
+
+
+def test_pip_pex_no_conflicts(
+    tmpdir,  # type: Any
+    baseline_venv_pip_version,  # type: Version
+    baseline_venv_setuptools_version,  # type: Version
+):
+    # type: (...) -> None
+
+    pex = os.path.join(str(tmpdir), "pex")
+    run_pex_command(
+        args=[
+            "-o",
+            pex,
+            "pip=={version}".format(version=baseline_venv_pip_version),
+            "setuptools=={version}".format(version=baseline_venv_setuptools_version),
+            "--include-tools",
+        ]
+    ).assert_success()
+
+    assert_venv_dists_no_conflicts(
+        tmpdir,
+        pex,
+        expected_pip_version=baseline_venv_pip_version,
+        expected_setuptools_version=baseline_venv_setuptools_version,
+    )
+
+
+def assert_venv_dists_conflicts(
+    tmpdir,  # type: Any
+    pex,  # type: str
+    baseline_venv_pip_version,  # type: Version
+    baseline_venv_setuptools_version,  # type: Version
+    expected_pip_version,  # type: Version
+    expected_setuptools_version,  # type: Version
+):
+    # type: (...) -> None
+
+    expected_conflicts = []
+    if baseline_venv_pip_version != expected_pip_version:
+        expected_conflicts.append("pip {version}".format(version=expected_pip_version))
+    if baseline_venv_setuptools_version != expected_setuptools_version:
+        expected_conflicts.append(
+            "setuptools {version}".format(version=expected_setuptools_version)
+        )
+    assert (
+        expected_conflicts
+    ), "The assert_venv_dists_conflicts function requires at least one conflict."
+
+    venv_dir = os.path.join(str(tmpdir), "venv_dir")
+    args = [pex, "venv", "--pip", venv_dir]
+
+    expected_message_prefix = (
+        dedent(
+            """\
+        You asked for --pip to be installed in the venv at {venv_dir},
+        but the PEX at {pex} already contains:
+        {conflicts}
+        """
+        )
+        .format(venv_dir=venv_dir, pex=pex, conflicts=os.linesep.join(expected_conflicts))
+        .strip()
+    )
+
+    process = subprocess.Popen(args, stderr=subprocess.PIPE, env=make_env(PEX_TOOLS=1))
+    _, stderr = process.communicate()
+    assert 0 != process.returncode
+
+    decoded_stderr = stderr.decode("utf-8")
+    assert (
+        dedent(
+            """\
+            {prefix}
+            Consider re-running either without --pip or with --collisions-ok.
+            """
+        ).format(prefix=expected_message_prefix)
+        in decoded_stderr
+    ), decoded_stderr
+
+    process = subprocess.Popen(
+        args + ["--force", "--collisions-ok"], stderr=subprocess.PIPE, env=make_env(PEX_TOOLS=1)
+    )
+    _, stderr = process.communicate()
+    assert 0 == process.returncode
+    decoded_stderr = stderr.decode("utf-8")
+    assert (
+        dedent(
+            """\
+            {prefix}
+            Uninstalling venv versions and using versions from the PEX.
+            """
+        ).format(prefix=expected_message_prefix)
+        in decoded_stderr
+    ), decoded_stderr
+
+    assert_venv_dists(venv_dir, expected_pip_version, expected_setuptools_version)
+
+
+def test_pip_pex_pip_conflict(
+    tmpdir,  # type: Any
+    baseline_venv_pip_version,  # type: Version
+    baseline_venv_setuptools_version,  # type: Version
+):
+    # type: (...) -> None
+
+    pex = os.path.join(str(tmpdir), "pex")
+    run_pex_command(
+        args=[
+            "-o",
+            pex,
+            "pip!={version}".format(version=baseline_venv_pip_version),
+            "--include-tools",
+        ]
+    ).assert_success()
+    pex_pip_version = index_distributions(PEX(pex).resolve())[PIP_PROJECT_NAME]
+
+    assert_venv_dists_conflicts(
+        tmpdir,
+        pex,
+        baseline_venv_pip_version=baseline_venv_pip_version,
+        baseline_venv_setuptools_version=baseline_venv_setuptools_version,
+        expected_pip_version=pex_pip_version,
+        expected_setuptools_version=baseline_venv_setuptools_version,
+    )
+
+
+def test_pip_pex_setuptools_conflict(
+    tmpdir,  # type: Any
+    baseline_venv_pip_version,  # type: Version
+    baseline_venv_setuptools_version,  # type: Version
+):
+    # type: (...) -> None
+
+    pex = os.path.join(str(tmpdir), "pex")
+    run_pex_command(
+        args=[
+            "-o",
+            pex,
+            "setuptools!={version}".format(version=baseline_venv_setuptools_version),
+            "--include-tools",
+        ]
+    ).assert_success()
+    pex_setuptools_version = index_distributions(PEX(pex).resolve())[SETUPTOOLS_PROJECT_NAME]
+
+    assert_venv_dists_conflicts(
+        tmpdir,
+        pex,
+        baseline_venv_pip_version=baseline_venv_pip_version,
+        baseline_venv_setuptools_version=baseline_venv_setuptools_version,
+        expected_pip_version=baseline_venv_pip_version,
+        expected_setuptools_version=pex_setuptools_version,
+    )
+
+
+def test_pip_pex_both_conflict(
+    tmpdir,  # type: Any
+    baseline_venv_pip_version,  # type: Version
+    baseline_venv_setuptools_version,  # type: Version
+):
+    # type: (...) -> None
+
+    pex = os.path.join(str(tmpdir), "pex")
+    run_pex_command(
+        args=[
+            "-o",
+            pex,
+            "pip!={version}".format(version=baseline_venv_pip_version),
+            "setuptools!={version}".format(version=baseline_venv_setuptools_version),
+            "--include-tools",
+        ]
+    ).assert_success()
+    pex_pip_version = index_distributions(PEX(pex).resolve())[PIP_PROJECT_NAME]
+    pex_setuptools_version = index_distributions(PEX(pex).resolve())[SETUPTOOLS_PROJECT_NAME]
+
+    assert_venv_dists_conflicts(
+        tmpdir,
+        pex,
+        baseline_venv_pip_version=baseline_venv_pip_version,
+        baseline_venv_setuptools_version=baseline_venv_setuptools_version,
+        expected_pip_version=pex_pip_version,
+        expected_setuptools_version=pex_setuptools_version,
+    )


### PR DESCRIPTION
Now, when creating a venv using pex tools and the `--pip` option from a
PEX that includes pip or setuptools or both, those embedded versions
will be used in place of the conflicting versions installed via `--pip`
if `--collisions-ok` is also specified; otherwise the venv pex tool will
error.

Closes #2105