### PR TITLE
Add support for `--pip-version latest`.

### DIFF
--- a/pex/pep_440.py
+++ b/pex/pep_440.py
@@ -27,7 +27,7 @@ def _ensure_ascii_str(text):
     return str(text)
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, order=True)
 class Version(object):
     """A PEP-440 normalized version: https://www.python.org/dev/peps/pep-0440/#normalization"""
 

--- a/pex/resolve/resolver_options.py
+++ b/pex/resolve/resolver_options.py
@@ -84,7 +84,7 @@ def register(
         "--pip-version",
         dest="pip_version",
         default=str(default_resolver_configuration.version),
-        choices=["vendored"] + [str(value) for value in PipVersion.values()],
+        choices=["latest", "vendored"] + [str(value) for value in PipVersion.values()],
         help="The version of Pip to use for resolving dependencies.",
     )
     parser.add_argument(
@@ -432,11 +432,12 @@ def create_pip_configuration(options):
 
     repos_configuration = create_repos_configuration(options)
 
-    pip_version = (
-        PipVersion.VENDORED
-        if options.pip_version == "vendored"
-        else PipVersion.for_value(options.pip_version)
-    )
+    if options.pip_version == "latest":
+        pip_version = PipVersion.LATEST
+    elif options.pip_version == "vendored":
+        pip_version = PipVersion.VENDORED
+    else:
+        pip_version = PipVersion.for_value(options.pip_version)
 
     return PipConfiguration(
         resolver_version=options.resolver_version,

--- a/pex/resolve/resolver_options.py
+++ b/pex/resolve/resolver_options.py
@@ -85,7 +85,11 @@ def register(
         dest="pip_version",
         default=str(default_resolver_configuration.version),
         choices=["latest", "vendored"] + [str(value) for value in PipVersion.values()],
-        help="The version of Pip to use for resolving dependencies.",
+        help=(
+            "The version of Pip to use for resolving dependencies. The `latest` version refers to "
+            "the latest version in this list ({latest}) which is not necessarily the latest Pip "
+            "version released on PyPI.".format(latest=PipVersion.LATEST)
+        ),
     )
     parser.add_argument(
         "--allow-pip-version-fallback",

--- a/tests/pip/test_version.py
+++ b/tests/pip/test_version.py
@@ -1,0 +1,12 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pex.pip.version import PipVersion
+
+
+def test_latest():
+    # type: () -> None
+
+    assert PipVersion.LATEST != PipVersion.VENDORED
+    assert PipVersion.LATEST >= PipVersion.v23_1
+    assert max(PipVersion.values(), key=lambda pv: pv.version) is PipVersion.LATEST

--- a/tests/resolve/test_resolver_options.py
+++ b/tests/resolve/test_resolver_options.py
@@ -5,6 +5,7 @@ from argparse import ArgumentParser
 
 import pytest
 
+from pex.pip.version import PipVersion
 from pex.resolve import resolver_options
 from pex.resolve.resolver_configuration import (
     PexRepositoryConfiguration,
@@ -149,3 +150,25 @@ def test_invalid_configuration(parser):
         compute_resolver_configuration(
             parser, args=["--pex-repository", "a.pex", "-f", "https://a.find/links/repo"]
         )
+
+
+def test_vendored_pip_version(parser):
+    # type: (ArgumentParser) -> None
+    resolver_options.register(parser)
+
+    pip_configuration = compute_pip_configuration(parser, args=[])
+    assert pip_configuration.version is PipVersion.VENDORED, "Expected the default Pip version to be the vendored one"
+
+    pip_configuration = compute_pip_configuration(parser, args=["--pip-version", "vendored"])
+    assert pip_configuration.version is PipVersion.VENDORED
+
+    pip_configuration = compute_pip_configuration(parser, args=["--pip-version", "20.3.4-patched"])
+    assert pip_configuration.version is PipVersion.VENDORED
+
+
+def test_latest_pip_version(parser):
+    # type: (ArgumentParser) -> None
+    resolver_options.register(parser)
+
+    pip_configuration = compute_pip_configuration(parser, args=["--pip-version", "latest"])
+    assert pip_configuration.version is PipVersion.LATEST

--- a/tests/resolve/test_resolver_options.py
+++ b/tests/resolve/test_resolver_options.py
@@ -156,11 +156,6 @@ def test_vendored_pip_version(parser):
     # type: (ArgumentParser) -> None
     resolver_options.register(parser)
 
-    pip_configuration = compute_pip_configuration(parser, args=[])
-    assert (
-        pip_configuration.version is PipVersion.VENDORED
-    ), "Expected the default Pip version to be the vendored one."
-
     pip_configuration = compute_pip_configuration(parser, args=["--pip-version", "vendored"])
     assert pip_configuration.version is PipVersion.VENDORED
 

--- a/tests/resolve/test_resolver_options.py
+++ b/tests/resolve/test_resolver_options.py
@@ -157,7 +157,9 @@ def test_vendored_pip_version(parser):
     resolver_options.register(parser)
 
     pip_configuration = compute_pip_configuration(parser, args=[])
-    assert pip_configuration.version is PipVersion.VENDORED, "Expected the default Pip version to be the vendored one"
+    assert (
+        pip_configuration.version is PipVersion.VENDORED
+    ), "Expected the default Pip version to be the vendored one."
 
     pip_configuration = compute_pip_configuration(parser, args=["--pip-version", "vendored"])
     assert pip_configuration.version is PipVersion.VENDORED


### PR DESCRIPTION
This allows an opt-in to always using the latest Pip supported by Pex
when upgrading through Pex versions. This is generally desirable for
most Pex consumers.