### PR TITLE
Convert PyPI publishing to OIDC.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,14 @@ jobs:
   org-check:
     name: Check GitHub Organization
     if: ${{ github.repository_owner == 'pantsbuild' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Noop
         run: "true"
   determine-tag:
     name: Determine the release tag to operate against.
     needs: org-check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       release-tag: ${{ steps.determine-tag.outputs.release-tag }}
       release-version: ${{ steps.determine-tag.outputs.release-version }}
@@ -42,8 +42,10 @@ jobs:
   pypi:
     name: Publish sdist and wheel to PyPI
     needs: determine-tag
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: Release
+    permissions:
+      id-token: write
     steps:
       - name: Checkout Pex ${{ needs.determine-tag.outputs.release-tag }}
         uses: actions/checkout@v3
@@ -53,17 +55,19 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - name: Publish Pex ${{ needs.determine-tag.outputs.release-tag }}
+      - name: Build sdist and wheel
         uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        env:
-          FLIT_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          FLIT_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         with:
-          tox-env: publish
+          tox-env: package -- --no-pex --additional-format sdist --additional-format wheel
+      - name: Publish Pex ${{ needs.determine-tag.outputs.release-tag }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          print-hash: true
+          verbose: true
   github-release:
     name: Create Github Release
     needs: determine-tag
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: Release
     steps:
       - name: Checkout Pex ${{ needs.determine-tag.outputs.release-tag }}

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -9,7 +9,7 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from enum import Enum, unique
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path, PurePath
-from typing import Tuple, cast
+from typing import Optional, Tuple, cast
 
 PROJECT_METADATA = Path("pyproject.toml")
 DIST_DIR = Path("dist")
@@ -99,18 +99,19 @@ def build_pex_dists(dist_fmt: Format, *additional_dist_fmts: Format, verbose: bo
 def main(
     *additional_dist_formats: Format,
     verbosity: int = 0,
-    pex_output_file: Path = DIST_DIR / "pex",
+    pex_output_file: Optional[Path] = DIST_DIR / "pex",
     local: bool = False,
     serve: bool = False
 ) -> None:
-    print(f"Building Pex PEX to `{pex_output_file}` ...")
-    build_pex_pex(pex_output_file, local, verbosity)
+    if pex_output_file:
+        print(f"Building Pex PEX to `{pex_output_file}` ...")
+        build_pex_pex(pex_output_file, local, verbosity)
 
-    git_rev = describe_git_rev()
-    sha256, size = describe_file(pex_output_file)
-    print(f"Built Pex PEX @ {git_rev}:")
-    print(f"sha256: {sha256}")
-    print(f"  size: {size}")
+        git_rev = describe_git_rev()
+        sha256, size = describe_file(pex_output_file)
+        print(f"Built Pex PEX @ {git_rev}:")
+        print(f"sha256: {sha256}")
+        print(f"  size: {size}")
 
     if additional_dist_formats:
         print(
@@ -157,6 +158,12 @@ if __name__ == "__main__":
         help="Package Pex in additional formats.",
     )
     parser.add_argument(
+        "--no-pex",
+        default=False,
+        action="store_true",
+        help="Build Pex PEX with just a single local interpreter.",
+    )
+    parser.add_argument(
         "--pex-output-file",
         default=DIST_DIR / "pex",
         type=Path,
@@ -179,7 +186,7 @@ if __name__ == "__main__":
     main(
         *(args.additional_formats or ()),
         verbosity=args.verbosity,
-        pex_output_file=args.pex_output_file,
+        pex_output_file=None if args.no_pex else args.pex_output_file,
         local=args.local,
         serve=args.serve
     )

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -161,7 +161,7 @@ if __name__ == "__main__":
         "--no-pex",
         default=False,
         action="store_true",
-        help="Build Pex PEX with just a single local interpreter.",
+        help="Do not build the Pex PEX.",
     )
     parser.add_argument(
         "--pex-output-file",

--- a/tests/integration/test_issue_2038.py
+++ b/tests/integration/test_issue_2038.py
@@ -26,8 +26,16 @@ if TYPE_CHECKING:
 def test_wheel_file_url_dep(tmpdir):
     # type: (Any) -> None
 
+    constraints = os.path.join(str(tmpdir), "constraints.txt")
+    with open(constraints, "w") as fp:
+        # The 20.22 release introduces a change that breaks resolution od poetry 1.3.2; so we pin
+        # low.
+        fp.write("virtualenv<20.22")
+
     poetry = os.path.join(str(tmpdir), "poetry.pex")
-    run_pex_command(args=["poetry==1.3.2", "-c", "poetry", "-o", poetry]).assert_success()
+    run_pex_command(
+        args=["poetry==1.3.2", "--constraints", constraints, "-c", "poetry", "-o", poetry]
+    ).assert_success()
 
     corelibrary = os.path.join(str(tmpdir), "corelibrary")
     touch(os.path.join(corelibrary, "README.md"))

--- a/tox.ini
+++ b/tox.ini
@@ -175,18 +175,6 @@ deps =
 commands =
     python scripts/package.py --additional-format wheel --local --serve {posargs}
 
-[testenv:publish]
-skip_install = true
-basepython = {[_flit]basepython}
-passenv =
-    # These are used in CI.
-    FLIT_USERNAME
-    FLIT_PASSWORD
-deps =
-    {[_flit]deps}
-commands =
-    flit publish
-
 [testenv:pip]
 description = Run Pex's vendored pip.
 skip_install = true


### PR DESCRIPTION
I've already configured the publisher for Pex on PyPI as described here:
  https://docs.pypi.org/trusted-publishers/adding-a-publisher/

This change addresses the GitHub side of things as described here:
  https://docs.pypi.org/trusted-publishers/using-a-publisher/

I'll delete the PYPI_USERNAME and PYPI_PASSWORD secrets after a
successful release using this new system.

Prep work for #2121