### PR TITLE
Use get_requires_for_build_wheel for metadata prep.

### DIFF
--- a/pex/build_system/pep_517.py
+++ b/pex/build_system/pep_517.py
@@ -187,17 +187,17 @@ def build_sdist(
     # type: (...) -> Union[Text, Error]
 
     extra_requirements = []
-    spawned_job = try_(
-        _invoke_build_hook(
-            project_directory,
-            pip_version,
-            target,
-            resolver,
-            hook_method="get_requires_for_build_sdist",
-        )
+    spawned_job_or_error = _invoke_build_hook(
+        project_directory,
+        pip_version,
+        target,
+        resolver,
+        hook_method="get_requires_for_build_sdist",
     )
+    if isinstance(spawned_job_or_error, Error):
+        return spawned_job_or_error
     try:
-        extra_requirements.extend(spawned_job.await_result())
+        extra_requirements.extend(spawned_job_or_error.await_result())
     except Job.Error as e:
         if e.exitcode != _HOOK_UNAVAILABLE_EXIT_CODE:
             raise e

--- a/pex/build_system/pep_517.py
+++ b/pex/build_system/pep_517.py
@@ -200,7 +200,11 @@ def build_sdist(
         extra_requirements.extend(spawned_job_or_error.await_result())
     except Job.Error as e:
         if e.exitcode != _HOOK_UNAVAILABLE_EXIT_CODE:
-            raise e
+            return Error(
+                "Failed to prepare build backend for building an sdist for local project "
+                "{project_directory}: {err}\n"
+                "{stderr}".format(project_directory=project_directory, err=e, stderr=e.stderr)
+            )
 
     spawned_job_or_error = _invoke_build_hook(
         project_directory,

--- a/pex/build_system/pep_518.py
+++ b/pex/build_system/pep_518.py
@@ -111,28 +111,30 @@ class BuildSystem(object):
             # the Python they come paired with.
             upgrade_pip = virtualenv.interpreter.version[:2] == (3, 5)
             virtualenv.install_pip(upgrade=upgrade_pip)
-            _, process = virtualenv.interpreter.open_process(
-                args=[
-                    "-m",
-                    "pip",
-                    "install",
-                    "--ignore-installed",
-                    "--no-user",
-                    "--no-warn-script-location",
-                ]
-                + list(extra_requirements),
-                stderr=subprocess.PIPE,
-            )
-            _, stderr = process.communicate()
-            if process.returncode != 0:
-                return Error(
-                    "Failed to install extra requirement in venv at {venv_dir}: "
-                    "{extra_requirements}\nSTDERR:\n{stderr}".format(
-                        venv_dir=venv_pex.venv_dir,
-                        extra_requirements=", ".join(extra_requirements),
-                        stderr=stderr.decode("utf-8"),
-                    )
+            with open(os.devnull, "wb") as dev_null:
+                _, process = virtualenv.interpreter.open_process(
+                    args=[
+                        "-m",
+                        "pip",
+                        "install",
+                        "--ignore-installed",
+                        "--no-user",
+                        "--no-warn-script-location",
+                    ]
+                    + list(extra_requirements),
+                    stdout=dev_null,
+                    stderr=subprocess.PIPE,
                 )
+                _, stderr = process.communicate()
+                if process.returncode != 0:
+                    return Error(
+                        "Failed to install extra requirement in venv at {venv_dir}: "
+                        "{extra_requirements}\nSTDERR:\n{stderr}".format(
+                            venv_dir=venv_pex.venv_dir,
+                            extra_requirements=", ".join(extra_requirements),
+                            stderr=stderr.decode("utf-8"),
+                        )
+                    )
 
         # Ensure all PEX* env vars are stripped except for PEX_ROOT and PEX_VERBOSE. We want folks
         # to be able to steer the location of the cache and the logging verbosity, but nothing else.

--- a/pex/build_system/pep_518.py
+++ b/pex/build_system/pep_518.py
@@ -103,7 +103,15 @@ class BuildSystem(object):
             virtualenv = Virtualenv(venv_pex.venv_dir)
             virtualenv.install_pip()
             _, process = virtualenv.interpreter.open_process(
-                args=["-m", "pip", "install"] + list(extra_requirements)
+                args=[
+                    "-m",
+                    "pip",
+                    "install",
+                    "--ignore-installed",
+                    "--no-user",
+                    "--no-warn-script-location",
+                ]
+                + list(extra_requirements)
             )
             result = process.wait()
             if result != 0:

--- a/pex/build_system/pep_518.py
+++ b/pex/build_system/pep_518.py
@@ -113,6 +113,7 @@ def load_build_system(
     target,  # type: Target
     resolver,  # type: Resolver
     project_directory,  # type: str
+    extra_requirements=(),  # type: Tuple[str, ...]
 ):
     # type: (...) -> Union[Optional[BuildSystem], Error]
 
@@ -131,13 +132,14 @@ def load_build_system(
             build_backend=build_system_table.build_backend
         )
     ):
+        requirements = build_system_table.requires + extra_requirements
         result = resolver.resolve_requirements(
             targets=Targets.from_target(target),
-            requirements=build_system_table.requires,
+            requirements=requirements,
         )
         return BuildSystem.create(
             interpreter=target.get_interpreter(),
-            requires=build_system_table.requires,
+            requires=requirements,
             resolved=tuple(
                 installed_distribution.distribution
                 for installed_distribution in result.installed_distributions

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -1195,6 +1195,7 @@ class PythonInterpreter(object):
 
     @property
     def version(self):
+        # type: () -> Tuple[int, int, int]
         return self._identity.version
 
     @property

--- a/pex/venv/virtualenv.py
+++ b/pex/venv/virtualenv.py
@@ -347,8 +347,8 @@ class Virtualenv(object):
                         # N.B.: These lines include the newline already.
                         buffer.write(cast(bytes, line))
 
-    def install_pip(self):
-        # type: () -> str
+    def install_pip(self, upgrade=False):
+        # type: (bool) -> str
         try:
             self._interpreter.execute(args=["-m", "ensurepip", "-U", "--default-pip"])
         except Executor.NonZeroExit:
@@ -376,4 +376,6 @@ class Virtualenv(object):
                     ) as dst_fp:
                         shutil.copyfileobj(src_fp, dst_fp)
             self._interpreter.execute(args=[get_pip, "--no-wheel"])
+        if upgrade:
+            self._interpreter.execute(args=["-m", "pip", "install", "-U", "pip"])
         return self.bin_path("pip")

--- a/tests/build_system/test_issue_2125.py
+++ b/tests/build_system/test_issue_2125.py
@@ -1,0 +1,100 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+from textwrap import dedent
+
+from pex.build_system import pep_517
+from pex.common import safe_open
+from pex.dist_metadata import DistMetadata, Requirement
+from pex.pep_440 import Version
+from pex.pep_503 import ProjectName
+from pex.pip.version import PipVersion
+from pex.resolve.configured_resolver import ConfiguredResolver
+from pex.resolve.resolver_configuration import PipConfiguration
+from pex.targets import LocalInterpreter
+from pex.third_party.packaging.specifiers import SpecifierSet
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_missing_get_requires_for_build_wheel(tmpdir):
+    # type: (Any) -> None
+
+    project_directory = str(tmpdir)
+
+    dist_info_dir = os.path.join(project_directory, "foo-0.1.0.dist-info")
+    metadata = os.path.join(dist_info_dir, "METADATA")
+    with safe_open(metadata, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                Metadata-Version: 1.2
+                Name: foo
+                Version: 0.1.0
+                Requires-Dist: conscript
+                Requires-Dist: pex>=2.1.134
+                Requires-Python: >=3.11
+                """
+            )
+        )
+
+    build_backend = os.path.join(project_directory, "pep517", "hooks.py")
+    with safe_open(build_backend, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                from __future__ import print_function
+
+                import os
+                import shutil
+                import sys
+
+                import colors
+
+
+                def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
+                    print(
+                        colors.green("Using pre-prepared metadata in {dist_info_dir}."),
+                        file=sys.stderr
+                    )
+                    shutil.move({dist_info_dir!r}, metadata_directory)
+                    return os.path.relpath({metadata!r}, {project_directory!r})
+                """
+            ).format(
+                dist_info_dir=dist_info_dir, metadata=metadata, project_directory=project_directory
+            )
+        )
+
+    pyproject_toml = os.path.join(project_directory, "pyproject.toml")
+    with open(pyproject_toml, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                [build-system]
+                requires = ["ansicolors==1.1.8"]
+                build-backend = "hooks"
+                backend-path = ["pep517"]
+                """
+            )
+        )
+
+    pip_version = PipVersion.VENDORED
+    dist_metadata = pep_517.spawn_prepare_metadata(
+        project_directory=project_directory,
+        pip_version=pip_version,
+        target=LocalInterpreter.create(),
+        resolver=ConfiguredResolver(PipConfiguration(version=pip_version)),
+    ).await_result()
+
+    assert (
+        DistMetadata(
+            project_name=ProjectName("foo"),
+            version=Version("0.1.0"),
+            requires_dists=(Requirement.parse("conscript"), Requirement.parse("pex>=2.1.134")),
+            requires_python=SpecifierSet(">=3.11"),
+        )
+        == dist_metadata
+    )

--- a/tests/integration/build_system/test_issue_2125.py
+++ b/tests/integration/build_system/test_issue_2125.py
@@ -1,0 +1,22 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import sys
+
+import pytest
+
+from pex.cli.testing import run_pex3
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+@pytest.mark.skipif(
+    sys.version_info[:2] < (3, 7),
+    reason="The tested distribution is only compatible with Python >= 3.7",
+)
+def test_get_requires_for_build_wheel(tmpdir):
+    # type: (Any) -> None
+
+    run_pex3("lock", "create", "cairocffi==1.5.1").assert_success()

--- a/tests/integration/test_issue_2038.py
+++ b/tests/integration/test_issue_2038.py
@@ -28,7 +28,7 @@ def test_wheel_file_url_dep(tmpdir):
 
     constraints = os.path.join(str(tmpdir), "constraints.txt")
     with open(constraints, "w") as fp:
-        # The 20.22 release introduces a change that breaks resolution od poetry 1.3.2; so we pin
+        # The 20.22 release introduces a change that breaks resolution of poetry 1.3.2; so we pin
         # low.
         fp.write("virtualenv<20.22")
 

--- a/tests/integration/test_issue_2038.py
+++ b/tests/integration/test_issue_2038.py
@@ -26,8 +26,16 @@ if TYPE_CHECKING:
 def test_wheel_file_url_dep(tmpdir):
     # type: (Any) -> None
 
+    constraints = os.path.join(str(tmpdir), "constraints.txt")
+    with open(constraints, "w") as fp:
+        # The 20.22 release introduces a change that breaks resolution od poetry 1.3.2; so we pin
+        # low.
+        fp.write("virtualenv<20.22")
+
     poetry = os.path.join(str(tmpdir), "poetry.pex")
-    run_pex_command(args=["poetry==1.3.2", "-c", "poetry", "-o", poetry]).assert_success()
+    run_pex_command(
+        args=["poetry==1.3.2", "--constraints", constraints, "-c", "poetry", "-o", poetry]
+    ).assert_success()
 
     corelibrary = os.path.join(str(tmpdir), "corelibrary")
     touch(os.path.join(corelibrary, "README.md"))


### PR DESCRIPTION
This is required by the PEP-517 spec.

Fixes #2125