### PR TITLE
Fix CI bitrot due to Pants 2.12.0.dev3 deletion.

### DIFF
--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -121,7 +121,8 @@ else:
 if PY3:
     from urllib import parse as urlparse
     from urllib.error import HTTPError as HTTPError
-    from urllib.parse import unquote as unquote
+    from urllib.parse import quote as _url_quote
+    from urllib.parse import unquote as _url_unquote
     from urllib.request import FileHandler as FileHandler
     from urllib.request import HTTPBasicAuthHandler as HTTPBasicAuthHandler
     from urllib.request import HTTPDigestAuthHandler as HTTPDigestAuthHandler
@@ -131,7 +132,8 @@ if PY3:
     from urllib.request import Request as Request
     from urllib.request import build_opener as build_opener
 else:
-    from urllib import unquote as unquote
+    from urllib import quote as _url_quote
+    from urllib import unquote as _url_unquote
 
     import urlparse as urlparse
     from urllib2 import FileHandler as FileHandler
@@ -143,6 +145,9 @@ else:
     from urllib2 import ProxyHandler as ProxyHandler
     from urllib2 import Request as Request
     from urllib2 import build_opener as build_opener
+
+url_unquote = _url_unquote
+url_quote = _url_quote
 
 if PY3:
     from queue import Queue as Queue
@@ -262,6 +267,8 @@ else:
 
 
 if PY3:
-    from shlex import quote as quote
+    from shlex import quote as _shlex_quote
 else:
-    from pipes import quote as quote
+    from pipes import quote as _shlex_quote
+
+shlex_quote = _shlex_quote

--- a/pex/pip/tool.py
+++ b/pex/pip/tool.py
@@ -14,7 +14,7 @@ from tempfile import mkdtemp
 from pex import dist_metadata, targets
 from pex.auth import PasswordEntry
 from pex.common import safe_mkdir, safe_mkdtemp
-from pex.compatibility import get_stderr_bytes_buffer, quote, urlparse
+from pex.compatibility import get_stderr_bytes_buffer, shlex_quote, urlparse
 from pex.interpreter import PythonInterpreter
 from pex.jobs import Job
 from pex.network_configuration import NetworkConfiguration
@@ -44,7 +44,6 @@ if TYPE_CHECKING:
         Mapping,
         Optional,
         Sequence,
-        Text,
         Tuple,
     )
 
@@ -353,8 +352,10 @@ class Pip(object):
 
             args = self._pip_pex.execute_args(*command)
 
-            rendered_env = " ".join("{}={}".format(key, quote(value)) for key, value in env.items())
-            rendered_args = " ".join(quote(s) for s in args)
+            rendered_env = " ".join(
+                "{}={}".format(key, shlex_quote(value)) for key, value in env.items()
+            )
+            rendered_args = " ".join(shlex_quote(s) for s in args)
             TRACER.log("Executing: {} {}".format(rendered_env, rendered_args), V=3)
 
             return args, subprocess.Popen(args=args, env=env, **popen_kwargs)

--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -8,7 +8,7 @@ import re
 from contextlib import contextmanager
 
 from pex import attrs, dist_metadata, pex_warnings
-from pex.compatibility import unquote, urlparse
+from pex.compatibility import url_unquote, urlparse
 from pex.dist_metadata import (
     MetadataError,
     ProjectNameAndVersion,
@@ -485,7 +485,7 @@ def _parse_requirement_line(
             project_name_and_specifier = _try_parse_project_name_and_specifier_from_path(
                 # There may be whitespace separated markers; so we strip the trailing whitespace
                 # used to support those.
-                unquote(parsed_url.path).rstrip()
+                url_unquote(parsed_url.path).rstrip()
             )
             if project_name_and_specifier is not None:
                 project_name = project_name_and_specifier.project_name

--- a/pex/resolve/downloads.py
+++ b/pex/resolve/downloads.py
@@ -1,3 +1,6 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 from __future__ import absolute_import
 
 import os.path
@@ -6,7 +9,7 @@ import shutil
 from pex import hashing
 from pex.atomic_directory import atomic_directory
 from pex.common import safe_mkdir, safe_mkdtemp
-from pex.compatibility import unquote, urlparse
+from pex.compatibility import url_unquote, urlparse
 from pex.hashing import Sha256
 from pex.jobs import Job, Raise, SpawnedJob, execute_parallel
 from pex.pip.download_observer import DownloadObserver
@@ -126,7 +129,7 @@ class ArtifactDownloader(object):
         download_dir = safe_mkdtemp(prefix="fingerprint_artifact.", dir=downloads)
 
         url_info = urlparse.urlparse(url)
-        src_file = urlparse.unquote(url_info.path)
+        src_file = url_unquote(url_info.path)
         temp_dest = os.path.join(download_dir, os.path.basename(src_file))
 
         if url_info.scheme == "file":
@@ -173,7 +176,7 @@ class ArtifactDownloader(object):
 
         url_info = urlparse.urlparse(artifact.url)
         if url_info.scheme == "file":
-            src_file = unquote(url_info.path)
+            src_file = url_unquote(url_info.path)
             try:
                 shutil.copy(src_file, dest_file)
             except (IOError, OSError) as e:

--- a/pex/resolve/locked_resolve.py
+++ b/pex/resolve/locked_resolve.py
@@ -8,7 +8,7 @@ import os
 from collections import OrderedDict, defaultdict, deque
 
 from pex.common import pluralize
-from pex.compatibility import unquote, urlparse
+from pex.compatibility import url_unquote, urlparse
 from pex.dist_metadata import DistMetadata, Requirement
 from pex.enum import Enum
 from pex.orderedset import OrderedSet

--- a/pex/resolve/resolved_requirement.py
+++ b/pex/resolve/resolved_requirement.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 import hashlib
 
 from pex import hashing
-from pex.compatibility import unquote, urlparse
+from pex.compatibility import url_unquote, urlparse
 from pex.dist_metadata import ProjectNameAndVersion, Requirement
 from pex.hashing import HashlibHasher
 from pex.pep_440 import Version
@@ -88,7 +88,7 @@ class ArtifactURL(object):
             raw_url=url,
             normalized_url=normalized_url,
             scheme=parse_scheme(url_info.scheme) if url_info.scheme else None,
-            path=unquote(url_info.path),
+            path=url_unquote(url_info.path),
         )
 
     raw_url = attr.ib(eq=False)  # type: str

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -17,7 +17,7 @@ from pex import targets
 from pex.atomic_directory import AtomicDirectory, atomic_directory
 from pex.auth import PasswordEntry
 from pex.common import safe_mkdir, safe_mkdtemp
-from pex.compatibility import unquote, urlparse
+from pex.compatibility import url_unquote, urlparse
 from pex.dist_metadata import DistMetadata, Distribution, ProjectNameAndVersion, Requirement
 from pex.fingerprinted_distribution import FingerprintedDistribution
 from pex.jobs import Raise, SpawnedJob, execute_parallel
@@ -711,7 +711,7 @@ class BuildAndInstallRequest(object):
                 urlinfo = urlparse.urlparse(requirement.url)
                 if urlinfo.scheme != "file":
                     continue
-                dist_path = unquote(urlinfo.path).rstrip()
+                dist_path = url_unquote(urlinfo.path).rstrip()
                 if not os.path.exists(dist_path):
                     raise Unsatisfiable(
                         "The {wheel} wheel has a dependency on {url} which does not exist on this "


### PR DESCRIPTION
The 2.12.0.dev3 release was deleted from PyPI to make room for the
latest batch of Pants releases; so switch to the Pants S3 bucket find
links repo.