### PR TITLE
Introduce `pex3 venv inspect`.

### DIFF
--- a/pex/cli/commands/__init__.py
+++ b/pex/cli/commands/__init__.py
@@ -4,6 +4,7 @@
 from pex.cli.command import BuildTimeCommand
 from pex.cli.commands.interpreter import Interpreter
 from pex.cli.commands.lock import Lock
+from pex.cli.commands.venv import Venv
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -12,4 +13,4 @@ if TYPE_CHECKING:
 
 def all_commands():
     # type: () -> Iterable[Type[BuildTimeCommand]]
-    return Interpreter, Lock
+    return Interpreter, Lock, Venv

--- a/pex/cli/commands/venv.py
+++ b/pex/cli/commands/venv.py
@@ -1,0 +1,103 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+from argparse import ArgumentParser, _ActionsContainer
+
+from pex.cli.command import BuildTimeCommand
+from pex.commands.command import JsonMixin, OutputMixin
+from pex.common import is_script
+from pex.pex_info import PexInfo
+from pex.result import Error, Ok, Result
+from pex.typing import TYPE_CHECKING
+from pex.venv.virtualenv import Virtualenv
+
+if TYPE_CHECKING:
+    from typing import Any, Dict
+
+
+class Venv(OutputMixin, JsonMixin, BuildTimeCommand):
+    @classmethod
+    def _add_inspect_arguments(cls, parser):
+        # type: (_ActionsContainer) -> None
+        parser.add_argument(
+            "venv",
+            help="The path of either the venv directory or its Python interpreter.",
+        )
+        cls.add_output_option(parser, entity="venv information")
+        cls.add_json_options(parser, entity="venv information")
+
+    @classmethod
+    def add_extra_arguments(
+        cls,
+        parser,  # type: ArgumentParser
+    ):
+        # type: (...) -> None
+        subcommands = cls.create_subcommands(
+            parser,
+            description="Interact with virtual environments via the following subcommands.",
+        )
+        with subcommands.parser(
+            name="inspect",
+            help="Inspect an existing venv.",
+            func=cls._inspect,
+            include_verbosity=False,
+        ) as inspect_parser:
+            cls._add_inspect_arguments(inspect_parser)
+
+    def _inspect(self):
+        # type: () -> Result
+
+        venv = self.options.venv
+        if not os.path.exists(venv):
+            return Error("The given venv path of {venv} does not exist.".format(venv=venv))
+
+        if os.path.isdir(venv):
+            virtualenv = Virtualenv(os.path.normpath(venv))
+            if not virtualenv.interpreter.is_venv:
+                return Error("{venv} is not a venv.".format(venv=venv))
+        else:
+            maybe_venv = Virtualenv.enclosing(os.path.normpath(venv))
+            if not maybe_venv:
+                return Error("{python} is not an venv interpreter.".format(python=venv))
+            virtualenv = maybe_venv
+
+        try:
+            pex = PexInfo.from_pex(virtualenv.venv_dir)
+            is_pex = True
+            pex_version = pex.build_properties.get("pex_version")
+        except (IOError, OSError, ValueError):
+            is_pex = False
+            pex_version = None
+
+        venv_info = dict(
+            venv_dir=virtualenv.venv_dir,
+            provenance=dict(
+                created_by=virtualenv.created_by,
+                is_pex=is_pex,
+                pex_version=pex_version,
+            ),
+            include_system_site_packages=virtualenv.include_system_site_packages,
+            interpreter=dict(
+                binary=virtualenv.interpreter.binary,
+                base_binary=virtualenv.interpreter.resolve_base_interpreter().binary,
+                version=virtualenv.interpreter.identity.version_str,
+                sys_path=virtualenv.sys_path,
+            ),
+            script_dir=virtualenv.bin_dir,
+            scripts=sorted(
+                os.path.relpath(exe, virtualenv.bin_dir)
+                for exe in virtualenv.iter_executables()
+                if is_script(exe)
+            ),
+            site_packages=virtualenv.site_packages_dir,
+            distributions=sorted(
+                str(dist.as_requirement()) for dist in virtualenv.iter_distributions()
+            ),
+        )  # type: Dict[str, Any]
+
+        with self.output(self.options) as out:
+            self.dump_json(self.options, venv_info, out)
+            out.write("\n")
+
+        return Ok()

--- a/pex/dist_metadata.py
+++ b/pex/dist_metadata.py
@@ -780,6 +780,7 @@ def find_distribution(
 def find_distributions(search_path=None):
     # type: (Optional[Iterable[str]]) -> Iterator[Distribution]
 
+    seen = set()
     for location in search_path or sys.path:
         if not os.path.isdir(location):
             continue
@@ -790,7 +791,10 @@ def find_distributions(search_path=None):
                 for path in glob.glob(os.path.join(location, "*.dist-info/METADATA"))
             ],
         ):
-            metadata_path = os.path.join(location, metadata_file.path)
+            metadata_path = os.path.realpath(os.path.join(location, metadata_file.path))
+            if metadata_path in seen:
+                continue
+            seen.add(metadata_path)
             with open(metadata_path, "rb") as fp:
                 pkg_info = _parse_message(fp.read())
                 yield Distribution(location=location, metadata=DistMetadata.load(pkg_info))

--- a/tests/integration/cli/commands/test_venv_inspect.py
+++ b/tests/integration/cli/commands/test_venv_inspect.py
@@ -71,7 +71,7 @@ def assert_inspect(
     result.assert_success()
 
     data = json.loads(result.output)
-    assert expected_venv_dir == data["venv_dir"]
+    assert os.path.realpath(expected_venv_dir) == os.path.realpath(data["venv_dir"])
     assert expected_system_site_packages == data["include_system_site_packages"]
 
     interpreter = data["interpreter"]

--- a/tests/integration/cli/commands/test_venv_inspect.py
+++ b/tests/integration/cli/commands/test_venv_inspect.py
@@ -1,0 +1,148 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import json
+import os.path
+import subprocess
+import sys
+from typing import Optional
+
+import pytest
+
+from pex.cli.testing import run_pex3
+from pex.interpreter import PythonInterpreter
+from pex.testing import (
+    PY27,
+    PY310,
+    ensure_python_interpreter,
+    ensure_python_venv,
+    make_env,
+    run_pex_command,
+)
+from pex.typing import TYPE_CHECKING
+from pex.venv.virtualenv import Virtualenv
+from pex.version import __version__
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_no_python(tmpdir):
+    # type: (Any) -> None
+
+    result = run_pex3("venv", "inspect", str(tmpdir))
+    result.assert_failure()
+    assert result.error.startswith(
+        "The virtualenv at {venv_dir} is not valid. Failed to load an interpreter ".format(
+            venv_dir=tmpdir
+        )
+    )
+
+
+def test_not_venv_interpreter(py310):
+    # type: (PythonInterpreter) -> None
+
+    result = run_pex3("venv", "inspect", py310.binary)
+    result.assert_failure()
+    assert (
+        "{python} is not an venv interpreter.".format(python=py310.binary) == result.error.strip()
+    )
+
+
+def test_not_venv_dir(py310):
+    # type: (PythonInterpreter) -> None
+
+    result = run_pex3("venv", "inspect", py310.prefix)
+    result.assert_failure()
+    assert "{venv} is not a venv.".format(venv=py310.prefix) == result.error.strip()
+
+
+def assert_inspect(
+    target,  # type: str
+    expected_venv_dir,  # type: str
+    expected_system_site_packages,  # type: Optional[bool]
+    expected_base_interpreter,  # type: PythonInterpreter
+    expected_pex_provenance,  # type: bool
+):
+    # type: (...) -> Any
+
+    result = run_pex3("venv", "inspect", target)
+    result.assert_success()
+
+    data = json.loads(result.output)
+    assert expected_venv_dir == data["venv_dir"]
+    assert expected_system_site_packages == data["include_system_site_packages"]
+
+    interpreter = data["interpreter"]
+    assert expected_base_interpreter.binary == interpreter["base_binary"]
+    assert ".".join(map(str, expected_base_interpreter.version)) == interpreter["version"]
+
+    provenance = data["provenance"]
+    assert provenance["is_pex"] is expected_pex_provenance
+    assert __version__ if expected_pex_provenance else None == provenance["pex_version"]
+
+    if expected_pex_provenance:
+        expected_created_by = (
+            "virtualenv {version}".format(version=Virtualenv.VIRTUALENV_VERSION)
+            if sys.version_info[0] == 2
+            else "venv"
+        )
+        assert expected_created_by == provenance["created_by"]
+
+    return data
+
+
+def test_inspect_pex_venv(tmpdir):
+    # type: (Any) -> None
+
+    pex = os.path.join(str(tmpdir), "cowsay.pex")
+    run_pex_command(
+        args=["--include-tools", "cowsay==5.0", "ansicolors==1.1.8", "-o", pex]
+    ).assert_success()
+
+    venv_dir = os.path.join(str(tmpdir), "venv")
+    subprocess.check_call(args=[sys.executable, pex, "venv", venv_dir], env=make_env(PEX_TOOLS=1))
+
+    current_base_interpreter = PythonInterpreter.get().resolve_base_interpreter()
+    data1 = assert_inspect(
+        target=venv_dir,
+        expected_venv_dir=venv_dir,
+        expected_system_site_packages=False,
+        expected_base_interpreter=current_base_interpreter,
+        expected_pex_provenance=True,
+    )
+    assert "cowsay" in data1["scripts"]
+    assert ["ansicolors==1.1.8", "cowsay==5.0"] == data1["distributions"]
+
+    data2 = assert_inspect(
+        target=Virtualenv(venv_dir).interpreter.binary,
+        expected_venv_dir=venv_dir,
+        expected_system_site_packages=False,
+        expected_base_interpreter=current_base_interpreter,
+        expected_pex_provenance=True,
+    )
+    assert data1 == data2
+
+
+@pytest.mark.parametrize("python_version", [PY27, PY310])
+@pytest.mark.parametrize(
+    "system_site_packages",
+    [pytest.param(value, id="system_site_packages={}".format(value)) for value in (True, False)],
+)
+def test_inspect_venv_virtualenv(
+    python_version,  # type: str
+    system_site_packages,  # type: bool
+):
+    # type: (...) -> None
+
+    python, _ = ensure_python_venv(python_version, system_site_packages=system_site_packages)
+    python_major_version = int(python_version.split(".")[0])
+    assert_inspect(
+        target=python,
+        expected_venv_dir=os.path.dirname(os.path.dirname(python)),
+        expected_system_site_packages=None if python_major_version == 2 else system_site_packages,
+        expected_base_interpreter=PythonInterpreter.from_binary(
+            ensure_python_interpreter(python_version)
+        ),
+        expected_pex_provenance=False,
+    )

--- a/tests/test_pyvenv_cfg.py
+++ b/tests/test_pyvenv_cfg.py
@@ -1,0 +1,80 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+from textwrap import dedent
+
+import pytest
+
+from pex.common import touch
+from pex.interpreter import PyVenvCfg
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_parse_invalid(tmpdir):
+    # type: (Any) -> None
+
+    pyvenv_cfg = os.path.join(str(tmpdir), "pyvenv.cfg")
+    touch(pyvenv_cfg)
+    with pytest.raises(PyVenvCfg.Error):
+        PyVenvCfg.parse(pyvenv_cfg)
+
+
+def test_parse_nominal(tmpdir):
+    # type: (Any) -> None
+
+    pyvenv_cfg = os.path.join(str(tmpdir), "pyvenv.cfg")
+    with open(pyvenv_cfg, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                home = foo
+                include-system-site-packages = true
+                version = 1.2.3
+                """
+            )
+        )
+
+    cfg = PyVenvCfg.parse(pyvenv_cfg)
+    assert pyvenv_cfg == cfg.path
+    assert "foo" == cfg.home
+    assert cfg.include_system_site_packages is True
+    assert "1.2.3" == cfg.config("version")
+    assert cfg.config("bar") is None
+    assert "baz" == cfg.config("bar", "baz")
+
+
+def test_find_not_found(tmpdir):
+    # type: (Any) -> None
+
+    python = os.path.join(str(tmpdir), "bin", "python")
+    touch(python)
+    assert PyVenvCfg.find(python) is None
+
+
+def test_find_python_sibling(tmpdir):
+    # type: (Any) -> None
+
+    bin_dir = os.path.join(str(tmpdir), "bin")
+    python = os.path.join(bin_dir, "python")
+    touch(python)
+    with open(os.path.join(bin_dir, "pyvenv.cfg"), "w") as fp:
+        fp.write("home = foo")
+    cfg = PyVenvCfg.find(python)
+    assert cfg is not None
+    assert "foo" == cfg.home
+
+
+def test_find_venv_sibling(tmpdir):
+    # type: (Any) -> None
+
+    python = os.path.join(str(tmpdir), "bin", "python")
+    touch(python)
+    with open(os.path.join(str(tmpdir), "pyvenv.cfg"), "w") as fp:
+        fp.write("home = foo")
+    cfg = PyVenvCfg.find(python)
+    assert cfg is not None
+    assert "foo" == cfg.home


### PR DESCRIPTION
This command allows inspecting venvs created by Pex as well as those
created by other tools.

Work towards #1752 and #2110