### PR TITLE
Switch from setup-python to pyenv-action.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,8 @@ jobs:
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
         uses: gabrielfalcao/pyenv-action@v13
         with:
-          versions: pypy${{ join(matrix.python-version, '.') }}-${{ env._PEX_PYENV_PYPY_RELEASE }}
-          default: pypy${{ join(matrix.python-version, '.') }}-${{ env._PEX_PYENV_PYPY_RELEASE }}
+          versions: pypy${{ join(matrix.pypy-version, '.') }}-${{ env._PEX_PYENV_PYPY_RELEASE }}
+          default: pypy${{ join(matrix.pypy-version, '.') }}-${{ env._PEX_PYENV_PYPY_RELEASE }}
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
       - name: Cache Pyenv Interpreters
@@ -205,8 +205,8 @@ jobs:
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
         uses: gabrielfalcao/pyenv-action@v13
         with:
-          versions: pypy${{ join(matrix.python-version, '.') }}-${{ env._PEX_PYENV_PYPY_RELEASE }}
-          default: pypy${{ join(matrix.python-version, '.') }}-${{ env._PEX_PYENV_PYPY_RELEASE }}
+          versions: pypy${{ join(matrix.pypy-version, '.') }}-${{ env._PEX_PYENV_PYPY_RELEASE }}
+          default: pypy${{ join(matrix.pypy-version, '.') }}-${{ env._PEX_PYENV_PYPY_RELEASE }}
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
       - name: Install Packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,7 @@ defaults:
     shell: bash
 env:
   _PEX_TEST_PYENV_ROOT: .pyenv_test
-  # We use this to skip exposing same-versioned Pythons present on Linux hosts. These otherwise can
-  # collide when attempting to load libpython<major>.<minor><flags>.so and lead to mysterious errors
-  # importing builtins like `fcntl` as outlined in https://github.com/pantsbuild/pex/issues/1391.
-  _PEX_TEST_PYENV_VERSIONS: "2.7 3.7 3.10"
+  _PEX_PYENV_PYPY_RELEASE: 7.3.11
 concurrency:
   group: CI-${{ github.ref }}
   # Queue on all branches and tags, but only cancel overlapping PR burns.
@@ -48,14 +45,13 @@ jobs:
     strategy:
       matrix:
         include:
-          # N.B.: We need 20.04 for Python 2.7 & 3.5 tool cache support.
           - os: macos-12
             python-version: [ 2, 7 ]
             pip-version: 20
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             python-version: [ 2, 7 ]
             pip-version: 20
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             python-version: [ 3, 5 ]
             pip-version: 20
           - os: macos-12
@@ -71,24 +67,14 @@ jobs:
             python-version: [ 3, 11 ]
             pip-version: 23_1_1
     steps:
-      - name: Calculate Pythons to Expose
-        id: calculate-pythons-to-expose
-        run: |
-          skip=""
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
-          fi
-          echo "skip=${skip}" >> $GITHUB_OUTPUT
       - name: Checkout Pex
         uses: actions/checkout@v3
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
-        uses: actions/setup-python@v4
+        uses: gabrielfalcao/pyenv-action@v13
         with:
-          python-version: "${{ join(matrix.python-version, '.') }}"
+          default: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        with:
-          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v3
         with:
@@ -101,42 +87,27 @@ jobs:
   pypy-unit-tests:
     name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}
     needs: org-check
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:
-          # N.B.: We need 20.04 for PyPy 2.7 tool cache support.
-          - os: ubuntu-20.04
-            pypy-version: [ 2, 7 ]
+          - pypy-version: [ 2, 7 ]
             pip-version: 20
-          - os: ubuntu-22.04
-            pypy-version: [ 3, 9 ]
+          - pypy-version: [ 3, 9 ]
             pip-version: 20
-          - os: ubuntu-22.04
-            pypy-version: [ 3, 9 ]
+          - pypy-version: [ 3, 9 ]
             pip-version: 22_3_1
-          - os: ubuntu-22.04
-            pypy-version: [ 3, 9 ]
+          - pypy-version: [ 3, 9 ]
             pip-version: 23_1_1
     steps:
-      - name: Calculate Pythons to Expose
-        id: calculate-pythons-to-expose
-        run: |
-          skip=""
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
-          fi
-          echo "skip=${skip}" >> $GITHUB_OUTPUT
       - name: Checkout Pex
         uses: actions/checkout@v3
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
-        uses: actions/setup-python@v4
+        uses: gabrielfalcao/pyenv-action@v13
         with:
-          python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
+          default: "pypy${{ join(matrix.python-version, '.') }}-${{ env._PEX_PYENV_PYPY_RELEASE }}"
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        with:
-          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v3
         with:
@@ -153,11 +124,10 @@ jobs:
     strategy:
       matrix:
         include:
-          # N.B.: We need 20.04 for Python 2.7 tool cache support.
           - os: macos-12
             python-version: [ 2, 7 ]
             pip-version: 20
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             python-version: [ 2, 7 ]
             pip-version: 20
           - os: ubuntu-22.04
@@ -179,27 +149,17 @@ jobs:
             python-version: [ 3, 11 ]
             pip-version: 23_1_1
     steps:
-      - name: Calculate Pythons to Expose
-        id: calculate-pythons-to-expose
-        run: |
-          skip=""
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
-          fi
-          echo "skip=${skip}" >> $GITHUB_OUTPUT
       - name: Checkout Pex
         uses: actions/checkout@v3
         with:
           # We need branches and tags for some ITs.
           fetch-depth: 0
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
-        uses: actions/setup-python@v4
+        uses: gabrielfalcao/pyenv-action@v13
         with:
-          python-version: "${{ join(matrix.python-version, '.') }}"
+          default: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        with:
-          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Cache Pyenv Interpreters
         uses: actions/cache@v3
         with:
@@ -219,45 +179,31 @@ jobs:
   pypy-integration-tests:
     name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}-integration
     needs: org-check
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:
           # N.B.: We need 20.04 for PyPy 2.7 tool cache support.
-          - os: ubuntu-20.04
-            pypy-version: [ 2, 7 ]
+          - pypy-version: [ 2, 7 ]
             pip-version: 20
-          - os: ubuntu-22.04
-            pypy-version: [ 3, 9 ]
+          - pypy-version: [ 3, 9 ]
             pip-version: 20
-          - os: ubuntu-22.04
-            pypy-version: [ 3, 9 ]
+          - pypy-version: [ 3, 9 ]
             pip-version: 22_3_1
-          - os: ubuntu-22.04
-            pypy-version: [ 3, 9 ]
+          - pypy-version: [ 3, 9 ]
             pip-version: 23_1_1
     steps:
-      - name: Calculate Pythons to Expose
-        id: calculate-pythons-to-expose
-        run: |
-          skip=""
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
-          fi
-          echo "skip=${skip}" >> $GITHUB_OUTPUT
       - name: Checkout Pex
         uses: actions/checkout@v3
         with:
           # We need branches and tags for some ITs.
           fetch-depth: 0
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
-        uses: actions/setup-python@v4
+        uses: gabrielfalcao/pyenv-action@v13
         with:
-          python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
+          default: "pypy${{ join(matrix.python-version, '.') }}--${{ env._PEX_PYENV_PYPY_RELEASE }}"
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        with:
-          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Install Packages
         run: |
           # This is needed for `test_requirement_file_from_url` for building `lxml`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,11 @@ jobs:
           # complete history.
           fetch-depth: 0
       - name: Setup Python 3.8
-        uses: actions/setup-python@v4
+        uses: gabrielfalcao/pyenv-action@v13
         with:
           # We need to keep Python 3.8 for consistent vendoring with tox.
-          python-version: "3.8"
+          versions: "3.8"
+          default: "3.8"
       - name: Check Formatting, Types, Vendoring and Packaging
         uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
@@ -72,6 +73,7 @@ jobs:
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
         uses: gabrielfalcao/pyenv-action@v13
         with:
+          versions: "${{ join(matrix.python-version, '.') }}"
           default: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
@@ -105,6 +107,7 @@ jobs:
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
         uses: gabrielfalcao/pyenv-action@v13
         with:
+          versions: "pypy${{ join(matrix.python-version, '.') }}-${{ env._PEX_PYENV_PYPY_RELEASE }}"
           default: "pypy${{ join(matrix.python-version, '.') }}-${{ env._PEX_PYENV_PYPY_RELEASE }}"
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
@@ -157,6 +160,7 @@ jobs:
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
         uses: gabrielfalcao/pyenv-action@v13
         with:
+          versions: "${{ join(matrix.python-version, '.') }}"
           default: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
@@ -201,6 +205,7 @@ jobs:
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
         uses: gabrielfalcao/pyenv-action@v13
         with:
+          versions: "pypy${{ join(matrix.python-version, '.') }}--${{ env._PEX_PYENV_PYPY_RELEASE }}"
           default: "pypy${{ join(matrix.python-version, '.') }}--${{ env._PEX_PYENV_PYPY_RELEASE }}"
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
         uses: gabrielfalcao/pyenv-action@v13
         with:
           # We need to keep Python 3.8 for consistent vendoring with tox.
-          versions: 3.8
-          default: 3.8
+          versions: 3.8.16
+          default: 3.8.16
       - name: Check Formatting, Types, Vendoring and Packaging
         uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
@@ -47,25 +47,25 @@ jobs:
       matrix:
         include:
           - os: macos-12
-            python-version: [ 2, 7 ]
+            python-version: [ 2, 7, 18 ]
             pip-version: 20
           - os: ubuntu-22.04
-            python-version: [ 2, 7 ]
+            python-version: [ 2, 7, 18 ]
             pip-version: 20
           - os: ubuntu-22.04
-            python-version: [ 3, 5 ]
+            python-version: [ 3, 5, 10 ]
             pip-version: 20
           - os: macos-12
-            python-version: [ 3, 11 ]
+            python-version: [ 3, 11, 1 ]
             pip-version: 20
           - os: ubuntu-22.04
-            python-version: [ 3, 11 ]
+            python-version: [ 3, 11, 1 ]
             pip-version: 20
           - os: ubuntu-22.04
-            python-version: [ 3, 11 ]
+            python-version: [ 3, 11, 1 ]
             pip-version: 22_3_1
           - os: ubuntu-22.04
-            python-version: [ 3, 11 ]
+            python-version: [ 3, 11, 1 ]
             pip-version: 23_1_1
     steps:
       - name: Checkout Pex
@@ -128,28 +128,28 @@ jobs:
       matrix:
         include:
           - os: macos-12
-            python-version: [ 2, 7 ]
+            python-version: [ 2, 7, 18 ]
             pip-version: 20
           - os: ubuntu-22.04
-            python-version: [ 2, 7 ]
+            python-version: [ 2, 7, 18 ]
             pip-version: 20
           - os: ubuntu-22.04
-            python-version: [ 3, 7 ]
+            python-version: [ 3, 7, 16 ]
             pip-version: 22_3_1
           - os: ubuntu-22.04
-            python-version: [ 3, 7 ]
+            python-version: [ 3, 7, 16 ]
             pip-version: 23_1_1
           - os: macos-12
-            python-version: [ 3, 11 ]
+            python-version: [ 3, 11, 1 ]
             pip-version: 20
           - os: ubuntu-22.04
-            python-version: [ 3, 11 ]
+            python-version: [ 3, 11, 1 ]
             pip-version: 20
           - os: ubuntu-22.04
-            python-version: [ 3, 11 ]
+            python-version: [ 3, 11, 1 ]
             pip-version: 22_3_1
           - os: ubuntu-22.04
-            python-version: [ 3, 11 ]
+            python-version: [ 3, 11, 1 ]
             pip-version: 23_1_1
     steps:
       - name: Checkout Pex

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
         uses: gabrielfalcao/pyenv-action@v13
         with:
           # We need to keep Python 3.8 for consistent vendoring with tox.
-          versions: "3.8"
-          default: "3.8"
+          versions: 3.8
+          default: 3.8
       - name: Check Formatting, Types, Vendoring and Packaging
         uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
@@ -73,8 +73,8 @@ jobs:
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
         uses: gabrielfalcao/pyenv-action@v13
         with:
-          versions: "${{ join(matrix.python-version, '.') }}"
-          default: "${{ join(matrix.python-version, '.') }}"
+          versions: ${{ join(matrix.python-version, '.') }}
+          default: ${{ join(matrix.python-version, '.') }}
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
       - name: Cache Pyenv Interpreters
@@ -107,8 +107,8 @@ jobs:
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
         uses: gabrielfalcao/pyenv-action@v13
         with:
-          versions: "pypy${{ join(matrix.python-version, '.') }}-${{ env._PEX_PYENV_PYPY_RELEASE }}"
-          default: "pypy${{ join(matrix.python-version, '.') }}-${{ env._PEX_PYENV_PYPY_RELEASE }}"
+          versions: pypy${{ join(matrix.python-version, '.') }}-${{ env._PEX_PYENV_PYPY_RELEASE }}
+          default: pypy${{ join(matrix.python-version, '.') }}-${{ env._PEX_PYENV_PYPY_RELEASE }}
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
       - name: Cache Pyenv Interpreters
@@ -160,8 +160,8 @@ jobs:
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
         uses: gabrielfalcao/pyenv-action@v13
         with:
-          versions: "${{ join(matrix.python-version, '.') }}"
-          default: "${{ join(matrix.python-version, '.') }}"
+          versions: ${{ join(matrix.python-version, '.') }}
+          default: ${{ join(matrix.python-version, '.') }}
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
       - name: Cache Pyenv Interpreters
@@ -205,8 +205,8 @@ jobs:
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
         uses: gabrielfalcao/pyenv-action@v13
         with:
-          versions: "pypy${{ join(matrix.python-version, '.') }}--${{ env._PEX_PYENV_PYPY_RELEASE }}"
-          default: "pypy${{ join(matrix.python-version, '.') }}--${{ env._PEX_PYENV_PYPY_RELEASE }}"
+          versions: pypy${{ join(matrix.python-version, '.') }}-${{ env._PEX_PYENV_PYPY_RELEASE }}
+          default: pypy${{ join(matrix.python-version, '.') }}-${{ env._PEX_PYENV_PYPY_RELEASE }}
       - name: Expose Pythons
         uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
       - name: Install Packages


### PR DESCRIPTION
This ensures support for CPython 2.7, PyPy 2.7 and any other versions we
test against that GHA images may decide to discontinue at any point.

Prompted by #2137