### PR TITLE
Add support for Pip 23.1.2.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
             pip-version: 22_3_1
           - os: ubuntu-22.04
             python-version: [ 3, 11 ]
-            pip-version: 23_1_1
+            pip-version: 23_1_2
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -117,7 +117,7 @@ jobs:
             pip-version: 22_3_1
           - os: ubuntu-22.04
             pypy-version: [ 3, 9 ]
-            pip-version: 23_1_1
+            pip-version: 23_1_2
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -165,7 +165,7 @@ jobs:
             pip-version: 22_3_1
           - os: ubuntu-22.04
             python-version: [ 3, 7 ]
-            pip-version: 23_1_1
+            pip-version: 23_1_2
           - os: macos-12
             python-version: [ 3, 11 ]
             pip-version: 20
@@ -177,7 +177,7 @@ jobs:
             pip-version: 22_3_1
           - os: ubuntu-22.04
             python-version: [ 3, 11 ]
-            pip-version: 23_1_1
+            pip-version: 23_1_2
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -235,7 +235,7 @@ jobs:
             pip-version: 22_3_1
           - os: ubuntu-22.04
             pypy-version: [ 3, 9 ]
-            pip-version: 23_1_1
+            pip-version: 23_1_2
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose

--- a/pex/pip/version.py
+++ b/pex/pip/version.py
@@ -138,5 +138,12 @@ class PipVersion(Enum["PipVersionValue"]):
         requires_python=">=3.7",
     )
 
+    v23_1_2 = PipVersionValue(
+        version="23.1.2",
+        setuptools_version="67.7.2",
+        wheel_version="0.40.0",
+        requires_python=">=3.7",
+    )
+
     VENDORED = v20_3_4_patched
     LATEST = LatestPipVersion()

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ setenv =
     pip23_0_1: _PEX_PIP_VERSION=23.0.1
     pip23_1: _PEX_PIP_VERSION=23.1
     pip23_1_1: _PEX_PIP_VERSION=23.1.1
+    pip23_1_2: _PEX_PIP_VERSION=23.1.2
     # Python 3 (until a fix here in 3.9: https://bugs.python.org/issue13601) switched from stderr
     # being unbuffered to stderr being buffered by default. This can lead to tests checking stderr
     # failing to see what they expect if the stderr buffer block has not been flushed. Force stderr
@@ -67,7 +68,7 @@ whitelist_externals =
     bash
     git
 
-[testenv:py{py27-subprocess,py27,py35,py36,py37,py38,py39,27,35,36,37,38,39,310,311}-{,pip20-,pip22_2-,pip22_3-,pip22_3_1-,pip23_0-,pip23_0_1-,pip23_1-,pip23_1_1-}integration]
+[testenv:py{py27-subprocess,py27,py35,py36,py37,py38,py39,27,35,36,37,38,39,310,311}-{,pip20-,pip22_2-,pip22_3-,pip22_3_1-,pip23_0-,pip23_0_1-,pip23_1-,pip23_1_1-,pip23_1_2-}integration]
 deps =
     pytest-xdist==1.34.0
     {[testenv]deps}


### PR DESCRIPTION
Just a bump in vendored setuptools this time to undo a rollback done in
the 23.1.1 release.

The change-log is here:
  https://pip.pypa.io/en/stable/news/#v23-1-2