### PR TITLE
Fix symlinked venv ns-package calcs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,13 +186,6 @@ jobs:
     strategy:
       matrix:
         include:
-          # N.B.: We need 20.04 for Python 2.7 tool cache support.
-          - os: macos-12
-            python-version: [ 2, 7 ]
-            pip-version: 20
-          - os: ubuntu-20.04
-            python-version: [ 2, 7 ]
-            pip-version: 20
           - os: ubuntu-22.04
             python-version: [ 3, 7 ]
             pip-version: 22_3_1
@@ -259,7 +252,7 @@ jobs:
           - os: macos-12
             python-version: [ 2, 7 ]
             pip-version: 20
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             python-version: [ 2, 7 ]
             pip-version: 20
     steps:
@@ -366,8 +359,10 @@ jobs:
     needs:
       - checks
       - cpython-unit-tests
+      - cpython-unit-tests-legacy
       - pypy-unit-tests
       - cpython-integration-tests
+      - cpython-integration-tests-legacy
       - pypy-integration-tests
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,10 +250,10 @@ jobs:
       matrix:
         include:
           - os: macos-12
-            python-version: [ 2, 7 ]
+            python-version: [ 2, 7, 18 ]
             pip-version: 20
           - os: ubuntu-22.04
-            python-version: [ 2, 7 ]
+            python-version: [ 2, 7, 18 ]
             pip-version: 20
     steps:
       - name: Calculate Pythons to Expose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
     strategy:
       matrix:
         include:
+          # N.B.: We need 20.04 for Python 3.5 tool cache support.
+          - os: ubuntu-20.04
+            python-version: [ 3, 5 ]
+            pip-version: 20
           - os: macos-12
             python-version: [ 3, 11 ]
             pip-version: 20
@@ -100,9 +104,6 @@ jobs:
             pip-version: 20
           - os: ubuntu-22.04
             python-version: [ 2, 7, 18 ]
-            pip-version: 20
-          - os: ubuntu-22.04
-            python-version: [ 3, 5, 10 ]
             pip-version: 20
     steps:
       - name: Calculate Pythons to Expose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,16 +48,6 @@ jobs:
     strategy:
       matrix:
         include:
-          # N.B.: We need 20.04 for Python 2.7 & 3.5 tool cache support.
-          - os: macos-12
-            python-version: [ 2, 7 ]
-            pip-version: 20
-          - os: ubuntu-20.04
-            python-version: [ 2, 7 ]
-            pip-version: 20
-          - os: ubuntu-20.04
-            python-version: [ 3, 5 ]
-            pip-version: 20
           - os: macos-12
             python-version: [ 3, 11 ]
             pip-version: 20
@@ -98,6 +88,49 @@ jobs:
         uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}
+  cpython-unit-tests-legacy:
+    name: (${{ matrix.os }}) Pip ${{ matrix.pip-version }} TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}
+    needs: org-check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-12
+            python-version: [ 2, 7, 18 ]
+            pip-version: 20
+          - os: ubuntu-22.04
+            python-version: [ 2, 7, 18 ]
+            pip-version: 20
+          - os: ubuntu-22.04
+            python-version: [ 3, 5, 10 ]
+            pip-version: 20
+    steps:
+      - name: Calculate Pythons to Expose
+        id: calculate-pythons-to-expose
+        run: |
+          skip=""
+          if [[ "$(uname -s)" == "Linux" ]]; then
+            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
+          fi
+          echo "skip=${skip}" >> $GITHUB_OUTPUT
+      - name: Checkout Pex
+        uses: actions/checkout@v3
+      - name: Setup Python ${{ join(matrix.python-version, '.') }}
+        uses: gabrielfalcao/pyenv-action@v14
+        with:
+          default: "${{ join(matrix.python-version, '.') }}"
+          command: pip install -U tox
+      - name: Expose Pythons
+        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+        with:
+          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
+      - name: Cache Pyenv Interpreters
+        uses: actions/cache@v3
+        with:
+          path: ${{ env._PEX_TEST_PYENV_ROOT }}
+          key: ${{ matrix.os }}-${{ runner.arch }}-pyenv-root-v1
+      - name: Run Unit Tests
+        run: tox -e py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}
   pypy-unit-tests:
     name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}
     needs: org-check
@@ -216,6 +249,56 @@ jobs:
         uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}-integration
+  cpython-integration-tests-legacy:
+    name: (${{ matrix.os }}) Pip ${{ matrix.pip-version }} TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-integration
+    needs: org-check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-12
+            python-version: [ 2, 7 ]
+            pip-version: 20
+          - os: ubuntu-20.04
+            python-version: [ 2, 7 ]
+            pip-version: 20
+    steps:
+      - name: Calculate Pythons to Expose
+        id: calculate-pythons-to-expose
+        run: |
+          skip=""
+          if [[ "$(uname -s)" == "Linux" ]]; then
+            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
+          fi
+          echo "skip=${skip}" >> $GITHUB_OUTPUT
+      - name: Checkout Pex
+        uses: actions/checkout@v3
+        with:
+          # We need branches and tags for some ITs.
+          fetch-depth: 0
+      - name: Setup Python ${{ join(matrix.python-version, '.') }}
+        uses: gabrielfalcao/pyenv-action@v14
+        with:
+          default: "${{ join(matrix.python-version, '.') }}"
+          command: pip install -U tox
+      - name: Expose Pythons
+        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+        with:
+          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
+      - name: Cache Pyenv Interpreters
+        uses: actions/cache@v3
+        with:
+          path: ${{ env._PEX_TEST_PYENV_ROOT }}
+          key: ${{ matrix.os }}-${{ runner.arch }}-pyenv-root-v1
+      - name: Setup SSH Agent
+        uses: webfactory/ssh-agent@v0.5.4
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        if: env.SSH_PRIVATE_KEY != ''
+        with:
+          ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
+      - name: Run Integration Tests
+        run: tox -e py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}-integration
   pypy-integration-tests:
     name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}-integration
     needs: org-check

--- a/pex/cli/commands/venv.py
+++ b/pex/cli/commands/venv.py
@@ -383,12 +383,14 @@ def _install_from_pex(
 
     if installer_configuration.scope in (InstallScope.ALL, InstallScope.DEPS_ONLY):
         if venv:
+            top_level_source_packages = tuple(installer.iter_top_level_source_packages(pex))
             installer.populate_venv_distributions(
                 venv=venv,
                 distributions=distributions,
                 provenance=provenance,
                 symlink=False,
                 hermetic_scripts=hermetic_scripts,
+                top_level_source_packages=top_level_source_packages,
             )
         else:
             installer.populate_flat_distributions(

--- a/pex/venv/virtualenv.py
+++ b/pex/venv/virtualenv.py
@@ -349,8 +349,7 @@ class Virtualenv(object):
 
     def iter_distributions(self):
         # type: () -> Iterator[Distribution]
-        """"""
-        for dist in find_distributions(search_path=self.sys_path):
+        for dist in find_distributions(search_path=self._interpreter.site_packages):
             yield dist
 
     def _rewrite_base_scripts(self, real_venv_dir):

--- a/tests/integration/cli/commands/test_issue_1667.py
+++ b/tests/integration/cli/commands/test_issue_1667.py
@@ -77,14 +77,19 @@ def test_interpreter_constraints_range_coverage(
 
     def assert_pex_works(python):
         # type: (str) -> None
-        assert (
-            subprocess.check_output(
-                args=[python, ipython_pex, "-c", "import IPython; print(IPython.__file__)"]
-            )
-            .decode("utf-8")
-            .strip()
-            .startswith(pex_root)
+        comm_channel = os.path.join(str(tmpdir), "comm")
+        subprocess.check_call(
+            args=[
+                python,
+                ipython_pex,
+                "-c",
+                "import IPython; print(IPython.__file__, file=open({comm!r}, 'w'))".format(
+                    comm=comm_channel
+                ),
+            ]
         )
+        with open(comm_channel) as fp:
+            assert fp.read().startswith(pex_root)
 
     assert_pex_works(py38.binary)
     if (3, 7) <= sys.version_info[:2] < (3, 11):

--- a/tests/integration/test_issue_1726.py
+++ b/tests/integration/test_issue_1726.py
@@ -46,6 +46,13 @@ def test_check_install_issue_1726(
             )
         )
 
+    # Via: jaraco-collections==3.5.1 -> jaraco-text -> inflect -> pydantic>=1.9.1
+    # Pydantic 2.0 can get pulled in which defeats the Pip legacy resolver and leads to a resolve
+    # conflict for PyPy; so we bound pydantic low.
+    constraints = os.path.join(str(tmpdir), "constraints.txt")
+    with open(constraints, "w") as fp:
+        fp.write("pydantic<2")
+
     pex_root = os.path.join(str(tmpdir), "pex_root")
     pex_args = [
         "--pex-root",
@@ -53,6 +60,8 @@ def test_check_install_issue_1726(
         "--runtime-pex-root",
         pex_root,
         src,
+        "--constraints",
+        constraints,
         "--",
         "-c",
         "from jaraco import collections; print(collections.__file__)",

--- a/tests/integration/venv_ITs/test_issue_2160.py
+++ b/tests/integration/venv_ITs/test_issue_2160.py
@@ -1,0 +1,126 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import glob
+import os.path
+import shutil
+import subprocess
+import sys
+from textwrap import dedent
+
+import pytest
+
+from pex.common import safe_open, safe_rmtree
+from pex.layout import Layout
+from pex.pep_440 import Version
+from pex.pep_503 import ProjectName
+from pex.pex import PEX
+from pex.testing import WheelBuilder, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, List
+
+
+@pytest.fixture
+def top_level_wheel(tmpdir):
+    # type: (Any) -> str
+    top_level_project = os.path.join(str(tmpdir), "project")
+
+    top_level_library = os.path.join(top_level_project, "top_level", "lib.py")
+    with safe_open(top_level_library, "w") as fp:
+        fp.write("OG = 'Henry Barber'")
+
+    with safe_open(os.path.join(top_level_project, "pyproject.toml"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                [build-system]
+                requires = ["setuptools"]
+                build-backend = "setuptools.build_meta"
+
+                [project]
+                name = "top_level"
+                version = "0.1.0"
+                """
+            )
+        )
+
+    wheel_dir = os.path.join(str(tmpdir), "wheels")
+    return WheelBuilder(source_dir=top_level_project, wheel_dir=wheel_dir).bdist()
+
+
+@pytest.mark.parametrize(
+    "style_args",
+    [
+        pytest.param([], id="zipapp"),
+        pytest.param(["--venv"], id="venv (site-packages symlinks)"),
+        pytest.param(["--venv", "--venv-site-packages-copies"], id="venv (site-packages copies)"),
+    ],
+)
+@pytest.mark.parametrize(
+    "layout", [pytest.param(layout, id=layout.value) for layout in Layout.values()]
+)
+def test_ns_package_split_across_sources_and_deps(
+    tmpdir,  # type: Any
+    top_level_wheel,  # type: str
+    style_args,  # type: List[str]
+    layout,  # type: Layout.Value
+):
+    # type: (...) -> None
+
+    sources = os.path.join(str(tmpdir), "sources")
+    with safe_open(os.path.join(sources, "top_level", "mymain.py"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                from top_level.lib import OG
+
+
+                print("Hello {}!".format(OG))
+                """
+            )
+        )
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    pex = os.path.join(str(tmpdir), "binary.pex")
+    run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            top_level_wheel,
+            "-D",
+            sources,
+            "-e",
+            "top_level.mymain",
+            "-o",
+            pex,
+            "--layout",
+            layout.value,
+        ]
+        + style_args
+    ).assert_success()
+
+    safe_rmtree(pex_root)
+    assert (
+        "Hello Henry Barber!"
+        == subprocess.check_output(args=[sys.executable, pex]).decode("utf-8").strip()
+    )
+
+    distributions = list(PEX(pex).resolve())
+    assert 1 == len(distributions)
+
+    top_level = distributions[0]
+    assert ProjectName("top_level") == top_level.metadata.project_name
+    assert Version("0.1.0") == top_level.metadata.version
+
+    assert [os.path.join(top_level.location, "top_level", "lib.py")] == [
+        os.path.join(root, f)
+        for root, dirs, files in os.walk(top_level.location)
+        for f in files
+        if f.endswith(".py")
+    ], (
+        "Even in venv symlink mode, we expect the PEX 3rd-party wheel sources to remain isolated "
+        "from the PEX user sources"
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 isolated_build = true
 skip_missing_interpreters = True
 minversion = 3.25.1
+requires =
+    virtualenv<20.16
 
 [tox:.package]
 # N.B.: tox will use the same python version as under what tox is installed to package, so unless


### PR DESCRIPTION
Previously namespace packages were handled only amongst 3rd-party deps.
Any ns-package also split across PEX user sources would lead to one of
the 3rd-party dep members of the namespace package getting its cached
wheel install contaminated with the PEX user source that was a member of
the ns-package.

Fixes #2160