### PR TITLE
Prepare for Pip 23.2 release.

### DIFF
--- a/pex/pip/tool.py
+++ b/pex/pip/tool.py
@@ -141,7 +141,7 @@ class PackageIndexConfiguration(object):
         password_entries=(),  # type: Iterable[PasswordEntry]
     ):
         # type: (...) -> PackageIndexConfiguration
-        resolver_version = resolver_version or ResolverVersion.PIP_LEGACY
+        resolver_version = resolver_version or ResolverVersion.default(pip_version)
         network_configuration = network_configuration or NetworkConfiguration()
 
         # We must pass `--client-cert` via PIP_CLIENT_CERT to work around
@@ -241,7 +241,7 @@ class Pip(object):
         return (
             package_index_configuration.resolver_version
             if package_index_configuration
-            else ResolverVersion.PIP_LEGACY
+            else ResolverVersion.default()
         )
 
     @classmethod

--- a/pex/pip/version.py
+++ b/pex/pip/version.py
@@ -202,9 +202,9 @@ class PipVersion(Enum["PipVersionValue"]):
     )
 
     v23_2 = PipVersionValue(
-        version="23.2.dev0+8a1eea4a",
-        requirement="pip @ git+https://github.com/pypa/pip@8a1eea4aaedb1fb1c6b4c652cd0c43502f05ff37",
-        setuptools_version="67.8.0",
+        version="23.2.dev0+ea727e4d",
+        requirement="pip @ git+https://github.com/pypa/pip@ea727e4d6ab598f34f97c50a22350febc1214a97",
+        setuptools_version="68.0.0",
         wheel_version="0.40.0",
         requires_python=">=3.7",
         hidden=True,

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -240,9 +240,9 @@ class Platform(object):
         job = SpawnedJob.stdout(
             # TODO(John Sirois): Plumb pip_version and the user-configured resolver:
             #  https://github.com/pantsbuild/pex/issues/1894
-            job=get_pip(
-                resolver=ConfiguredResolver(pip_configuration=PipConfiguration())
-            ).spawn_debug(platform=self, manylinux=manylinux),
+            job=get_pip(resolver=ConfiguredResolver.default()).spawn_debug(
+                platform=self, manylinux=manylinux
+            ),
             result_func=parse_tags,
         )
         return job.await_result()

--- a/pex/resolve/configured_resolver.py
+++ b/pex/resolve/configured_resolver.py
@@ -4,10 +4,10 @@
 from __future__ import absolute_import
 
 from pex import resolver
-from pex.pip.version import PipVersionValue
+from pex.pip.version import PipVersion, PipVersionValue
 from pex.resolve import lock_resolver
 from pex.resolve.lockfile.model import Lockfile
-from pex.resolve.resolver_configuration import PipConfiguration, ReposConfiguration
+from pex.resolve.resolver_configuration import PipConfiguration, ReposConfiguration, ResolverVersion
 from pex.resolve.resolvers import Installed, Resolver
 from pex.result import try_
 from pex.targets import Targets
@@ -29,7 +29,12 @@ class ConfiguredResolver(Resolver):
     @classmethod
     def default(cls):
         # type: () -> ConfiguredResolver
-        return cls(PipConfiguration())
+        pip_version = PipVersion.DEFAULT
+        return cls(
+            PipConfiguration(
+                version=pip_version, resolver_version=ResolverVersion.default(pip_version)
+            )
+        )
 
     pip_configuration = attr.ib()  # type: PipConfiguration
 

--- a/pex/resolve/lockfile/model.py
+++ b/pex/resolve/lockfile/model.py
@@ -34,7 +34,6 @@ class Lockfile(object):
         style,  # type: LockStyle.Value
         requires_python,  # type: Iterable[str]
         target_systems,  # type: Iterable[TargetSystem.Value]
-        resolver_version,  # type: ResolverVersion.Value
         requirements,  # type: Iterable[Union[Requirement, ParsedRequirement]]
         constraints,  # type: Iterable[Requirement]
         allow_prereleases,  # type: bool
@@ -47,6 +46,7 @@ class Lockfile(object):
         locked_resolves,  # type: Iterable[LockedResolve]
         source=None,  # type: Optional[str]
         pip_version=None,  # type: Optional[PipVersionValue]
+        resolver_version=None,  # type: Optional[ResolverVersion.Value]
     ):
         # type: (...) -> Lockfile
 
@@ -88,13 +88,14 @@ class Lockfile(object):
 
         resolve_requirements = OrderedSet(extract_requirement(req) for req in requirements)
 
+        pip_ver = pip_version or PipVersion.DEFAULT
         return cls(
             pex_version=pex_version,
             style=style,
             requires_python=SortedTuple(requires_python),
             target_systems=SortedTuple(target_systems),
-            pip_version=pip_version or PipVersion.DEFAULT,
-            resolver_version=resolver_version,
+            pip_version=pip_ver,
+            resolver_version=resolver_version or ResolverVersion.default(pip_ver),
             requirements=SortedTuple(resolve_requirements, key=str),
             constraints=SortedTuple(constraints, key=str),
             allow_prereleases=allow_prereleases,

--- a/pex/resolve/resolver_options.py
+++ b/pex/resolve/resolver_options.py
@@ -72,7 +72,7 @@ def register(
     parser.add_argument(
         "--resolver-version",
         dest="resolver_version",
-        default=default_resolver_configuration.resolver_version,
+        default=ResolverVersion.default(),
         choices=ResolverVersion.values(),
         type=ResolverVersion.for_value,
         help=(
@@ -446,7 +446,6 @@ def create_pip_configuration(options):
         pip_version = PipVersion.for_value(options.pip_version)
 
     return PipConfiguration(
-        resolver_version=options.resolver_version,
         repos_configuration=repos_configuration,
         network_configuration=create_network_configuration(options),
         allow_prereleases=options.allow_prereleases,
@@ -459,6 +458,7 @@ def create_pip_configuration(options):
         max_jobs=get_max_jobs_value(options),
         preserve_log=options.preserve_pip_download_log,
         version=pip_version,
+        resolver_version=options.resolver_version,
         allow_version_fallback=options.allow_pip_version_fallback,
     )
 

--- a/tests/build_system/test_pep_518.py
+++ b/tests/build_system/test_pep_518.py
@@ -10,9 +10,7 @@ from pex.build_system.pep_518 import BuildSystem
 from pex.common import touch
 from pex.environment import PEXEnvironment
 from pex.pep_503 import ProjectName
-from pex.pip.version import PipVersion
 from pex.resolve.configured_resolver import ConfiguredResolver
-from pex.resolve.resolver_configuration import PipConfiguration
 from pex.result import Error
 from pex.targets import LocalInterpreter
 from pex.typing import TYPE_CHECKING
@@ -26,7 +24,7 @@ def load_build_system(project_directory):
     # type: (...) -> Union[Optional[BuildSystem], Error]
     return pep_518.load_build_system(
         LocalInterpreter.create(),
-        ConfiguredResolver(PipConfiguration(version=PipVersion.DEFAULT)),
+        ConfiguredResolver.default(),
         project_directory,
     )
 

--- a/tests/integration/cli/commands/test_issue_1801.py
+++ b/tests/integration/cli/commands/test_issue_1801.py
@@ -4,10 +4,12 @@
 import os.path
 import re
 
+import pytest
 from colors import green
 
 from pex.cli.testing import run_pex3
 from pex.resolve.lockfile import json_codec
+from pex.resolve.resolver_configuration import ResolverVersion
 from pex.testing import run_pex_command
 
 
@@ -58,6 +60,13 @@ def test_preserve_pip_download_log():
     assert expected_hash == artifact.fingerprint.hash
 
 
+@pytest.mark.skipif(
+    ResolverVersion.default() is ResolverVersion.PIP_2020,
+    reason=(
+        "The PIP_2020 resolver triggers download analysis in normal resolves but this test is "
+        "concerned with the case when there is no analysis to be performed."
+    ),
+)
 def test_preserve_pip_download_log_none():
     # type: () -> None
 
@@ -76,4 +85,4 @@ def test_preserve_pip_download_log_none():
     assert (
         "pex: The `pip download` log is not being utilized, to see more `pip download` details, "
         "re-run with more Pex verbosity (more `-v`s).\n"
-    ) in result.error
+    ) in result.error, result.error

--- a/tests/integration/cli/commands/test_issue_2050.py
+++ b/tests/integration/cli/commands/test_issue_2050.py
@@ -15,7 +15,6 @@ from pex.cli.testing import run_pex3
 from pex.dist_metadata import Requirement
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
-from pex.pip.version import PipVersion
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.locked_resolve import LockedRequirement
 from pex.resolve.lockfile import json_codec

--- a/tests/integration/cli/commands/test_lock.py
+++ b/tests/integration/cli/commands/test_lock.py
@@ -1821,6 +1821,7 @@ EXPECTED_LOCKFILES = {
             resolver_version, EXPECTED_LOCKFILES.get(resolver_version), id=resolver_version.value
         )
         for resolver_version in ResolverVersion.values()
+        if ResolverVersion.applies(resolver_version)
     ],
 )
 def test_universal_lock(

--- a/tests/integration/resolve/test_issue_1918.py
+++ b/tests/integration/resolve/test_issue_1918.py
@@ -71,6 +71,7 @@ def has_ssh_access():
     [
         pytest.param(resolver_version, id=resolver_version.value)
         for resolver_version in ResolverVersion.values()
+        if ResolverVersion.applies(resolver_version)
     ],
 )
 def test_redacted_requirement_handling(

--- a/tests/integration/test_downloads.py
+++ b/tests/integration/test_downloads.py
@@ -56,7 +56,7 @@ MAC_ARTIFACT = file_artifact(
 @pytest.fixture
 def downloader():
     # type: () -> ArtifactDownloader
-    return ArtifactDownloader(ConfiguredResolver(PipConfiguration()))
+    return ArtifactDownloader(ConfiguredResolver.default())
 
 
 def test_issue_1849_download_foreign_artifact(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1666,6 +1666,7 @@ def test_constraint_file_from_url(tmpdir):
             # requirements URL contains `requests[security]>=2.20.1` which uses an extra; so we use
             # older Pip here.
             "--pip-version=20.3.4-patched",
+            "--resolver-version=pip-legacy-resolver",
             "-o",
             pex_file,
         ],

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -141,7 +141,7 @@ def assert_force_local_implicit_ns_packages_issues_598(
         for installed_dist in resolver.resolve(
             targets=Targets(interpreters=(builder.interpreter,)),
             requirements=requirements,
-            resolver=ConfiguredResolver(pip_configuration=PipConfiguration()),
+            resolver=ConfiguredResolver.default(),
         ).installed_distributions:
             builder.add_distribution(installed_dist.distribution)
             for direct_req in installed_dist.direct_requirements:
@@ -274,7 +274,7 @@ def test_osx_platform_intel_issue_523():
         for installed_dist in resolver.resolve(
             targets=Targets(interpreters=(pb.interpreter,)),
             requirements=["psutil==5.4.3"],
-            resolver=ConfiguredResolver(pip_configuration=PipConfiguration()),
+            resolver=ConfiguredResolver.default(),
         ).installed_distributions:
             pb.add_dist_location(installed_dist.distribution.location)
         pb.build(pex_file)
@@ -342,7 +342,7 @@ def test_activate_extras_issue_615():
         for installed_dist in resolver.resolve(
             targets=Targets(interpreters=(pb.interpreter,)),
             requirements=["pex[requests]==1.6.3"],
-            resolver=ConfiguredResolver(pip_configuration=PipConfiguration()),
+            resolver=ConfiguredResolver.default(),
         ).installed_distributions:
             for direct_req in installed_dist.direct_requirements:
                 pb.add_requirement(direct_req)
@@ -369,7 +369,7 @@ def assert_namespace_packages_warning(distribution, version, expected_warning):
     pb = PEXBuilder()
     for installed_dist in resolver.resolve(
         requirements=[requirement],
-        resolver=ConfiguredResolver(pip_configuration=PipConfiguration()),
+        resolver=ConfiguredResolver.default(),
     ).installed_distributions:
         pb.add_dist_location(installed_dist.distribution.location)
     pb.freeze()

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -839,7 +839,7 @@ def test_pex_run_custom_setuptools_useable(
     # type: (...) -> None
     result = resolver.resolve(
         requirements=[setuptools_requirement],
-        resolver=ConfiguredResolver(pip_configuration=PipConfiguration()),
+        resolver=ConfiguredResolver.default(),
     )
     dists = [installed_dist.distribution for installed_dist in result.installed_distributions]
     with temporary_dir() as temp_dir:
@@ -864,7 +864,7 @@ def test_pex_run_conflicting_custom_setuptools_useable(
 
     result = resolver.resolve(
         requirements=[setuptools_requirement],
-        resolver=ConfiguredResolver(pip_configuration=PipConfiguration()),
+        resolver=ConfiguredResolver.default(),
     )
     dists = [installed_dist.distribution for installed_dist in result.installed_distributions]
     with temporary_dir() as temp_dir:
@@ -891,7 +891,7 @@ def test_pex_run_custom_pex_useable():
     old_pex_version = "0.7.0"
     result = resolver.resolve(
         requirements=["pex=={}".format(old_pex_version), "setuptools==40.6.3"],
-        resolver=ConfiguredResolver(pip_configuration=PipConfiguration()),
+        resolver=ConfiguredResolver.default(),
     )
     dists = [installed_dist.distribution for installed_dist in result.installed_distributions]
     with temporary_dir() as temp_dir:

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -52,7 +52,7 @@ def create_sdist(**kwargs):
             project_directory=project_dir,
             dist_dir=dist_dir,
             target=targets.current(),
-            resolver=ConfiguredResolver(pip_configuration=PipConfiguration()),
+            resolver=ConfiguredResolver.default(),
         )
 
     dists = os.listdir(dist_dir)
@@ -68,7 +68,7 @@ def build_wheel(**kwargs):
 
 def resolve(**kwargs):
     # type: (**Any) -> Installed
-    kwargs.setdefault("resolver", ConfiguredResolver(pip_configuration=PipConfiguration()))
+    kwargs.setdefault("resolver", ConfiguredResolver.default())
     return resolve_under_test(**kwargs)
 
 
@@ -500,7 +500,7 @@ def test_download():
     result = download(
         requirements=["{}[foo]".format(project1_sdist)],
         find_links=[os.path.dirname(project2_wheel)],
-        resolver=ConfiguredResolver(pip_configuration=PipConfiguration()),
+        resolver=ConfiguredResolver.default(),
     )
     for local_distribution in result.local_distributions:
         distribution = pkginfo.get_metadata(local_distribution.path)

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ setenv =
     pip23_1: _PEX_PIP_VERSION=23.1
     pip23_1_1: _PEX_PIP_VERSION=23.1.1
     pip23_1_2: _PEX_PIP_VERSION=23.1.2
-    pip23_2: _PEX_PIP_VERSION=23.2.dev0+8a1eea4a
+    pip23_2: _PEX_PIP_VERSION=23.2.dev0+ea727e4d
     # Python 3 (until a fix here in 3.9: https://bugs.python.org/issue13601) switched from stderr
     # being unbuffered to stderr being buffered by default. This can lead to tests checking stderr
     # failing to see what they expect if the stderr buffer block has not been flushed. Force stderr


### PR DESCRIPTION
A recent Pip commit has broken
`pip --use-deprecated legacy-resolver download ...` which is our
backwards-compatible default use case. Whether or not Pip decides to
fix, the legacy resolver will be yanked at some point and it seems
reasonable to just require any Pex user on Python 3.12 and thus Pip 23.2
to only use the Pip 2020 resolver.

See: https://github.com/pypa/pip/issues/12138