### PR TITLE
Add official support for Python 3.12 / Pip 23.2.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,11 @@ jobs:
             pip-version: 23_1_2
             tox-env-python: python
           - os: macos-12
-            python-version: [ 3, 12, "0-beta.3" ]
+            python-version: [ 3, 12, "0-beta.4" ]
             pip-version: 23_2
             tox-env-python: python3.11
           - os: ubuntu-22.04
-            python-version: [ 3, 12, "0-beta.3" ]
+            python-version: [ 3, 12, "0-beta.4" ]
             pip-version: 23_2
             tox-env-python: python3.11
     steps:
@@ -219,11 +219,11 @@ jobs:
             pip-version: 23_1_2
             tox-env-python: python
           - os: macos-12
-            python-version: [ 3, 12, "0-beta.3" ]
+            python-version: [ 3, 12, "0-beta.4" ]
             pip-version: 23_2
             tox-env-python: python3.11
           - os: ubuntu-22.04
-            python-version: [ 3, 12, "0-beta.3" ]
+            python-version: [ 3, 12, "0-beta.4" ]
             pip-version: 23_2
             tox-env-python: python3.11
     steps:

--- a/pex/pip/version.py
+++ b/pex/pip/version.py
@@ -202,12 +202,10 @@ class PipVersion(Enum["PipVersionValue"]):
     )
 
     v23_2 = PipVersionValue(
-        version="23.2.dev0+ea727e4d",
-        requirement="pip @ git+https://github.com/pypa/pip@ea727e4d6ab598f34f97c50a22350febc1214a97",
+        version="23.2",
         setuptools_version="68.0.0",
         wheel_version="0.40.0",
         requires_python=">=3.7",
-        hidden=True,
     )
 
     VENDORED = v20_3_4_patched

--- a/tests/integration/test_issue_1817.py
+++ b/tests/integration/test_issue_1817.py
@@ -3,6 +3,9 @@
 
 import os
 import shutil
+import sys
+
+import pytest
 
 from pex.cli.testing import run_pex3
 from pex.testing import run_pex_command
@@ -60,6 +63,7 @@ def test_sdist_for_project_with_native_extensions(tmpdir):
     assert_create_and_use_sdist_lock(tmpdir, "psutil==5.9.1", "import psutil")
 
 
+@pytest.mark.skipif(sys.version_info[:2] < (3, 6), reason="PyYAML 6.0.1 requires Python >= 3.6")
 def test_sdist_for_project_with_pep517_build(tmpdir):
     # type: (Any) -> None
-    assert_create_and_use_sdist_lock(tmpdir, "PyYAML==5.4.1", "import yaml")
+    assert_create_and_use_sdist_lock(tmpdir, "PyYAML==6.0.1", "import yaml")

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ setenv =
     pip23_1: _PEX_PIP_VERSION=23.1
     pip23_1_1: _PEX_PIP_VERSION=23.1.1
     pip23_1_2: _PEX_PIP_VERSION=23.1.2
-    pip23_2: _PEX_PIP_VERSION=23.2.dev0+ea727e4d
+    pip23_2: _PEX_PIP_VERSION=23.2
     # Python 3 (until a fix here in 3.9: https://bugs.python.org/issue13601) switched from stderr
     # being unbuffered to stderr being buffered by default. This can lead to tests checking stderr
     # failing to see what they expect if the stderr buffer block has not been flushed. Force stderr


### PR DESCRIPTION
Pip 23.2 is both the latest release and the only release that supports
Python 3.12.

The Pip 23.2 release notes are here:
  https://pip.pypa.io/en/stable/news/#v23-2

Fixes #2173