### PR TITLE
Fail fast for Pip>=23.2 + pip-legacy-resolver.

### DIFF
--- a/pex/pip/version.py
+++ b/pex/pip/version.py
@@ -71,12 +71,14 @@ class PipVersionValue(Enum.Value):
         # type: () -> Iterable[str]
         return self.requirement, self.setuptools_requirement, self.wheel_requirement
 
-    def requires_python_applies(self, target):
-        # type: (Target) -> bool
+    def requires_python_applies(self, target=None):
+        # type: (Optional[Target]) -> bool
         if not self.requires_python:
             return True
 
-        return LocalInterpreter.create(target.get_interpreter()).requires_python_applies(
+        return LocalInterpreter.create(
+            interpreter=target.get_interpreter() if target else None
+        ).requires_python_applies(
             requires_python=self.requires_python,
             source=Requirement.parse(self.requirement),
         )

--- a/tests/resolve/test_resolver_options.py
+++ b/tests/resolve/test_resolver_options.py
@@ -169,3 +169,13 @@ def test_latest_pip_version(parser):
 
     pip_configuration = compute_pip_configuration(parser, args=["--pip-version", "latest"])
     assert pip_configuration.version is PipVersion.LATEST
+
+
+def test_resolver_version_invalid(parser):
+    # type: (ArgumentParser) -> None
+    resolver_options.register(parser)
+
+    with pytest.raises(resolver_options.InvalidConfigurationError):
+        compute_pip_configuration(
+            parser, args=["--pip-version", "23.2", "--resolver-version", "pip-legacy-resolver"]
+        )

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -81,7 +81,7 @@ applicable_pip_versions = pytest.mark.parametrize(
     [
         pytest.param(version, id=str(version))
         for version in PipVersion.values()
-        if version.requires_python_applies(LocalInterpreter.create())
+        if version.requires_python_applies()
     ],
 )
 


### PR DESCRIPTION
This was an oversight in the commits that landed Pip 23.2 / Python 3.12
support.