### PR TITLE
Cleanup `sys.path` after `__pex__` is imported.

### DIFF
--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -595,12 +595,16 @@ def bootstrap_pex(
     # possible in the run.
     with ENV.patch(PEX_ROOT=pex_info.pex_root):
         if not execute:
-            for location in _activate_pex(entry_point, pex_info, venv_dir=venv_dir):
-                from pex.third_party import VendorImporter
+            locations = list(_activate_pex(entry_point, pex_info, venv_dir=venv_dir))
+            from pex.bootstrap import Bootstrap
+            from pex.third_party import VendorImporter, uninstall
 
+            for location in locations:
                 VendorImporter.install(
                     uninstallable=False, prefix="__pex__", path_items=["."], root=location
                 )
+            uninstall()
+            Bootstrap.locate().demote()
             return
 
         interpreter_test = InterpreterTest(entry_point=entry_point, pex_info=pex_info)

--- a/tests/integration/test_pex_import.py
+++ b/tests/integration/test_pex_import.py
@@ -3,14 +3,13 @@
 
 import os.path
 import subprocess
-import sys
 from textwrap import dedent
 
 import colors
 import pytest
 
+from pex import targets
 from pex.common import safe_open
-from pex.interpreter import PythonInterpreter
 from pex.layout import DEPS_DIR, Layout
 from pex.resolve.pex_repository_resolver import resolve_from_pex
 from pex.targets import Targets
@@ -70,7 +69,7 @@ def test_import_from_pex(
             src,
             "ansicolors==1.1.8",
             # Add pex to verify that it will shadow bootstrap pex
-            "pex==2.1.110",
+            "pex==2.1.139",
             "-o",
             pex,
             "--layout",
@@ -103,7 +102,7 @@ def test_import_from_pex(
         ambient_sys_path = [
             installed_distribution.fingerprinted_distribution.distribution.location
             for installed_distribution in resolve_from_pex(
-                targets=Targets(interpreters=(PythonInterpreter.from_binary(sys.executable),)),
+                targets=Targets.from_target(targets.current()),
                 pex=pex,
                 requirements=["ansicolors==1.1.8"],
             ).installed_distributions

--- a/tests/integration/test_pex_import.py
+++ b/tests/integration/test_pex_import.py
@@ -17,6 +17,7 @@ from pex.targets import Targets
 from pex.testing import make_env, run_pex_command
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
+from pex.venv.virtualenv import Virtualenv
 
 if TYPE_CHECKING:
     from typing import Any, List, Text
@@ -34,6 +35,12 @@ def test_import_from_pex(
     execution_mode_args,  # type: List[str]
 ):
     # type: (...) -> None
+
+    empty_env_dir = os.path.join(str(tmpdir), "empty_env")
+    empty_venv = Virtualenv.create(
+        venv_dir=empty_env_dir,
+    )
+    empty_python = empty_venv.interpreter.binary
 
     src = os.path.join(str(tmpdir), "src")
     with safe_open(os.path.join(src, "first_party.py"), "w") as fp:
@@ -62,6 +69,8 @@ def test_import_from_pex(
             "-D",
             src,
             "ansicolors==1.1.8",
+            # Add pex to verify that it will shadow bootstrap pex
+            "pex==2.1.110",
             "-o",
             pex,
             "--layout",
@@ -73,10 +82,20 @@ def test_import_from_pex(
     def execute_with_pex_on_pythonpath(code):
         # type: (str) -> Text
         return (
-            subprocess.check_output(args=[sys.executable, "-c", code], env=make_env(PYTHONPATH=pex))
+            subprocess.check_output(
+                args=[empty_python, "-c", code], env=make_env(PYTHONPATH=pex), cwd=str(tmpdir)
+            )
             .decode("utf-8")
             .strip()
         )
+
+    def get_third_party_prefix():
+        if is_venv:
+            return os.path.join(pex_root, "venvs")
+        elif layout is Layout.LOOSE:
+            return os.path.join(pex, DEPS_DIR)
+        else:
+            return os.path.join(pex_root, "installed_wheels")
 
     # Verify 3rd party code can be imported hermetically from the PEX.
     alternate_pex_root = os.path.join(str(tmpdir), "alternate_pex_root")
@@ -95,24 +114,19 @@ def test_import_from_pex(
             """\
             # Executor code like the AWS runtime.
             import sys
-            
+
             sys.path = {ambient_sys_path!r} + sys.path
-            
+
             # User code residing in the PEX.
             from __pex__ import colors
-            
+
             print(colors.__file__)
             """.format(
                 ambient_sys_path=ambient_sys_path
             )
         )
     )
-    if is_venv:
-        expected_prefix = os.path.join(pex_root, "venvs")
-    elif layout is Layout.LOOSE:
-        expected_prefix = os.path.join(pex, DEPS_DIR)
-    else:
-        expected_prefix = os.path.join(pex_root, "installed_wheels")
+    expected_prefix = get_third_party_prefix()
     assert third_party_path.startswith(
         expected_prefix
     ), "Expected 3rd party ansicolors path {path} to start with {expected_prefix}".format(
@@ -141,10 +155,49 @@ def test_import_from_pex(
 
             import colors
             import first_party
-            
-            
+
+
             print(colors.blue("42"))
             first_party.warn("Vogon")
             """
         )
     )
+
+    # Verify bootstrap code does not leak attrs from vendored code
+    assert "no leak" == execute_with_pex_on_pythonpath(
+        dedent(
+            """\
+            import __pex__
+
+            try:
+                import attr
+                print(attr.__file__)
+            except ImportError:
+                print("no leak")
+            """
+        )
+    )
+
+    # Verify bootstrap pex code is demoted to the end of `sys.path`
+    assert os.path.join(pex, ".bootstrap") == execute_with_pex_on_pythonpath(
+        dedent(
+            """\
+            import __pex__
+            import sys
+            print(sys.path[-1])
+            """
+        )
+    )
+
+    # Verify third party pex shadows bootstrap pex
+    pex_third_party_path = execute_with_pex_on_pythonpath(
+        dedent(
+            """\
+            import __pex__
+            import pex
+            print(pex.__file__)
+            """
+        )
+    )
+
+    assert pex_third_party_path.startswith(get_third_party_prefix())


### PR DESCRIPTION
This fixes #1954 by ensuring all vendored code is uninstalled from the
path and bootstrap code is demoted to the end of `sys.path` after
`__pex__` is imported.

Fixes #1954