### PR TITLE
Remove un-needed test dep on pkg_info.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,6 @@ deps =
     pytest==4.6.11; python_version < "3.6"
     pytest==6.2.5; python_version == "3.6"
     pytest==7.4.0; python_version >= "3.7"
-    pkginfo==1.7.0
     py{27,py27}: mock==3.0.5
     subprocess: subprocess32
 passenv =


### PR DESCRIPTION
Pex learned how to parse distributions on its own some time back. Just
dogfood that support.