### PR TITLE
Guard against too long filenames on eCryptFS.

### DIFF
--- a/pex/atomic_directory.py
+++ b/pex/atomic_directory.py
@@ -81,7 +81,7 @@ class AtomicDirectory(object):
             # cases we replace the basename with its sha256 hex digest which is a fixed 64
             # characters.
             #
-            # No attempt is made to probe for en eCryptFS partition or even guess if the OS supports
+            # No attempt is made to probe for an eCryptFS partition or even guess if the OS supports
             # this sort of thing since not many wheel names are this long and just always performing
             # this compaction is more robust.
             #

--- a/pex/atomic_directory.py
+++ b/pex/atomic_directory.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import errno
 import fcntl
+import hashlib
 import os
 import threading
 from contextlib import contextmanager
@@ -68,6 +69,27 @@ class AtomicDirectory(object):
         # type: (...) -> None
         self._target_dir = target_dir
         self._work_dir = "{}.{}.work".format(target_dir, "lck" if locked else uuid4().hex)
+        if len(os.path.basename(self._work_dir)) > 143:
+            # Guard against eCryptFS home dir encryption which restricts file names to 143
+            # characters when the underlying file system has a max file name length of 255
+            # characters, which is the common case. We can break this limit with wheels like
+            # `pycryptodome-3.16.0-cp35-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl`.
+            # That wheel name is only 116 characters long, but can have something like
+            # `.a4d26b5a48ca4a8c92e788d1879f39e6.work` appended, which is an additional 39
+            # characters totalling 155 characters when the AtomicDirectory is unlocked. In these
+            # cases we replace the basename with its sha256 hex digest which is a fixed 64
+            # characters.
+            #
+            # No attempt is made to probe for en eCryptFS partition or even guess if the OS supports
+            # this sort of thing since not many wheel names are this long and just always performing
+            # this compaction is more robust.
+            #
+            # See: https://bugs.launchpad.net/ecryptfs/+bug/344878
+            # See: https://github.com/pantsbuild/pex/issues/2087
+            self._work_dir = os.path.join(
+                os.path.dirname(self._target_dir),
+                hashlib.sha256(self._work_dir.encode("utf-8")).hexdigest(),
+            )
 
     @property
     def work_dir(self):

--- a/tests/integration/test_issue_2087.py
+++ b/tests/integration/test_issue_2087.py
@@ -16,8 +16,11 @@ if TYPE_CHECKING:
 def test_long_wheel_names(tmpdir):
     # type: (Any) -> None
 
+    # N.B.: The pycryptodome 3.16.0 release has a wheel with a 116 character name in
+    # pycryptodome-3.16.0-cp35-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+    # that triggers special logic to deal with temporary work dir names being too long for some
+    # systems, notably those that house the PEX_ROOT on an eCryptFS volume.
     pex_root = os.path.join(str(tmpdir), "pex_root")
-
     result = run_pex_command(
         args=[
             "--pex-root",
@@ -41,6 +44,7 @@ def test_long_wheel_names(tmpdir):
         ]
     )
     result.assert_success()
+
     data = json.loads(result.output)
     assert "3.16.0" == data["version"]
     assert pex_root == commonpath((pex_root, data["path"]))

--- a/tests/integration/test_issue_2087.py
+++ b/tests/integration/test_issue_2087.py
@@ -1,0 +1,46 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import json
+import os.path
+from textwrap import dedent
+
+from pex.compatibility import commonpath
+from pex.typing import TYPE_CHECKING
+from testing import run_pex_command
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_long_wheel_names(tmpdir):
+    # type: (Any) -> None
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+
+    result = run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "pycryptodome==3.16.0",
+            "--",
+            "-c",
+            dedent(
+                """\
+                import json
+                import sys
+
+                import Crypto
+
+
+                json.dump({"version": Crypto.__version__, "path": Crypto.__file__}, sys.stdout)
+                """
+            ),
+        ]
+    )
+    result.assert_success()
+    data = json.loads(result.output)
+    assert "3.16.0" == data["version"]
+    assert pex_root == commonpath((pex_root, data["path"]))

--- a/tests/test_atomic_directory.py
+++ b/tests/test_atomic_directory.py
@@ -167,7 +167,8 @@ def test_long_file_name_issue_2087():
     assert 143 == len(
         os.path.basename(atomic_directory.work_dir)
     ), "Expected longer directory names to use a workdir that is 143 characters in length."
-    assert (
-        "pycryptodome-3.16.0-cp35-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylin..."
-        "5236c5dd62d3eb5d9467975a2986463b99734b88882321925ccb3c50fde8bd82"
-    ) == os.path.basename(atomic_directory.work_dir)
+    assert re.match(
+        r"^pycryptodome-3\.16\.0-cp35-abi3-manylinux_2_5_x86_64\.manylinux1_x86_64\.manylin"
+        r"\.\.\.[a-f0-9]{64}$",
+        os.path.basename(atomic_directory.work_dir),
+    ), "Expected longer directory names to retain their prefix with a `...<hash>` suffix."

--- a/tests/test_atomic_directory.py
+++ b/tests/test_atomic_directory.py
@@ -154,7 +154,7 @@ def test_long_file_name_issue_2087():
         r"pycryptodome-3\.16\.0-cp35-abi3-manylinux_2_5_x86_64\.manylinux1_x86_64\."
         r"manylinux_2_12_x86_64\.[a-f0-9]+.work",
         os.path.basename(atomic_directory.work_dir),
-    ), "Expected shor, ter filenames to use a workdir with the target dir as a prefix."
+    ), "Expected shorter directory names to use a workdir with the target dir as a prefix."
 
     atomic_directory = AtomicDirectory(
         "/tmp/pycryptodome-3.16.0-cp35-abi3-manylinux_2_5_x86_64.manylinux1_x86_64."
@@ -166,4 +166,4 @@ def test_long_file_name_issue_2087():
     ), "Expected the workdir to be co-located with the target dir to ensure atomic rename works."
     assert 64 == len(
         os.path.basename(atomic_directory.work_dir)
-    ), "Expected longer filenames to use a workdir that is a sha256 hexdigest."
+    ), "Expected longer directory names to use a workdir that is a sha256 hex digest."

--- a/tests/test_atomic_directory.py
+++ b/tests/test_atomic_directory.py
@@ -164,6 +164,10 @@ def test_long_file_name_issue_2087():
     assert "/tmp" == os.path.dirname(
         atomic_directory.work_dir
     ), "Expected the workdir to be co-located with the target dir to ensure atomic rename works."
-    assert 64 == len(
+    assert 143 == len(
         os.path.basename(atomic_directory.work_dir)
-    ), "Expected longer directory names to use a workdir that is a sha256 hex digest."
+    ), "Expected longer directory names to use a workdir that is 143 characters in length."
+    assert (
+        "pycryptodome-3.16.0-cp35-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylin..."
+        "5236c5dd62d3eb5d9467975a2986463b99734b88882321925ccb3c50fde8bd82"
+    ) == os.path.basename(atomic_directory.work_dir)

--- a/tests/test_atomic_directory.py
+++ b/tests/test_atomic_directory.py
@@ -3,6 +3,7 @@
 
 import errno
 import os
+import re
 from contextlib import contextmanager
 
 import pytest
@@ -139,3 +140,30 @@ def test_atomic_directory_locked_mode():
         AtomicDirectory("locked", locked=True).work_dir
         == AtomicDirectory("locked", locked=True).work_dir
     )
+
+
+def test_long_file_name_issue_2087():
+    # type: () -> None
+
+    atomic_directory = AtomicDirectory(
+        "/tmp/pycryptodome-3.16.0-cp35-abi3-manylinux_2_5_x86_64.manylinux1_x86_64."
+        "manylinux_2_12_x86_64",
+        locked=False,
+    )
+    assert re.match(
+        r"pycryptodome-3\.16\.0-cp35-abi3-manylinux_2_5_x86_64\.manylinux1_x86_64\."
+        r"manylinux_2_12_x86_64\.[a-f0-9]+.work",
+        os.path.basename(atomic_directory.work_dir),
+    ), "Expected shor, ter filenames to use a workdir with the target dir as a prefix."
+
+    atomic_directory = AtomicDirectory(
+        "/tmp/pycryptodome-3.16.0-cp35-abi3-manylinux_2_5_x86_64.manylinux1_x86_64."
+        "manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
+        locked=False,
+    )
+    assert "/tmp" == os.path.dirname(
+        atomic_directory.work_dir
+    ), "Expected the workdir to be co-located with the target dir to ensure atomic rename works."
+    assert 64 == len(
+        os.path.basename(atomic_directory.work_dir)
+    ), "Expected longer filenames to use a workdir that is a sha256 hexdigest."


### PR DESCRIPTION
The `AtomicDirectory` mechanism inflates the target directory file name
length when deriving a work directory name. In the case of unlocked 
operation in particular, this can lead to file name length violations
when the PEX_ROOT is the default `~/.pex` and the home dir is encrypted
with eCryptFS, which generally limits file name lengths to 143
characters. Guard against this explicitly.

Fixes #2087