### PR TITLE
Traverse directories in stable order when building a PEX

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -694,8 +694,8 @@ class Chroot(object):
                         yield full_path, path
                         continue
 
-                    for root, _, files in os.walk(full_path):
-                        for f in sorted(files):
+                    for root, _, files in deterministic_walk(full_path):
+                        for f in files:
                             if exclude_file(f):
                                 continue
                             abs_path = os.path.join(root, f)

--- a/pex/common.py
+++ b/pex/common.py
@@ -241,9 +241,15 @@ def deterministic_walk(*args, **kwargs):
     # type: (*Any, **Any) -> Iterator[Tuple[str, List[str], List[str]]]
     """Walk the specified directory tree in deterministic order.
 
-    Takes the same parameters as os.walk and yields tuples of the same shape.
+    Takes the same parameters as os.walk and yields tuples of the same shape,
+    except for the `topdown` parameter, which must always be true.
+    `deterministic_walk` is essentially a wrapper of os.walk, and os.walk doesn't
+    allow modifying the order of the walk when called with `topdown` set to false.
+
     os.walk uses os.listdir or os.scandir, depending on the Python version,
     both of which don't guarantee the order in which directory entries get listed.
+    So when the build output depends on the order of directory traversal,
+    use deterministic_walk instead.
     """
     # when topdown is false, modifying ``dirs`` has no effect
     assert kwargs.get("topdown", True), "Determinism cannot be guaranteed when ``topdown`` is false"

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -13,6 +13,7 @@ from pex.atomic_directory import atomic_directory
 from pex.common import (
     Chroot,
     chmod_plus_x,
+    deterministic_walk,
     filter_pyc_files,
     is_pyc_temporary_file,
     safe_copy,
@@ -586,7 +587,7 @@ class PEXBuilder(object):
         bootstrap_packages = ["third_party", "venv"]
         if self._pex_info.includes_tools:
             bootstrap_packages.extend(["commands", "tools"])
-        for root, dirs, files in os.walk(_ABS_PEX_PACKAGE_DIR):
+        for root, dirs, files in deterministic_walk(_ABS_PEX_PACKAGE_DIR):
             if root == _ABS_PEX_PACKAGE_DIR:
                 dirs[:] = bootstrap_packages
 

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -10,7 +10,7 @@ import platform
 import random
 import subprocess
 import sys
-from collections import defaultdict
+from collections import Counter
 from contextlib import contextmanager
 from textwrap import dedent
 
@@ -28,7 +28,7 @@ from pex.pip.installation import get_pip
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.resolver_configuration import PipConfiguration
 from pex.targets import LocalInterpreter
-from pex.typing import TYPE_CHECKING, cast
+from pex.typing import TYPE_CHECKING
 from pex.util import named_temporary_file
 from pex.venv.virtualenv import Virtualenv
 
@@ -777,7 +777,7 @@ class NonDeterministicWalk:
     """
 
     def __init__(self):
-        self._counters = defaultdict(int)
+        self._counter = Counter()  # type: Counter[str, int]
         self._original_walk = os.walk
 
     def __call__(self, *args, **kwargs):
@@ -790,12 +790,12 @@ class NonDeterministicWalk:
 
     def _increment_counter(self, counter_key):
         # type: (str) -> int
-        self._counters[counter_key] += 1
-        return cast(int, self._counters[counter_key])
+        self._counter[counter_key] += 1
+        return self._counter[counter_key]
 
     def _rotate(self, counter_key, x):
         # type: (str, List[str]) -> List[str]
         if not x:
             return x
-        rotate_by = self._counters[counter_key] % len(x)
+        rotate_by = self._counter[counter_key] % len(x)
         return x[-rotate_by:] + x[:-rotate_by]

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -28,7 +28,7 @@ from pex.pip.installation import get_pip
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.resolver_configuration import PipConfiguration
 from pex.targets import LocalInterpreter
-from pex.typing import TYPE_CHECKING
+from pex.typing import TYPE_CHECKING, cast
 from pex.util import named_temporary_file
 from pex.venv.virtualenv import Virtualenv
 
@@ -791,7 +791,7 @@ class NonDeterministicWalk:
     def _increment_counter(self, counter_key):
         # type: (str) -> int
         self._counters[counter_key] += 1
-        return self._counters[counter_key]
+        return cast(int, self._counters[counter_key])
 
     def _rotate(self, counter_key, x):
         # type: (str, List[str]) -> List[str]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -146,13 +146,10 @@ def test_chroot_zip_is_deterministic():
     # type: () -> None
     with temporary_dir() as tmp:
         root_dir = os.path.join(tmp, "root")
-        os.mkdir(root_dir)
         dir_a = os.path.join(root_dir, "a")
-        os.mkdir(dir_a)
         src_path_a = os.path.join(dir_a, "file_a")
         touch(src_path_a)
         dir_b = os.path.join(root_dir, "b")
-        os.mkdir(dir_b)
         src_path_b = os.path.join(dir_b, "file_b")
         touch(src_path_b)
 
@@ -228,13 +225,10 @@ def test_deterministic_walk():
     # type: () -> None
     with temporary_dir() as tmp:
         root_dir = os.path.join(tmp, "root")
-        os.mkdir(root_dir)
         dir_a = os.path.join(root_dir, "a")
-        os.mkdir(dir_a)
         file_a = os.path.join(dir_a, "file_a")
         touch(file_a)
         dir_b = os.path.join(root_dir, "b")
-        os.mkdir(dir_b)
         file_b = os.path.join(dir_b, "file_b")
         touch(file_b)
 


### PR DESCRIPTION
Addresses one part of #2155.

Adds a wrapper for `os.walk` that sorts directory entries as it traverses directories. As discussed in the issue, `os.walk` may yield directory entries in a different order depending on (possibly) the file system.

I don't know if the two `os.walk` calls that this PR replaces are enough for addressing this class of non-determinism in pex, but these were sufficient for solving the issue in my case. Happy to expand the use of the wrapper if there are other places that it should be used.