### PR TITLE
Use a data-only image for cache in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 concurrency:
   group: CI-${{ github.ref }}
   # Queue on all branches and tags, but only cancel overlapping PR burns.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' || !startsWith(github.ref, 'refs/tags/') }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 jobs:
   org-check:
     name: Check GitHub Organization
@@ -23,7 +23,7 @@ jobs:
       - name: Noop
         run: "true"
   checks:
-    name:  TOXENV=format-check,typecheck,vendor-check,package -- --additional-format sdist --additional-format wheel
+    name:  tox -e format-check,typecheck,vendor-check,package
     needs: org-check
     runs-on: ubuntu-22.04
     steps:
@@ -42,231 +42,70 @@ jobs:
         uses: pantsbuild/actions/run-tox@b16b9cf47cd566acfe217b1dafc5b452e27e6fd7
         with:
           tox-env: format-check,typecheck,vendor-check,package -- --additional-format sdist --additional-format wheel
-  cpython-unit-tests:
-    name: (${{ matrix.os }}) Pip ${{ matrix.pip-version }} TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}
+  # N.B.: The name of this job key (linux-tests) is depended on by scrips/build_cache_image.py. In
+  # particular, the tox-env matrix list is used to ensure the cache covers all Linux CI jobs.
+  linux-tests:
+    name: ./dtox.sh -e ${{ matrix.tox-env }}
     needs: org-check
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        include:
-          - os: macos-12
-            python-version: [ 3, 11 ]
-            pip-version: 20
-            tox-env-python: python
-          - os: ubuntu-22.04
-            python-version: [ 3, 11 ]
-            pip-version: 20
-            tox-env-python: python
-          - os: ubuntu-22.04
-            python-version: [ 3, 11 ]
-            pip-version: 22_3_1
-            tox-env-python: python
-          - os: ubuntu-22.04
-            python-version: [ 3, 11 ]
-            pip-version: 23_1_2
-            tox-env-python: python
-          - os: macos-12
-            python-version: [ 3, 12, "0-rc.1" ]
-            pip-version: 23_2
-            tox-env-python: python3.11
-          - os: ubuntu-22.04
-            python-version: [ 3, 12, "0-rc.1" ]
-            pip-version: 23_2
-            tox-env-python: python3.11
-    env:
-      _TOX_ENV: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}
+        tox-env:
+          - py27-pip20
+          - py35-pip20
+          - py311-pip20
+          - py311-pip22_3_1
+          - py311-pip23_1_2
+          - py312-pip23_2
+          - pypy310-pip20
+          - pypy310-pip22_3_1
+          - pypy310-pip23_1_2
+          - py27-pip20-integration
+          - py37-pip22_3_1-integration
+          - py37-pip23_1_2-integration
+          - py311-pip20-integration
+          - py311-pip22_3_1-integration
+          - py311-pip23_1_2-integration
+          - py312-pip23_2-integration
+          - pypy310-pip20-integration
+          - pypy310-pip22_3_1-integration
+          - pypy310-pip23_1_2-integration
     steps:
-      - name: Calculate Pythons to Expose
-        id: calculate-pythons-to-expose
-        run: |
-          skip=""
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
-          fi
-          echo "skip=${skip}" >> $GITHUB_OUTPUT
       - name: Checkout Pex
         uses: actions/checkout@v3
         with:
-          path: repo
-      - name: Setup Python ${{ join(matrix.python-version, '.') }}
-        uses: actions/setup-python@v4
+          # We need branches and tags for some ITs.
+          fetch-depth: 0
+      # Some ITs need this for VCS URLs of the form git+ssh://git@github.com/...
+      - name: Setup SSH Agent
+        uses: webfactory/ssh-agent@v0.5.4
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        if: env.SSH_PRIVATE_KEY != ''
         with:
-          python-version: "${{ join(matrix.python-version, '.') }}"
-      - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        with:
-          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
-      - name: Cache Pyenv Interpreters
-        uses: actions/cache@v3
-        with:
-          path: ${{ env._PEX_TEST_DEV_ROOT }}/pyenv
-          key: ${{ matrix.os }}-${{ runner.arch }}-pex-test-dev-root-pyenv-v1
-      - name: Cache Devpi Server
-        uses: actions/cache@v3
-        with:
-          path: ${{ env._PEX_TEST_DEV_ROOT }}/devpi
-          # We're using a key suffix / restore-keys prefix trick here to get an updatable cache.
-          # See: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
-          key: ${{ matrix.os }}-${{ runner.arch }}-${{ env._TOX_ENV }}-pex-test-dev-root-devpi-v1-${{ github.run_id }}
-          restore-keys: ${{ matrix.os }}-${{ runner.arch }}-${{ env._TOX_ENV }}-pex-test-dev-root-devpi-v1
+          ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
       - name: Run Unit Tests
-        uses: pantsbuild/actions/run-tox@b16b9cf47cd566acfe217b1dafc5b452e27e6fd7
-        with:
-          path: repo/tox.ini
-          python: ${{ matrix.tox-env-python }}
-          tox-env: ${{ env._TOX_ENV }} -- ${{ env._PEX_TEST_POS_ARGS }}
-  cpython-unit-tests-legacy:
-    name: (${{ matrix.os }}) Pip ${{ matrix.pip-version }} TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}
+        run: |
+          BASE_MODE=pull CACHE_MODE=pull ./dtox.sh -e ${{ matrix.tox-env }} -- ${{ env._PEX_TEST_POS_ARGS }}
+  mac-tests:
+    name: tox -e ${{ matrix.tox-env }}
     needs: org-check
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-12
     strategy:
       matrix:
         include:
-          - os: macos-12
-            python-version: [ 2, 7, 18 ]
-            pip-version: 20
-          - os: ubuntu-22.04
-            python-version: [ 2, 7, 18 ]
-            pip-version: 20
-          # Ubuntu 20.04 is required to avoid inscrutable errors with Python 3.5 trying to use
-          # python3.10 libpython.so.
-          - os: ubuntu-20.04
-            python-version: [ 3, 5, 10 ]
-            pip-version: 20
-    env:
-      _TOX_ENV: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}
-    steps:
-      - name: Calculate Pythons to Expose
-        id: calculate-pythons-to-expose
-        run: |
-          skip=""
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
-          fi
-          echo "skip=${skip}" >> $GITHUB_OUTPUT
-      - name: Checkout Pex
-        uses: actions/checkout@v3
-        with:
-          path: repo
-      - name: Setup Python ${{ join(matrix.python-version, '.') }}
-        uses: pantsbuild/actions/pyenv@1356087bfd1be04670c2ffde4ba94a9c6898ecd7
-        with:
-          python-version: "${{ join(matrix.python-version, '.') }}"
-      - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        with:
-          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
-      - name: Cache Pyenv Interpreters
-        uses: actions/cache@v3
-        with:
-          path: ${{ env._PEX_TEST_DEV_ROOT }}/pyenv
-          key: ${{ matrix.os }}-${{ runner.arch }}-pex-test-dev-root-pyenv-v1
-      - name: Cache Devpi Server
-        uses: actions/cache@v3
-        with:
-          path: ${{ env._PEX_TEST_DEV_ROOT }}/devpi
-          # We're using a key suffix / restore-keys prefix trick here to get an updatable cache.
-          # See: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
-          key: ${{ matrix.os }}-${{ runner.arch }}-${{ env._TOX_ENV }}-pex-test-dev-root-devpi-v1-${{ github.run_id }}
-          restore-keys: ${{ matrix.os }}-${{ runner.arch }}-${{ env._TOX_ENV }}-pex-test-dev-root-devpi-v1
-      - name: Run Unit Tests
-        run: |
-          pip install -U tox
-          tox -c repo/tox.ini -e ${{ env._TOX_ENV }} -- ${{ env._PEX_TEST_POS_ARGS }}
-  pypy-unit-tests:
-    name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}
-    needs: org-check
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          # N.B.: We need 20.04 for PyPy 2.7 tool cache support.
-          - os: ubuntu-20.04
-            pypy-version: [ 2, 7 ]
-            pip-version: 20
-          - os: ubuntu-22.04
-            pypy-version: [ 3, 9 ]
-            pip-version: 20
-          - os: ubuntu-22.04
-            pypy-version: [ 3, 9 ]
-            pip-version: 22_3_1
-          - os: ubuntu-22.04
-            pypy-version: [ 3, 9 ]
-            pip-version: 23_1_2
-    env:
-      _TOX_ENV: pypy${{ join(matrix.pypy-version, '') }}-pip${{ matrix.pip-version }}
-    steps:
-      - name: Calculate Pythons to Expose
-        id: calculate-pythons-to-expose
-        run: |
-          skip=""
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
-          fi
-          echo "skip=${skip}" >> $GITHUB_OUTPUT
-      - name: Checkout Pex
-        uses: actions/checkout@v3
-        with:
-          path: repo
-      - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
-      - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        with:
-          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
-      - name: Cache Pyenv Interpreters
-        uses: actions/cache@v3
-        with:
-          path: ${{ env._PEX_TEST_DEV_ROOT }}/pyenv
-          key: ${{ matrix.os }}-${{ runner.arch }}-pex-test-dev-root-pyenv-v1
-      - name: Cache Devpi Server
-        uses: actions/cache@v3
-        with:
-          path: ${{ env._PEX_TEST_DEV_ROOT }}/devpi
-          # We're using a key suffix / restore-keys prefix trick here to get an updatable cache.
-          # See: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
-          key: ${{ matrix.os }}-${{ runner.arch }}-${{ env._TOX_ENV }}-pex-test-dev-root-devpi-v1-${{ github.run_id }}
-          restore-keys: ${{ matrix.os }}-${{ runner.arch }}-${{ env._TOX_ENV }}-pex-test-dev-root-devpi-v1
-      - name: Run Unit Tests
-        uses: pantsbuild/actions/run-tox@b16b9cf47cd566acfe217b1dafc5b452e27e6fd7
-        with:
-          path: repo/tox.ini
-          tox-env: ${{ env._TOX_ENV }} -- ${{ env._PEX_TEST_POS_ARGS }}
-  cpython-integration-tests:
-    name: (${{ matrix.os }}) Pip ${{ matrix.pip-version }} TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-integration
-    needs: org-check
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: macos-12
-            python-version: [ 3, 11 ]
-            pip-version: 20
+          - python-version: [ 3, 11 ]
+            tox-env: py311-pip20
             tox-env-python: python
-          - os: ubuntu-22.04
-            python-version: [ 3, 11 ]
-            pip-version: 20
+          - python-version: [ 3, 11 ]
+            tox-env: py311-pip20-integration
             tox-env-python: python
-          - os: ubuntu-22.04
-            python-version: [ 3, 11 ]
-            pip-version: 22_3_1
-            tox-env-python: python
-          - os: ubuntu-22.04
-            python-version: [ 3, 11 ]
-            pip-version: 23_1_2
-            tox-env-python: python
-          - os: macos-12
-            python-version: [ 3, 12, "0-rc.1" ]
-            pip-version: 23_2
+          - python-version: [ 3, 12, "0-rc.1" ]
+            tox-env: py312-pip23_2
             tox-env-python: python3.11
-          - os: ubuntu-22.04
-            python-version: [ 3, 12, "0-rc.1" ]
-            pip-version: 23_2
+          - python-version: [ 3, 12, "0-rc.1" ]
+            tox-env: py312-pip23_2-integration
             tox-env-python: python3.11
-    env:
-      _TOX_ENV: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}-integration
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -294,15 +133,16 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env._PEX_TEST_DEV_ROOT }}/pyenv
-          key: ${{ matrix.os }}-${{ runner.arch }}-pex-test-dev-root-pyenv-v1
+          key: macos-12-${{ runner.arch }}-pex-test-dev-root-pyenv-v1
       - name: Cache Devpi Server
         uses: actions/cache@v3
         with:
           path: ${{ env._PEX_TEST_DEV_ROOT }}/devpi
           # We're using a key suffix / restore-keys prefix trick here to get an updatable cache.
           # See: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
-          key: ${{ matrix.os }}-${{ runner.arch }}-${{ env._TOX_ENV }}-pex-test-dev-root-devpi-v1-${{ github.run_id }}
-          restore-keys: ${{ matrix.os }}-${{ runner.arch }}-${{ env._TOX_ENV }}-pex-test-dev-root-devpi-v1i Cache
+          key: macos-12-${{ runner.arch }}-${{ matrix.tox-env }}-pex-test-dev-root-devpi-v1-${{ github.run_id }}
+          restore-keys: macos-12-${{ runner.arch }}-${{ matrix.tox-env }}-pex-test-dev-root-devpi-v1
+      # Some ITs need this for VCS URLs of the form git+ssh://git@github.com/...
       - name: Setup SSH Agent
         uses: webfactory/ssh-agent@v0.5.4
         env:
@@ -315,159 +155,13 @@ jobs:
         with:
           path: repo/tox.ini
           python: ${{ matrix.tox-env-python }}
-          tox-env: ${{ env._TOX_ENV }} -- ${{ env._PEX_TEST_POS_ARGS }}
-  cpython-integration-tests-legacy:
-    name: (${{ matrix.os }}) Pip ${{ matrix.pip-version }} TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-integration
-    needs: org-check
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: macos-12
-            python-version: [ 2, 7, 18 ]
-            pip-version: 20
-          - os: ubuntu-22.04
-            python-version: [ 2, 7, 18 ]
-            pip-version: 20
-          - os: ubuntu-22.04
-            python-version: [ 3, 7, 17 ]
-            pip-version: 22_3_1
-          - os: ubuntu-22.04
-            python-version: [ 3, 7, 17 ]
-            pip-version: 23_1_2
-    env:
-      _TOX_ENV: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}-integration
-    steps:
-      - name: Calculate Pythons to Expose
-        id: calculate-pythons-to-expose
-        run: |
-          skip=""
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
-          fi
-          echo "skip=${skip}" >> $GITHUB_OUTPUT
-      - name: Checkout Pex
-        uses: actions/checkout@v3
-        with:
-          # We need branches and tags for some ITs.
-          fetch-depth: 0
-          path: repo
-      - name: Setup Python ${{ join(matrix.python-version, '.') }}
-        uses: pantsbuild/actions/pyenv@1356087bfd1be04670c2ffde4ba94a9c6898ecd7
-        with:
-          python-version: "${{ join(matrix.python-version, '.') }}"
-      - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        with:
-          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
-      - name: Cache Pyenv Interpreters
-        uses: actions/cache@v3
-        with:
-          path: ${{ env._PEX_TEST_DEV_ROOT }}/pyenv
-          key: ${{ matrix.os }}-${{ runner.arch }}-pex-test-dev-root-pyenv-v1
-      - name: Cache Devpi Server
-        uses: actions/cache@v3
-        with:
-          path: ${{ env._PEX_TEST_DEV_ROOT }}/devpi
-          # We're using a key suffix / restore-keys prefix trick here to get an updatable cache.
-          # See: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
-          key: ${{ matrix.os }}-${{ runner.arch }}-${{ env._TOX_ENV }}-pex-test-dev-root-devpi-v1-${{ github.run_id }}
-          restore-keys: ${{ matrix.os }}-${{ runner.arch }}-${{ env._TOX_ENV }}-pex-test-dev-root-devpi-v1
-      - name: Setup SSH Agent
-        uses: webfactory/ssh-agent@v0.5.4
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-        if: env.SSH_PRIVATE_KEY != ''
-        with:
-          ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
-      - name: Run Integration Tests
-        run: |
-          pip install -U tox
-          tox -c repo/tox.ini -e ${{ env._TOX_ENV }} -- ${{ env._PEX_TEST_POS_ARGS }}
-  pypy-integration-tests:
-    name: (PyPy ${{ join(matrix.pypy-version, '.') }}) Pip ${{ matrix.pip-version }} TOXENV=pypy${{ join(matrix.pypy-version, '') }}-integration
-    needs: org-check
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          # N.B.: We need 20.04 for PyPy 2.7 tool cache support.
-          - os: ubuntu-20.04
-            pypy-version: [ 2, 7 ]
-            pip-version: 20
-          - os: ubuntu-22.04
-            pypy-version: [ 3, 9 ]
-            pip-version: 20
-          - os: ubuntu-22.04
-            pypy-version: [ 3, 9 ]
-            pip-version: 22_3_1
-          - os: ubuntu-22.04
-            pypy-version: [ 3, 9 ]
-            pip-version: 23_1_2
-    env:
-      _TOX_ENV: pypy${{ join(matrix.pypy-version, '') }}-pip${{ matrix.pip-version }}-integration
-    steps:
-      - name: Calculate Pythons to Expose
-        id: calculate-pythons-to-expose
-        run: |
-          skip=""
-          if [[ "$(uname -s)" == "Linux" ]]; then
-            skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
-          fi
-          echo "skip=${skip}" >> $GITHUB_OUTPUT
-      - name: Checkout Pex
-        uses: actions/checkout@v3
-        with:
-          # We need branches and tags for some ITs.
-          fetch-depth: 0
-          path: repo
-      - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
-      - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
-        with:
-          skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
-      - name: Install Packages
-        run: |
-          # This is needed for `test_requirement_file_from_url` for building `lxml`.
-          sudo apt install --yes libxslt-dev
-      - name: Cache Pyenv Interpreters
-        uses: actions/cache@v3
-        with:
-          path: ${{ env._PEX_TEST_DEV_ROOT }}/pyenv
-          key: ${{ matrix.os }}-${{ runner.arch }}-pex-test-dev-root-pyenv-v1
-      - name: Cache Devpi Server
-        uses: actions/cache@v3
-        with:
-          path: ${{ env._PEX_TEST_DEV_ROOT }}/devpi
-          # We're using a key suffix / restore-keys prefix trick here to get an updatable cache.
-          # See: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
-          key: ${{ matrix.os }}-${{ runner.arch }}-${{ env._TOX_ENV }}-pex-test-dev-root-devpi-v1-${{ github.run_id }}
-          restore-keys: ${{ matrix.os }}-${{ runner.arch }}-${{ env._TOX_ENV }}-pex-test-dev-root-devpi-v1
-      - name: Setup SSH Agent
-        uses: webfactory/ssh-agent@v0.5.4
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-        if: env.SSH_PRIVATE_KEY != ''
-        with:
-          ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
-      - name: Run Integration Tests
-        uses: pantsbuild/actions/run-tox@b16b9cf47cd566acfe217b1dafc5b452e27e6fd7
-        with:
-          path: repo/tox.ini
-          tox-env: ${{ env._TOX_ENV }} -- ${{ env._PEX_TEST_POS_ARGS }}
+          tox-env: ${{ matrix.tox-env }} -- ${{ env._PEX_TEST_POS_ARGS }}
   final-status:
     name: Gather Final Status
     needs:
       - checks
-      - cpython-unit-tests
-      - cpython-unit-tests-legacy
-      - pypy-unit-tests
-      - cpython-integration-tests
-      - cpython-integration-tests-legacy
-      - pypy-integration-tests
+      - linux-tests
+      - mac-tests
     runs-on: ubuntu-22.04
     steps:
       - name: Check Non-Success

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,11 +1,14 @@
 # An image with the necessary binaries and libraries to develop pex.
 FROM ubuntu:22.04
 
+# We use pyenv to bootstrap interpreters and pyenv needs most of these packages.
+# See: https://github.com/pyenv/pyenv/wiki#suggested-build-environment
+# Additionally, some sdists need cargo to build native extensions.
 RUN apt update && \
+  DEBIAN_FRONTEND=noninteractive apt upgrade --yes && \
   DEBIAN_FRONTEND=noninteractive apt install --yes \
-    # We use pyenv to bootstrap interpreters and pyenv needs these.
-    # See: https://github.com/pyenv/pyenv/wiki#suggested-build-environment
     build-essential \
+    cargo \
     curl \
     git \
     libbz2-dev \

--- a/docker/base/install_pythons.sh
+++ b/docker/base/install_pythons.sh
@@ -31,7 +31,21 @@ git clone https://github.com/pyenv/pyenv.git "${PYENV_ROOT}" && (
 PATH="${PATH}:${PYENV_ROOT}/bin"
 
 for version in "${PYENV_VERSIONS[@]}"; do
-  pyenv install "${version}"
+  if [[ "${version}" == "pypy2.7-7.3.12" ]]; then
+    # Installation of pypy2.7-7.3.12 fails like so without adjusting the version of get-pip it
+    # uses:
+    #  $ pyenv install pypy2.7-7.3.12
+    #  Downloading pypy2.7-v7.3.12-linux64.tar.bz2...
+    #  -> https://downloads.python.org/pypy/pypy2.7-v7.3.12-linux64.tar.bz2
+    #  Installing pypy2.7-v7.3.12-linux64...
+    #  Installing pip from https://bootstrap.pypa.io/get-pip.py...
+    #  error: failed to install pip via get-pip.py
+    #  ...
+    #  ERROR: This script does not work on Python 2.7 The minimum supported Python version is 3.7. Please use https://bootstrap.pypa.io/pip/2.7/get-pip.py instead.
+    GET_PIP_URL="https://bootstrap.pypa.io/pip/2.7/get-pip.py" pyenv install "${version}"
+  else
+    pyenv install "${version}"
+  fi
 
   exe="$(echo "${version}" | sed -r -e 's/^([0-9])/python\1/' | tr - . | cut -d. -f1-2)"
   exe_path="${PYENV_ROOT}/versions/${version}/bin/${exe}"

--- a/docker/base/install_pythons.sh
+++ b/docker/base/install_pythons.sh
@@ -7,16 +7,20 @@ export PYENV_ROOT=/pyenv
 # N.B.: The 1st listed version will supply the default `python` on the PATH; otherwise order does
 # not matter.
 PYENV_VERSIONS=(
-  3.11.4
+  3.11.5
   2.7.18
   3.5.10
   3.6.15
   3.7.17
-  3.8.17
-  3.9.17
-  3.10.12
+  3.8.18
+  3.9.18
+  3.10.13
   3.12.0rc1
   pypy2.7-7.3.12
+  pypy3.5-7.0.0
+  pypy3.6-7.3.3
+  pypy3.7-7.3.9
+  pypy3.8-7.3.11
   pypy3.9-7.3.12
   pypy3.10-7.3.12
 )

--- a/docker/cache/Dockerfile
+++ b/docker/cache/Dockerfile
@@ -1,0 +1,24 @@
+# A data image with the necessary binaries and libraries to develop pex.
+
+# Populate the ~/.pex_dev cache.
+FROM ghcr.io/pantsbuild/pex/base:latest as cache
+
+ARG PEX_REPO=https://github.com/pantsbuild/pex
+ARG GIT_REF=HEAD
+
+# These must be set as a comma-separated list of all tox envs to cache.
+ARG TOX_ENVS
+
+RUN git clone "${PEX_REPO}" /development/pex && \
+    cd /development/pex && \
+    git reset --hard "${GIT_REF}"
+
+WORKDIR /development/pex
+COPY populate_cache.sh /root/
+RUN /root/populate_cache.sh /development/pex_dev "${TOX_ENVS}"
+
+# Grab just the ~/.pex_dev cache files for the final data-only image.
+FROM scratch
+VOLUME /development/pex_dev
+COPY --from=cache /development/pex_dev /development/pex_dev
+CMD ["I am a pure data image meant only for volume mounting."]

--- a/docker/cache/populate_cache.sh
+++ b/docker/cache/populate_cache.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -xuo pipefail
+
+if (( $# != 2 )); then
+  echo >&2 "usage: $0 [pex dev cache dir] [tox env][,tox env]*"
+  echo >&2 "Expected 2 arguments, got $#: $*"
+  exit 1
+fi
+
+function run_tox() {
+  local env="$1"
+  tox -e "${env}" -- --color --devpi --require-devpi -vvs
+  if (( $? == 42 )); then
+    echo >&2 "tox -e ${env} failed to start or connect to the devpi-server, exiting..."
+    exit 1
+  elif (( $? != 0 )); then
+    echo >&2 "tox -e ${env} failed, continuing..."
+  fi
+}
+
+export _PEX_TEST_DEV_ROOT="$1"
+for tox_env in $(echo "$2" | tr , ' '); do
+  run_tox "${tox_env}"
+
+  # Tox test environments can leave quite large /tmp/pytest-of-<user> trees; relieve disk pressure
+  # by cleaning these up as we go.
+  rm -rf /tmp/pytest*
+done
+
+echo "Cached ${_PEX_TEST_DEV_ROOT}:"
+du -sh "${_PEX_TEST_DEV_ROOT}"/*

--- a/docker/user/Dockerfile
+++ b/docker/user/Dockerfile
@@ -1,4 +1,5 @@
-FROM pantsbuild/pex:base
+ARG BASE_IMAGE_TAG=latest
+FROM ghcr.io/pantsbuild/pex/base:${BASE_IMAGE_TAG}
 
 # Prepare developer shim that can operate on local files and not mess up perms in the process.
 ARG USER
@@ -12,33 +13,32 @@ RUN /root/create_docker_image_user.sh "${USER}" "${UID}" "${GROUP}" "${GID}"
 # This will be mounted from the Pex clone directory on the host.
 VOLUME /development/pex
 
-# This will be a named volume used to persist the Pex development cache on the host but isolated
-# from the host ~/.pex_dev development cache.
-VOLUME /development/pex_dev
-
-# This will be a named volume used to persist the Pex cache on the host but isolated from the nost
-# ~/.pex cache.
-VOLUME /development/pex_root
-
-# This will be a named volume used to persist the pytest tmp tree for use in `./dtox inspect`
-# sessions.
-VOLUME /development/tmp
-
 # This will be a named volume used to persist .tox venvs and keep them isolated from the host.
 VOLUME /development/pex/.tox
 
+# This will be a named volume used to persist the Pex development cache on the host but isolated
+# from the host ~/.pex_dev development cache.
+VOLUME /development/pex_dev
+ENV _PEX_TEST_DEV_ROOT=/development/pex_dev
+
+# This will be a named volume used to persist the Pex cache on the host but isolated from the nost
+# ~/.pex cache.
+VOLUME "/home/${USER}/.pex"
+
 RUN mkdir -p  \
     /development/pex \
+    /development/pex/.tox \
     /development/pex_dev \
-    /development/pex_root \
-    /development/tmp \
-    /development/pex/.tox && \
+    "/home/${USER}/.pex" && \
   chown -R "${UID}:${GID}" \
     /development/pex \
+    /development/pex/.tox \
     /development/pex_dev \
-    /development/pex_root \
-    /development/tmp \
-    /development/pex/.tox
+    "/home/${USER}/.pex"
+
+# This will be a named volume used to persist the pytest tmp tree (/tmp/pytest-of-$USER/) for use \
+# in `./dtox inspect` sessions.
+VOLUME /tmp
 
 WORKDIR /development/pex
 USER "${USER}":"${GROUP}"

--- a/dtox.sh
+++ b/dtox.sh
@@ -4,20 +4,27 @@ set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
 
+BASE_MODE="${BASE_MODE:-build}"
+CACHE_MODE="${CACHE_MODE:-}"
+CACHE_TAG="${CACHE_TAG:-latest}"
+
 BASE_INPUT=(
   "${ROOT}/docker/base/Dockerfile"
+  "${ROOT}/docker/base/install_pythons.sh"
 )
 base_hash=$(cat "${BASE_INPUT[@]}" | git hash-object -t blob --stdin)
 
-function base_id() {
-  docker images -q -f label=base_hash="${base_hash}" pantsbuild/pex:base
+function base_image_id() {
+  docker image ls -q "ghcr.io/pantsbuild/pex/base:${base_hash}"
 }
 
-if [[ -z "$(base_id)" ]]; then
+if [[ "${BASE_MODE}" == "build" && -z "$(base_image_id)" ]]; then
   docker build \
-    --tag pantsbuild/pex:base \
-    --label base_hash="${base_hash}" \
+    --tag ghcr.io/pantsbuild/pex/base:latest \
+    --tag "ghcr.io/pantsbuild/pex/base:${base_hash}" \
     "${ROOT}/docker/base"
+elif [[ "${BASE_MODE}" == "pull" ]]; then
+  docker pull "ghcr.io/pantsbuild/pex/base:${base_hash}"
 fi
 
 USER_INPUT=(
@@ -25,20 +32,41 @@ USER_INPUT=(
   "${ROOT}/docker/user/create_docker_image_user.sh"
 )
 user_hash=$(cat "${USER_INPUT[@]}" | git hash-object -t blob --stdin)
-if [[ -z "$(docker images -q -f label=user_hash="${user_hash}" pantsbuild/pex:user)" ]]; then
+
+function user_image_id() {
+  docker image ls -q "pantsbuild/pex/user:${user_hash}"
+}
+
+if [[ -z "$(user_image_id)" ]]; then
   docker build \
-    --build-arg BASE_ID="$(base_id)" \
+    --build-arg BASE_IMAGE_TAG="${base_hash}" \
     --build-arg USER="$(id -un)" \
     --build-arg UID="$(id -u)" \
     --build-arg GROUP="$(id -gn)" \
     --build-arg GID="$(id -g)" \
-    --tag pantsbuild/pex:user \
-    --label user_hash="${user_hash}" \
+    --tag pantsbuild/pex/user:latest \
+    --tag "pantsbuild/pex/user:${user_hash}" \
     "${ROOT}/docker/user"
 fi
 
+if [[ "${CACHE_MODE}" == "pull" ]]; then
+  docker volume rm --force pex-caches
+  docker volume create pex-caches
+  docker run \
+    --rm \
+    --volume pex-caches:/development/pex_dev \
+    "ghcr.io/pantsbuild/pex/cache:${CACHE_TAG}" || true
+  docker run \
+    --rm \
+    --volume pex-caches:/development/pex_dev \
+    --entrypoint bash \
+    --user root \
+    "pantsbuild/pex/user:${user_hash}" \
+    -c "chown -R $(id -u):$(id -g) /development/pex_dev"
+fi
+
 DOCKER_ARGS=()
-if [[ "$1" == "inspect" ]]; then
+if [[ "${1:-}" == "inspect" ]]; then
   shift
   DOCKER_ARGS+=(
     --entrypoint bash
@@ -51,19 +79,29 @@ if [[ -t 1 ]]; then
   )
 fi
 
+if [[ -n "${SSH_AUTH_SOCK:-}" ]]; then
+  # Some integration tests need an SSH agent. Propagate it when available.
+  DOCKER_ARGS+=(
+    --volume "${SSH_AUTH_SOCK}:${SSH_AUTH_SOCK}"
+    --env SSH_AUTH_SOCK="${SSH_AUTH_SOCK}"
+  )
+fi
+
+# This ensures the current user owns the host .tox/ dir before launching the container, which
+# otherwise sets the ownership as root for undetermined reasons
+mkdir -p "${ROOT}/.tox"
+
+CONTAINER_HOME="/home/$(id -un)"
 exec docker run \
-    --rm \
-    --volume "${HOME}/.netrc:/home/$(id -un)/.netrc" \
-    --volume "${HOME}/.ssh:/home/$(id -un)/.ssh" \
-    --volume "$(pwd):/development/pex" \
-    --volume pex_dev:/development/pex_dev \
-    --volume pex_root:/development/pex_root \
-    --volume pex_tmp:/development/tmp \
-    --volume pex_tox:/development/pex/.tox \
-    --env _PEX_TEST_DEV_ROOT=/development/pex_dev \
-    --env PEX_ROOT=/development/pex_root \
-    --env TMPDIR=/development/tmp \
-    "${DOCKER_ARGS[@]}" \
-    pantsbuild/pex:user \
-    "$@"
+  --rm \
+  --volume pex-tmp:/tmp \
+  --volume "${HOME}/.netrc:${CONTAINER_HOME}/.netrc" \
+  --volume "${HOME}/.ssh:${CONTAINER_HOME}/.ssh" \
+  --volume "pex-root:${CONTAINER_HOME}/.pex" \
+  --volume pex-caches:/development/pex_dev \
+  --volume "${ROOT}:/development/pex" \
+  --volume pex-tox:/development/pex/.tox \
+  "${DOCKER_ARGS[@]}" \
+  "pantsbuild/pex/user:${user_hash}" \
+  "$@"
 

--- a/dtox.sh
+++ b/dtox.sh
@@ -50,6 +50,10 @@ if [[ -z "$(user_image_id)" ]]; then
 fi
 
 if [[ "${CACHE_MODE}" == "pull" ]]; then
+  # N.B.: This is a fairly particular dance / trick that serves to populate a local named volume
+  # with the contents of a data-only image. In particular, starting with an empty named volume is
+  # required to get the subsequent no-op `docker run --volume pex-caches:...` to populate that
+  # volume. This population only happens under that condition.
   docker volume rm --force pex-caches
   docker volume create pex-caches
   docker run \

--- a/scripts/build_cache_image.py
+++ b/scripts/build_cache_image.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from pathlib import Path, PurePath
+
+import coloredlogs
+import yaml
+
+
+def build_cache_image(
+    tox_envs: list[str], tag: str, pex_repo: str, git_ref: str, push: bool = False
+) -> None:
+    image_tag = f"ghcr.io/pantsbuild/pex/cache:{tag}"
+    subprocess.run(
+        args=[
+            "docker",
+            "build",
+            "--progress",
+            "plain",
+            "--build-arg",
+            f"PEX_REPO={pex_repo}",
+            "--build-arg",
+            f"GIT_REF={git_ref}",
+            "--build-arg",
+            f"TOX_ENVS={','.join(tox_envs)}",
+            "--tag",
+            image_tag,
+            str(PurePath("docker") / "cache"),
+        ],
+        check=True,
+    )
+    if push:
+        subprocess.run(args=["docker", "push", image_tag], check=True)
+
+
+def main() -> None:
+    parser = ArgumentParser(
+        formatter_class=ArgumentDefaultsHelpFormatter,
+        description=(
+            "Builds (and optionally pushes) a data-only cache image for use with "
+            "`CACHE_MODE=pull ./dtox.sh ...`."
+        ),
+    )
+    parser.add_argument(
+        "-l",
+        "--log-level",
+        type=lambda arg: arg.upper(),
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARN", "WARNING", "ERROR", "CRITICAL"],
+        help="Set the logging level (case insensitive).",
+    )
+    parser.add_argument("--color", default=None, action="store_true", help="Force colored logging.")
+    parser.add_argument(
+        "--tag",
+        type=str,
+        default="latest",
+        help="The tag for the ghcr.io/pantsbuild/pex/cache-all image.",
+    )
+    parser.add_argument(
+        "--pex-repo",
+        type=str,
+        default="https://github.com/pantsbuild/pex",
+        help="The pex repo to clone and use for the docker/cache population.",
+    )
+    parser.add_argument(
+        "--git-ref",
+        type=str,
+        default="HEAD",
+        help="The git ref to use within `--pex-repo`.",
+    )
+    parser.add_argument(
+        "--push",
+        default=False,
+        action="store_true",
+        help="Push the image to the registry after building and tagging it.",
+    )
+
+    options = parser.parse_args()
+
+    coloredlogs.install(
+        level=options.log_level, fmt="%(levelname)s %(message)s", isatty=options.color
+    )
+    logger = logging.getLogger(parser.prog)
+    logger.log(
+        logging.root.level, "Logging configured at level {level}.".format(level=options.log_level)
+    )
+
+    with (Path(".github") / "workflows" / "ci.yml").open() as fp:
+        data = yaml.full_load(fp)
+    tox_envs = data["jobs"]["linux-tests"]["strategy"]["matrix"]["tox-env"]
+
+    logger.info(f"Building caches for {len(tox_envs)} tox environments.")
+    for tox_env in tox_envs:
+        logger.debug(tox_env)
+
+    build_cache_image(
+        tox_envs,
+        tag=options.tag,
+        pex_repo=options.pex_repo,
+        git_ref=options.git_ref,
+        push=options.push,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/devpi.py
+++ b/testing/devpi.py
@@ -21,7 +21,7 @@ from pex.venv.virtualenv import InvalidVirtualenvError, Virtualenv
 from testing import PEX_TEST_DEV_ROOT
 
 if TYPE_CHECKING:
-    from typing import List, Optional
+    from typing import List, Optional, Union
 
     import attr  # vendor:skip
 else:
@@ -174,12 +174,13 @@ class LaunchResult(object):
 
 
 def launch(
+    host,  # type: str
     port,  # type: int
     timeout,  # type: float
     max_connection_retries,  # type: int
     request_timeout,  # type: int
 ):
-    # type: (...) -> Optional[LaunchResult]
+    # type: (...) -> Union[str, LaunchResult]
 
     pidfile = Pidfile.load()
     if pidfile and pidfile.alive():
@@ -192,6 +193,8 @@ def launch(
     with safe_open(log, "w") as fp:
         process = subprocess.Popen(
             args=devpi_server.launch_args(
+                "--host",
+                host,
                 "--port",
                 str(port),
                 "--replica-max-retries",
@@ -212,7 +215,7 @@ def launch(
         except OSError as e:
             if e.errno != errno.ESRCH:  # No such process.
                 raise
-        return None
+        return log
 
     return LaunchResult(url=pidfile.url, already_running=False)
 

--- a/tests/integration/resolve/test_issue_1918.py
+++ b/tests/integration/resolve/test_issue_1918.py
@@ -4,6 +4,7 @@
 import itertools
 import os.path
 import subprocess
+import sys
 
 import pytest
 

--- a/tests/integration/tools/commands/test_venv.py
+++ b/tests/integration/tools/commands/test_venv.py
@@ -101,7 +101,6 @@ def test_collisions(
         "PEXWarning: Encountered collision populating {venv_dir} from PEX at {pex}:\n"
         "1. {venv_dir}/bin/pex was provided by:".format(venv_dir=venv_dir, pex=collisions_pex)
     ) in result.error, result.error
-    assert 42 == subprocess.call(args=[Virtualenv(venv_dir=venv_dir).bin_path("pex")])
 
 
 def test_collisions_mergeable_issue_1570(tmpdir):

--- a/tests/test_dist_metadata.py
+++ b/tests/test_dist_metadata.py
@@ -82,7 +82,7 @@ def pygoogleearth_zip_sdist():
         yield sdist
 
 
-PIP_PROJECT_NAME_AND_VERSION = ProjectNameAndVersion("pip", "20.3.1")
+PIP_PROJECT_NAME_AND_VERSION = ProjectNameAndVersion("pip", "9.0.1")
 
 
 @pytest.fixture(scope="module")
@@ -219,7 +219,7 @@ def test_requires_python(
     pip_distribution,  # type: Distribution
 ):
     # type: (...) -> None
-    expected_requires_python = SpecifierSet(">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*")
+    expected_requires_python = SpecifierSet(">=2.6,!=3.0.*,!=3.1.*,!=3.2.*")
     assert expected_requires_python == requires_python(pip_tgz_sdist)
     assert expected_requires_python == requires_python(pip_wheel)
     assert expected_requires_python == requires_python(pip_distribution)

--- a/tests/tools/commands/test_venv.py
+++ b/tests/tools/commands/test_venv.py
@@ -70,7 +70,7 @@ def pex():
                 pex_path,
                 "--include-tools",
             ]
-        )
+        ).assert_success()
         yield os.path.realpath(pex_path)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ whitelist_externals =
     bash
     git
 
-[testenv:py{py27-subprocess,py27,py35,py36,py37,py38,py39,27,35,36,37,38,39,310,311,312}-{,pip20-,pip22_2-,pip22_3-,pip22_3_1-,pip23_0-,pip23_0_1-,pip23_1-,pip23_1_1-,pip23_1_2-,pip23_2-}integration]
+[testenv:py{py27-subprocess,py27,py35,py36,py37,py38,py39,py310,27,35,36,37,38,39,310,311,312}-{,pip20-,pip22_2-,pip22_3-,pip22_3_1-,pip23_0-,pip23_0_1-,pip23_1-,pip23_1_1-,pip23_1_2-,pip23_2-}integration]
 deps =
     pytest-xdist==1.34.0
     {[testenv]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ deps =
 passenv =
     # This allows working around broken xcode Python SDKs.
     ARCHFLAGS
-    # This allows re-locating the pyenv interpreter and devpi-server test caches for CI.
+    # This allows re-locating the various test caches for CI.
     _PEX_TEST_DEV_ROOT
     # These are to support directing test environments to the correct headers on OSX.
     CPATH
@@ -104,6 +104,7 @@ deps =
     mypy[python2]==0.931
     typing-extensions
     types-mock
+    types-PyYAML
     types-toml==0.10.5
     httpx==0.23.0
 commands =
@@ -206,7 +207,7 @@ commands =
   python -s -mwheel {posargs}
 
 [testenv:devpi-lock]
-description = Re-create the devpi-server lock
+description = Re-create the devpi-server lock.
 skip_install = true
 commands =
   python -mpex.cli lock create \
@@ -217,3 +218,13 @@ commands =
     devpi-server \
     --indent 2 \
     -o testing/devpi-server.lock
+
+[testenv:build-cache-image]
+description = Build the CI cache data image.
+skip_install = true
+basepython = python3
+deps =
+  coloredlogs==15.0.1
+  PyYAML==6.0.1
+commands =
+  python scripts/build_cache_image.py {posargs}


### PR DESCRIPTION
The previous cache strategy is left in place for Mac, but it was too
expensive for the 10GB limit GitHub imposes on total cache size and was
leading to cache thrash.

The new strategy sidesteps the cache size limit by creating a cache
offline in a data-only image and switching the Linux CI jobs - the
lion's share - to run via docker / `./dtox.sh`. It takes ~3 minutes to
download the images now whereas loading the cache took ~30 seconds
previously, but there is no longer any worry about cache size limits.
Obviously running the same thing you run locally in CI is a big benefit
and was one of the goals when I introduced `./dtox.sh` in ~2018. The
downside of the image load times could possibly be overcome by using the
GH cache with docker save / load, but this is good enough for now.