### PR TITLE
Raise the flit-core limit for Python 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=2,<3"]
+requires = ["flit_core>=2,<4"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]


### PR DESCRIPTION
flit-core is on version 3.9 now so I hope we can unpin this.