### PR TITLE
Fix non executable venv sys path bug

### DIFF
--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -669,7 +669,7 @@ def _activate_venv_dir(
         die("Failed to load virtualenv for interpreter at {path}.".format(path=venv_python))
 
     site_packages_dir = venv.site_packages_dir
-    sys.path[:-1] = [site_packages_dir]
+    sys.path.insert(0, site_packages_dir)
     import site
 
     site.addsitedir(site_packages_dir)

--- a/tests/integration/test_issue_2235.py
+++ b/tests/integration/test_issue_2235.py
@@ -13,7 +13,7 @@ def test_standard_library_is_included(
 ):
     # type: (...) -> None
 
-    built_pex_path = os.path.join(tmpdir, "flask.pex")
+    built_pex_path = os.path.join(str(tmpdir), "flask.pex")
     run_pex_command(
         args=[
             "Flask==2.3.3",
@@ -23,7 +23,7 @@ def test_standard_library_is_included(
         ]
     ).assert_success()
 
-    output_path = os.path.join(tmpdir, "output.txt")
+    output_path = os.path.join(str(tmpdir), "output.txt")
     script = """
 import sys
 error = ""
@@ -41,7 +41,7 @@ with open("{}", 'w') as f:
         built_pex_path, output_path
     )
 
-    script_path = os.path.join(tmpdir, "script.py")
+    script_path = os.path.join(str(tmpdir), "script.py")
     with open(script_path, "w") as f:
         f.write(script)
 

--- a/tests/integration/test_issue_2235.py
+++ b/tests/integration/test_issue_2235.py
@@ -29,6 +29,7 @@ def test_standard_library_is_included(
             "Flask==2.3.3",
             "-o",
             "flask.pex",
+            "--venv",
         ],
         check=True,
         env=os.environ,

--- a/tests/integration/test_issue_2235.py
+++ b/tests/integration/test_issue_2235.py
@@ -49,7 +49,7 @@ with open("{}", 'w') as f:
     with open(script_path, "w") as f:
         f.write(script)
 
-    subprocess.run([sys.executable, script_path], check=True)  # type: ignore
+    subprocess.check_call([sys.executable, script_path])
 
     with open(output_path, "r") as f:
         output = f.read()

--- a/tests/integration/test_issue_2235.py
+++ b/tests/integration/test_issue_2235.py
@@ -1,0 +1,66 @@
+import os
+import subprocess
+import sys
+
+import pytest
+
+from pex.compatibility import PY3
+from testing import PY38, ensure_python_interpreter
+
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="Flask 2.3.3 requires Python3.8+.")
+def test_standard_library_is_included(
+    tmpdir,  # type: Any
+    pex_project_dir,  # type: str
+):
+    # type: (...) -> None
+
+    # N.B.: The package script requires Python 3.
+    python = sys.executable if PY3 else ensure_python_interpreter(PY38)
+
+    package_script = os.path.join(pex_project_dir, "scripts", "package.py")
+    pex_pex = os.path.join(str(tmpdir), "pex")
+    subprocess.check_call(args=[python, package_script, "--pex-output-file", pex_pex])
+
+    subprocess.run(
+        [
+            sys.executable,
+            pex_pex,
+            "Flask==2.3.3",
+            "-o",
+            "flask.pex",
+        ],
+        check=True,
+        env=os.environ,
+    )
+
+    output_path = "{}/output.txt".format(tmpdir)
+
+    script = """
+import sys
+error = ""
+
+try:
+    sys.path.append("flask.pex")
+    import __pex__
+    import flask
+except Exception as e:
+    error = str(e)
+
+with open("{}", 'w') as f:
+    f.write(error)
+""".format(
+        output_path
+    )
+
+    script_path = "{}/script.py".format(tmpdir)
+    with open(script_path, "w") as f:
+        f.write(script)
+
+    subprocess.run([sys.executable, script_path], check=True, env=os.environ)
+
+    with open(output_path, "r") as f:
+        output = f.read()
+
+    if output:
+        pytest.fail(f"Test failed with exception: {output}")

--- a/tests/integration/test_issue_2235.py
+++ b/tests/integration/test_issue_2235.py
@@ -4,7 +4,11 @@ import sys
 
 import pytest
 
+from pex.typing import TYPE_CHECKING
 from testing import run_pex_command
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="Flask 2.3.3 requires Python3.8+.")
@@ -45,10 +49,10 @@ with open("{}", 'w') as f:
     with open(script_path, "w") as f:
         f.write(script)
 
-    subprocess.run([sys.executable, script_path], check=True)
+    subprocess.run([sys.executable, script_path], check=True)  # type: ignore
 
     with open(output_path, "r") as f:
         output = f.read()
 
     if output:
-        pytest.fail(f"Test failed with exception: {output}")
+        pytest.fail("Test failed with exception: {}".format(output))


### PR DESCRIPTION
This PR fixes the bug  identified in https://github.com/pantsbuild/pex/issues/2235 when importing dependencies from a non executable pex  created with the `--venv ` flag. 

For example, the snippet

```
import sys
sys.path.append('flask.pex')  # via `pex Flask -o flask.pex --venv`
import __pex__
import flask
```

would mangle `sys.path` removing necessary paths such as `/usr/lib/python3.9` when executing against `/usr/bin/python3.9`.