### PR TITLE
Remove docker-cache step.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,11 +76,6 @@ jobs:
         with:
           # We need branches and tags for some ITs.
           fetch-depth: 0
-      - name: Cache Docker images
-        uses: ScribeMD/docker-cache@0.3.6
-        with:
-          read-only: ${{ github.ref != 'refs/heads/main' && 'true' || 'false' }}
-          key: docker-${{ runner.os }}-${{ hashFiles('docker/base/**', 'docker/cache/**') }}
       # Some ITs need this for VCS URLs of the form git+ssh://git@github.com/...
       - name: Setup SSH Agent
         uses: webfactory/ssh-agent@v0.5.4
@@ -89,16 +84,9 @@ jobs:
         if: env.SSH_PRIVATE_KEY != ''
         with:
           ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
-      - name: Run Unit Tests
+      - name: Run Tests
         run: |
           BASE_MODE=pull CACHE_MODE=pull ./dtox.sh -e ${{ matrix.tox-env }} -- ${{ env._PEX_TEST_POS_ARGS }}
-      - name: Free Disk Space for Cache prep
-        if: github.ref == 'refs/heads/main'
-        run: |
-          # The Docker image caching step uses docker save which generate large tarballs that
-          # encounter disk-fulls. An easy 10s of GB savings in disk space is had by nuking the tool
-          # cache, which we use no tools from.
-          rm -rf ${{ runner.tool_cache }}
   mac-tests:
     name: tox -e ${{ matrix.tox-env }}
     needs: org-check
@@ -164,7 +152,7 @@ jobs:
         if: env.SSH_PRIVATE_KEY != ''
         with:
           ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
-      - name: Run Integration Tests
+      - name: Run Tests
         uses: pantsbuild/actions/run-tox@b16b9cf47cd566acfe217b1dafc5b452e27e6fd7
         with:
           path: repo/tox.ini


### PR DESCRIPTION
The docker-cache step actually increased wall time by more than a
minute.