### PR TITLE
Add support for `--use-pip-config`.

### DIFF
--- a/pex/cli/commands/lock.py
+++ b/pex/cli/commands/lock.py
@@ -360,6 +360,7 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
         resolver_options.register_repos_options(resolver_options_parser)
         resolver_options.register_network_options(resolver_options_parser)
         resolver_options.register_max_jobs_option(resolver_options_parser)
+        resolver_options.register_use_pip_config(resolver_options_parser)
 
     @classmethod
     def add_extra_arguments(
@@ -619,6 +620,7 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
             repos_configuration=resolver_options.create_repos_configuration(self.options),
             network_configuration=network_configuration,
             max_jobs=resolver_options.get_max_jobs_value(self.options),
+            use_pip_config=resolver_options.get_use_pip_config_value(self.options),
         )
 
         target_configuration = target_options.configure(self.options)

--- a/pex/resolve/configured_resolve.py
+++ b/pex/resolve/configured_resolve.py
@@ -58,6 +58,7 @@ def resolve(
                     compile=compile_pyc,
                     max_parallel_jobs=pip_configuration.max_jobs,
                     pip_version=lock.pip_version,
+                    use_pip_config=pip_configuration.use_pip_config,
                 )
             )
     elif isinstance(resolver_configuration, PexRepositoryConfiguration):
@@ -101,4 +102,5 @@ def resolve(
                 preserve_log=resolver_configuration.preserve_log,
                 pip_version=resolver_configuration.version,
                 resolver=ConfiguredResolver(pip_configuration=resolver_configuration),
+                use_pip_config=resolver_configuration.use_pip_config,
             )

--- a/pex/resolve/configured_resolver.py
+++ b/pex/resolve/configured_resolver.py
@@ -67,6 +67,7 @@ class ConfiguredResolver(Resolver):
                 verify_wheels=True,
                 max_parallel_jobs=self.pip_configuration.max_jobs,
                 pip_version=pip_version or self.pip_configuration.version,
+                use_pip_config=self.pip_configuration.use_pip_config,
             )
         )
 
@@ -77,7 +78,6 @@ class ConfiguredResolver(Resolver):
         pip_version=None,  # type: Optional[PipVersionValue]
     ):
         # type: (...) -> Installed
-        # TODO(John Sirois): Use pip_version.
         return resolver.resolve(
             targets=targets,
             requirements=requirements,
@@ -98,4 +98,5 @@ class ConfiguredResolver(Resolver):
             verify_wheels=True,
             pip_version=pip_version or self.pip_configuration.version,
             resolver=self,
+            use_pip_config=self.pip_configuration.use_pip_config,
         )

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -85,6 +85,7 @@ class VCSArtifactDownloadManager(DownloadManager[VCSArtifact]):
         pex_root=None,  # type: Optional[str]
         pip_version=None,  # type: Optional[PipVersionValue]
         resolver=None,  # type: Optional[Resolver]
+        use_pip_config=False,  # type: bool
     ):
         super(VCSArtifactDownloadManager, self).__init__(
             pex_root=pex_root, file_lock_style=file_lock_style
@@ -100,6 +101,7 @@ class VCSArtifactDownloadManager(DownloadManager[VCSArtifact]):
         self._build_isolation = build_isolation
         self._pip_version = pip_version
         self._resolver = resolver
+        self._use_pip_config = use_pip_config
 
     def save(
         self,
@@ -127,6 +129,7 @@ class VCSArtifactDownloadManager(DownloadManager[VCSArtifact]):
             max_parallel_jobs=1,
             pip_version=self._pip_version,
             resolver=self._resolver,
+            use_pip_config=self._use_pip_config,
         )
         if len(downloaded_vcs.local_distributions) != 1:
             return Error(
@@ -243,6 +246,7 @@ def resolve_from_lock(
     verify_wheels=True,  # type: bool
     max_parallel_jobs=None,  # type: Optional[int]
     pip_version=None,  # type: Optional[PipVersionValue]
+    use_pip_config=False,  # type: bool
 ):
     # type: (...) -> Union[Installed, Error]
 
@@ -288,6 +292,7 @@ def resolve_from_lock(
                     find_links=find_links,
                     network_configuration=network_configuration,
                     password_entries=PasswordDatabase.from_netrc().append(password_entries).entries,
+                    use_pip_config=use_pip_config,
                 ),
                 max_parallel_jobs=max_parallel_jobs,
             ),
@@ -308,6 +313,7 @@ def resolve_from_lock(
             build_isolation=build_isolation,
             pip_version=pip_version,
             resolver=resolver,
+            use_pip_config=use_pip_config,
         )
         for resolved_subset in subset_result.subsets
     }
@@ -424,6 +430,7 @@ def resolve_from_lock(
                 find_links=find_links,
                 network_configuration=network_configuration,
                 password_entries=PasswordDatabase.from_netrc().append(password_entries).entries,
+                use_pip_config=use_pip_config,
             ),
             compile=compile,
             prefer_older_binary=prefer_older_binary,

--- a/pex/resolve/lockfile/create.py
+++ b/pex/resolve/lockfile/create.py
@@ -369,6 +369,7 @@ def create(
         password_entries=PasswordDatabase.from_netrc()
         .append(pip_configuration.repos_configuration.password_entries)
         .entries,
+        use_pip_config=pip_configuration.use_pip_config,
     )
 
     configured_resolver = ConfiguredResolver(pip_configuration=pip_configuration)
@@ -421,6 +422,7 @@ def create(
             preserve_log=pip_configuration.preserve_log,
             pip_version=pip_configuration.version,
             resolver=configured_resolver,
+            use_pip_config=pip_configuration.use_pip_config,
         )
     except resolvers.ResolveError as e:
         return Error(str(e))
@@ -482,6 +484,7 @@ def create(
                     transitive=pip_configuration.transitive,
                     max_parallel_jobs=pip_configuration.max_jobs,
                     pip_version=pip_configuration.version,
+                    use_pip_config=pip_configuration.use_pip_config,
                 )
             )
 

--- a/pex/resolve/lockfile/updater.py
+++ b/pex/resolve/lockfile/updater.py
@@ -382,6 +382,7 @@ class LockUpdater(object):
         repos_configuration,  # type: ReposConfiguration
         network_configuration,  # type: NetworkConfiguration
         max_jobs,  # type: int
+        use_pip_config,  # type: bool
     ):
         # type: (...) -> LockUpdater
 
@@ -403,6 +404,7 @@ class LockUpdater(object):
             repos_configuration=repos_configuration,
             network_configuration=network_configuration,
             max_jobs=max_jobs,
+            use_pip_config=use_pip_config,
         )
         return cls(
             lock_file=lock_file,

--- a/pex/resolve/resolver_configuration.py
+++ b/pex/resolve/resolver_configuration.py
@@ -25,7 +25,7 @@ else:
     from pex.third_party import attr
 
 
-PYPI = os.environ.get("_PEX_TEST_DEFAULT_INDEX", "https://pypi.org/simple")
+PYPI = "https://pypi.org/simple"
 
 
 class ResolverVersion(Enum["ResolverVersion.Value"]):
@@ -98,6 +98,7 @@ class PipConfiguration(object):
     version = attr.ib(default=None)  # type: Optional[PipVersionValue]
     resolver_version = attr.ib(default=None)  # type: Optional[ResolverVersion.Value]
     allow_version_fallback = attr.ib(default=True)  # type: bool
+    use_pip_config = attr.ib(default=False)  # type: bool
 
 
 @attr.s(frozen=True)

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -957,6 +957,7 @@ def resolve(
     preserve_log=False,  # type: bool
     pip_version=None,  # type: Optional[PipVersionValue]
     resolver=None,  # type: Optional[Resolver]
+    use_pip_config=False,  # type: bool
 ):
     # type: (...) -> Installed
     """Resolves all distributions needed to meet requirements for multiple distribution targets.
@@ -1048,6 +1049,7 @@ def resolve(
         find_links=find_links,
         network_configuration=network_configuration,
         password_entries=password_entries,
+        use_pip_config=use_pip_config,
     )
     build_requests, download_results = _download_internal(
         targets=targets,
@@ -1202,6 +1204,7 @@ def download(
     preserve_log=False,  # type: bool
     pip_version=None,  # type: Optional[PipVersionValue]
     resolver=None,  # type: Optional[Resolver]
+    use_pip_config=False,  # type: bool
 ):
     # type: (...) -> Downloaded
     """Downloads all distributions needed to meet requirements for multiple distribution targets.
@@ -1256,6 +1259,7 @@ def download(
         find_links=find_links,
         network_configuration=network_configuration,
         password_entries=password_entries,
+        use_pip_config=use_pip_config,
     )
     build_requests, download_results = _download_internal(
         targets=targets,

--- a/pex/venv/installer.py
+++ b/pex/venv/installer.py
@@ -731,9 +731,9 @@ def _populate_first_party(
                     # These are _not_ used at runtime, but are present under testing / CI and
                     # simplest to add an exception for here and not warn about in CI runs.
                     "_PEX_PIP_VERSION",
-                    "_PEX_TEST_DEFAULT_INDEX",
                     "_PEX_TEST_DEV_ROOT",
                     "_PEX_TEST_PROJECT_DIR",
+                    "_PEX_USE_PIP_CONFIG",
                     # This is used by Pex's Pip to inject runtime patches dynamically.
                     "_PEX_PIP_RUNTIME_PATCHES_PACKAGE",
                     # These are used by Pex's Pip venv to provide foreign platform support and work

--- a/testing/bin/run_tests.py
+++ b/testing/bin/run_tests.py
@@ -118,7 +118,7 @@ def main():
             request_timeout=options.devpi_request_timeout,
         )
         if isinstance(launch_result, devpi.LaunchResult):
-            os.environ["_PEX_TEST_DEFAULT_INDEX"] = launch_result.url
+            os.environ["_PEX_USE_PIP_CONFIG"] = str(True)
             os.environ["PIP_INDEX_URL"] = launch_result.url
             os.environ["PIP_TRUSTED_HOST"] = cast(
                 # We know the local devpi server URL will always have a host and never be None.

--- a/tests/integration/cli/commands/test_lock.py
+++ b/tests/integration/cli/commands/test_lock.py
@@ -533,7 +533,7 @@ def lock_file_path(tmpdir):
 
 def ensure_pypi(*args):
     # type: (*str) -> Tuple[str, ...]
-    return ("--no-pypi", "--index", "https://pypi.org/simple") + args
+    return ("--no-use-pip-config", "--no-pypi", "--index", "https://pypi.org/simple") + args
 
 
 def run_pypi_lock_create(


### PR DESCRIPTION
When `--use-pip-config` is specified, both `PIP_*` env vars and Pip
configuration files will be read by the Pip Pex delegates to.

Fixes #336
Fixes #838