### PR TITLE
Fix hang when running repl with python options

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -620,6 +620,9 @@ class PEX(object):  # noqa: T000
             else:
                 args = args[index:]
                 break
+        else:
+            # All the args were python options
+            args = []
 
         # The pex was called with Python interpreter options
         if python_options:

--- a/pex/venv/installer.py
+++ b/pex/venv/installer.py
@@ -849,6 +849,9 @@ def _populate_first_party(
                     else:
                         args = args[index:]
                         break
+                else:
+                    # All the args were python options
+                    args = []
 
                 # The pex was called with Python interpreter options, so we need to re-exec to
                 # respect those:

--- a/tests/integration/venv_ITs/test_issue_2248.py
+++ b/tests/integration/venv_ITs/test_issue_2248.py
@@ -1,0 +1,81 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import subprocess
+from textwrap import dedent
+
+import pytest
+from colors import colors
+
+from pex.typing import TYPE_CHECKING
+from testing import IntegResults, run_pex_command
+
+if TYPE_CHECKING:
+    from typing import Any, List
+
+
+# N.B.: To test that we are running a REPL we'll show that it computes result even after
+# assertion errors and exceptions that would normally halt a script.
+# To check that it forwards python options we use -O to deactivate asserts
+# See: https://docs.python.org/3/using/cmdline.html#cmdoption-O
+@pytest.mark.parametrize(
+    "execution_mode_args",
+    [
+        pytest.param([], id="ZIPAPP"),
+    ],  # pytest.param(["--venv"], id="VENV")]
+)
+def test_repl_python_options(
+    execution_mode_args,  # type: List[str]
+    tmpdir,  # type: Any
+):
+    # type: (...) -> None
+
+    pex = os.path.join(str(tmpdir), "pex")
+    run_pex_command(args=["ansicolors==1.1.8", "-o", pex] + execution_mode_args).assert_success()
+
+    repl_commands = dedent(
+        """
+        import colors
+        assert False
+        raise Exception("customexc")
+        result = 20 + 103
+        print(colors.green(f"Worked: {result}"))
+        quit()
+        """
+    )
+
+    def execute_pex(disable_assertions):
+        # type: (bool) -> IntegResults
+        args = [pex]
+        if disable_assertions:
+            args.append("-O")
+        process = subprocess.Popen(
+            args=args,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdout, stderr = process.communicate(input=repl_commands.encode("utf-8"))
+        return IntegResults(
+            output=stdout.decode("utf-8"),
+            error=stderr.decode("utf-8"),
+            return_code=process.returncode,
+        )
+
+    # The assertion will fail and print but since it is a REPL it will keep going
+    # and compute the result
+    result = execute_pex(disable_assertions=False)
+    result.assert_success()
+    assert "InteractiveConsole" in result.error
+    assert "AssertionError" in result.error
+    assert "customexc" in result.error
+    assert colors.green("Worked: 123") in result.output
+
+    # The -O will disable the assertion, but the regular exception will still get raised.
+    result = execute_pex(disable_assertions=True)
+    result.assert_success()
+    assert "InteractiveConsole" in result.error
+    assert "AssertionError" not in result.error
+    assert "customexc" in result.error
+    assert colors.green("Worked: 123") in result.output

--- a/tests/integration/venv_ITs/test_issue_2248.py
+++ b/tests/integration/venv_ITs/test_issue_2248.py
@@ -41,7 +41,7 @@ def test_repl_python_options(
         assert False
         raise Exception("customexc")
         result = 20 + 103
-        print(colors.green(f"Worked: {result}"))
+        print(colors.green("Worked: {}".format(result)))
         quit()
         """
     )

--- a/tests/integration/venv_ITs/test_issue_2248.py
+++ b/tests/integration/venv_ITs/test_issue_2248.py
@@ -23,7 +23,8 @@ if TYPE_CHECKING:
     "execution_mode_args",
     [
         pytest.param([], id="ZIPAPP"),
-    ],  # pytest.param(["--venv"], id="VENV")]
+        pytest.param(["--venv"], id="VENV"),
+    ],
 )
 def test_repl_python_options(
     execution_mode_args,  # type: List[str]

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -789,6 +789,33 @@ def test_execute_interpreter_file_program():
             assert b"" == stderr
 
 
+def test_execute_repl():
+    with temporary_dir() as pex_chroot:
+        pex_builder = PEXBuilder(path=pex_chroot)
+        pex_builder.freeze()
+        process = PEX(pex_chroot).run(
+            args=[],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            stdin=subprocess.PIPE,
+            blocking=False,
+        )
+        commands = dedent(
+            """
+            assert False
+            20 + 103
+            quit()
+            """
+        )
+        stdout, stderr = process.communicate(input=commands.encode("utf-8"))
+
+        assert b"(InteractiveConsole)" in stderr
+        assert b"AssertionError" in stderr
+        assert b">>> " in stdout
+        assert b"123" in stdout
+        assert 0 == process.returncode
+
+
 def test_pex_run_strip_env():
     # type: () -> None
     with temporary_dir() as pex_root:


### PR DESCRIPTION
Fixes #2248 .

Hang is averted, but not all options work as they would be intended. For example `-q` is not quiet. But that can be separated to another issue.