### PR TITLE
Allow PyPI fallback on Mac CI runners.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,10 @@ jobs:
           ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
       - name: Run Tests
         uses: pantsbuild/actions/run-tox@b16b9cf47cd566acfe217b1dafc5b452e27e6fd7
+        env:
+          # It's been observed that the --devpi server crashes sometimes on the Mac runners; so
+          # allow fallback to PyPI for better test stability.
+          PIP_EXTRA_INDEX_URL: https://pypi.org/simple
         with:
           path: repo/tox.ini
           python: ${{ matrix.tox-env-python }}

--- a/testing/devpi.py
+++ b/testing/devpi.py
@@ -102,7 +102,14 @@ class Pidfile(object):
 
     def kill(self):
         # type: () -> None
-        os.kill(self.pid, signal.SIGTERM)
+        try:
+            os.kill(self.pid, signal.SIGTERM)
+        except OSError as e:
+            logger.warning(
+                "Failed to kill devpi server {pid} @ {url}: {err}".format(
+                    pid=self.pid, url=self.url, err=e
+                )
+            )
 
 
 @attr.s(frozen=True)


### PR DESCRIPTION
Also guard against premature devpi server death by just warning on
failure to shut down the devpi server.