### PR TITLE
Fix site-packages identification.

### DIFF
--- a/pex/pex.py
+++ b/pex/pex.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 
 import ast
+import itertools
 import os
 import sys
 from site import USER_SITE
@@ -50,18 +51,13 @@ if TYPE_CHECKING:
 class IsolatedSysPath(object):
     @staticmethod
     def _expand_paths(*paths):
-        # type: (*str) -> Iterator[str]
-        seen = set()
-        for path in paths:
-            if path in seen:
-                continue
-            seen.add(path)
+        # type: (*str) -> OrderedSet[str]
+        def iter_synonyms(path):
             yield path
-            if not os.path.isabs(path):
-                yield os.path.abspath(path)
-            realpath = os.path.realpath(path)
-            if realpath != path:
-                yield realpath
+            yield os.path.abspath(path)
+            yield os.path.realpath(path)
+
+        return OrderedSet(itertools.chain.from_iterable(iter_synonyms(path) for path in paths))
 
     @classmethod
     def for_pex(

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import
 
 import ast
 import os
@@ -17,7 +17,7 @@ from pex.environment import PEXEnvironment
 from pex.executor import Executor
 from pex.finders import get_entry_point_from_console_script, get_script_from_distributions
 from pex.inherit_path import InheritPath
-from pex.interpreter import PythonInterpreter
+from pex.interpreter import PythonIdentity, PythonInterpreter
 from pex.layout import Layout
 from pex.orderedset import OrderedSet
 from pex.pex_info import PexInfo
@@ -51,33 +51,40 @@ class IsolatedSysPath(object):
     @staticmethod
     def _expand_paths(*paths):
         # type: (*str) -> Iterator[str]
+        seen = set()
         for path in paths:
+            if path in seen:
+                continue
+            seen.add(path)
             yield path
             if not os.path.isabs(path):
                 yield os.path.abspath(path)
-            yield os.path.realpath(path)
+            realpath = os.path.realpath(path)
+            if realpath != path:
+                yield realpath
 
     @classmethod
     def for_pex(
         cls,
-        interpreter,  # type: PythonInterpreter
+        interpreter,  # type: Union[PythonInterpreter, PythonIdentity]
         pex,  # type: str
         pex_pex=None,  # type: Optional[str]
     ):
         # type: (...) -> IsolatedSysPath
-        sys_path = OrderedSet(interpreter.sys_path)
+        ident = interpreter.identity if isinstance(interpreter, PythonInterpreter) else interpreter
+        sys_path = OrderedSet(ident.sys_path)
         sys_path.add(pex)
         sys_path.add(Bootstrap.locate().path)
         if pex_pex:
             sys_path.add(pex_pex)
 
         site_packages = OrderedSet()  # type: OrderedSet[str]
-        for site_lib in interpreter.site_packages:
+        for site_lib in ident.site_packages:
             TRACER.log("Discarding site packages path: {site_lib}".format(site_lib=site_lib))
             site_packages.add(site_lib)
 
         extras_paths = OrderedSet()  # type: OrderedSet[str]
-        for extras_path in interpreter.extras_paths:
+        for extras_path in ident.extras_paths:
             TRACER.log("Discarding site extras path: {extras_path}".format(extras_path=extras_path))
             extras_paths.add(extras_path)
 
@@ -85,7 +92,7 @@ class IsolatedSysPath(object):
             sys_path=sys_path,
             site_packages=site_packages,
             extras_paths=extras_paths,
-            is_venv=interpreter.is_venv,
+            is_venv=ident.is_venv,
         )
 
     def __init__(
@@ -339,7 +346,7 @@ class PEX(object):  # noqa: T000
             # type: (Optional[str]) -> Iterable[str]
             if path is None:
                 return ()
-            locations = set(dist.location for dist in find_distributions(path))
+            locations = set(dist.location for dist in find_distributions([path]))
             return {path} | locations | set(os.path.realpath(path) for path in locations)
 
         for path_element in sys.path:

--- a/pex/resolve/downloads.py
+++ b/pex/resolve/downloads.py
@@ -51,9 +51,9 @@ def get_downloads_dir(pex_root=None):
 @attr.s(frozen=True)
 class ArtifactDownloader(object):
     resolver = attr.ib()  # type: Resolver
-    target = attr.ib(default=LocalInterpreter.create())  # type: Target
+    target = attr.ib(factory=LocalInterpreter.create)  # type: Target
     package_index_configuration = attr.ib(
-        default=PackageIndexConfiguration.create()
+        factory=PackageIndexConfiguration.create
     )  # type: PackageIndexConfiguration
     max_parallel_jobs = attr.ib(default=None)  # type: Optional[int]
     pip = attr.ib(init=False)  # type: Pip

--- a/pex/resolve/target_options.py
+++ b/pex/resolve/target_options.py
@@ -61,7 +61,7 @@ def register(
         ),
     )
 
-    singe_interpreter_info_cmd = (
+    single_interpreter_info_cmd = (
         "pex3 interpreter inspect --python {current_interpreter} --verbose --indent 4".format(
             current_interpreter=sys.executable
         )
@@ -83,14 +83,14 @@ def register(
             "constraints of {current_interpreter} and `{all_interpreters_info_cmd}` to find out "
             "the interpreter constraints of all Python interpreters on the $PATH.".format(
                 current_interpreter=sys.executable,
-                singe_interpreter_info_cmd=singe_interpreter_info_cmd,
+                singe_interpreter_info_cmd=single_interpreter_info_cmd,
                 all_interpreters_info_cmd=all_interpreters_info_cmd,
             )
         ),
     )
 
     if include_platforms:
-        _register_platform_options(parser, singe_interpreter_info_cmd, all_interpreters_info_cmd)
+        _register_platform_options(parser, single_interpreter_info_cmd, all_interpreters_info_cmd)
 
 
 def _register_platform_options(

--- a/pex/resolve/target_options.py
+++ b/pex/resolve/target_options.py
@@ -61,16 +61,12 @@ def register(
         ),
     )
 
-    current_interpreter = PythonInterpreter.get()
-    program = sys.argv[0]
     singe_interpreter_info_cmd = (
-        "PEX_TOOLS=1 {current_interpreter} {program} interpreter --verbose --indent 4".format(
-            current_interpreter=current_interpreter.binary, program=program
+        "pex3 interpreter inspect --python {current_interpreter} --verbose --indent 4".format(
+            current_interpreter=sys.executable
         )
     )
-    all_interpreters_info_cmd = (
-        "PEX_TOOLS=1 {program} interpreter --all --verbose --indent 4".format(program=program)
-    )
+    all_interpreters_info_cmd = "pex3 interpreter inspect --all --verbose --indent 4"
 
     parser.add_argument(
         "--interpreter-constraint",
@@ -86,7 +82,7 @@ def register(
             "the constraints. Try `{singe_interpreter_info_cmd}` to find the exact interpreter "
             "constraints of {current_interpreter} and `{all_interpreters_info_cmd}` to find out "
             "the interpreter constraints of all Python interpreters on the $PATH.".format(
-                current_interpreter=current_interpreter.binary,
+                current_interpreter=sys.executable,
                 singe_interpreter_info_cmd=singe_interpreter_info_cmd,
                 all_interpreters_info_cmd=all_interpreters_info_cmd,
             )
@@ -94,14 +90,11 @@ def register(
     )
 
     if include_platforms:
-        _register_platform_options(
-            parser, current_interpreter, singe_interpreter_info_cmd, all_interpreters_info_cmd
-        )
+        _register_platform_options(parser, singe_interpreter_info_cmd, all_interpreters_info_cmd)
 
 
 def _register_platform_options(
     parser,  # type: _ActionsContainer
-    current_interpreter,  # type: PythonInterpreter
     singe_interpreter_info_cmd,  # type: str
     all_interpreters_info_cmd,  # type: str
 ):
@@ -120,13 +113,11 @@ def _register_platform_options(
             "string composed of fields: <platform>-<python impl abbr>-<python version>-<abi>. "
             "These fields stem from wheel name conventions as outlined in "
             "https://www.python.org/dev/peps/pep-0427#file-name-convention and influenced by "
-            "https://www.python.org/dev/peps/pep-0425. For the current interpreter at "
-            "{current_interpreter} the full platform string is {current_platform}. To find out "
-            "more, try `{all_interpreters_info_cmd}` to print out the platform for all "
-            "interpreters on the $PATH or `{singe_interpreter_info_cmd}` to inspect the single "
-            "interpreter {current_interpreter}.".format(
-                current_interpreter=current_interpreter.binary,
-                current_platform=current_interpreter.platform,
+            "https://www.python.org/dev/peps/pep-0425. To find out more, try "
+            "`{all_interpreters_info_cmd}` to print out the platform for all interpreters on the "
+            "$PATH or `{singe_interpreter_info_cmd}` to inspect the single interpreter "
+            "{current_interpreter}.".format(
+                current_interpreter=sys.executable,
                 singe_interpreter_info_cmd=singe_interpreter_info_cmd,
                 all_interpreters_info_cmd=all_interpreters_info_cmd,
             )

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -1154,7 +1154,7 @@ def _download_internal(
 class LocalDistribution(object):
     path = attr.ib()  # type: str
     fingerprint = attr.ib()  # type: str
-    target = attr.ib(default=targets.current())  # type: Target
+    target = attr.ib(factory=targets.current)  # type: Target
 
     @fingerprint.default
     def _calculate_fingerprint(self):

--- a/tests/integration/test_issue_1232.py
+++ b/tests/integration/test_issue_1232.py
@@ -95,13 +95,10 @@ def test_isolated_pex_zip(tmpdir):
     current_pex_isolation = set(current_isolated_vendoreds.keys()) ^ set(
         current_pex_isolated_vendoreds.keys()
     )
-    assert 1 == len(current_pex_isolation), (
-        "Since the modified Pex PEX was built from a Pex PEX an isolation of the Pex PEX bootstrap "
-        "code should have occurred bringing the total isolations up to two."
+    assert 0 == len(current_pex_isolation), (
+        "Since the current Pex PEX was built from the same Pex code as the current loose source "
+        "Pex, a new isolation of the Pex PEX bootstrap code should not have occurred."
     )
-    current_pex_vendoreds = current_pex_isolated_vendoreds[current_pex_isolation.pop()]
-    assert "pip" not in current_pex_vendoreds, "Expected a Pex runtime isolation."
-    assert "wheel" not in current_pex_vendoreds, "Expected a Pex runtime isolation."
 
     # 3. Isolate modified Pex PEX at build-time.
     # ===

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -17,13 +17,12 @@ import pytest
 from pex import resolver
 from pex.common import safe_mkdir, safe_open, temporary_dir
 from pex.compatibility import PY2, WINDOWS, to_bytes
-from pex.dist_metadata import Distribution, Requirement
-from pex.interpreter import PythonInterpreter
+from pex.dist_metadata import Distribution
+from pex.interpreter import PythonIdentity, PythonInterpreter
 from pex.pex import PEX, IsolatedSysPath
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
 from pex.resolve.configured_resolver import ConfiguredResolver
-from pex.resolve.resolver_configuration import PipConfiguration
 from pex.typing import TYPE_CHECKING
 from pex.util import named_temporary_file
 from testing import (
@@ -222,8 +221,7 @@ def test_site_libs(tmpdir):
         site_packages = os.path.join(str(tmpdir), "site-packages")
         os.mkdir(site_packages)
         mock_site_packages.return_value = {site_packages}
-        with PythonInterpreter._cleared_memory_cache():
-            site_libs = PythonInterpreter.get().site_packages
+        site_libs = PythonIdentity.get().site_packages
         assert site_packages in site_libs
 
 
@@ -245,10 +243,9 @@ def test_site_libs_symlink(tmpdir):
         os.symlink(site_packages, site_packages_link)
         mock_site_packages.return_value = [site_packages_link]
 
-        with PythonInterpreter._cleared_memory_cache():
-            isolated_sys_path = IsolatedSysPath.for_pex(
-                interpreter=PythonInterpreter.get(), pex=os.devnull
-            )
+        isolated_sys_path = IsolatedSysPath.for_pex(
+            interpreter=PythonIdentity.get(), pex=os.devnull
+        )
         assert os.path.join(sys_path_entry, "module.py") in isolated_sys_path
         assert os.path.realpath(site_packages) not in isolated_sys_path
         assert site_packages_link not in isolated_sys_path
@@ -267,8 +264,7 @@ def test_site_libs_excludes_prefix():
         site_packages = os.path.join(tempdir, "site-packages")
         os.mkdir(site_packages)
         mock_site_packages.return_value = [site_packages, sys.prefix]
-        with PythonInterpreter._cleared_memory_cache():
-            site_libs = PythonInterpreter.get().site_packages
+        site_libs = PythonIdentity.get().site_packages
         assert site_packages in site_libs
         assert sys.prefix not in site_libs
 


### PR DESCRIPTION
Fix site-packages identification.

In the process of working a new feature, it was discovered that
`sys.path` manipulations leaked into `PythonInterpreter` when they were
performed before the `__pex__` import hook. This is fixed by always
going through the interpreter disk cache path, which has properly
isolated `sys.path` for quite some time, eliminating the one exception
for the current interpreter. Fixing this case caused several tests to
fail that exposed several eager uses of `PythonInterpreter.get()` that
would execute in import of various modules. Those cases are fixed to
either be lazy or use `sys.executable`.

Along the way, fix up the ~TODO for migrating from `distutils.sysconfig`
to `sysconfig` for determining the site-packages directories. This
should preempt issues with vendor (e.g.: Debian) supplied Python 3.12+.