### PR TITLE
Migrate many types from str to Text.

### DIFF
--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -17,7 +17,7 @@ from pex.common import (
     Chroot,
     chmod_plus_x,
     deterministic_walk,
-    filter_pyc_files,
+    is_pyc_file,
     is_pyc_temporary_file,
     safe_copy,
     safe_delete,
@@ -651,7 +651,9 @@ class PEXBuilder(object):
             if root == _ABS_PEX_PACKAGE_DIR:
                 dirs[:] = bootstrap_packages
 
-            for f in filter_pyc_files(files):
+            for f in files:
+                if is_pyc_file(f):
+                    continue
                 abs_src = os.path.join(root, f)
                 # N.B.: Some of the `pex.*` package files (__init__.py) will already have been
                 # prepared when vendoring the runtime above; so we skip them here.

--- a/pex/pip/vcs.py
+++ b/pex/pip/vcs.py
@@ -7,7 +7,7 @@ import os
 import re
 
 from pex import hashing
-from pex.common import filter_pyc_dirs, filter_pyc_files, open_zip, temporary_dir
+from pex.common import is_pyc_dir, is_pyc_file, open_zip, temporary_dir
 from pex.hashing import Sha256
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
@@ -102,6 +102,6 @@ def digest_vcs_archive(
         hashing.dir_hash(
             directory=chroot,
             digest=digest,
-            dir_filter=lambda dirs: [d for d in filter_pyc_dirs(dirs) if d != vcs_control_dir],
-            file_filter=filter_pyc_files,
+            dir_filter=lambda dir_path: not is_pyc_dir(dir_path) and dir_path != vcs_control_dir,
+            file_filter=lambda f: not is_pyc_file(f),
         )

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -406,13 +406,17 @@ def _isolate_pex_from_dir(
     isolate_to_dir,  # type: str
     exclude_files,  # type: Container[str]
 ):
-    from pex.common import filter_pyc_dirs, filter_pyc_files, is_pyc_temporary_file, safe_copy
+    from pex.common import is_pyc_dir, is_pyc_file, is_pyc_temporary_file, safe_copy
 
     for root, dirs, files in os.walk(pex_directory):
         relroot = os.path.relpath(root, pex_directory)
-        for d in filter_pyc_dirs(dirs):
+        for d in dirs:
+            if is_pyc_dir(d):
+                continue
             os.makedirs(os.path.join(isolate_to_dir, "pex", relroot, d))
-        for f in filter_pyc_files(files):
+        for f in files:
+            if is_pyc_file(f):
+                continue
             rel_f = os.path.join(relroot, f)
             if not is_pyc_temporary_file(rel_f) and rel_f not in exclude_files:
                 safe_copy(

--- a/pex/vendor/__init__.py
+++ b/pex/vendor/__init__.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 from textwrap import dedent
 
-from pex.common import Chroot, filter_pyc_dirs, filter_pyc_files, safe_mkdtemp, touch
+from pex.common import Chroot, is_pyc_dir, is_pyc_file, safe_mkdtemp, touch
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 
@@ -320,8 +320,10 @@ def vendor_runtime(
                 files[:] = modules
 
             # We copy over sources and data only; no pyc files.
-            dirs[:] = filter_pyc_dirs(dirs)
-            for filename in filter_pyc_files(files):
+            dirs[:] = [d for d in dirs if not is_pyc_dir(d)]
+            for filename in files:
+                if is_pyc_file(filename):
+                    continue
                 src = os.path.join(root, filename)
                 if src in vendored_sources:
                     continue

--- a/pex/venv/installer.py
+++ b/pex/venv/installer.py
@@ -31,7 +31,17 @@ from pex.venv.virtualenv import PipUnavailableError, Virtualenv
 
 if TYPE_CHECKING:
     import typing
-    from typing import Container, DefaultDict, Iterable, Iterator, List, Optional, Tuple, Union
+    from typing import (
+        Container,
+        DefaultDict,
+        Iterable,
+        Iterator,
+        List,
+        Optional,
+        Text,
+        Tuple,
+        Union,
+    )
 
     import attr  # vendor:skip
 else:
@@ -156,7 +166,7 @@ def _copytree(
     exclude=(),  # type: Container[str]
     symlink=False,  # type: bool
 ):
-    # type: (...) -> Iterator[Tuple[str, str]]
+    # type: (...) -> Iterator[Tuple[Text, Text]]
     safe_mkdir(dst)
     link = True
     for root, dirs, files in os.walk(src, topdown=True, followlinks=True):
@@ -224,7 +234,7 @@ class Provenance(object):
         # type: (...) -> None
         self._target_dir = target_dir
         self._target_python = target_python
-        self._provenance = defaultdict(list)  # type: DefaultDict[str, List[str]]
+        self._provenance = defaultdict(list)  # type: DefaultDict[Text, List[Text]]
 
     @property
     def target_python(self):
@@ -241,7 +251,7 @@ class Provenance(object):
         return "#!{shebang}".format(shebang=" ".join(shebang_argv))
 
     def record(self, src_to_dst):
-        # type: (Iterable[Tuple[str, str]]) -> None
+        # type: (Iterable[Tuple[Text, Text]]) -> None
         for src, dst in src_to_dst:
             self._provenance[dst].append(src)
 
@@ -305,7 +315,7 @@ def _populate_flat_deps(
     distributions,  # type: Iterable[Distribution]
     symlink=False,  # type: bool
 ):
-    # type: (...) -> Iterator[Tuple[str, str]]
+    # type: (...) -> Iterator[Tuple[Text, Text]]
     for dist in distributions:
         try:
             installed_wheel = InstalledWheel.load(dist.location)
@@ -477,7 +487,7 @@ def _populate_venv_deps(
     hermetic_scripts=True,  # type: bool
     top_level_source_packages=(),  # type: Iterable[str]
 ):
-    # type: (...) -> Iterator[Tuple[str, str]]
+    # type: (...) -> Iterator[Tuple[Text, Text]]
 
     # Since the pex distributions are all materialized to ~/.pex/installed_wheels, which we control,
     # we can optionally symlink to take advantage of sharing generated *.pyc files for auto-venvs
@@ -586,18 +596,18 @@ def _populate_sources(
     pex,  # type: PEX
     dst,  # type: str
 ):
-    # type: (...) -> Iterator[Tuple[str, str]]
+    # type: (...) -> Iterator[Tuple[Text, Text]]
 
     # Since the pex.path() is ~always outside our control (outside ~/.pex), we copy all PEX user
     # sources into the venv.
     pex_sources = PEXSources.mount(pex)
-    for src, dst in _copytree(
+    for src, dest in _copytree(
         src=pex_sources.path,
         dst=dst,
         exclude=pex_sources.excludes,
         symlink=False,
     ):
-        yield src, dst
+        yield src, dest
 
 
 def _populate_first_party(
@@ -607,7 +617,7 @@ def _populate_first_party(
     venv_python,  # type: str
     bin_path,  # type: BinPath.Value
 ):
-    # type: (...) -> Iterator[Tuple[str, str]]
+    # type: (...) -> Iterator[Tuple[Text, Text]]
 
     # We want the venv at rest to reflect the PEX it was created from at rest; as such we use the
     # PEX's at-rest PEX-INFO to perform the layout. The venv can then be executed with various PEX

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -94,7 +94,7 @@ def random_bytes(length):
 
 
 def get_dep_dist_names_from_pex(pex_path, match_prefix=""):
-    # type: (str, str) -> Set[str]
+    # type: (str, str) -> Set[Text]
     """Given an on-disk pex, extract all of the unique first-level paths under `.deps`."""
     with open_zip(pex_path) as pex_zip:
         dep_gen = (f.split(os.sep)[1] for f in pex_zip.namelist() if f.startswith(".deps/"))
@@ -667,7 +667,7 @@ def environment_as(**kwargs):
 
 @contextmanager
 def pushd(directory):
-    # type: (str) -> Iterator[None]
+    # type: (Text) -> Iterator[None]
     cwd = os.getcwd()
     try:
         os.chdir(directory)

--- a/tests/integration/tools/commands/test_venv.py
+++ b/tests/integration/tools/commands/test_venv.py
@@ -8,14 +8,14 @@ from textwrap import dedent
 
 from colors import cyan
 
-from pex.common import filter_pyc_files, safe_open
+from pex.common import is_pyc_file, safe_open
 from pex.typing import TYPE_CHECKING
 from pex.util import CacheHelper
 from pex.venv.virtualenv import Virtualenv
 from testing import IntegResults, make_env, run_pex_command
 
 if TYPE_CHECKING:
-    from typing import Any, Set
+    from typing import Any, Set, Text
 
 
 def run_pex_tools(*args):
@@ -198,11 +198,12 @@ def test_scope_issue_1631(tmpdir):
         return Virtualenv(venv_dir)
 
     def recursive_listing(venv_dir):
-        # type: (str) -> Set[str]
+        # type: (str) -> Set[Text]
         return {
             os.path.relpath(os.path.join(root, f), venv_dir)
             for root, _, files in os.walk(venv_dir)
-            for f in filter_pyc_files(files)
+            for f in files
+            if not is_pyc_file(f)
         }
 
     def site_packages_path(

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -160,7 +160,10 @@ def assert_force_local_implicit_ns_packages_issues_598(
                 builder.add_source(os.path.join(project, path), path)
 
     with temporary_dir() as root:
+        pex_root = os.path.join(root, "pex_root")
+
         pex_info1 = PexInfo.default()
+        pex_info1.pex_root = pex_root
         pex1 = os.path.join(root, "pex1.pex")
         builder1 = PEXBuilder(interpreter=interpreter, pex_info=pex_info1)
         add_requirements(builder1)
@@ -169,6 +172,7 @@ def assert_force_local_implicit_ns_packages_issues_598(
         builder1.build(pex1)
 
         pex_info2 = PexInfo.default()
+        pex_info2.pex_root = pex_root
         pex_info2.pex_path = [pex1]
         pex2 = os.path.join(root, "pex2")
         builder2 = PEXBuilder(path=pex2, interpreter=interpreter, pex_info=pex_info2)

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -14,7 +14,7 @@ from pex.pip.installation import get_pip
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Dict
+    from typing import Any, Dict, Text
 
     import attr  # vendor:skip
 else:
@@ -54,7 +54,7 @@ def create_dist(
     @attr.s(frozen=True)
     class FakeDist(Distribution):
         def get_entry_map(self):
-            # type: () -> Dict[str, Dict[str, EntryPoint]]
+            # type: () -> Dict[Text, Dict[Text, EntryPoint]]
             return {"console_scripts": {entry_point.name: entry_point}}
 
     return FakeDist(

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -31,7 +31,7 @@ except ImportError:
     import mock  # type: ignore[no-redef,import]
 
 if TYPE_CHECKING:
-    from typing import Any, Iterator, List, Set
+    from typing import Any, Iterator, List, Set, Text
 
 exe_main = """
 import sys
@@ -355,7 +355,7 @@ def test_pex_builder_exclude_bootstrap_testing(
     pb.build(pex_path, layout=layout)
 
     bootstrap_location = os.path.join(pex_path, pb.info.bootstrap)
-    bootstrap_files = set()  # type: Set[str]
+    bootstrap_files = set()  # type: Set[Text]
     if Layout.ZIPAPP == layout:
         with open_zip(pex_path) as zf:
             bootstrap_files.update(


### PR DESCRIPTION
This supports an up coming refactor of `pex.{dist_metadata,pep_376}`
which also requires re-formulating the pyc filters from `Iterable` ->
`Iterable` form to boolean predicates to make typing easier at the
loss of ~nothing.