### PR TITLE
Fix ReadTheDocs generation.

### DIFF
--- a/docs/rtd/requirements.txt
+++ b/docs/rtd/requirements.txt
@@ -4,3 +4,7 @@ docutils<0.18
 
 sphinx==3.2.1
 sphinx_rtd_theme==0.5.0
+
+# N.B.: Sphinx doesn't work with jinja2 3.1.0.
+# See: https://github.com/sphinx-doc/sphinx/issues/10291
+jinja2<3.1.0


### PR DESCRIPTION
Sphinx is incompatible with Jinja2==3.1.0. 

RTD used to pin Jinja2 below that version, but they stopped
doing so when they changed the set of packages they install
by default:
https://blog.readthedocs.com/defaulting-latest-build-tools/

So now we must pin explicitly ourselves.