### PR TITLE
Add support for Pip 23.3.1.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           - py311-pip20
           - py311-pip22_3_1
           - py311-pip23_1_2
-          - py312-pip23_2
+          - py312-pip23_3_1
           - pypy310-pip20
           - pypy310-pip22_3_1
           - pypy310-pip23_1_2
@@ -66,7 +66,7 @@ jobs:
           - py311-pip20-integration
           - py311-pip22_3_1-integration
           - py311-pip23_1_2-integration
-          - py312-pip23_2-integration
+          - py312-pip23_3_1-integration
           - pypy310-pip20-integration
           - pypy310-pip22_3_1-integration
           - pypy310-pip23_1_2-integration
@@ -107,10 +107,10 @@ jobs:
       matrix:
         include:
           - python-version: [ 3, 12 ]
-            tox-env: py312-pip23_2
+            tox-env: py312-pip23_3_1
             tox-env-python: python3.11
           - python-version: [ 3, 12 ]
-            tox-env: py312-pip23_2-integration
+            tox-env: py312-pip23_3_1-integration
             tox-env-python: python3.11
     steps:
       - name: Calculate Pythons to Expose

--- a/pex/pip/version.py
+++ b/pex/pip/version.py
@@ -213,6 +213,15 @@ class PipVersion(Enum["PipVersionValue"]):
         requires_python=">=3.7",
     )
 
+    v23_3_1 = PipVersionValue(
+        version="23.3.1",
+        # N.B.: The setuptools 68.2.2 release was available on 10/21/2023 (the Pip 23.3.1 release
+        # date) but 68.0.0 is the last setuptools version to support 3.7.
+        setuptools_version="68.0.0",
+        wheel_version="0.41.2",
+        requires_python=">=3.7",
+    )
+
     VENDORED = v20_3_4_patched
     LATEST = LatestPipVersion()
     DEFAULT = DefaultPipVersion(preferred=(VENDORED, v23_2))

--- a/pex/resolve/lockfile/create.py
+++ b/pex/resolve/lockfile/create.py
@@ -20,7 +20,6 @@ from pex.orderedset import OrderedSet
 from pex.pep_503 import ProjectName
 from pex.pip.download_observer import DownloadObserver
 from pex.pip.tool import PackageIndexConfiguration
-from pex.pip.version import PipVersion
 from pex.resolve import lock_resolver, locker, resolvers
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.downloads import ArtifactDownloader

--- a/pex/resolve/resolved_requirement.py
+++ b/pex/resolve/resolved_requirement.py
@@ -119,9 +119,7 @@ class PartialArtifact(object):
 class ResolvedRequirement(object):
     pin = attr.ib()  # type: Pin
     artifact = attr.ib()  # type: PartialArtifact
-    requirement = attr.ib()  # type: Requirement
     additional_artifacts = attr.ib(default=())  # type: Tuple[PartialArtifact, ...]
-    via = attr.ib(default=())  # type: Tuple[str, ...]
 
     def iter_artifacts(self):
         # type: () -> Iterator[PartialArtifact]

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ setenv =
     pip23_1_1: _PEX_PIP_VERSION=23.1.1
     pip23_1_2: _PEX_PIP_VERSION=23.1.2
     pip23_2: _PEX_PIP_VERSION=23.2
+    pip23_3_1: _PEX_PIP_VERSION=23.3.1
     # Python 3 (until a fix here in 3.9: https://bugs.python.org/issue13601) switched from stderr
     # being unbuffered to stderr being buffered by default. This can lead to tests checking stderr
     # failing to see what they expect if the stderr buffer block has not been flushed. Force stderr
@@ -69,7 +70,7 @@ whitelist_externals =
     bash
     git
 
-[testenv:py{py27-subprocess,py27,py35,py36,py37,py38,py39,py310,27,35,36,37,38,39,310,311,312}-{,pip20-,pip22_2-,pip22_3-,pip22_3_1-,pip23_0-,pip23_0_1-,pip23_1-,pip23_1_1-,pip23_1_2-,pip23_2-}integration]
+[testenv:py{py27-subprocess,py27,py35,py36,py37,py38,py39,py310,27,35,36,37,38,39,310,311,312}-{,pip20-,pip22_2-,pip22_3-,pip22_3_1-,pip23_0-,pip23_0_1-,pip23_1-,pip23_1_1-,pip23_1_2-,pip23_2-,pip23_3_1-}integration]
 deps =
     pytest-xdist==1.34.0
     {[testenv]deps}


### PR DESCRIPTION
This required updating the locker parsing to account for differences in
23.3.x log output.

Although 23.3 has significant changes from 23.2.x, I was away during its
release and no one clamored for it; so I'm just moving ahead to the
small 23.3.1 update. The changelogs are here:
+ https://pip.pypa.io/en/stable/news/#v23-3-1
+ https://pip.pypa.io/en/stable/news/#v23-3