### PR TITLE
Move wheel install logic into Pex.

### DIFF
--- a/docker/base/install_pythons.sh
+++ b/docker/base/install_pythons.sh
@@ -16,13 +16,13 @@ PYENV_VERSIONS=(
   3.9.18
   3.10.13
   3.12.0
-  pypy2.7-7.3.12
+  pypy2.7-7.3.13
   pypy3.5-7.0.0
   pypy3.6-7.3.3
   pypy3.7-7.3.9
   pypy3.8-7.3.11
-  pypy3.9-7.3.12
-  pypy3.10-7.3.12
+  pypy3.9-7.3.13
+  pypy3.10-7.3.13
 )
 
 git clone https://github.com/pyenv/pyenv.git "${PYENV_ROOT}" && (
@@ -31,13 +31,13 @@ git clone https://github.com/pyenv/pyenv.git "${PYENV_ROOT}" && (
 PATH="${PATH}:${PYENV_ROOT}/bin"
 
 for version in "${PYENV_VERSIONS[@]}"; do
-  if [[ "${version}" == "pypy2.7-7.3.12" ]]; then
-    # Installation of pypy2.7-7.3.12 fails like so without adjusting the version of get-pip it
+  if [[ "${version}" == "pypy2.7-7.3.13" ]]; then
+    # Installation of pypy2.7-7.3.13 fails like so without adjusting the version of get-pip it
     # uses:
-    #  $ pyenv install pypy2.7-7.3.12
-    #  Downloading pypy2.7-v7.3.12-linux64.tar.bz2...
-    #  -> https://downloads.python.org/pypy/pypy2.7-v7.3.12-linux64.tar.bz2
-    #  Installing pypy2.7-v7.3.12-linux64...
+    #  $ pyenv install pypy2.7-7.3.13
+    #  Downloading pypy2.7-v7.3.13-linux64.tar.bz2...
+    #  -> https://downloads.python.org/pypy/pypy2.7-v7.3.13-linux64.tar.bz2
+    #  Installing pypy2.7-v7.3.13-linux64...
     #  Installing pip from https://bootstrap.pypa.io/get-pip.py...
     #  error: failed to install pip via get-pip.py
     #  ...

--- a/pex/build_system/pep_517.py
+++ b/pex/build_system/pep_517.py
@@ -47,7 +47,9 @@ def _default_build_system(
                 requires = ["setuptools", "wheel"]
                 resolved = tuple(
                     Distribution.load(dist_location)
-                    for dist_location in third_party.expose(requires)
+                    for dist_location in third_party.expose(
+                        requires, interpreter=target.get_interpreter()
+                    )
                 )
                 extra_env.update(__PEX_UNVENDORED__="1")
             else:

--- a/pex/common.py
+++ b/pex/common.py
@@ -444,7 +444,7 @@ def can_write_dir(path):
 
 
 def touch(file):
-    # type: (str) -> None
+    # type: (Text) -> None
     """Equivalent of unix `touch path`."""
     with safe_open(file, "a"):
         os.utime(file, None)

--- a/pex/dist_metadata.py
+++ b/pex/dist_metadata.py
@@ -83,7 +83,7 @@ def _strip_sdist_path(sdist_path):
     return filename
 
 
-def _parse_message(message):
+def parse_message(message):
     # type: (bytes) -> Message
     return cast(Message, Parser().parse(StringIO(to_unicode(message))))
 
@@ -153,7 +153,7 @@ def _find_installed_metadata_files(
     metadata_files = glob.glob(os.path.join(location, metadata_dir_glob, metadata_file_name))
     for path in metadata_files:
         with open(path, "rb") as fp:
-            metadata = _parse_message(fp.read())
+            metadata = parse_message(fp.read())
             project_name_and_version = ProjectNameAndVersion.from_parsed_pkg_info(
                 source=path, pkg_info=metadata
             )
@@ -194,7 +194,7 @@ def find_wheel_metadata(location):
                 continue
 
             with zf.open(name) as fp:
-                metadata = _parse_message(fp.read())
+                metadata = parse_message(fp.read())
                 project_name_and_version = ProjectNameAndVersion.from_parsed_pkg_info(
                     source=os.path.join(location, name), pkg_info=metadata
                 )
@@ -245,7 +245,7 @@ def find_zip_sdist_metadata(location):
             if name.endswith("/") or not _is_dist_pkg_info_file_path(name):
                 continue
             with zf.open(name) as fp:
-                metadata = _parse_message(fp.read())
+                metadata = parse_message(fp.read())
                 project_name_and_version = ProjectNameAndVersion.from_parsed_pkg_info(
                     source=os.path.join(location, name), pkg_info=metadata
                 )
@@ -277,7 +277,7 @@ def find_tar_sdist_metadata(location):
                     ),
                 )
             with closing(file_obj) as fp:
-                metadata = _parse_message(fp.read())
+                metadata = parse_message(fp.read())
                 project_name_and_version = ProjectNameAndVersion.from_parsed_pkg_info(
                     source=os.path.join(location, member.name), pkg_info=metadata
                 )

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -1493,7 +1493,7 @@ def create_shebang(
         return shebang
 
     # This trick relies on /bin/sh being ubiquitous and the concordance of:
-    # 1. Python: triple quoted strings plus allowance for free=floating string values in
+    # 1. Python: triple quoted strings plus allowance for free-floating string values in
     #    python files.
     # 2. sh: Any number of pairs of `'` evaluating away when followed immediately by a
     #    command string (`''command` -> `command`) and lazy parsing allowing for invalid sh

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -1329,7 +1329,7 @@ class PythonInterpreter(object):
         return self._supported_platforms
 
     def shebang(self, args=None):
-        # type: (Optional[str]) -> str
+        # type: (Optional[Text]) -> Text
         """Return the contents of an appropriate shebang for this interpreter and args.
 
         The shebang will include the leading `#!` but will not include a trailing new line character.
@@ -1476,11 +1476,11 @@ MAX_SHEBANG_LENGTH = 512 if sys.platform == "darwin" else 128
 
 
 def create_shebang(
-    python_exe,  # type: str
-    python_args=None,  # type: Optional[str]
+    python_exe,  # type: Text
+    python_args=None,  # type: Optional[Text]
     max_shebang_length=MAX_SHEBANG_LENGTH,  # type: int
 ):
-    # type: (...) -> str
+    # type: (...) -> Text
     """Return the contents of an appropriate shebang for the given Python interpreter and args.
 
     The shebang will include the leading `#!` but will not include a trailing new line character.

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -212,6 +212,7 @@ class PythonIdentity(object):
             sys_path=sys_path,
             site_packages=site_packages,
             extras_paths=extras_paths,
+            paths=sysconfig.get_paths(),
             packaging_version=packaging_version,
             python_tag=preferred_tag.interpreter,
             abi_tag=preferred_tag.abi,
@@ -226,7 +227,7 @@ class PythonIdentity(object):
     def decode(cls, encoded):
         TRACER.log("creating PythonIdentity from encoded: %s" % encoded, V=9)
         values = json.loads(encoded)
-        if len(values) != 14:
+        if len(values) != 15:
             raise cls.InvalidError("Invalid interpreter identity: %s" % encoded)
 
         supported_tags = values.pop("supported_tags")
@@ -264,6 +265,7 @@ class PythonIdentity(object):
         sys_path,  # type: Iterable[str]
         site_packages,  # type: Iterable[str]
         extras_paths,  # type: Iterable[str]
+        paths,  # type: Mapping[str, str]
         packaging_version,  # type: str
         python_tag,  # type: str
         abi_tag,  # type: str
@@ -284,6 +286,7 @@ class PythonIdentity(object):
         self._sys_path = tuple(sys_path)
         self._site_packages = tuple(site_packages)
         self._extras_paths = tuple(extras_paths)
+        self._paths = dict(paths)
         self._packaging_version = packaging_version
         self._python_tag = python_tag
         self._abi_tag = abi_tag
@@ -301,6 +304,7 @@ class PythonIdentity(object):
             sys_path=self._sys_path,
             site_packages=self._site_packages,
             extras_paths=self._extras_paths,
+            paths=self._paths,
             packaging_version=self._packaging_version,
             python_tag=self._python_tag,
             abi_tag=self._abi_tag,
@@ -347,6 +351,11 @@ class PythonIdentity(object):
     def extras_paths(self):
         # type: () -> Tuple[str, ...]
         return self._extras_paths
+
+    @property
+    def paths(self):
+        # type: () -> Mapping[str, str]
+        return self._paths
 
     @property
     def python_tag(self):
@@ -1319,6 +1328,14 @@ class PythonInterpreter(object):
             self._supported_platforms = frozenset(self._identity.iter_supported_platforms())
         return self._supported_platforms
 
+    def shebang(self, args=None):
+        # type: (Optional[str]) -> str
+        """Return the contents of an appropriate shebang for this interpreter and args.
+
+        The shebang will include the leading `#!` but will not include a trailing new line character.
+        """
+        return create_shebang(self._binary, python_args=args)
+
     def create_isolated_cmd(
         self,
         args=None,  # type: Optional[Iterable[str]]
@@ -1444,10 +1461,56 @@ def spawn_python_job(
         # need to set `__PEX_UNVENDORED__`. See: vendor.__main__.ImportRewriter._modify_import.
         subprocess_env["__PEX_UNVENDORED__"] = "1"
 
-        pythonpath.extend(third_party.expose(expose))
+        pythonpath.extend(third_party.expose(expose, interpreter=interpreter))
 
     interpreter = interpreter or PythonInterpreter.get()
     cmd, process = interpreter.open_process(
         args=args, pythonpath=pythonpath, env=subprocess_env, **subprocess_kwargs
     )
     return Job(command=cmd, process=process)
+
+
+# See the "Test results from various systems" table here:
+#  https://www.in-ulm.de/~mascheck/various/shebang/#length
+MAX_SHEBANG_LENGTH = 512 if sys.platform == "darwin" else 128
+
+
+def create_shebang(
+    python_exe,  # type: str
+    python_args=None,  # type: Optional[str]
+    max_shebang_length=MAX_SHEBANG_LENGTH,  # type: int
+):
+    # type: (...) -> str
+    """Return the contents of an appropriate shebang for the given Python interpreter and args.
+
+    The shebang will include the leading `#!` but will not include a trailing new line character.
+    """
+    python = "{exe} {args}".format(exe=python_exe, args=python_args) if python_args else python_exe
+    shebang = "#!{python}".format(python=python)
+
+    # N.B.: We add 1 to be conservative and account for the EOL character.
+    if len(shebang) + 1 <= max_shebang_length:
+        return shebang
+
+    # This trick relies on /bin/sh being ubiquitous and the concordance of:
+    # 1. Python: triple quoted strings plus allowance for free=floating string values in
+    #    python files.
+    # 2. sh: Any number of pairs of `'` evaluating away when followed immediately by a
+    #    command string (`''command` -> `command`) and lazy parsing allowing for invalid sh
+    #    content immediately following an exec line.
+    # The end result is a file that is both a valid sh script with a short shebang and a
+    # valid Python program.
+    return (
+        dedent(
+            """\
+            #!/bin/sh
+            # N.B.: This python script executes via a /bin/sh re-exec as a hack to work around a
+            # potential maximum shebang length of {max_shebang_length} bytes on this system which
+            # the python interpreter `exec`ed below would violate.
+            ''''exec {python} "$0" "$@"
+            '''
+            """
+        )
+        .format(max_shebang_length=max_shebang_length, python=python)
+        .strip()
+    )

--- a/pex/pep_376.py
+++ b/pex/pep_376.py
@@ -524,43 +524,6 @@ class Record(object):
         return None
 
     @classmethod
-    def from_pex_prefix_install(
-        cls,
-        install_dir,  # type: str
-        project_name,  # type: str
-        version,  # type: str
-    ):
-        # type: (...) -> Record
-        metadata_files = MetadataType.DIST_INFO.load_metadata(
-            install_dir, project_name=ProjectName(project_name)
-        )
-        if not metadata_files:
-            raise RecordNotFoundError(
-                "Could not find project metadata for {project_name} {version} under "
-                "{install_dir}".format(
-                    project_name=project_name, version=version, install_dir=install_dir
-                )
-            )
-        record_relpath = metadata_files.metadata_file_rel_path("RECORD")
-        if not record_relpath:
-            raise RecordNotFoundError(
-                "Could not find the installation RECORD for {project_name} {version} under "
-                "{location}".format(
-                    project_name=project_name,
-                    version=version,
-                    location=metadata_files.metadata.location,
-                )
-            )
-
-        return cls(
-            project_name=project_name,
-            version=version,
-            prefix_dir=install_dir,
-            rel_base_dir="",
-            relative_path=record_relpath,
-        )
-
-    @classmethod
     def from_pip_prefix_install(
         cls,
         prefix_dir,  # type: str

--- a/pex/pep_376.py
+++ b/pex/pep_376.py
@@ -251,25 +251,17 @@ class InstalledWheel(object):
         installed_files,  # type: Iterable[InstalledFile]
     ):
         # type: (...) -> None
-
-        # The RECORD is a csv file with the path to each installed file in the 1st column.
-        # See: https://www.python.org/dev/peps/pep-0376/#record
-        with safe_open(os.path.join(dst, self.record_relpath), "w") as fp:
-            csv_writer = cast(
-                "CSVWriter",
-                csv.writer(fp, delimiter=",", quotechar='"', lineterminator="\n"),
-            )
-            for installed_file in sorted(installed_files, key=lambda installed: installed.path):
-                csv_writer.writerow(
-                    attr.astuple(
-                        # The RECORD entry should never include hash or size; so we replace any such
-                        # entry with an un-hashed and un-sized one.
-                        InstalledFile(self.record_relpath, hash=None, size=None)
-                        if installed_file.path == self.record_relpath
-                        else installed_file,
-                        recurse=False,
-                    )
-                )
+        Record.write(
+            dst=os.path.join(dst, self.record_relpath),
+            installed_files=[
+                # The RECORD entry should never include hash or size; so we replace any such entry
+                # with an un-hashed and un-sized one.
+                InstalledFile(self.record_relpath, hash=None, size=None)
+                if installed_file.path == self.record_relpath
+                else installed_file
+                for installed_file in installed_files
+            ],
+        )
 
     def reinstall_flat(
         self,

--- a/pex/pep_427.py
+++ b/pex/pep_427.py
@@ -218,7 +218,7 @@ def install_wheel(
                     )
                 entry_path = os.path.join(data_path, entry)
                 copied = [dst for _, dst in iter_copytree(entry_path, dest_dir)]
-                if "scripts" == entry:
+                if copied and "scripts" == entry:
                     for script in copied:
                         chmod_plus_x(script)
                     if interpreter:

--- a/pex/pep_427.py
+++ b/pex/pep_427.py
@@ -1,0 +1,310 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, print_function
+
+import itertools
+import json
+import os.path
+import re
+import shutil
+import subprocess
+import sys
+from os.path import commonprefix
+from textwrap import dedent
+
+from pex import pex_warnings
+from pex.common import chmod_plus_x, is_pyc_file, open_zip, safe_open, touch
+from pex.compatibility import urlparse
+from pex.dist_metadata import (
+    DistMetadata,
+    Distribution,
+    MetadataFiles,
+    MetadataType,
+    ProjectNameAndVersion,
+    load_metadata,
+    parse_message,
+)
+from pex.interpreter import PythonInterpreter
+from pex.pep_376 import InstalledFile, InstalledWheel, Record
+from pex.pep_503 import ProjectName
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Iterable, List, Optional, Text
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class InstallPaths(object):
+
+    CHROOT_STASH = ".prefix"
+
+    @classmethod
+    def chroot(
+        cls,
+        destination,  # type: str
+        project_name,  # type: ProjectName
+    ):
+        # type: (...) -> InstallPaths
+        base = os.path.join(destination, cls.CHROOT_STASH)
+        return InstallPaths(
+            purelib=destination,
+            platlib=destination,
+            headers=os.path.join(base, "include", "site", "pythonX.Y", project_name.raw),
+            scripts=os.path.join(base, "bin"),
+            data=base,
+        )
+
+    @classmethod
+    def interpreter(cls, interpreter):
+        # type: (PythonInterpreter) -> InstallPaths
+        sysconfig_paths = interpreter.identity.paths
+        return InstallPaths(
+            purelib=sysconfig_paths["purelib"],
+            platlib=sysconfig_paths["platlib"],
+            headers=sysconfig_paths["include"],
+            scripts=sysconfig_paths["scripts"],
+            data=sysconfig_paths["data"],
+        )
+
+    purelib = attr.ib()  # type: str
+    platlib = attr.ib()  # type: str
+    headers = attr.ib()  # type: str
+    scripts = attr.ib()  # type: str
+    data = attr.ib()  # type: str
+
+    def __getitem__(self, item):
+        # type: (Text) -> str
+        if "purelib" == item:
+            return self.purelib
+        elif "platlib" == item:
+            return self.platlib
+        elif "headers" == item:
+            return self.headers
+        elif "scripts" == item:
+            return self.scripts
+        elif "data" == item:
+            return self.data
+        raise KeyError("Not a known install path: {item}".format(item=item))
+
+
+def install_wheel_chroot(
+    wheel_path,  # type: str
+    destination,  # type: str
+    compile=False,  # type: bool
+    requested=True,  # type: bool
+):
+    # type: (...) -> InstalledWheel
+
+    metadata_files = install_wheel(
+        wheel_path,
+        InstallPaths.chroot(
+            destination,
+            project_name=ProjectNameAndVersion.from_filename(wheel_path).canonicalized_project_name,
+        ),
+        compile=compile,
+        requested=requested,
+    )
+
+    record_relpath = metadata_files.metadata_file_rel_path("RECORD")
+    assert (
+        record_relpath is not None
+    ), "The {module}.install_wheel function should always create a RECORD.".format(module=__name__)
+
+    direct_url_file_relpath = metadata_files.metadata_file_rel_path("direct_url.json")
+    if direct_url_file_relpath:
+        direct_url_file_abspath = os.path.join(
+            metadata_files.metadata.location, direct_url_file_relpath
+        )
+        if os.path.isfile(direct_url_file_abspath):
+            with open(direct_url_file_abspath) as fp:
+                if urlparse.urlparse(json.load(fp).get("url", "")).scheme == "file":
+                    os.unlink(direct_url_file_abspath)
+
+    return InstalledWheel.save(
+        prefix_dir=destination, stash_dir=InstallPaths.CHROOT_STASH, record_relpath=record_relpath
+    )
+
+
+def install_wheel_interpreter(
+    wheel_path,  # type: str
+    interpreter,  # type: PythonInterpreter
+    compile=True,  # type: bool
+    requested=True,  # type: bool
+):
+    # type: (...) -> MetadataFiles
+
+    return install_wheel(
+        wheel_path,
+        InstallPaths.interpreter(interpreter),
+        interpreter=interpreter,
+        compile=compile,
+        requested=requested,
+    )
+
+
+def install_wheel(
+    wheel_path,  # type: str
+    install_paths,  # type: InstallPaths
+    interpreter=None,  # type: Optional[PythonInterpreter]
+    compile=False,  # type: bool
+    requested=True,  # type: bool
+):
+    # type: (...) -> MetadataFiles
+
+    # See: https://packaging.python.org/en/latest/specifications/binary-distribution-format/#installing-a-wheel-distribution-1-0-py32-none-any-whl
+    metadata_files = load_metadata(wheel_path, restrict_types_to=(MetadataType.DIST_INFO,))
+    if not metadata_files:
+        raise ValueError("Could not find any metadata in {wheel}.".format(wheel=wheel_path))
+
+    wheel_metadata_path = metadata_files.metadata_file_rel_path("WHEEL")
+    wheel_metadata = metadata_files.read("WHEEL")
+    if not wheel_metadata_path or not wheel_metadata:
+        raise ValueError("Could not find WHEEL metadata in {wheel}.".format(wheel=wheel_path))
+    wheel_metadata_dir = os.path.dirname(wheel_metadata_path)
+    if not wheel_metadata_dir.endswith(".dist-info"):
+        raise ValueError(
+            "Expected WHEEL metadata for {wheel} to be housed in a .dist-info directory, but was "
+            "found at {wheel_metadata_path}.".format(
+                wheel=wheel_path, wheel_metadata_path=wheel_metadata_path
+            )
+        )
+
+    purelib = "true" == parse_message(wheel_metadata).get("Root-Is-Purelib")
+    dest = install_paths.purelib if purelib else install_paths.platlib
+
+    record_relpath = os.path.join(wheel_metadata_dir, "RECORD")
+    record_abspath = os.path.join(dest, record_relpath)
+
+    data_rel_path = re.sub(r"\.dist-info$", ".data", wheel_metadata_dir)
+    data_path = os.path.join(dest, data_rel_path)
+
+    installed_files = []  # type: List[InstalledFile]
+
+    def record_files(
+        root_dir,  # type: Text
+        names,  # type: Iterable[Text]
+    ):
+        # type: (...) -> None
+        for name in sorted(names):
+            if is_pyc_file(name):
+                # These files are both optional to RECORD and should never be present in wheels
+                # anyway per the spec.
+                continue
+            file_abspath = os.path.join(root_dir, name)
+            if record_relpath == name:
+                # We'll generate a new RECORD below.
+                os.unlink(file_abspath)
+                continue
+            installed_files.append(
+                InstalledWheel.create_installed_file(path=file_abspath, dest_dir=dest)
+            )
+
+    with open_zip(wheel_path) as zf:
+        zf.extractall(dest)
+        # TODO(John Sirois): Consider verifying signatures.
+        # N.B.: Pip does not and its also not clear what good this does. A zip can be easily poked
+        # on a per-entry basis allowing forging a RECORD entry and its associated file. Only an
+        # outer fingerprint of the whole wheel really solves this sort of tampering.
+        record_files(
+            root_dir=dest,
+            names=[
+                name
+                for name in zf.namelist()
+                if not name.endswith("/") and data_rel_path != commonprefix((data_rel_path, name))
+            ],
+        )
+        if os.path.isdir(data_path):
+            for entry in sorted(os.listdir(data_path)):
+                entry_path = os.path.join(data_path, entry)
+                shutil.copytree(entry_path, install_paths[entry])
+                record_files(
+                    root_dir=install_paths[entry],
+                    names=[
+                        os.path.relpath(os.path.join(root, f), entry_path)
+                        for root, _, files in os.walk(entry_path)
+                        for f in files
+                    ],
+                )
+            shutil.rmtree(data_path)
+
+    if compile:
+        args = [
+            interpreter.binary if interpreter else sys.executable,
+            "-sE",
+            "-m",
+            "compileall",
+        ]  # type: List[Text]
+        py_files = [
+            os.path.join(dest, installed_file.path)
+            for installed_file in installed_files
+            if installed_file.path.endswith(".py")
+        ]
+        process = subprocess.Popen(
+            args=args + py_files, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        _, stderr = process.communicate()
+        if process.returncode != 0:
+            pex_warnings.warn(
+                "Failed to compile some .py files for install of {wheel} to {dest}:\n"
+                "{stderr}".format(wheel=wheel_path, dest=dest, stderr=stderr.decode("utf-8"))
+            )
+        for root, _, files in os.walk(commonprefix(py_files)):
+            for f in files:
+                if f.endswith(".pyc"):
+                    file = InstalledFile(path=os.path.relpath(os.path.join(root, f), dest))
+                    installed_files.append(file)
+
+    dist = Distribution(location=dest, metadata=DistMetadata.from_metadata_files(metadata_files))
+    entry_points = dist.get_entry_map()
+    for entry_point in itertools.chain.from_iterable(
+        entry_points.get(key, {}).values() for key in ("console_scripts", "gui_scripts")
+    ):
+        script_abspath = os.path.join(install_paths.scripts, entry_point.name)
+        with safe_open(script_abspath, "w") as fp:
+            fp.write(
+                dedent(
+                    """\
+                    {shebang}
+                    # -*- coding: utf-8 -*-
+                    import importlib
+                    import sys
+
+                    object_ref = "{object_ref}"
+                    modname, qualname_separator, qualname = object_ref.partition(':')
+                    entry_point = importlib.import_module(modname)
+                    if qualname_separator:
+                        for attr in qualname.split('.'):
+                            entry_point = getattr(entry_point, attr)
+
+                    if __name__ == '__main__':
+                        sys.exit(entry_point())
+                    """
+                ).format(
+                    shebang=interpreter.shebang() if interpreter else "#!python",
+                    object_ref=str(entry_point),
+                )
+            )
+        chmod_plus_x(fp.name)
+        installed_files.append(
+            InstalledWheel.create_installed_file(path=script_abspath, dest_dir=dest)
+        )
+
+    with safe_open(os.path.join(dest, wheel_metadata_dir, "INSTALLER"), "w") as fp:
+        print("pex", file=fp)
+    installed_files.append(InstalledWheel.create_installed_file(path=fp.name, dest_dir=dest))
+
+    if requested:
+        requested_path = os.path.join(dest, wheel_metadata_dir, "REQUESTED")
+        touch(requested_path)
+        installed_files.append(
+            InstalledWheel.create_installed_file(path=requested_path, dest_dir=dest)
+        )
+
+    installed_files.append(InstalledFile(path=record_relpath, hash=None, size=None))
+    Record.write(dst=record_abspath, installed_files=installed_files)
+    return metadata_files

--- a/pex/pep_427.py
+++ b/pex/pep_427.py
@@ -218,24 +218,25 @@ def install_wheel(
                     )
                 entry_path = os.path.join(data_path, entry)
                 copied = [dst for _, dst in iter_copytree(entry_path, dest_dir)]
-                if "scripts" == entry and interpreter:
-                    with closing(FileInput(files=copied, inplace=True, mode="rb")) as script_fi:
-                        for line in cast("Iterator[bytes]", script_fi):
-                            buffer = get_stdout_bytes_buffer()
-                            if script_fi.isfirstline() and re.match(br"^#!pythonw?", line):
-                                _, _, shebang_args = line.partition(b" ")
-                                buffer.write(
-                                    "{shebang}\n".format(
-                                        shebang=interpreter.shebang(
-                                            args=shebang_args.decode("utf-8")
-                                        )
-                                    ).encode("utf-8")
-                                )
-                            else:
-                                # N.B.: These lines include the newline already.
-                                buffer.write(cast(bytes, line))
+                if "scripts" == entry:
                     for script in copied:
                         chmod_plus_x(script)
+                    if interpreter:
+                        with closing(FileInput(files=copied, inplace=True, mode="rb")) as script_fi:
+                            for line in cast("Iterator[bytes]", script_fi):
+                                buffer = get_stdout_bytes_buffer()
+                                if script_fi.isfirstline() and re.match(br"^#!pythonw?", line):
+                                    _, _, shebang_args = line.partition(b" ")
+                                    buffer.write(
+                                        "{shebang}\n".format(
+                                            shebang=interpreter.shebang(
+                                                args=shebang_args.decode("utf-8")
+                                            )
+                                        ).encode("utf-8")
+                                    )
+                                else:
+                                    # N.B.: These lines include the newline already.
+                                    buffer.write(cast(bytes, line))
 
                 record_files(
                     root_dir=dest_dir,

--- a/pex/pep_427.py
+++ b/pex/pep_427.py
@@ -51,7 +51,7 @@ class InstallPaths(object):
     ):
         # type: (...) -> InstallPaths
         base = os.path.join(destination, cls.CHROOT_STASH)
-        return InstallPaths(
+        return cls(
             purelib=destination,
             platlib=destination,
             headers=os.path.join(base, "include", "site", "pythonX.Y", project_name.raw),
@@ -63,7 +63,7 @@ class InstallPaths(object):
     def interpreter(cls, interpreter):
         # type: (PythonInterpreter) -> InstallPaths
         sysconfig_paths = interpreter.identity.paths
-        return InstallPaths(
+        return cls(
             purelib=sysconfig_paths["purelib"],
             platlib=sysconfig_paths["platlib"],
             headers=sysconfig_paths["include"],

--- a/pex/pip/installation.py
+++ b/pex/pip/installation.py
@@ -83,7 +83,9 @@ def _vendored_installation(interpreter=None):
 
     return _pip_installation(
         version=PipVersion.VENDORED,
-        iter_distribution_locations=lambda: third_party.expose(("pip", "setuptools", "wheel")),
+        iter_distribution_locations=lambda: third_party.expose(
+            ("pip", "setuptools", "wheel"), interpreter=interpreter
+        ),
         interpreter=interpreter,
     )
 

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -177,7 +177,7 @@ class VendorImporter(object):
             for spec in vendor.iter_vendor_specs(
                 # N.B.: The VendorImporter should only see the versions of vendored projects that
                 # support the current Python interpreter.
-                filter_requires_python=True
+                filter_requires_python=sys.version_info[:2]
             )
         )
 
@@ -280,7 +280,7 @@ class VendorImporter(object):
 
         def iter_available():
             yield "pex", root  # The pex distribution itself is trivially available to expose.
-            for spec in vendor.iter_vendor_specs(interpreter=interpreter):
+            for spec in vendor.iter_vendor_specs(filter_requires_python=interpreter):
                 yield spec.key, spec.relpath
 
         path_by_key = OrderedDict(
@@ -473,7 +473,7 @@ def isolated(interpreter=None):
         # PEX_ROOT or built PEXs.
         vendor_lockfiles = tuple(
             os.path.join(os.path.relpath(vendor_spec.relpath, module), "constraints.txt")
-            for vendor_spec in vendor.iter_vendor_specs(interpreter=interpreter)
+            for vendor_spec in vendor.iter_vendor_specs(filter_requires_python=interpreter)
         )
 
         pex_zip_paths = None  # type: Optional[Tuple[str, str]]

--- a/pex/vendor/__init__.py
+++ b/pex/vendor/__init__.py
@@ -16,6 +16,8 @@ from pex.typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Iterable, Iterator, Optional, Sequence, Set, Text, Tuple
 
+    from pex.interpreter import PythonInterpreter
+
 _PACKAGE_COMPONENTS = __name__.split(".")
 
 
@@ -156,8 +158,11 @@ class VendorSpec(
             touch(os.path.join(self.ROOT, *relpath))
 
 
-def iter_vendor_specs(filter_requires_python=False):
-    # type: (bool) -> Iterator[VendorSpec]
+def iter_vendor_specs(
+    filter_requires_python=False,  # type: bool
+    interpreter=None,  # type: Optional[PythonInterpreter]
+):
+    # type: (...) -> Iterator[VendorSpec]
     """Iterate specifications for code vendored by pex.
 
     :return: An iterator over specs of all vendored code.
@@ -175,18 +180,22 @@ def iter_vendor_specs(filter_requires_python=False):
 
     # We use this via pex.third_party at runtime to check for compatible wheel tags and at build
     # time to implement resolving distributions from a PEX repository.
-    if not filter_requires_python or sys.version_info[:2] < (3, 6):
+    # TODO(John Sirois): XXX: filter_requires_python = False + interpreter non None is a bit
+    #  contradictory.
+    filter_requires_python = filter_requires_python or interpreter is not None
+    python_major_minor = interpreter.version[:2] if interpreter else sys.version_info[:2]
+    if not filter_requires_python or python_major_minor < (3, 6):
         # N.B.: The pyparsing constraint is needed for 2.7 support.
         yield VendorSpec.pinned(
             "packaging", "20.9", import_path="packaging_20_9", constraints=("pyparsing<3",)
         )
-    if not filter_requires_python or sys.version_info[:2] == (3, 6):
+    if not filter_requires_python or python_major_minor == (3, 6):
         # N.B.: The pyparsing constraint is needed because our import re-writer (RedBaron) chokes on
         # newer versions.
         yield VendorSpec.pinned(
             "packaging", "21.3", import_path="packaging_21_3", constraints=("pyparsing<3",)
         )
-    if not filter_requires_python or sys.version_info[:2] >= (3, 7):
+    if not filter_requires_python or python_major_minor >= (3, 7):
         yield VendorSpec.pinned("packaging", "23.1", import_path="packaging_23_1")
 
     # We use toml to read pyproject.toml when building sdists from local source projects.

--- a/pex/vendor/__init__.py
+++ b/pex/vendor/__init__.py
@@ -14,7 +14,7 @@ from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Iterable, Iterator, Optional, Sequence, Set, Text, Tuple
+    from typing import Iterable, Iterator, Optional, Sequence, Set, Text, Tuple, Union
 
     from pex.interpreter import PythonInterpreter
 
@@ -158,15 +158,22 @@ class VendorSpec(
             touch(os.path.join(self.ROOT, *relpath))
 
 
-def iter_vendor_specs(
-    filter_requires_python=False,  # type: bool
-    interpreter=None,  # type: Optional[PythonInterpreter]
-):
-    # type: (...) -> Iterator[VendorSpec]
+def iter_vendor_specs(filter_requires_python=None):
+    # type: (Optional[Union[Tuple[int, int], PythonInterpreter]]) -> Iterator[VendorSpec]
     """Iterate specifications for code vendored by pex.
 
+    :param filter_requires_python: An optional interpreter (or its major and minor version) to
+                                   tailor the vendor specs to.
     :return: An iterator over specs of all vendored code.
     """
+    python_major_minor = None  # type: Optional[Tuple[int, int]]
+    if filter_requires_python:
+        python_major_minor = (
+            filter_requires_python
+            if isinstance(filter_requires_python, tuple)
+            else filter_requires_python.version[:2]
+        )
+
     # We use this for a better @dataclass that is also Python2.7 and PyPy compatible.
     # N.B.: The `[testenv:typecheck]` section in `tox.ini` should have its deps list updated to
     # reflect this attrs version.
@@ -180,22 +187,18 @@ def iter_vendor_specs(
 
     # We use this via pex.third_party at runtime to check for compatible wheel tags and at build
     # time to implement resolving distributions from a PEX repository.
-    # TODO(John Sirois): XXX: filter_requires_python = False + interpreter non None is a bit
-    #  contradictory.
-    filter_requires_python = filter_requires_python or interpreter is not None
-    python_major_minor = interpreter.version[:2] if interpreter else sys.version_info[:2]
-    if not filter_requires_python or python_major_minor < (3, 6):
+    if not python_major_minor or python_major_minor < (3, 6):
         # N.B.: The pyparsing constraint is needed for 2.7 support.
         yield VendorSpec.pinned(
             "packaging", "20.9", import_path="packaging_20_9", constraints=("pyparsing<3",)
         )
-    if not filter_requires_python or python_major_minor == (3, 6):
+    if not python_major_minor or python_major_minor == (3, 6):
         # N.B.: The pyparsing constraint is needed because our import re-writer (RedBaron) chokes on
         # newer versions.
         yield VendorSpec.pinned(
             "packaging", "21.3", import_path="packaging_21_3", constraints=("pyparsing<3",)
         )
-    if not filter_requires_python or python_major_minor >= (3, 7):
+    if not python_major_minor or python_major_minor >= (3, 7):
         yield VendorSpec.pinned("packaging", "23.1", import_path="packaging_23_1")
 
     # We use toml to read pyproject.toml when building sdists from local source projects.

--- a/pex/vendor/__main__.py
+++ b/pex/vendor/__main__.py
@@ -358,7 +358,7 @@ def vendorize(interpreter, root_dir, vendor_specs, prefix, update):
         dist = dist_by_vendor_spec[vendor_spec]
 
         # Finally, let Record fixup the chroot to its final importable form.
-        record = Record.from_prefix_install(
+        record = Record.from_pip_prefix_install(
             prefix_dir=vendor_spec.target_dir,
             project_name=dist.project_name,
             version=dist.version,

--- a/pex/venv/virtualenv.py
+++ b/pex/venv/virtualenv.py
@@ -19,7 +19,7 @@ from pex.compatibility import commonpath, get_stdout_bytes_buffer
 from pex.dist_metadata import Distribution, find_distributions
 from pex.executor import Executor
 from pex.fetcher import URLFetcher
-from pex.interpreter import PythonInterpreter, PyVenvCfg
+from pex.interpreter import PythonInterpreter, PyVenvCfg, create_shebang
 from pex.orderedset import OrderedSet
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING, cast
@@ -388,12 +388,10 @@ class Virtualenv(object):
                 for line in fi:
                     buffer = get_stdout_bytes_buffer()
                     if fi.isfirstline():
-                        shebang = [python or self._interpreter.binary]
-                        if python_args:
-                            shebang.append(python_args)
-                        buffer.write(
-                            "#!{shebang}\n".format(shebang=" ".join(shebang)).encode("utf-8")
+                        shebang = create_shebang(
+                            python_exe=python or self._interpreter.binary, python_args=python_args
                         )
+                        buffer.write("{shebang}\n".format(shebang=shebang).encode("utf-8"))
                         yield fi.filename()
                     else:
                         # N.B.: These lines include the newline already.

--- a/tests/integration/test_pep_427.py
+++ b/tests/integration/test_pep_427.py
@@ -1,0 +1,45 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+import subprocess
+from glob import glob
+
+from pex.common import is_exe
+from pex.pep_427 import install_wheel_interpreter
+from pex.pip.installation import get_pip
+from pex.typing import TYPE_CHECKING
+from pex.venv.virtualenv import Virtualenv
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_install_wheel_interpreter(tmpdir):
+    # type: (Any) -> None
+
+    venv_dir = os.path.join(str(tmpdir), "venv")
+    venv = Virtualenv.create(venv_dir)
+    cowsay_script = venv.bin_path("cowsay")
+    assert not os.path.exists(cowsay_script)
+
+    download_dir = os.path.join(str(tmpdir), "downloads")
+    get_pip().spawn_download_distributions(
+        download_dir=download_dir, requirements=["cowsay==5.0"]
+    ).wait()
+
+    wheel_dir = os.path.join(str(tmpdir), "wheels")
+    get_pip().spawn_build_wheels(
+        distributions=glob(os.path.join(download_dir, "*.tar.gz")), wheel_dir=wheel_dir
+    ).wait()
+    wheels = glob(os.path.join(wheel_dir, "*.whl"))
+    assert 1 == len(wheels)
+    cowsay_wheel = wheels[0]
+
+    install_wheel_interpreter(cowsay_wheel, interpreter=venv.interpreter)
+    assert is_exe(cowsay_script)
+    assert b"5.0\n" == subprocess.check_output(args=[cowsay_script, "--version"])
+
+    pip = venv.install_pip()
+    subprocess.check_call(args=[pip, "uninstall", "--yes", "cowsay"])
+    assert not os.path.exists(cowsay_script)

--- a/tests/integration/test_pep_427.py
+++ b/tests/integration/test_pep_427.py
@@ -12,7 +12,7 @@ from pex.pep_427 import install_wheel_interpreter
 from pex.pip.installation import get_pip
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import Virtualenv
-from testing import WheelBuilder
+from testing import WheelBuilder, make_env
 
 if TYPE_CHECKING:
     from typing import Any
@@ -103,7 +103,11 @@ def test_install_scripts(tmpdir):
     assert is_exe(script)
 
     process = subprocess.Popen(
-        args=[script], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.PIPE
+        args=[script],
+        env=make_env(TERM=os.environ.get("TERM", "xterm")),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        stdin=subprocess.PIPE,
     )
     output, _ = process.communicate()
     assert re.match(

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -571,7 +571,7 @@ def test_create_shebang(tmpdir):
                 )
             )
         chmod_plus_x(fp.name)
-        result = json.loads(subprocess.check_output(args=[fp.name] + list(extra_args)))
+        result = json.loads(subprocess.check_output(args=[fp.name] + list(extra_args)).decode("utf-8"))
         assert [fp.name] + list(extra_args) == result["argv"]
         return cast(str, result["shebang"])
 

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -571,7 +571,9 @@ def test_create_shebang(tmpdir):
                 )
             )
         chmod_plus_x(fp.name)
-        result = json.loads(subprocess.check_output(args=[fp.name] + list(extra_args)).decode("utf-8"))
+        result = json.loads(
+            subprocess.check_output(args=[fp.name] + list(extra_args)).decode("utf-8")
+        )
         assert [fp.name] + list(extra_args) == result["argv"]
         return cast(str, result["shebang"])
 

--- a/tests/tools/commands/test_repository.py
+++ b/tests/tools/commands/test_repository.py
@@ -257,5 +257,5 @@ def test_extract_lifecycle(pex, pex_tools_env, tmpdir):
     assert -1 * int(signal.SIGTERM) == find_links_server.wait()
 
     expected_output = b"Fetching from https://example.com ...\n"
-    assert expected_output == subprocess.check_output(args=[example_sdist_pex])
-    assert expected_output == subprocess.check_output(args=[example_console_script])
+    assert expected_output in subprocess.check_output(args=[example_sdist_pex])
+    assert expected_output in subprocess.check_output(args=[example_console_script])

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,9 @@ passenv =
     USERNAME
     # Needed for tests of git+ssh://...
     SSH_AUTH_SOCK
+    # Needed for interactive tests.
+    TERM
+    TERMINFO
 setenv =
     pip20: _PEX_PIP_VERSION=20.3.4-patched
     pip22_2: _PEX_PIP_VERSION=22.2.2

--- a/tox.ini
+++ b/tox.ini
@@ -47,9 +47,6 @@ passenv =
     USERNAME
     # Needed for tests of git+ssh://...
     SSH_AUTH_SOCK
-    # Needed for interactive tests.
-    TERM
-    TERMINFO
 setenv =
     pip20: _PEX_PIP_VERSION=20.3.4-patched
     pip22_2: _PEX_PIP_VERSION=22.2.2


### PR DESCRIPTION
This sets the stage for doing runtime installation of wheels without
needing to ship a copy of Pip in every PEX file. To help prove the
robustness, convert the current build time installation of wheel chroots
to this mechanism.

Work towards #2292