### PR TITLE
Update Python versions.

### DIFF
--- a/docker/base/install_pythons.sh
+++ b/docker/base/install_pythons.sh
@@ -7,7 +7,7 @@ export PYENV_ROOT=/pyenv
 # N.B.: The 1st listed version will supply the default `python` on the PATH; otherwise order does
 # not matter.
 PYENV_VERSIONS=(
-  3.11.6
+  3.11.7
   2.7.18
   3.5.10
   3.6.15
@@ -15,7 +15,7 @@ PYENV_VERSIONS=(
   3.8.18
   3.9.18
   3.10.13
-  3.12.0
+  3.12.1
   pypy2.7-7.3.13
   pypy3.5-7.0.0
   pypy3.6-7.3.3

--- a/pex/interpreter_constraints.py
+++ b/pex/interpreter_constraints.py
@@ -321,8 +321,8 @@ COMPATIBLE_PYTHON_VERSIONS = (
     PythonVersion(Lifecycle.STABLE, 3, 8, 18),
     PythonVersion(Lifecycle.STABLE, 3, 9, 18),
     PythonVersion(Lifecycle.STABLE, 3, 10, 13),
-    PythonVersion(Lifecycle.STABLE, 3, 11, 6),
-    PythonVersion(Lifecycle.STABLE, 3, 12, 0),
+    PythonVersion(Lifecycle.STABLE, 3, 11, 7),
+    PythonVersion(Lifecycle.STABLE, 3, 12, 1),
     PythonVersion(Lifecycle.DEV, 3, 13, 0),
 )
 

--- a/tests/integration/test_issue_1537.py
+++ b/tests/integration/test_issue_1537.py
@@ -5,9 +5,6 @@ import os.path
 import shutil
 import subprocess
 
-import pytest
-
-from pex.compatibility import PY3
 from pex.typing import TYPE_CHECKING
 from testing import run_pex_command
 
@@ -15,9 +12,6 @@ if TYPE_CHECKING:
     from typing import Any, Callable, ContextManager, Tuple
 
 
-@pytest.mark.skipif(
-    condition=not PY3, reason="Test relies on a distribution that is Python 3 only."
-)
 def test_rel_cert_path(
     run_proxy,  # type: Callable[[], ContextManager[Tuple[int, str]]]
     tmpdir,  # type: Any
@@ -32,7 +26,12 @@ def test_rel_cert_path(
                 "http://localhost:{port}".format(port=port),
                 "--cert",
                 "cert",
-                "avro-python3==1.10.0",
+                # N.B.: The original issue (https://github.com/pantsbuild/pex/issues/1537) involved
+                # avro-python3 1.10.0, but that distribution utilizes setup_requires which leads to
+                # issues in CI for Mac. We use the Python 2/3 version of the same distribution
+                # instead, which had setup_requires removed in
+                # https://github.com/apache/avro/pull/818.
+                "avro==1.10.0",
                 "-o",
                 pex_file,
             ]


### PR DESCRIPTION
This picks up the 3.11.7 and 3.12.1 releases for both IC range checks
and dtox.sh hermetic builds.