### PR TITLE
Add support for `--no-pre-install-wheels` and `--max-install-jobs`.

### DIFF
--- a/docs/_ext/vars.py
+++ b/docs/_ext/vars.py
@@ -1,14 +1,24 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from docutils import nodes
+from docutils import nodes, statemachine
 from docutils.parsers.rst import Directive
 from sphinx import addnodes
+from sphinx.util.nodes import nested_parse_with_titles
 
 from pex.variables import DefaultedProperty, Variables
 
 
 class Vars(Directive):
+    def convert_rst_to_nodes(self, rst_source):
+        """Turn an RST string into a node that can be used in the document."""
+        node = nodes.Element()
+        node.document = self.state.document
+        nested_parse_with_titles(
+            state=self.state, content=statemachine.ViewList(rst_source.split("\n")), node=node
+        )
+        return node.children
+
     def run(self):
         def make_nodes(var_name):
             var_obj = Variables.__dict__[var_name]
@@ -19,13 +29,11 @@ class Vars(Directive):
             desc_str = desc_str or "NO DESC"
 
             sig = addnodes.desc()
+            sig["objtype"] = sig["desctype"] = "var"
             sig.append(nodes.target("", "", ids=[var_name]))
             sig.append(addnodes.desc_signature(var_name, var_name))
-            desc = nodes.paragraph()
-            for line in desc_str.split("\n"):
-                desc += nodes.line(line, line)
-            sig["objtype"] = sig["desctype"] = "var"
-            return sig, desc
+
+            return [sig] + self.convert_rst_to_nodes(desc_str)
 
         return [
             node for var in dir(Variables) if var.startswith("PEX_") for node in make_nodes(var)

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -848,7 +848,7 @@ def build_pex(
         )
     ):
         try:
-            dependency_manager.add_from_installed(
+            dependency_manager.add_from_resolved(
                 resolve(
                     targets=targets,
                     requirement_configuration=requirement_configuration,

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -30,6 +30,7 @@ from pex.inherit_path import InheritPath
 from pex.interpreter_constraints import InterpreterConstraints
 from pex.layout import Layout, ensure_installed
 from pex.orderedset import OrderedSet
+from pex.pep_427 import InstallableType
 from pex.pex import PEX
 from pex.pex_bootstrapper import ensure_venv
 from pex.pex_builder import Check, CopyMode, PEXBuilder
@@ -892,6 +893,11 @@ def build_pex(
                     resolver_configuration=resolver_configuration,
                     compile_pyc=options.compile,
                     ignore_errors=options.ignore_errors,
+                    result_type=(
+                        InstallableType.INSTALLED_WHEEL_CHROOT
+                        if options.pre_install_wheels
+                        else InstallableType.WHEEL_FILE
+                    ),
                 )
             )
         except Unsatisfiable as e:

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -176,7 +176,7 @@ def configure_clp_pex_options(parser):
             "always yield slightly faster PEX cold boot times; so they are used by default, but "
             "they also slow down PEX build time. As the size of dependencies grows you may find a "
             "tipping point where it makes sense to not pre-install wheels; either because the "
-            "increased cold boot time is is irrelevant to your use case or marginal compared to "
+            "increased cold boot time is irrelevant to your use case or marginal compared to "
             "other costs. Note that you may be able to use --max-install-jobs to decrease cold "
             "boot times for some PEX deployment scenarios."
         ),

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -28,7 +28,7 @@ from pex.dependency_manager import DependencyManager
 from pex.enum import Enum
 from pex.inherit_path import InheritPath
 from pex.interpreter_constraints import InterpreterConstraints
-from pex.layout import Layout, maybe_install
+from pex.layout import Layout, ensure_installed
 from pex.orderedset import OrderedSet
 from pex.pex import PEX
 from pex.pex_bootstrapper import ensure_venv
@@ -1100,9 +1100,7 @@ def seed_cache(
 
         with TRACER.timed("Seeding caches for {}".format(pex_path)):
             final_pex_path = os.path.join(
-                maybe_install(pex=pex_path, pex_root=pex_root, pex_hash=pex_hash)
-                or os.path.abspath(pex_path),
-                "__main__.py",
+                ensure_installed(pex=pex_path, pex_root=pex_root, pex_hash=pex_hash), "__main__.py"
             )
             if verbose:
                 return json.dumps(create_verbose_info(final_pex_path=final_pex_path))

--- a/pex/build_system/pep_517.py
+++ b/pex/build_system/pep_517.py
@@ -58,11 +58,11 @@ def _default_build_system(
                     selected_pip_version.wheel_requirement,
                 ]
                 resolved = tuple(
-                    installed_distribution.fingerprinted_distribution.distribution
-                    for installed_distribution in resolver.resolve_requirements(
+                    resolved_distribution.fingerprinted_distribution.distribution
+                    for resolved_distribution in resolver.resolve_requirements(
                         requirements=requires,
                         targets=Targets.from_target(target),
-                    ).installed_distributions
+                    ).distributions
                 )
             build_system = try_(
                 BuildSystem.create(

--- a/pex/build_system/pep_518.py
+++ b/pex/build_system/pep_518.py
@@ -185,8 +185,7 @@ def load_build_system(
             interpreter=target.get_interpreter(),
             requires=build_system_table.requires,
             resolved=tuple(
-                installed_distribution.distribution
-                for installed_distribution in result.installed_distributions
+                resolved_distribution.distribution for resolved_distribution in result.distributions
             ),
             build_backend=build_system_table.build_backend,
             backend_path=build_system_table.backend_path,

--- a/pex/cli/commands/venv.py
+++ b/pex/cli/commands/venv.py
@@ -265,7 +265,7 @@ class Venv(OutputMixin, JsonMixin, BuildTimeCommand):
         requirement_configuration = requirement_options.configure(self.options)
         resolver_configuration = resolver_options.configure(self.options)
         with TRACER.timed("Resolving distributions"):
-            installed = configured_resolve.resolve(
+            resolved = configured_resolve.resolve(
                 targets=targets,
                 requirement_configuration=requirement_configuration,
                 resolver_configuration=resolver_configuration,
@@ -280,16 +280,16 @@ class Venv(OutputMixin, JsonMixin, BuildTimeCommand):
 
         with TRACER.timed(
             "Installing {count} {wheels} in {subject} at {dest_dir}".format(
-                count=len(installed.installed_distributions),
-                wheels=pluralize(installed.installed_distributions, "wheel"),
+                count=len(resolved.distributions),
+                wheels=pluralize(resolved.distributions, "wheel"),
                 subject=subject,
                 dest_dir=dest_dir,
             )
         ):
             hermetic_scripts = not update and installer_configuration.hermetic_scripts
             distributions = tuple(
-                installed_distribution.distribution
-                for installed_distribution in installed.installed_distributions
+                resolved_distribution.distribution
+                for resolved_distribution in resolved.distributions
             )
             provenance = (
                 Provenance.create(venv=venv)

--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -160,7 +160,8 @@ if PY3:
         def cpu_count():
             # type: () -> Optional[int]
             # The set of CPUs accessible to the current process (pid 0).
-            cpu_set = os.sched_getaffinity(0)
+            # N.B.: MyPy does not track the hasattr guard above under interpreters without the attr.
+            cpu_set = os.sched_getaffinity(0)  # type: ignore[attr-defined]
             return len(cpu_set)
 
 else:

--- a/pex/dependency_manager.py
+++ b/pex/dependency_manager.py
@@ -14,7 +14,7 @@ from pex.orderedset import OrderedSet
 from pex.pep_503 import ProjectName
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
-from pex.resolve.resolvers import Installed
+from pex.resolve.resolvers import ResolveResult
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 
@@ -42,12 +42,12 @@ class DependencyManager(object):
 
         return pex_info
 
-    def add_from_installed(self, installed):
-        # type: (Installed) -> None
+    def add_from_resolved(self, resolved):
+        # type: (ResolveResult) -> None
 
-        for installed_dist in installed.installed_distributions:
-            self._requirements.update(installed_dist.direct_requirements)
-            self._distributions.add(installed_dist.fingerprinted_distribution)
+        for resolved_dist in resolved.distributions:
+            self._requirements.update(resolved_dist.direct_requirements)
+            self._distributions.add(resolved_dist.fingerprinted_distribution)
 
     def configure(
         self,

--- a/pex/dist_metadata.py
+++ b/pex/dist_metadata.py
@@ -785,6 +785,24 @@ def _realpath(path):
     return os.path.realpath(path)
 
 
+class DistributionType(Enum["DistributionType.Value"]):
+    class Value(Enum.Value):
+        pass
+
+    WHEEL = Value("whl")
+    SDIST = Value("sdist")
+    INSTALLED = Value("installed")
+
+    @classmethod
+    def of(cls, location):
+        # type: (Text) -> DistributionType.Value
+        if os.path.isdir(location):
+            return cls.INSTALLED
+        if location.endswith(".whl") and zipfile.is_zipfile(location):
+            return cls.WHEEL
+        return cls.SDIST
+
+
 @attr.s(frozen=True)
 class Distribution(object):
     @staticmethod
@@ -829,6 +847,11 @@ class Distribution(object):
     location = attr.ib(converter=_realpath)  # type: str
 
     metadata = attr.ib()  # type: DistMetadata
+
+    @property
+    def type(self):
+        # type: () -> DistributionType.Value
+        return DistributionType.of(self.location)
 
     @property
     def key(self):

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -658,7 +658,9 @@ class PEXEnvironment(object):
                     "Failed to resolve requirements from PEX environment @ {pex}.\n"
                     "Needed {platform} compatible dependencies for:\n"
                     "{items}".format(
-                        pex=self._pex, platform=self._target.platform.tag, items="\n".join(items)
+                        pex=self.source_pex,
+                        platform=self._target.platform.tag,
+                        items="\n".join(items),
                     )
                 )
 

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -16,7 +16,7 @@ from pex.exclude_configuration import ExcludeConfiguration
 from pex.fingerprinted_distribution import FingerprintedDistribution
 from pex.inherit_path import InheritPath
 from pex.interpreter import PythonInterpreter
-from pex.layout import maybe_install
+from pex.layout import ensure_installed
 from pex.orderedset import OrderedSet
 from pex.pep_425 import CompatibilityTags, TagRank
 from pex.pep_503 import ProjectName
@@ -239,8 +239,8 @@ class PEXEnvironment(object):
         mounted = cls._CACHE.get(key)
         if mounted is None:
             pex_root = pex_info.pex_root
-            pex = maybe_install(pex=pex, pex_root=pex_root, pex_hash=pex_hash) or pex
-            mounted = cls(pex=pex, pex_info=pex_info, target=target)
+            installed_pex = ensure_installed(pex=pex, pex_root=pex_root, pex_hash=pex_hash)
+            mounted = cls(pex=installed_pex, pex_info=pex_info, target=target)
             cls._CACHE[key] = mounted
         return mounted
 

--- a/pex/layout.py
+++ b/pex/layout.py
@@ -306,7 +306,11 @@ def _ensure_distributions_installed_parallel(
             pass
 
 
-AVERAGE_DISTRIBUTION_SIZE_PARALLEL_JOB_THRESHOLD = 1 * 1024 * 1024  # ~1MB
+# This value was found via experiment on a single laptop with 16 cores and SSD storage. The
+# threshold that needs to be overcome is the startup overhead of a Python process that imports
+# enough Pex code to do the distribution install (~100ms) for each distribution in the PEX. It's
+# completely unclear this is a good value in general let alone the heuristic using it is reasonable.
+AVERAGE_DISTRIBUTION_SIZE_PARALLEL_JOB_THRESHOLD = 5 * 1024 * 1024  # ~5MB
 
 
 def _ensure_distributions_installed(

--- a/pex/layout.py
+++ b/pex/layout.py
@@ -9,14 +9,17 @@ from abc import abstractmethod
 from contextlib import contextmanager
 
 from pex.atomic_directory import atomic_directory
-from pex.common import is_script, open_zip, safe_copy, safe_mkdir
+from pex.common import is_script, open_zip, safe_copy, safe_mkdir, safe_mkdtemp
 from pex.enum import Enum
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 from pex.variables import unzip_dir
 
 if TYPE_CHECKING:
-    from typing import Iterator, Optional
+    from typing import Iterator, Optional, Tuple
+
+    from pex.pex_info import PexInfo
+
 
 BOOTSTRAP_DIR = ".bootstrap"
 DEPS_DIR = ".deps"
@@ -64,7 +67,7 @@ class Layout(Enum["Layout.Value"]):
     def identify_original(cls, pex):
         # type: (str) -> Layout.Value
         layout = cls.identify(pex)
-        if layout != Layout.LOOSE:
+        if layout is not Layout.LOOSE:
             return layout
         return cls.Value.try_load(pex) or Layout.LOOSE
 
@@ -78,6 +81,11 @@ class _Layout(object):
         # type: (...) -> None
         self._layout = layout
         self._path = os.path.normpath(path)
+
+    @property
+    def type(self):
+        # type: () -> Layout.Value
+        return self._layout
 
     @property
     def path(self):
@@ -98,12 +106,27 @@ class _Layout(object):
         return None
 
     @abstractmethod
+    def dist_size(
+        self,
+        dist_relpath,  # type: str
+        is_wheel_file,  # type: bool
+    ):
+        # type: (...) -> int
+        raise NotImplementedError()
+
+    @abstractmethod
     def extract_dist(
         self,
         dest_dir,  # type: str
         dist_relpath,  # type: str
+        is_wheel_file,  # type: bool
     ):
         # type: (...) -> None
+        raise NotImplementedError()
+
+    @abstractmethod
+    def wheel_file_path(self, dist_relpath):
+        # type: (str) -> str
         raise NotImplementedError()
 
     @abstractmethod
@@ -126,18 +149,243 @@ class _Layout(object):
         self._layout.record(dest_dir)
 
 
-def _install(
+def _ensure_distributions_installed_serial(
+    layout,  # type: _Layout
+    pex_info,  # type: PexInfo
+    work_dir,  # type: str
+    install_to,  # type: str
+):
+    # type: (...) -> None
+
+    deps_are_wheel_files = pex_info.deps_are_wheel_files
+    install_cache = pex_info.install_cache
+
+    for location, sha in pex_info.distributions.items():
+        spread_dest = os.path.join(install_cache, sha, location)
+        dist_relpath = os.path.join(DEPS_DIR, location)
+        source = None if deps_are_wheel_files else layout.dist_strip_prefix(location)
+        extracting_message = (
+            "Installing wheel file {dist_relpath}".format(dist_relpath=dist_relpath)
+            if deps_are_wheel_files
+            else "Extracting {layout_type} distribution {dist_relpath}".format(
+                layout_type=layout.type, dist_relpath=dist_relpath
+            )
+        )
+        symlink_src = os.path.relpath(
+            spread_dest,
+            os.path.join(install_to, os.path.dirname(dist_relpath)),
+        )
+        symlink_dest = os.path.join(work_dir, dist_relpath)
+
+        with atomic_directory(spread_dest, source=source) as spread_chroot:
+            if not spread_chroot.is_finalized():
+                with TRACER.timed(extracting_message):
+                    layout.extract_dist(
+                        dest_dir=spread_chroot.work_dir,
+                        dist_relpath=dist_relpath,
+                        is_wheel_file=deps_are_wheel_files,
+                    )
+
+        safe_mkdir(os.path.dirname(symlink_dest))
+        os.symlink(symlink_src, symlink_dest)
+
+
+def _ensure_distributions_installed_parallel(
+    layout,  # type: _Layout
+    pex_info,  # type: PexInfo
+    work_dir,  # type: str
+    install_to,  # type: str
+    max_jobs,  # type: int
+):
+    # type: (...) -> None
+
+    from textwrap import dedent
+
+    from pex.interpreter import spawn_python_job
+    from pex.jobs import SpawnedJob, execute_parallel
+
+    deps_are_wheel_files = pex_info.deps_are_wheel_files
+    install_cache = pex_info.install_cache
+
+    def install_distribution(item):
+        # type: (Tuple[str, str]) -> SpawnedJob[None]
+
+        location, sha = item
+        spread_dest = os.path.join(install_cache, sha, location)
+        dist_relpath = os.path.join(DEPS_DIR, location)
+        source = None if deps_are_wheel_files else layout.dist_strip_prefix(location)
+        extracting_message = (
+            "Installing wheel file {dist_relpath}".format(dist_relpath=dist_relpath)
+            if deps_are_wheel_files
+            else "Extracting {layout_type} distribution {dist_relpath}".format(
+                layout_type=layout.type, dist_relpath=dist_relpath
+            )
+        )
+        symlink_src = os.path.relpath(
+            spread_dest,
+            os.path.join(install_to, os.path.dirname(dist_relpath)),
+        )
+        symlink_dest = os.path.join(work_dir, dist_relpath)
+
+        return SpawnedJob.wait(
+            job=spawn_python_job(
+                args=[
+                    "-c",
+                    dedent(
+                        """\
+                        import os
+
+                        from pex.atomic_directory import atomic_directory
+                        from pex.common import safe_mkdir
+                        from pex.layout import _identify_layout
+                        from pex.tracer import TRACER
+
+
+                        with _identify_layout({pex!r}) as layout, atomic_directory(
+                            {spread_dest!r}, source={source!r}
+                        ) as spread_chroot:
+                            if not spread_chroot.is_finalized():
+                                with TRACER.timed({extracting_msg!r}):
+                                    layout.extract_dist(
+                                        dest_dir=spread_chroot.work_dir,
+                                        dist_relpath={dist_relpath!r},
+                                        is_wheel_file={is_wheel_file!r}
+                                    )
+
+                        symlink_dest = {symlink_dest!r}
+                        safe_mkdir(os.path.dirname(symlink_dest))
+                        os.symlink({symlink_src!r}, symlink_dest)
+                        """
+                    ).format(
+                        pex=layout.path,
+                        spread_dest=spread_dest,
+                        source=source,
+                        extracting_msg=extracting_message,
+                        dist_relpath=dist_relpath,
+                        is_wheel_file=deps_are_wheel_files,
+                        symlink_src=symlink_src,
+                        symlink_dest=symlink_dest,
+                    ),
+                ],
+                expose=["pex"],
+            ),
+            result=None,
+        )
+
+    # Assuming that extract / install time scales with distribution size, we ensure no job slot is
+    # so unlucky as to get all the biggest jobs and thus become an un-necessarily long pole by
+    # sorting based on distribution size. Some examples to illustrate the effect using 6 input
+    # distributions and 2 job slots:
+    #
+    # 1.) Random worst case ordering:
+    #         [9, 1, 1, 1, 1, 10] -> slot1[9] slot2[1, 1, 1, 1, 10]: 14 long pole
+    #     Sorted becomes:
+    #         [10, 9, 1, 1, 1, 1] -> slot1[10, 1, 1] slot2[9, 1, 1]: 12 long pole
+    # 2.) Random worst case ordering:
+    #         [6, 4, 3, 10, 1, 1] -> slot1[6, 10] slot2[4, 3, 1, 1]: 16 long pole
+    #     Sorted becomes:
+    #         [10, 6, 4, 3, 1, 1] -> slot1[10, 3] slot2[6, 4, 1, 1]: 13 long pole
+    #
+    # TODO(John Sirois): Consider having execute_parallel take an optional costing function and
+    #  move this sorting logic and explanation centrally there.
+    inputs = sorted(
+        (item for item in pex_info.distributions.items()),
+        key=lambda item: layout.dist_size(
+            os.path.join(DEPS_DIR, item[0]), is_wheel_file=deps_are_wheel_files
+        ),
+        reverse=True,
+    )
+    with TRACER.timed(
+        "Using a maximum of {max_jobs} parallel jobs to install {count} distributions".format(
+            max_jobs="<auto>" if max_jobs == 0 else max_jobs, count=len(pex_info.distributions)
+        )
+    ):
+        for _ in execute_parallel(
+            inputs=inputs, spawn_func=install_distribution, max_jobs=max_jobs
+        ):
+            pass
+
+
+AVERAGE_DISTRIBUTION_SIZE_PARALLEL_JOB_THRESHOLD = 1 * 1024 * 1024  # ~1MB
+
+
+def _ensure_distributions_installed(
+    layout,  # type: _Layout
+    pex_info,  # type: PexInfo
+    work_dir,  # type: str
+    install_to,  # type: str
+):
+    # type: (...) -> None
+
+    dist_count = len(pex_info.distributions)
+    if dist_count == 0:
+        return
+
+    install_serial = dist_count == 1 or pex_info.max_install_jobs == 1
+    if not install_serial and pex_info.max_install_jobs == -1:
+        total_size = sum(
+            layout.dist_size(os.path.join(DEPS_DIR, location), pex_info.deps_are_wheel_files)
+            for location in pex_info.distributions
+        )
+        average_distribution_size = total_size // dist_count
+        install_serial = (
+            average_distribution_size < AVERAGE_DISTRIBUTION_SIZE_PARALLEL_JOB_THRESHOLD
+        )
+        if install_serial:
+            TRACER.log(
+                "Installing {count} distributions in serial based on average distribution "
+                "size of {avg_size} bytes".format(
+                    count=dist_count, avg_size=average_distribution_size
+                )
+            )
+        else:
+            TRACER.log(
+                "Installing {count} distributions in parallel based on average distribution "
+                "size of {avg_size} bytes".format(
+                    count=dist_count, avg_size=average_distribution_size
+                )
+            )
+
+    if install_serial:
+        _ensure_distributions_installed_serial(
+            layout=layout, pex_info=pex_info, work_dir=work_dir, install_to=install_to
+        )
+    else:
+        max_jobs = 0 if pex_info.max_install_jobs == -1 else pex_info.max_install_jobs
+        _ensure_distributions_installed_parallel(
+            layout=layout,
+            pex_info=pex_info,
+            work_dir=work_dir,
+            install_to=install_to,
+            max_jobs=max_jobs,
+        )
+
+
+def _ensure_installed(
     layout,  # type: _Layout
     pex_root,  # type: str
     pex_hash,  # type: str
 ):
     # type: (...) -> str
+    if layout.type is Layout.LOOSE:
+        from pex.pex_info import PexInfo
+
+        pex_info = PexInfo.from_pex(layout.path)
+        if not pex_info.distributions or not pex_info.deps_are_wheel_files:
+            # A loose PEX with no dependencies or dependencies that are pre-installed wheel chroots
+            # is in the canonical form of a PEX executable zipapp already and needs no install.
+            return layout.path
+
     with TRACER.timed("Laying out {}".format(layout)):
         pex = layout.path
         install_to = unzip_dir(pex_root=pex_root, pex_hash=pex_hash)
         with atomic_directory(install_to) as chroot:
             if not chroot.is_finalized():
-                with TRACER.timed("Installing {} to {}".format(pex, install_to)):
+                from pex.variables import ENV
+
+                with ENV.patch(PEX_ROOT=pex_root), TRACER.timed(
+                    "Installing {} to {}".format(pex, install_to)
+                ):
                     from pex.pex_info import PexInfo
 
                     pex_info = PexInfo.from_pex(pex)
@@ -164,24 +412,12 @@ def _install(
                         os.path.join(chroot.work_dir, BOOTSTRAP_DIR),
                     )
 
-                    for location, sha in pex_info.distributions.items():
-                        spread_dest = os.path.join(pex_info.install_cache, sha, location)
-                        dist_relpath = os.path.join(DEPS_DIR, location)
-                        with atomic_directory(
-                            spread_dest,
-                            source=layout.dist_strip_prefix(location),
-                        ) as spread_chroot:
-                            if not spread_chroot.is_finalized():
-                                layout.extract_dist(spread_chroot.work_dir, dist_relpath)
-                        symlink_dest = os.path.join(chroot.work_dir, dist_relpath)
-                        safe_mkdir(os.path.dirname(symlink_dest))
-                        os.symlink(
-                            os.path.relpath(
-                                spread_dest,
-                                os.path.join(install_to, os.path.dirname(dist_relpath)),
-                            ),
-                            symlink_dest,
-                        )
+                    _ensure_distributions_installed(
+                        layout=layout,
+                        pex_info=pex_info,
+                        work_dir=chroot.work_dir,
+                        install_to=install_to,
+                    )
 
                     code_dest = os.path.join(pex_info.zip_unsafe_cache, code_hash)
                     with atomic_directory(code_dest) as code_chroot:
@@ -224,14 +460,42 @@ class _ZipAppPEX(_Layout):
         # type: (str) -> Optional[str]
         return os.path.join(DEPS_DIR, dist_name)
 
+    def dist_size(
+        self,
+        dist_relpath,  # type: str
+        is_wheel_file,  # type: bool
+    ):
+        # type: (...) -> int
+        if is_wheel_file:
+            return self._zfp.getinfo(dist_relpath).file_size
+        else:
+            return sum(
+                self._zfp.getinfo(name).file_size
+                for name in self._names
+                if name.startswith(dist_relpath)
+            )
+
     def extract_dist(
         self,
         dest_dir,  # type: str
         dist_relpath,  # type: str
+        is_wheel_file,  # type: bool
     ):
-        for name in self._names:
-            if name.startswith(dist_relpath) and not name.endswith("/"):
-                self._zfp.extract(name, dest_dir)
+        # type: (...) -> None
+        if is_wheel_file:
+            from pex.pep_427 import install_wheel_chroot
+
+            install_wheel_chroot(self.wheel_file_path(dist_relpath), dest_dir)
+        else:
+            for name in self._names:
+                if name.startswith(dist_relpath) and not name.endswith("/"):
+                    self._zfp.extract(name, dest_dir)
+
+    def wheel_file_path(self, dist_relpath):
+        # type: (str) -> str
+        extract_chroot = safe_mkdtemp()
+        self._zfp.extract(dist_relpath, extract_chroot)
+        return os.path.join(extract_chroot, dist_relpath)
 
     def extract_code(self, dest_dir):
         # type: (str) -> None
@@ -263,13 +527,35 @@ class _PackedPEX(_Layout):
         with open_zip(os.path.join(self._path, BOOTSTRAP_DIR)) as zfp:
             zfp.extractall(dest_dir)
 
+    def dist_size(
+        self,
+        dist_relpath,  # type: str
+        is_wheel_file,  # type: bool
+    ):
+        # type: (...) -> int
+        return os.path.getsize(os.path.join(self._path, dist_relpath))
+
     def extract_dist(
         self,
         dest_dir,  # type: str
         dist_relpath,  # type: str
+        is_wheel_file,  # type: bool
     ):
-        with open_zip(os.path.join(self._path, dist_relpath)) as zfp:
-            zfp.extractall(dest_dir)
+        # type: (...) -> None
+        dist_path = self.wheel_file_path(dist_relpath)
+        if is_wheel_file:
+            from pex.pep_427 import install_wheel_chroot
+
+            with TRACER.timed("Installing wheel file {}".format(dist_relpath)):
+                install_wheel_chroot(dist_path, dest_dir)
+        else:
+            with TRACER.timed("Installing zipped wheel install {}".format(dist_relpath)):
+                with open_zip(dist_path) as zfp:
+                    zfp.extractall(dest_dir)
+
+    def wheel_file_path(self, dist_relpath):
+        # type: (str) -> str
+        return os.path.join(self._path, dist_relpath)
 
     def extract_code(self, dest_dir):
         # type: (str) -> None
@@ -300,9 +586,78 @@ class _PackedPEX(_Layout):
         return "Spread PEX directory {}".format(self._path)
 
 
+class _LoosePEX(_Layout):
+    def __init__(self, path):
+        super(_LoosePEX, self).__init__(Layout.LOOSE, path)
+
+    def extract_bootstrap(self, dest_dir):
+        # type: (str) -> None
+        bootstrap_dir = os.path.join(self._path, BOOTSTRAP_DIR)
+        for root, dirs, files in os.walk(bootstrap_dir):
+            rel_root = os.path.relpath(root, bootstrap_dir)
+            for d in dirs:
+                safe_mkdir(os.path.join(dest_dir, rel_root, d))
+            for f in files:
+                safe_copy(os.path.join(root, f), os.path.join(dest_dir, rel_root, f))
+
+    def dist_size(
+        self,
+        dist_relpath,  # type: str
+        is_wheel_file,  # type: bool
+    ):
+        assert (
+            is_wheel_file
+        ), "Expected loose layout install to be skipped when deps are pre-installed wheel chroots."
+        return os.path.getsize(os.path.join(self._path, dist_relpath))
+
+    def extract_dist(
+        self,
+        dest_dir,
+        dist_relpath,  # type: str
+        is_wheel_file,  # type: bool
+    ):
+        assert (
+            is_wheel_file
+        ), "Expected loose layout install to be skipped when deps are pre-installed wheel chroots."
+        from pex.pep_427 import install_wheel_chroot
+
+        with TRACER.timed("Installing wheel file {}".format(dist_relpath)):
+            install_wheel_chroot(self.wheel_file_path(dist_relpath), dest_dir)
+
+    def wheel_file_path(self, dist_relpath):
+        # type: (str) -> str
+        return os.path.join(self._path, dist_relpath)
+
+    def extract_code(self, dest_dir):
+        # type: (str) -> None
+        for root, dirs, files in os.walk(self._path):
+            rel_root = os.path.relpath(root, self._path)
+            if root == self._path:
+                dirs[:] = [d for d in dirs if d not in (DEPS_DIR, BOOTSTRAP_DIR)]
+                files[:] = [f for f in files if f not in ("__main__.py", PEX_INFO_PATH)]
+            for d in dirs:
+                safe_mkdir(os.path.join(dest_dir, rel_root, d))
+            for f in files:
+                safe_copy(
+                    os.path.join(root, f),
+                    os.path.join(dest_dir, rel_root, f),
+                )
+
+    def extract_pex_info(self, dest_dir):
+        # type: (str) -> None
+        safe_copy(os.path.join(self._path, PEX_INFO_PATH), os.path.join(dest_dir, PEX_INFO_PATH))
+
+    def extract_main(self, dest_dir):
+        # type: (str) -> None
+        safe_copy(os.path.join(self._path, "__main__.py"), os.path.join(dest_dir, "__main__.py"))
+
+    def __str__(self):
+        return "Loose PEX directory {}".format(self._path)
+
+
 @contextmanager
-def _identify_layout(pex):
-    # type: (str) -> Iterator[Optional[_Layout]]
+def identify_layout(pex):
+    # type: (str) -> Iterator[_Layout]
 
     layout = Layout.identify(pex)
     if Layout.ZIPAPP is layout:
@@ -310,23 +665,22 @@ def _identify_layout(pex):
             yield _ZipAppPEX(pex, zfp)
     elif Layout.PACKED is layout:
         yield _PackedPEX(pex)
+    elif Layout.LOOSE is layout:
+        yield _LoosePEX(pex)
     else:
-        # A loose PEX which needs no layout.
-        yield None
+        raise AssertionError("Un-handled PEX layout type: {layout}".format(layout=layout))
 
 
-def maybe_install(
+def ensure_installed(
     pex,  # type: str
     pex_root,  # type: str
     pex_hash,  # type: str
 ):
-    # type: (...) -> Optional[str]
+    # type: (...) -> str
     """Installs a zipapp or packed PEX into the pex root as a loose PEX.
 
     Returns the path of the installed PEX or `None` if the PEX needed no installation and can be
     executed directly.
     """
-    with _identify_layout(pex) as layout:
-        if layout:
-            return _install(layout, pex_root, pex_hash)
-    return None
+    with identify_layout(pex) as layout:
+        return _ensure_installed(layout, pex_root, pex_hash)

--- a/pex/layout.py
+++ b/pex/layout.py
@@ -237,11 +237,11 @@ def _ensure_distributions_installed_parallel(
 
                         from pex.atomic_directory import atomic_directory
                         from pex.common import safe_mkdir
-                        from pex.layout import _identify_layout
+                        from pex.layout import identify_layout
                         from pex.tracer import TRACER
 
 
-                        with _identify_layout({pex!r}) as layout, atomic_directory(
+                        with identify_layout({pex!r}) as layout, atomic_directory(
                             {spread_dest!r}, source={source!r}
                         ) as spread_chroot:
                             if not spread_chroot.is_finalized():

--- a/pex/pep_427.py
+++ b/pex/pep_427.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 from contextlib import closing
+from email.message import Message
 from fileinput import FileInput
 from textwrap import dedent
 
@@ -145,6 +146,70 @@ def install_wheel_interpreter(
     )
 
 
+@attr.s(frozen=True)
+class Wheel(object):
+    @classmethod
+    def load(cls, wheel_path):
+        # type: (str) -> Wheel
+
+        metadata_files = load_metadata(wheel_path, restrict_types_to=(MetadataType.DIST_INFO,))
+        if not metadata_files:
+            raise ValueError("Could not find any metadata in {wheel}.".format(wheel=wheel_path))
+
+        metadata_path = metadata_files.metadata_file_rel_path("WHEEL")
+        metadata_bytes = metadata_files.read("WHEEL")
+        if not metadata_path or not metadata_bytes:
+            raise ValueError("Could not find WHEEL metadata in {wheel}.".format(wheel=wheel_path))
+        wheel_metadata_dir = os.path.dirname(metadata_path)
+        if not wheel_metadata_dir.endswith(".dist-info"):
+            raise ValueError(
+                "Expected WHEEL metadata for {wheel} to be housed in a .dist-info directory, but was "
+                "found at {wheel_metadata_path}.".format(
+                    wheel=wheel_path, wheel_metadata_path=metadata_path
+                )
+            )
+        # Although not crisply defined, all PEPs lead to PEP-508 which restricts project names
+        # to ASCII: https://peps.python.org/pep-0508/#names. Likewise, version numbers are also
+        # restricted to ASCII: https://peps.python.org/pep-0440/. Since the `.dist-info` dir
+        # path is defined as `<project name>-<version>.dist-info` in
+        # https://peps.python.org/pep-0427/, we are safe in assuming ASCII overall for the wheel
+        # metadata dir path.
+        metadata_dir = str(wheel_metadata_dir)
+        metadata = parse_message(metadata_bytes)
+
+        data_dir = re.sub(r"\.dist-info$", ".data", metadata_dir)
+
+        return cls(
+            location=wheel_path,
+            metadata_dir=metadata_dir,
+            metadata_files=metadata_files,
+            metadata=metadata,
+            data_dir=data_dir,
+        )
+
+    location = attr.ib()  # type: str
+    metadata_dir = attr.ib()  # type: str
+    metadata_files = attr.ib()  # type: MetadataFiles
+    metadata = attr.ib()  # type: Message
+    data_dir = attr.ib()  # type: str
+
+    @property
+    def purelib(self):
+        # type: () -> bool
+        return cast(bool, "true" == self.metadata.get("Root-Is-Purelib"))
+
+    def dist_metadata(self):
+        return DistMetadata.from_metadata_files(self.metadata_files)
+
+    def metadata_path(self, *components):
+        # typ: (*str) -> str
+        return os.path.join(self.metadata_dir, *components)
+
+    def data_path(self, *components):
+        # typ: (*str) -> str
+        return os.path.join(self.data_dir, *components)
+
+
 def install_wheel(
     wheel_path,  # type: str
     install_paths,  # type: InstallPaths
@@ -155,30 +220,13 @@ def install_wheel(
     # type: (...) -> MetadataFiles
 
     # See: https://packaging.python.org/en/latest/specifications/binary-distribution-format/#installing-a-wheel-distribution-1-0-py32-none-any-whl
-    metadata_files = load_metadata(wheel_path, restrict_types_to=(MetadataType.DIST_INFO,))
-    if not metadata_files:
-        raise ValueError("Could not find any metadata in {wheel}.".format(wheel=wheel_path))
+    wheel = Wheel.load(wheel_path)
+    dest = install_paths.purelib if wheel.purelib else install_paths.platlib
 
-    wheel_metadata_path = metadata_files.metadata_file_rel_path("WHEEL")
-    wheel_metadata = metadata_files.read("WHEEL")
-    if not wheel_metadata_path or not wheel_metadata:
-        raise ValueError("Could not find WHEEL metadata in {wheel}.".format(wheel=wheel_path))
-    wheel_metadata_dir = os.path.dirname(wheel_metadata_path)
-    if not wheel_metadata_dir.endswith(".dist-info"):
-        raise ValueError(
-            "Expected WHEEL metadata for {wheel} to be housed in a .dist-info directory, but was "
-            "found at {wheel_metadata_path}.".format(
-                wheel=wheel_path, wheel_metadata_path=wheel_metadata_path
-            )
-        )
-
-    purelib = "true" == parse_message(wheel_metadata).get("Root-Is-Purelib")
-    dest = install_paths.purelib if purelib else install_paths.platlib
-
-    record_relpath = os.path.join(wheel_metadata_dir, "RECORD")
+    record_relpath = wheel.metadata_path("RECORD")
     record_abspath = os.path.join(dest, record_relpath)
 
-    data_rel_path = re.sub(r"\.dist-info$", ".data", wheel_metadata_dir)
+    data_rel_path = wheel.data_dir
     data_path = os.path.join(dest, data_rel_path)
 
     installed_files = []  # type: List[InstalledFile]
@@ -284,7 +332,7 @@ def install_wheel(
                     file = InstalledFile(path=os.path.relpath(os.path.join(root, f), dest))
                     installed_files.append(file)
 
-    dist = Distribution(location=dest, metadata=DistMetadata.from_metadata_files(metadata_files))
+    dist = Distribution(location=dest, metadata=wheel.dist_metadata())
     entry_points = dist.get_entry_map()
     for entry_point in itertools.chain.from_iterable(
         entry_points.get(key, {}).values() for key in ("console_scripts", "gui_scripts")
@@ -319,12 +367,12 @@ def install_wheel(
             InstalledWheel.create_installed_file(path=script_abspath, dest_dir=dest)
         )
 
-    with safe_open(os.path.join(dest, wheel_metadata_dir, "INSTALLER"), "w") as fp:
+    with safe_open(os.path.join(dest, wheel.metadata_path("INSTALLER")), "w") as fp:
         print("pex", file=fp)
     installed_files.append(InstalledWheel.create_installed_file(path=fp.name, dest_dir=dest))
 
     if requested:
-        requested_path = os.path.join(dest, wheel_metadata_dir, "REQUESTED")
+        requested_path = os.path.join(dest, wheel.metadata_path("REQUESTED"))
         touch(requested_path)
         installed_files.append(
             InstalledWheel.create_installed_file(path=requested_path, dest_dir=dest)
@@ -332,4 +380,4 @@ def install_wheel(
 
     installed_files.append(InstalledFile(path=record_relpath, hash=None, size=None))
     Record.write(dst=record_abspath, installed_files=installed_files)
-    return metadata_files
+    return wheel.metadata_files

--- a/pex/pep_427.py
+++ b/pex/pep_427.py
@@ -15,7 +15,7 @@ from textwrap import dedent
 
 from pex import pex_warnings
 from pex.common import chmod_plus_x, is_pyc_file, iter_copytree, open_zip, safe_open, touch
-from pex.compatibility import commonpath, get_stdout_bytes_buffer, urlparse
+from pex.compatibility import commonpath, get_stdout_bytes_buffer
 from pex.dist_metadata import (
     DistMetadata,
     Distribution,
@@ -25,6 +25,7 @@ from pex.dist_metadata import (
     load_metadata,
     parse_message,
 )
+from pex.enum import Enum
 from pex.interpreter import PythonInterpreter
 from pex.pep_376 import InstalledFile, InstalledWheel, Record
 from pex.pep_503 import ProjectName
@@ -36,6 +37,14 @@ if TYPE_CHECKING:
     import attr  # vendor:skip
 else:
     from pex.third_party import attr
+
+
+class InstallableType(Enum["InstallableType.Value"]):
+    class Value(Enum.Value):
+        pass
+
+    INSTALLED_WHEEL_CHROOT = Value("installed wheel chroot")
+    WHEEL_FILE = Value(".whl file")
 
 
 @attr.s(frozen=True)

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -132,12 +132,12 @@ def __re_exec__(argv0, *extra_launch_args):
 
 __execute__ = __name__ == "__main__"
 
-def __maybe_install_pex__(pex, pex_root, pex_hash):
-  from pex.layout import maybe_install
+def __ensure_pex_installed__(pex, pex_root, pex_hash):
+  from pex.layout import ensure_installed
   from pex.tracer import TRACER
 
-  installed_location = maybe_install(pex, pex_root, pex_hash)
-  if not __execute__ or not installed_location:
+  installed_location = ensure_installed(pex, pex_root, pex_hash)
+  if not __execute__ or pex == installed_location:
     return installed_location
 
   # N.B.: This is read upon re-exec below to point sys.argv[0] back to the original pex before
@@ -215,11 +215,9 @@ if not __installed_from__:
         pex_root=__pex_root__,
         pex_path=ENV.PEX_PATH or {pex_path!r},
       )
-    __installed_location__ = __maybe_install_pex__(
+    __entry_point__ = __ensure_pex_installed__(
       __entry_point__, pex_root=__pex_root__, pex_hash={pex_hash!r}
     )
-    if __installed_location__:
-      __entry_point__ = __installed_location__
 else:
     os.environ['PEX'] = os.path.realpath(__installed_from__)
 

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -843,7 +843,7 @@ class PEXBuilder(object):
             with TRACER.timed(
                 "{action} {count} distributions.".format(
                     action="Copying" if pex_info.deps_are_wheel_files else "Zipping",
-                    count=len(pex_info.distributions)
+                    count=len(pex_info.distributions),
                 )
             ):
                 for location, fingerprint in pex_info.distributions.items():

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -105,6 +105,7 @@ class PexInfo(object):
             "venv": Variables.PEX_VENV.strip_default(env),
             "inherit_path": inherit_path,
             "ignore_errors": Variables.PEX_IGNORE_ERRORS.strip_default(env),
+            "max_install_jobs": Variables.PEX_MAX_INSTALL_JOBS.strip_default(env),
         }
         # Filter out empty entries not explicitly set in the environment.
         return cls(info={k: v for k, v in pex_info.items() if v is not None})
@@ -502,6 +503,32 @@ class PexInfo(object):
     def bootstrap_hash(self, value):
         # type: (str) -> None
         self._pex_info["bootstrap_hash"] = value
+
+    @property
+    def deps_are_wheel_files(self):
+        # type: () -> bool
+        return self._pex_info.get("deps_are_wheel_files", False)
+
+    @deps_are_wheel_files.setter
+    def deps_are_wheel_files(self, value):
+        # type: (bool) -> None
+        self._pex_info["deps_are_wheel_files"] = value
+
+    @property
+    def max_install_jobs(self):
+        # type: () -> int
+        return self._pex_info.get("max_install_jobs", 1)
+
+    @max_install_jobs.setter
+    def max_install_jobs(self, value):
+        # type: (int) -> None
+        if value < -1:
+            raise ValueError(
+                "The value for max_install_jobs must be -1 or greater; given: {jobs}".format(
+                    jobs=value
+                )
+            )
+        self._pex_info["max_install_jobs"] = value
 
     @property
     def bootstrap(self):

--- a/pex/pip/installation.py
+++ b/pex/pip/installation.py
@@ -143,12 +143,12 @@ def _resolved_installation(
         )
 
     def resolve_distribution_locations():
-        for installed_distribution in resolver.resolve_requirements(
+        for resolved_distribution in resolver.resolve_requirements(
             requirements=version.requirements,
             targets=targets,
             pip_version=PipVersion.VENDORED,
-        ).installed_distributions:
-            yield installed_distribution.distribution.location
+        ).distributions:
+            yield resolved_distribution.distribution.location
 
     return _pip_installation(
         version=version,

--- a/pex/resolve/configured_resolve.py
+++ b/pex/resolve/configured_resolve.py
@@ -11,7 +11,7 @@ from pex.resolve.resolver_configuration import (
     LockRepositoryConfiguration,
     PexRepositoryConfiguration,
 )
-from pex.resolve.resolvers import Installed
+from pex.resolve.resolvers import ResolveResult
 from pex.resolver import resolve as resolve_via_pip
 from pex.result import try_
 from pex.targets import Targets
@@ -29,7 +29,7 @@ def resolve(
     compile_pyc=False,  # type: bool
     ignore_errors=False,  # type: bool
 ):
-    # type: (...) -> Installed
+    # type: (...) -> ResolveResult
     if isinstance(resolver_configuration, LockRepositoryConfiguration):
         lock = try_(resolver_configuration.parse_lock())
         with TRACER.timed(

--- a/pex/resolve/configured_resolve.py
+++ b/pex/resolve/configured_resolve.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import
 
+from pex.pep_427 import InstallableType
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.lock_resolver import resolve_from_lock
 from pex.resolve.pex_repository_resolver import resolve_from_pex
@@ -28,6 +29,7 @@ def resolve(
     resolver_configuration,  # type: ResolverConfiguration
     compile_pyc=False,  # type: bool
     ignore_errors=False,  # type: bool
+    result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
 ):
     # type: (...) -> ResolveResult
     if isinstance(resolver_configuration, LockRepositoryConfiguration):
@@ -59,6 +61,7 @@ def resolve(
                     max_parallel_jobs=pip_configuration.max_jobs,
                     pip_version=lock.pip_version,
                     use_pip_config=pip_configuration.use_pip_config,
+                    result_type=result_type,
                 )
             )
     elif isinstance(resolver_configuration, PexRepositoryConfiguration):
@@ -76,6 +79,7 @@ def resolve(
                 network_configuration=resolver_configuration.network_configuration,
                 transitive=resolver_configuration.transitive,
                 ignore_errors=ignore_errors,
+                result_type=result_type,
             )
     else:
         with TRACER.timed("Resolving requirements."):
@@ -103,4 +107,5 @@ def resolve(
                 pip_version=resolver_configuration.version,
                 resolver=ConfiguredResolver(pip_configuration=resolver_configuration),
                 use_pip_config=resolver_configuration.use_pip_config,
+                result_type=result_type,
             )

--- a/pex/resolve/configured_resolver.py
+++ b/pex/resolve/configured_resolver.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 
 from pex import resolver
+from pex.pep_427 import InstallableType
 from pex.pip.version import PipVersion, PipVersionValue
 from pex.resolve import lock_resolver
 from pex.resolve.lockfile.model import Lockfile
@@ -46,6 +47,7 @@ class ConfiguredResolver(Resolver):
         lock,  # type: Lockfile
         targets=Targets(),  # type: Targets
         pip_version=None,  # type: Optional[PipVersionValue]
+        result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
     ):
         # type: (...) -> ResolveResult
         return try_(
@@ -68,6 +70,7 @@ class ConfiguredResolver(Resolver):
                 max_parallel_jobs=self.pip_configuration.max_jobs,
                 pip_version=pip_version or self.pip_configuration.version,
                 use_pip_config=self.pip_configuration.use_pip_config,
+                result_type=result_type,
             )
         )
 
@@ -76,6 +79,7 @@ class ConfiguredResolver(Resolver):
         requirements,  # type: Iterable[str]
         targets=Targets(),  # type: Targets
         pip_version=None,  # type: Optional[PipVersionValue]
+        result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
     ):
         # type: (...) -> ResolveResult
         return resolver.resolve(
@@ -99,4 +103,5 @@ class ConfiguredResolver(Resolver):
             pip_version=pip_version or self.pip_configuration.version,
             resolver=self,
             use_pip_config=self.pip_configuration.use_pip_config,
+            result_type=result_type,
         )

--- a/pex/resolve/configured_resolver.py
+++ b/pex/resolve/configured_resolver.py
@@ -8,7 +8,7 @@ from pex.pip.version import PipVersion, PipVersionValue
 from pex.resolve import lock_resolver
 from pex.resolve.lockfile.model import Lockfile
 from pex.resolve.resolver_configuration import PipConfiguration, ReposConfiguration, ResolverVersion
-from pex.resolve.resolvers import Installed, Resolver
+from pex.resolve.resolvers import Resolver, ResolveResult
 from pex.result import try_
 from pex.targets import Targets
 from pex.typing import TYPE_CHECKING
@@ -47,7 +47,7 @@ class ConfiguredResolver(Resolver):
         targets=Targets(),  # type: Targets
         pip_version=None,  # type: Optional[PipVersionValue]
     ):
-        # type: (...) -> Installed
+        # type: (...) -> ResolveResult
         return try_(
             lock_resolver.resolve_from_lock(
                 targets=targets,
@@ -77,7 +77,7 @@ class ConfiguredResolver(Resolver):
         targets=Targets(),  # type: Targets
         pip_version=None,  # type: Optional[PipVersionValue]
     ):
-        # type: (...) -> Installed
+        # type: (...) -> ResolveResult
         return resolver.resolve(
             targets=targets,
             requirements=requirements,

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -20,7 +20,7 @@ from pex.pep_503 import ProjectName
 from pex.pip.local_project import digest_local_project
 from pex.pip.tool import PackageIndexConfiguration
 from pex.pip.vcs import digest_vcs_archive
-from pex.pip.version import PipVersion, PipVersionValue
+from pex.pip.version import PipVersionValue
 from pex.resolve.downloads import ArtifactDownloader
 from pex.resolve.locked_resolve import (
     DownloadableArtifact,
@@ -33,7 +33,7 @@ from pex.resolve.lockfile.model import Lockfile
 from pex.resolve.lockfile.subset import subset
 from pex.resolve.requirement_configuration import RequirementConfiguration
 from pex.resolve.resolver_configuration import ResolverVersion
-from pex.resolve.resolvers import MAX_PARALLEL_DOWNLOADS, Installed, Resolver
+from pex.resolve.resolvers import MAX_PARALLEL_DOWNLOADS, Resolver, ResolveResult
 from pex.resolver import BuildAndInstallRequest, BuildRequest, InstallRequest
 from pex.result import Error, catch, try_
 from pex.targets import Target, Targets
@@ -248,7 +248,7 @@ def resolve_from_lock(
     pip_version=None,  # type: Optional[PipVersionValue]
     use_pip_config=False,  # type: bool
 ):
-    # type: (...) -> Union[Installed, Error]
+    # type: (...) -> Union[ResolveResult, Error]
 
     subset_result = try_(
         subset(
@@ -440,7 +440,7 @@ def resolve_from_lock(
             pip_version=pip_version,
             resolver=resolver,
         )
-        installed_distributions = build_and_install_request.install_distributions(
+        distributions = build_and_install_request.install_distributions(
             # This otherwise checks that resolved distributions all meet internal requirement
             # constraints (This allows pip-legacy-resolver resolves with invalid solutions to be
             # failed post-facto by Pex at PEX build time). We've already done this via
@@ -453,4 +453,4 @@ def resolve_from_lock(
                 if isinstance(downloadable_artifact.artifact, LocalProjectArtifact)
             },
         )
-    return Installed(installed_distributions=tuple(installed_distributions))
+    return ResolveResult(distributions=tuple(distributions))

--- a/pex/resolve/pex_repository_resolver.py
+++ b/pex/resolve/pex_repository_resolver.py
@@ -11,6 +11,7 @@ from pex.dist_metadata import Requirement
 from pex.environment import PEXEnvironment
 from pex.network_configuration import NetworkConfiguration
 from pex.orderedset import OrderedSet
+from pex.pep_427 import InstallableType
 from pex.pep_503 import ProjectName
 from pex.pex_info import PexInfo
 from pex.requirements import Constraint, LocalProjectRequirement, parse_requirement_strings
@@ -32,6 +33,7 @@ def resolve_from_pex(
     network_configuration=None,  # type: Optional[NetworkConfiguration]
     transitive=True,  # type: bool
     ignore_errors=False,  # type: bool
+    result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
 ):
     # type: (...) -> ResolveResult
 
@@ -73,7 +75,7 @@ def resolve_from_pex(
     for target in targets.unique_targets():
         pex_env = PEXEnvironment.mount(pex, target=target)
         try:
-            fingerprinted_distributions = pex_env.resolve_dists(all_reqs)
+            fingerprinted_distributions = pex_env.resolve_dists(all_reqs, result_type=result_type)
         except environment.ResolveError as e:
             raise Unsatisfiable(str(e))
 
@@ -105,4 +107,4 @@ def resolve_from_pex(
                     direct_requirements=direct_requirements,
                 )
             )
-    return ResolveResult(distributions=tuple(distributions))
+    return ResolveResult(distributions=tuple(distributions), type=result_type)

--- a/pex/resolve/pex_repository_resolver.py
+++ b/pex/resolve/pex_repository_resolver.py
@@ -13,14 +13,9 @@ from pex.network_configuration import NetworkConfiguration
 from pex.orderedset import OrderedSet
 from pex.pep_503 import ProjectName
 from pex.pex_info import PexInfo
-from pex.requirements import (
-    Constraint,
-    LocalProjectRequirement,
-    parse_requirement_string,
-    parse_requirement_strings,
-)
+from pex.requirements import Constraint, LocalProjectRequirement, parse_requirement_strings
 from pex.resolve.requirement_configuration import RequirementConfiguration
-from pex.resolve.resolvers import Installed, InstalledDistribution, Unsatisfiable, Untranslatable
+from pex.resolve.resolvers import ResolvedDistribution, ResolveResult, Unsatisfiable, Untranslatable
 from pex.targets import Targets
 from pex.typing import TYPE_CHECKING
 
@@ -38,7 +33,7 @@ def resolve_from_pex(
     transitive=True,  # type: bool
     ignore_errors=False,  # type: bool
 ):
-    # type: (...) -> Installed
+    # type: (...) -> ResolveResult
 
     requirement_configuration = RequirementConfiguration(
         requirements=requirements,
@@ -74,7 +69,7 @@ def resolve_from_pex(
     all_reqs = OrderedSet(
         itertools.chain.from_iterable(direct_requirements_by_project_name.values())
     )
-    installed_distributions = OrderedSet()  # type: OrderedSet[InstalledDistribution]
+    distributions = OrderedSet()  # type: OrderedSet[ResolvedDistribution]
     for target in targets.unique_targets():
         pex_env = PEXEnvironment.mount(pex, target=target)
         try:
@@ -103,11 +98,11 @@ def resolve_from_pex(
                     )
                 )
 
-            installed_distributions.add(
-                InstalledDistribution(
+            distributions.add(
+                ResolvedDistribution(
                     target=target,
                     fingerprinted_distribution=fingerprinted_distribution,
                     direct_requirements=direct_requirements,
                 )
             )
-    return Installed(installed_distributions=tuple(installed_distributions))
+    return ResolveResult(distributions=tuple(distributions))

--- a/pex/resolve/resolvers.py
+++ b/pex/resolve/resolvers.py
@@ -7,6 +7,7 @@ from abc import abstractmethod
 
 from pex.dist_metadata import Distribution, Requirement
 from pex.fingerprinted_distribution import FingerprintedDistribution
+from pex.pep_427 import InstallableType
 from pex.pip.version import PipVersionValue
 from pex.resolve.lockfile.model import Lockfile
 from pex.sorted_tuple import SortedTuple
@@ -82,6 +83,7 @@ class ResolvedDistribution(object):
 @attr.s(frozen=True)
 class ResolveResult(object):
     distributions = attr.ib()  # type: Tuple[ResolvedDistribution, ...]
+    type = attr.ib()  # type: InstallableType.Value
 
 
 class Resolver(object):
@@ -96,6 +98,7 @@ class Resolver(object):
         lock,  # type: Lockfile
         targets=Targets(),  # type: Targets
         pip_version=None,  # type: Optional[PipVersionValue]
+        result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
     ):
         # type: (...) -> ResolveResult
         raise NotImplementedError()
@@ -105,6 +108,7 @@ class Resolver(object):
         requirements,  # type: Iterable[str]
         targets=Targets(),  # type: Targets
         pip_version=None,  # type: Optional[PipVersionValue]
+        result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
     ):
         # type: (...) -> ResolveResult
         raise NotImplementedError()

--- a/pex/resolve/resolvers.py
+++ b/pex/resolve/resolvers.py
@@ -44,11 +44,11 @@ def _sorted_requirements(requirements):
 
 
 @attr.s(frozen=True)
-class InstalledDistribution(object):
-    """A distribution target, and the installed distribution that satisfies it.
+class ResolvedDistribution(object):
+    """A distribution target, and the resolved distribution that satisfies it.
 
-    If installed distribution directly satisfies a user-specified requirement, that requirement is
-    included.
+    If the resolved distribution directly satisfies a user-specified requirement, that requirement
+    is included.
     """
 
     target = attr.ib()  # type: Target
@@ -68,11 +68,11 @@ class InstalledDistribution(object):
         return self.fingerprinted_distribution.fingerprint
 
     def with_direct_requirements(self, direct_requirements=None):
-        # type: (Optional[Iterable[Requirement]]) -> InstalledDistribution
+        # type: (Optional[Iterable[Requirement]]) -> ResolvedDistribution
         direct_requirements = _sorted_requirements(direct_requirements)
         if direct_requirements == self.direct_requirements:
             return self
-        return InstalledDistribution(
+        return ResolvedDistribution(
             self.target,
             self.fingerprinted_distribution,
             direct_requirements=direct_requirements,
@@ -80,8 +80,8 @@ class InstalledDistribution(object):
 
 
 @attr.s(frozen=True)
-class Installed(object):
-    installed_distributions = attr.ib()  # type: Tuple[InstalledDistribution, ...]
+class ResolveResult(object):
+    distributions = attr.ib()  # type: Tuple[ResolvedDistribution, ...]
 
 
 class Resolver(object):
@@ -97,7 +97,7 @@ class Resolver(object):
         targets=Targets(),  # type: Targets
         pip_version=None,  # type: Optional[PipVersionValue]
     ):
-        # type: (...) -> Installed
+        # type: (...) -> ResolveResult
         raise NotImplementedError()
 
     def resolve_requirements(
@@ -106,5 +106,5 @@ class Resolver(object):
         targets=Targets(),  # type: Targets
         pip_version=None,  # type: Optional[PipVersionValue]
     ):
-        # type: (...) -> Installed
+        # type: (...) -> ResolveResult
         raise NotImplementedError()

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -24,6 +24,7 @@ from pex.jobs import Raise, SpawnedJob, execute_parallel
 from pex.network_configuration import NetworkConfiguration
 from pex.orderedset import OrderedSet
 from pex.pep_425 import CompatibilityTags
+from pex.pep_427 import InstallableType
 from pex.pep_503 import ProjectName
 from pex.pex_info import PexInfo
 from pex.pip.download_observer import DownloadObserver
@@ -1038,6 +1039,7 @@ def resolve(
     pip_version=None,  # type: Optional[PipVersionValue]
     resolver=None,  # type: Optional[Resolver]
     use_pip_config=False,  # type: bool
+    result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
 ):
     # type: (...) -> ResolveResult
     """Resolves all distributions needed to meet requirements for multiple distribution targets.
@@ -1175,8 +1177,12 @@ def resolve(
         build_and_install_request.install_distributions(
             ignore_errors=ignore_errors, max_parallel_jobs=max_parallel_jobs
         )
+        if result_type is InstallableType.INSTALLED_WHEEL_CHROOT
+        else build_and_install_request.build_distributions(
+            ignore_errors=ignore_errors, max_parallel_jobs=max_parallel_jobs
+        )
     )
-    return ResolveResult(distributions=distributions)
+    return ResolveResult(distributions=distributions, type=result_type)
 
 
 def _download_internal(

--- a/pex/venv/installer.py
+++ b/pex/venv/installer.py
@@ -672,6 +672,7 @@ def _populate_first_party(
                     "PEX_PYTHON_PATH",
                     "PEX_VERBOSE",
                     "PEX_EMIT_WARNINGS",
+                    "PEX_MAX_INSTALL_JOBS",
                     # This is used by the vendoring system.
                     "__PEX_UNVENDORED__",
                     # These are _not_ used at runtime, but are present under testing / CI and

--- a/testing/pep_427.py
+++ b/testing/pep_427.py
@@ -1,0 +1,10 @@
+from pex.pep_427 import InstallableType
+
+
+def get_installable_type_flag(installable_type):
+    # type: (InstallableType.Value) -> str
+    return (
+        "--no-pre-install-wheels"
+        if installable_type is InstallableType.WHEEL_FILE
+        else "--pre-install-wheels"
+    )

--- a/tests/integration/cli/commands/test_issue_1667.py
+++ b/tests/integration/cli/commands/test_issue_1667.py
@@ -32,9 +32,11 @@ def test_interpreter_constraints_range_coverage(
     # type: (...) -> None
 
     # The traitlets 5.2.2 release breaks IPython.
+    # The prompt-toolkit 3.0.42 release breaks under pypy3.10.
     constraints = os.path.join(str(tmpdir), "constraints.txt")
     with open(constraints, "w") as fp:
         fp.write("traitlets<5.2.2\n")
+        fp.write("prompt-toolkit<3.0.42\n")
 
     # We lock with an unconstrained IPython requirement and we know IPython latest does not support
     # Python 3.7. If locking respects ICs it should not pick latest, but a version that supports at

--- a/tests/integration/test_issue_1879.py
+++ b/tests/integration/test_issue_1879.py
@@ -6,9 +6,11 @@ import os.path
 import pytest
 
 from pex.layout import Layout
+from pex.pep_427 import InstallableType
 from pex.pex_info import PexInfo
 from pex.typing import TYPE_CHECKING
 from testing import run_pex_command
+from testing.pep_427 import get_installable_type_flag
 
 if TYPE_CHECKING:
     from typing import Any
@@ -21,7 +23,21 @@ if TYPE_CHECKING:
 # zipapp (layout1) to loose (layout2) and "test_overwrite[packed-packed]" to indicate an overwrite
 # of the packed layout by another packed layout, etc.
 @pytest.mark.parametrize(
+    "installable_type2",
+    [
+        pytest.param(installable_type, id=installable_type.value)
+        for installable_type in InstallableType.values()
+    ],
+)
+@pytest.mark.parametrize(
     "layout2", [pytest.param(layout, id=layout.value) for layout in Layout.values()]
+)
+@pytest.mark.parametrize(
+    "installable_type1",
+    [
+        pytest.param(installable_type, id=installable_type.value)
+        for installable_type in InstallableType.values()
+    ],
 )
 @pytest.mark.parametrize(
     "layout1", [pytest.param(layout, id=layout.value) for layout in Layout.values()]
@@ -29,16 +45,38 @@ if TYPE_CHECKING:
 def test_overwrite(
     tmpdir,  # type: Any
     layout1,  # type: Layout.Value
+    installable_type1,  # type: InstallableType.Value
     layout2,  # type: Layout.Value
+    installable_type2,  # type: InstallableType.Value
 ):
     # type: (...) -> None
 
     pex = os.path.join(str(tmpdir), "pex")
 
-    run_pex_command(args=["-e", "one", "-o", pex, "--layout", layout1.value]).assert_success()
+    run_pex_command(
+        args=[
+            "-e",
+            "one",
+            "-o",
+            pex,
+            "--layout",
+            layout1.value,
+            get_installable_type_flag(installable_type1),
+        ]
+    ).assert_success()
     assert layout1 is Layout.identify(pex)
     assert "one" == PexInfo.from_pex(pex).entry_point
 
-    run_pex_command(args=["-e", "two", "-o", pex, "--layout", layout2.value]).assert_success()
+    run_pex_command(
+        args=[
+            "-e",
+            "two",
+            "-o",
+            pex,
+            "--layout",
+            layout2.value,
+            get_installable_type_flag(installable_type2),
+        ]
+    ).assert_success()
     assert layout2 is Layout.identify(pex)
     assert "two" == PexInfo.from_pex(pex).entry_point

--- a/tests/integration/test_issue_2023.py
+++ b/tests/integration/test_issue_2023.py
@@ -11,8 +11,10 @@ import pytest
 from colors import colors
 
 from pex.layout import Layout
+from pex.pep_427 import InstallableType
 from pex.typing import TYPE_CHECKING
 from testing import run_pex_command
+from testing.pep_427 import get_installable_type_flag
 
 if TYPE_CHECKING:
     from typing import Any, List
@@ -20,6 +22,13 @@ if TYPE_CHECKING:
 
 @pytest.mark.parametrize(
     "layout", [pytest.param(layout, id=layout.value) for layout in Layout.values()]
+)
+@pytest.mark.parametrize(
+    "installable_type",
+    [
+        pytest.param(installable_type, id=installable_type.value)
+        for installable_type in InstallableType.values()
+    ],
 )
 @pytest.mark.parametrize(
     "execution_mode_args",
@@ -32,6 +41,7 @@ if TYPE_CHECKING:
 def test_unpack_robustness(
     tmpdir,  # type: Any
     layout,  # type: Layout.Value
+    installable_type,  # type: InstallableType.Value
     execution_mode_args,  # type: List[str]
 ):
     # type: (...) -> None
@@ -58,6 +68,7 @@ def test_unpack_robustness(
             exe,
             "--layout",
             layout.value,
+            get_installable_type_flag(installable_type),
             "-o",
             pex,
         ]

--- a/tests/integration/test_layout.py
+++ b/tests/integration/test_layout.py
@@ -9,8 +9,10 @@ import pytest
 
 from pex.common import safe_open, safe_rmtree
 from pex.layout import Layout
+from pex.pep_427 import InstallableType
 from pex.typing import TYPE_CHECKING
 from testing import run_pex_command
+from testing.pep_427 import get_installable_type_flag
 
 if TYPE_CHECKING:
     from typing import Any, List
@@ -22,10 +24,18 @@ if TYPE_CHECKING:
 @pytest.mark.parametrize(
     "layout", [pytest.param(layout, id=layout.value) for layout in Layout.values()]
 )
+@pytest.mark.parametrize(
+    "installable_type",
+    [
+        pytest.param(installable_type, id=installable_type.value)
+        for installable_type in InstallableType.values()
+    ],
+)
 def test_resiliency(
     tmpdir,  # type: Any
     execution_mode_args,  # type: List[str]
     layout,  # type: Layout.Value
+    installable_type,  # type: InstallableType.Value
 ):
     # type: (...) -> None
     src_dir = os.path.join(str(tmpdir), "src")
@@ -50,6 +60,7 @@ def test_resiliency(
             pex_app,
             "--layout",
             layout.value,
+            get_installable_type_flag(installable_type),
         ]
         + execution_mode_args
     ).assert_success()

--- a/tests/integration/test_lock_resolver.py
+++ b/tests/integration/test_lock_resolver.py
@@ -539,13 +539,13 @@ def test_resolve_wheel_files(tmpdir):
     pex = os.path.join(str(tmpdir), "pex")
     exe = os.path.join(str(tmpdir), "exe")
     with open(exe, "w") as fp:
-        fp.write("import colors; print(colors.blue('Moo?'))")
+        fp.write("import colors, cowsay; cowsay.tux(colors.blue('Moo?'))")
 
     run_pex_command(
         args=["--lock", lock, "--no-pre-install-wheels", "-o", pex, "--exe", exe]
     ).assert_success()
 
-    assert colors.blue("Moo?") == subprocess.check_output(args=[pex]).decode("utf-8").strip()
+    assert colors.blue("Moo?") in subprocess.check_output(args=[pex]).decode("utf-8")
 
     pex_info = PexInfo.from_pex(pex)
     assert frozenset(

--- a/tests/integration/test_no_pre_install_wheels.py
+++ b/tests/integration/test_no_pre_install_wheels.py
@@ -1,0 +1,89 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import hashlib
+import os
+import subprocess
+import zipfile
+from textwrap import dedent
+
+import colors
+
+from pex.common import open_zip, safe_open
+from pex.dist_metadata import ProjectNameAndVersion
+from pex.pex_info import PexInfo
+from pex.typing import TYPE_CHECKING
+from pex.util import CacheHelper
+from testing import run_pex_command
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_no_pre_install_wheels(tmpdir):
+    # type: (Any) -> None
+
+    pex = os.path.join(str(tmpdir), "pex")
+    src = os.path.join(str(tmpdir), "src")
+    with safe_open(os.path.join(src, "main.py"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                import colors
+                import cowsay
+
+
+                cowsay.tux(colors.blue("Moo?"))
+                """
+            )
+        )
+
+    # N.B.: We choose ansicolors 1.1.8 since it works with all Pythons and has a universal wheel
+    # published on PyPI and cowsay 5.0 since it also works with all Pythons and only has an sdist
+    # published on PyPI. This combination ensures the resolve process can handle both building
+    # wheels (cowsay stresses this) and using pre-existing ones (ansicolors stresses this).
+    run_pex_command(
+        args=[
+            "ansicolors==1.1.8",
+            "cowsay==5.0",
+            "--no-pre-install-wheels",
+            "-o",
+            pex,
+            "-D",
+            src,
+            "-m",
+            "main",
+        ]
+    ).assert_success()
+
+    assert colors.blue("Moo?") in subprocess.check_output(args=[pex]).decode("utf-8")
+
+    pex_info = PexInfo.from_pex(pex)
+    assert frozenset(
+        (ProjectNameAndVersion("ansicolors", "1.1.8"), ProjectNameAndVersion("cowsay", "5.0"))
+    ) == frozenset(ProjectNameAndVersion.from_filename(dist) for dist in pex_info.distributions)
+
+    dist_dir = os.path.join(str(tmpdir), "dist_dir")
+    os.mkdir(dist_dir)
+    with open_zip(pex) as zfp:
+        for known_file in (
+            "__main__.py",
+            "__pex__/__init__.py",
+            "PEX-INFO",
+            ".bootstrap/pex/pex.py",
+            "main.py",
+        ):
+            assert (
+                zipfile.ZIP_DEFLATED == zfp.getinfo(known_file).compress_type
+            ), "Expected non-deps files to be stored with compression."
+
+        for location, sha in pex_info.distributions.items():
+            dist_relpath = os.path.join(pex_info.internal_cache, location)
+            info = zfp.getinfo(dist_relpath)
+            assert (
+                zipfile.ZIP_STORED == info.compress_type
+            ), "Expected raw .whl files to be stored without (re-)compression."
+
+            zfp.extract(info, dist_dir)
+            assert sha == CacheHelper.hash(
+                os.path.join(dist_dir, dist_relpath), hasher=hashlib.sha256
+            )

--- a/tests/integration/test_pex_import.py
+++ b/tests/integration/test_pex_import.py
@@ -100,12 +100,12 @@ def test_import_from_pex(
     alternate_pex_root = os.path.join(str(tmpdir), "alternate_pex_root")
     with ENV.patch(PEX_ROOT=alternate_pex_root):
         ambient_sys_path = [
-            installed_distribution.fingerprinted_distribution.distribution.location
-            for installed_distribution in resolve_from_pex(
+            resolved_distribution.fingerprinted_distribution.distribution.location
+            for resolved_distribution in resolve_from_pex(
                 targets=Targets.from_target(targets.current()),
                 pex=pex,
                 requirements=["ansicolors==1.1.8"],
-            ).installed_distributions
+            ).distributions
         ]
 
     third_party_path = execute_with_pex_on_pythonpath(

--- a/tests/integration/test_setproctitle.py
+++ b/tests/integration/test_setproctitle.py
@@ -13,9 +13,11 @@ from pex.common import safe_open
 from pex.compatibility import commonpath
 from pex.interpreter import PythonInterpreter
 from pex.layout import Layout
+from pex.pep_427 import InstallableType
 from pex.pex_info import PexInfo
 from pex.typing import TYPE_CHECKING
 from testing import IS_MAC, run_pex_command
+from testing.pep_427 import get_installable_type_flag
 
 if TYPE_CHECKING:
     from typing import Any, Text, Tuple
@@ -25,10 +27,18 @@ if TYPE_CHECKING:
 @pytest.mark.parametrize(
     "layout", [pytest.param(layout, id=layout.value) for layout in Layout.values()]
 )
+@pytest.mark.parametrize(
+    "installable_type",
+    [
+        pytest.param(installable_type, id=installable_type.value)
+        for installable_type in InstallableType.values()
+    ],
+)
 def test_setproctitle(
     tmpdir,  # type: Any
     venv,  # type: bool
     layout,  # type: Layout.Value
+    installable_type,  # type: InstallableType.Value
 ):
     # type: (...) -> None
 
@@ -59,7 +69,15 @@ def test_setproctitle(
             )
         )
 
-    build_pex_args = ["-D", src, "-m", "app", "--layout", layout.value]
+    build_pex_args = [
+        "-D",
+        src,
+        "-m",
+        "app",
+        "--layout",
+        layout.value,
+        get_installable_type_flag(installable_type),
+    ]
     if venv:
         build_pex_args.append("--venv")
 

--- a/tests/resolve/test_pex_repository_resolver.py
+++ b/tests/resolve/test_pex_repository_resolver.py
@@ -2,20 +2,22 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+import re
 from collections import defaultdict
 
 import pytest
 
 from pex.common import safe_mkdtemp
-from pex.dist_metadata import Requirement
+from pex.dist_metadata import DistributionType, Requirement
 from pex.interpreter import PythonInterpreter
+from pex.pep_427 import InstallableType
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
 from pex.platforms import Platform
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.pex_repository_resolver import resolve_from_pex
 from pex.resolve.resolver_configuration import PipConfiguration
-from pex.resolve.resolvers import Unsatisfiable
+from pex.resolve.resolvers import ResolveResult, Unsatisfiable
 from pex.resolver import resolve
 from pex.targets import Targets
 from pex.typing import TYPE_CHECKING, cast
@@ -32,9 +34,11 @@ def create_pex_repository(
     requirement_files=None,  # type: Optional[Iterable[str]]
     constraint_files=None,  # type: Optional[Iterable[str]]
     manylinux=None,  # type: Optional[str]
+    result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
 ):
     # type: (...) -> str
     pex_builder = PEXBuilder()
+    pex_builder.info.deps_are_wheel_files = result_type is InstallableType.WHEEL_FILE
     for resolved_dist in resolve(
         targets=Targets(
             interpreters=tuple(interpreters) if interpreters else (),
@@ -45,6 +49,7 @@ def create_pex_repository(
         requirement_files=requirement_files,
         constraint_files=constraint_files,
         resolver=ConfiguredResolver(PipConfiguration()),
+        result_type=result_type,
     ).distributions:
         pex_builder.add_distribution(resolved_dist.distribution)
         for direct_req in resolved_dist.direct_requirements:
@@ -101,9 +106,21 @@ def foreign_platform(
     return macosx if IS_LINUX else linux
 
 
-@pytest.fixture(scope="module")
-def pex_repository(py27, py310, foreign_platform, manylinux):
-    # type () -> str
+@pytest.fixture(
+    scope="module",
+    params=[
+        pytest.param(installable_type, id=installable_type.value)
+        for installable_type in InstallableType.values()
+    ],
+)
+def pex_repository(
+    py27,  # type: PythonInterpreter
+    py310,  # type: PythonInterpreter
+    foreign_platform,  # type: Platform
+    manylinux,  # type: Optional[str]
+    request,  # type: pytest.FixtureRequest
+):
+    # type (...) -> str
 
     constraints_file = create_constraints_file(
         # The 2.25.1 release of requests constrains urllib3 to <1.27,>=1.21.1 and picks 1.26.2 on
@@ -119,6 +136,7 @@ def pex_repository(py27, py310, foreign_platform, manylinux):
         requirements=["requests[security,socks]==2.25.1"],
         constraint_files=[constraints_file],
         manylinux=manylinux,
+        result_type=request.param,
     )
 
 
@@ -134,46 +152,96 @@ def test_resolve_from_pex(
     direct_requirements = pex_info.requirements
     assert 1 == len(direct_requirements)
 
-    result = resolve_from_pex(
-        pex=pex_repository,
-        requirements=direct_requirements,
-        targets=Targets(
-            interpreters=(py27, py310),
-            platforms=(foreign_platform,),
-            assume_manylinux=manylinux,
-        ),
-    )
+    def assert_resolve_result(
+        result,  # type: ResolveResult
+        expected_result_type,  # type: InstallableType.Value
+    ):
+        # type: (...) -> None
 
-    distribution_locations_by_key = defaultdict(set)  # type: DefaultDict[str, Set[str]]
-    for resolved_distribution in result.distributions:
-        distribution_locations_by_key[resolved_distribution.distribution.key].add(
-            resolved_distribution.distribution.location
+        assert expected_result_type is result.type
+        expected_dist_type = (
+            DistributionType.WHEEL
+            if expected_result_type is InstallableType.WHEEL_FILE
+            else DistributionType.INSTALLED
         )
 
-    assert {
-        os.path.basename(location)
-        for locations in distribution_locations_by_key.values()
-        for location in locations
-    } == set(pex_info.distributions.keys()), (
-        "Expected to resolve the same full set of distributions from the pex repository as make "
-        "it up when using the same requirements."
+        distribution_locations_by_key = defaultdict(set)  # type: DefaultDict[str, Set[str]]
+        for resolved_distribution in result.distributions:
+            assert expected_dist_type is resolved_distribution.distribution.type
+            distribution_locations_by_key[resolved_distribution.distribution.key].add(
+                resolved_distribution.distribution.location
+            )
+
+        assert {
+            os.path.basename(location)
+            for locations in distribution_locations_by_key.values()
+            for location in locations
+        } == set(pex_info.distributions.keys()), (
+            "Expected to resolve the same full set of distributions from the pex repository as make "
+            "it up when using the same requirements."
+        )
+
+        assert "requests" in distribution_locations_by_key
+        assert 1 == len(distribution_locations_by_key["requests"])
+
+        assert "pysocks" in distribution_locations_by_key
+        assert 2 == len(distribution_locations_by_key["pysocks"]), (
+            "PySocks has a non-platform-specific Python 2.7 distribution and a non-platform-specific "
+            "Python 3 distribution; so we expect to resolve two distributions - one covering "
+            "Python 2.7 and one covering local Python 3.6 and our cp36 foreign platform."
+        )
+
+        assert "cryptography" in distribution_locations_by_key
+        assert 3 == len(distribution_locations_by_key["cryptography"]), (
+            "The cryptography requirement of the security extra is platform specific; so we expect a "
+            "unique distribution to be resolved for each of the three distribution targets"
+        )
+
+    assert_resolve_result(
+        resolve_from_pex(
+            pex=pex_repository,
+            requirements=direct_requirements,
+            targets=Targets(
+                interpreters=(py27, py310),
+                platforms=(foreign_platform,),
+                assume_manylinux=manylinux,
+            ),
+        ),
+        expected_result_type=InstallableType.INSTALLED_WHEEL_CHROOT,
     )
 
-    assert "requests" in distribution_locations_by_key
-    assert 1 == len(distribution_locations_by_key["requests"])
-
-    assert "pysocks" in distribution_locations_by_key
-    assert 2 == len(distribution_locations_by_key["pysocks"]), (
-        "PySocks has a non-platform-specific Python 2.7 distribution and a non-platform-specific "
-        "Python 3 distribution; so we expect to resolve two distributions - one covering "
-        "Python 2.7 and one covering local Python 3.6 and our cp36 foreign platform."
-    )
-
-    assert "cryptography" in distribution_locations_by_key
-    assert 3 == len(distribution_locations_by_key["cryptography"]), (
-        "The cryptography requirement of the security extra is platform specific; so we expect a "
-        "unique distribution to be resolved for each of the three distribution targets"
-    )
+    if pex_info.deps_are_wheel_files:
+        assert_resolve_result(
+            resolve_from_pex(
+                pex=pex_repository,
+                requirements=direct_requirements,
+                targets=Targets(
+                    interpreters=(py27, py310),
+                    platforms=(foreign_platform,),
+                    assume_manylinux=manylinux,
+                ),
+                result_type=InstallableType.WHEEL_FILE,
+            ),
+            expected_result_type=InstallableType.WHEEL_FILE,
+        )
+    else:
+        with pytest.raises(
+            Unsatisfiable,
+            match=(
+                r"Cannot resolve \.whl files from PEX at {pex}; its dependencies are in the form "
+                r"of pre-installed wheel chroots\.".format(pex=re.escape(pex_repository))
+            ),
+        ):
+            resolve_from_pex(
+                pex=pex_repository,
+                requirements=direct_requirements,
+                targets=Targets(
+                    interpreters=(py27, py310),
+                    platforms=(foreign_platform,),
+                    assume_manylinux=manylinux,
+                ),
+                result_type=InstallableType.WHEEL_FILE,
+            )
 
 
 def test_resolve_from_pex_subset(

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -137,13 +137,13 @@ def assert_force_local_implicit_ns_packages_issues_598(
 
     def add_requirements(builder):
         # type: (PEXBuilder) -> None
-        for installed_dist in resolver.resolve(
+        for resolved_dist in resolver.resolve(
             targets=Targets(interpreters=(builder.interpreter,)),
             requirements=requirements,
             resolver=ConfiguredResolver.default(),
-        ).installed_distributions:
-            builder.add_distribution(installed_dist.distribution)
-            for direct_req in installed_dist.direct_requirements:
+        ).distributions:
+            builder.add_distribution(resolved_dist.distribution)
+            for direct_req in resolved_dist.direct_requirements:
                 builder.add_requirement(direct_req)
 
     def add_wheel(builder, content):
@@ -274,12 +274,12 @@ def test_osx_platform_intel_issue_523():
     # successfully install psutil; yield_pex_builder sets up the bad interpreter with our vendored
     # setuptools and wheel extras.
     with yield_pex_builder(interpreter=bad_interpreter()) as pb, temporary_filename() as pex_file:
-        for installed_dist in resolver.resolve(
+        for resolved_dist in resolver.resolve(
             targets=Targets(interpreters=(pb.interpreter,)),
             requirements=["psutil==5.4.3"],
             resolver=ConfiguredResolver.default(),
-        ).installed_distributions:
-            pb.add_dist_location(installed_dist.distribution.location)
+        ).distributions:
+            pb.add_dist_location(resolved_dist.distribution.location)
         pb.build(pex_file)
 
         # NB: We want PEX to find the bare bad interpreter at runtime.
@@ -342,14 +342,14 @@ def test_osx_platform_intel_issue_523():
 def test_activate_extras_issue_615():
     # type: () -> None
     with yield_pex_builder() as pb:
-        for installed_dist in resolver.resolve(
+        for resolved_dist in resolver.resolve(
             targets=Targets(interpreters=(pb.interpreter,)),
             requirements=["pex[requests]==1.6.3"],
             resolver=ConfiguredResolver.default(),
-        ).installed_distributions:
-            for direct_req in installed_dist.direct_requirements:
+        ).distributions:
+            for direct_req in resolved_dist.direct_requirements:
                 pb.add_requirement(direct_req)
-            pb.add_dist_location(installed_dist.distribution.location)
+            pb.add_dist_location(resolved_dist.distribution.location)
         pb.set_script("pex")
         pb.freeze()
         process = PEX(pb.path(), interpreter=pb.interpreter).run(
@@ -370,11 +370,11 @@ def assert_namespace_packages_warning(distribution, version, expected_warning):
     # type: (str, str, bool) -> None
     requirement = "{}=={}".format(distribution, version)
     pb = PEXBuilder()
-    for installed_dist in resolver.resolve(
+    for resolved_dist in resolver.resolve(
         requirements=[requirement],
         resolver=ConfiguredResolver.default(),
-    ).installed_distributions:
-        pb.add_dist_location(installed_dist.distribution.location)
+    ).distributions:
+        pb.add_dist_location(resolved_dist.distribution.location)
     pb.freeze()
 
     process = PEX(pb.path()).run(args=["-c", ""], blocking=False, stderr=subprocess.PIPE)

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -894,7 +894,7 @@ def test_pex_run_custom_setuptools_useable(
         requirements=[setuptools_requirement],
         resolver=ConfiguredResolver.default(),
     )
-    dists = [installed_dist.distribution for installed_dist in result.installed_distributions]
+    dists = [resolved_dist.distribution for resolved_dist in result.distributions]
     with temporary_dir() as temp_dir:
         pex = write_simple_pex(
             temp_dir,
@@ -919,7 +919,7 @@ def test_pex_run_conflicting_custom_setuptools_useable(
         requirements=[setuptools_requirement],
         resolver=ConfiguredResolver.default(),
     )
-    dists = [installed_dist.distribution for installed_dist in result.installed_distributions]
+    dists = [resolved_dist.distribution for resolved_dist in result.distributions]
     with temporary_dir() as temp_dir:
         pex = write_simple_pex(
             temp_dir,
@@ -946,7 +946,7 @@ def test_pex_run_custom_pex_useable():
         requirements=["pex=={}".format(old_pex_version), "setuptools==40.6.3"],
         resolver=ConfiguredResolver.default(),
     )
-    dists = [installed_dist.distribution for installed_dist in result.installed_distributions]
+    dists = [resolved_dist.distribution for resolved_dist in result.distributions]
     with temporary_dir() as temp_dir:
         from pex.version import __version__
 

--- a/tests/tools/commands/test_venv.py
+++ b/tests/tools/commands/test_venv.py
@@ -769,7 +769,7 @@ def test_remove(
     # type: (...) -> None
     pex_root = os.path.join(str(tmpdir), "pex_root")
 
-    def create_venv_pex():
+    def create_pex():
         # type: () -> str
         venv_pex = os.path.join(str(tmpdir), "venv.pex")
         run_pex_command(
@@ -778,6 +778,8 @@ def test_remove(
                 pex_root,
                 "--runtime-pex-root",
                 pex_root,
+                "--layout",
+                str(layout),
                 "-o",
                 venv_pex,
                 "--include-tools",
@@ -788,29 +790,31 @@ def test_remove(
     venv_dir = os.path.join(str(tmpdir), "venv_dir")
     assert not os.path.exists(venv_dir)
 
-    venv_pex = create_venv_pex()
-    subprocess.check_call(args=[venv_pex, "venv", venv_dir], env=make_env(PEX_TOOLS=True))
+    pex = create_pex()
+    subprocess.check_call(
+        args=[sys.executable, pex, "venv", venv_dir], env=make_env(PEX_TOOLS=True)
+    )
     assert os.path.exists(venv_dir)
-    assert os.path.exists(venv_pex)
+    assert os.path.exists(pex)
     assert os.path.exists(pex_root)
 
     shutil.rmtree(venv_dir)
     assert not os.path.exists(venv_dir)
 
     subprocess.check_call(
-        args=[venv_pex, "venv", "--rm", "pex", venv_dir], env=make_env(PEX_TOOLS=True)
+        args=[sys.executable, pex, "venv", "--rm", "pex", venv_dir], env=make_env(PEX_TOOLS=True)
     )
     assert os.path.exists(venv_dir)
-    assert not os.path.exists(venv_pex)
+    assert not os.path.exists(pex)
     assert os.path.exists(pex_root)
 
     shutil.rmtree(venv_dir)
     assert not os.path.exists(venv_dir)
-    venv_pex = create_venv_pex()
+    pex = create_pex()
 
     subprocess.check_call(
-        args=[venv_pex, "venv", "--rm", "all", venv_dir], env=make_env(PEX_TOOLS=True)
+        args=[sys.executable, pex, "venv", "--rm", "all", venv_dir], env=make_env(PEX_TOOLS=True)
     )
     assert os.path.exists(venv_dir)
-    assert not os.path.exists(venv_pex)
+    assert not os.path.exists(pex)
     assert not os.path.exists(pex_root)

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,8 @@ passenv =
     CPPFLAGS
     LDFLAGS
     PEX_VERBOSE
+    # Mac (Homebrew) needs these.
+    HOME
     # Windows needs these.
     PATHEXT
     USER


### PR DESCRIPTION
The `--no-pre-install-wheels` option causes built PEXes to use raw
`.whl` files. For `--layout zipapp` this means a single `.whl` file is
`STORED` per dep, and for `--layout {packed,loose}` this means the loose
`.deps/` dir contains raw `.whl` files. This speeds up all PEX builds by
avoiding pre-installing wheel deps (~unzipping into the `PEX_ROOT`) and
then, in the case of zipapp and packed layout, re-zipping. For large
dependencies the time savings can be dramatic.

Not pre-installing wheels comes with a PEX boot cold-start performance
tradeoff since installation now needs to be done at runtime. This is
generally a penalty of O(100ms), but that penalty can be erased for some
deployment scenarios with the new `--max-install-jobs` build option / 
`PEX_MAX_INSTALL_JOBS` runtime env var. By default, runtime installs are
performed serially, but this new option can be set to use multiple
parallel install processes, which can speed up cold boots for large
dependencies.

Fixes #2292