### PR TITLE
Fix 2-space indent stragglers.

### DIFF
--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -127,50 +127,50 @@ __INSTALLED_FROM__ = '__PEX_EXE__'
 
 
 def __re_exec__(argv0, *extra_launch_args):
-  os.execv(argv0, [argv0] + list(extra_launch_args) + sys.argv[1:])
+    os.execv(argv0, [argv0] + list(extra_launch_args) + sys.argv[1:])
 
 
 __execute__ = __name__ == "__main__"
 
 def __ensure_pex_installed__(pex, pex_root, pex_hash):
-  from pex.layout import ensure_installed
-  from pex.tracer import TRACER
+    from pex.layout import ensure_installed
+    from pex.tracer import TRACER
 
-  installed_location = ensure_installed(pex, pex_root, pex_hash)
-  if not __execute__ or pex == installed_location:
-    return installed_location
+    installed_location = ensure_installed(pex, pex_root, pex_hash)
+    if not __execute__ or pex == installed_location:
+        return installed_location
 
-  # N.B.: This is read upon re-exec below to point sys.argv[0] back to the original pex before
-  # unconditionally scrubbing the env var and handing off to user code.
-  os.environ[__INSTALLED_FROM__] = pex
+    # N.B.: This is read upon re-exec below to point sys.argv[0] back to the original pex before
+    # unconditionally scrubbing the env var and handing off to user code.
+    os.environ[__INSTALLED_FROM__] = pex
 
-  TRACER.log('Executing installed PEX for {{}} at {{}}'.format(pex, installed_location))
-  __re_exec__(sys.executable, installed_location)
+    TRACER.log('Executing installed PEX for {{}} at {{}}'.format(pex, installed_location))
+    __re_exec__(sys.executable, installed_location)
 
 
 def __maybe_run_venv__(pex, pex_root, pex_path):
-  from pex.common import is_exe
-  from pex.tracer import TRACER
-  from pex.variables import venv_dir
+    from pex.common import is_exe
+    from pex.tracer import TRACER
+    from pex.variables import venv_dir
 
-  venv_dir = venv_dir(
-    pex_file=pex,
-    pex_root=pex_root, 
-    pex_hash={pex_hash!r},
-    has_interpreter_constraints={has_interpreter_constraints!r},
-    pex_path=pex_path,
-  )
-  venv_pex = os.path.join(venv_dir, 'pex')
-  if not __execute__ or not is_exe(venv_pex):
-    # Code in bootstrap_pex will (re)create the venv after selecting the correct interpreter. 
-    return venv_dir
+    venv_dir = venv_dir(
+        pex_file=pex,
+        pex_root=pex_root,
+        pex_hash={pex_hash!r},
+        has_interpreter_constraints={has_interpreter_constraints!r},
+        pex_path=pex_path,
+    )
+    venv_pex = os.path.join(venv_dir, 'pex')
+    if not __execute__ or not is_exe(venv_pex):
+        # Code in bootstrap_pex will (re)create the venv after selecting the correct interpreter.
+        return venv_dir
 
-  TRACER.log('Executing venv PEX for {{}} at {{}}'.format(pex, venv_pex))
-  venv_python = os.path.join(venv_dir, 'bin', 'python')
-  if {hermetic_venv_scripts!r}:
-    __re_exec__(venv_python, '-sE', venv_pex)
-  else:
-    __re_exec__(venv_python, venv_pex)
+    TRACER.log('Executing venv PEX for {{}} at {{}}'.format(pex, venv_pex))
+    venv_python = os.path.join(venv_dir, 'bin', 'python')
+    if {hermetic_venv_scripts!r}:
+        __re_exec__(venv_python, '-sE', venv_pex)
+    else:
+        __re_exec__(venv_python, venv_pex)
 
 
 def __entry_point_from_filename__(filename):
@@ -184,19 +184,19 @@ def __entry_point_from_filename__(filename):
 
 __entry_point__ = None
 if '__file__' in locals() and __file__ is not None and os.path.exists(__file__):
-  __entry_point__ = __entry_point_from_filename__(__file__)
+    __entry_point__ = __entry_point_from_filename__(__file__)
 elif '__loader__' in locals():
-  if hasattr(__loader__, 'archive'):
-    __entry_point__ = __loader__.archive
-  elif hasattr(__loader__, 'get_filename'):
-    # The source of the loader interface has changed over the course of Python history from
-    # `pkgutil.ImpLoader` to `importlib.abc.Loader`, but the existence and semantics of
-    # `get_filename` has remained constant; so we just check for the method.
-    __entry_point__ = __entry_point_from_filename__(__loader__.get_filename())
+    if hasattr(__loader__, 'archive'):
+        __entry_point__ = __loader__.archive
+    elif hasattr(__loader__, 'get_filename'):
+        # The source of the loader interface has changed over the course of Python history from
+        # `pkgutil.ImpLoader` to `importlib.abc.Loader`, but the existence and semantics of
+        # `get_filename` has remained constant; so we just check for the method.
+        __entry_point__ = __entry_point_from_filename__(__loader__.get_filename())
 
 if __entry_point__ is None:
-  sys.stderr.write('Could not launch python executable!\\n')
-  sys.exit(2)
+    sys.stderr.write('Could not launch python executable!\\n')
+    sys.exit(2)
 
 __installed_from__ = os.environ.pop(__INSTALLED_FROM__, None)
 sys.argv[0] = __installed_from__ or sys.argv[0]
@@ -210,13 +210,13 @@ if not __installed_from__:
     from pex.variables import ENV, Variables
     __pex_root__ = Variables.PEX_ROOT.value_or(ENV, {pex_root!r})
     if not ENV.PEX_TOOLS and Variables.PEX_VENV.value_or(ENV, {is_venv!r}):
-      __venv_dir__ = __maybe_run_venv__(
-        __entry_point__,
-        pex_root=__pex_root__,
-        pex_path=ENV.PEX_PATH or {pex_path!r},
-      )
+        __venv_dir__ = __maybe_run_venv__(
+            __entry_point__,
+            pex_root=__pex_root__,
+            pex_path=ENV.PEX_PATH or {pex_path!r},
+        )
     __entry_point__ = __ensure_pex_installed__(
-      __entry_point__, pex_root=__pex_root__, pex_hash={pex_hash!r}
+        __entry_point__, pex_root=__pex_root__, pex_hash={pex_hash!r}
     )
 else:
     os.environ['PEX'] = os.path.realpath(__installed_from__)

--- a/tox.ini
+++ b/tox.ini
@@ -195,31 +195,31 @@ commands =
 description = Run Python with Pex's vendored setuptools on the sys.path.
 skip_install = true
 setenv   =
-  __PEX_UNVENDORED__ = 1
-  PYTHONPATH = {env:PYTHONPATH:}{:}{toxinidir}/pex/vendor/_vendored/setuptools
-  SETUPTOOLS_USE_DISTUTILS = stdlib
+    __PEX_UNVENDORED__ = 1
+    PYTHONPATH = {env:PYTHONPATH:}{:}{toxinidir}/pex/vendor/_vendored/setuptools
+    SETUPTOOLS_USE_DISTUTILS = stdlib
 commands =
-  python {posargs}
+    python {posargs}
 
 [testenv:devpi-lock]
 description = Re-create the devpi-server lock.
 skip_install = true
 commands =
-  python -mpex.cli lock create \
-    --style universal \
-    --pip-version latest \
-    --resolver-version pip-2020-resolver \
-    --interpreter-constraint >=3.8,<3.13 \
-    devpi-server \
-    --indent 2 \
-    -o testing/devpi-server.lock
+    python -mpex.cli lock create \
+        --style universal \
+        --pip-version latest \
+        --resolver-version pip-2020-resolver \
+        --interpreter-constraint >=3.8,<3.13 \
+        devpi-server \
+        --indent 2 \
+        -o testing/devpi-server.lock
 
 [testenv:build-cache-image]
 description = Build the CI cache data image.
 skip_install = true
 basepython = python3
 deps =
-  coloredlogs==15.0.1
-  PyYAML==6.0.1
+    coloredlogs==15.0.1
+    PyYAML==6.0.1
 commands =
-  python scripts/build_cache_image.py {posargs}
+    python scripts/build_cache_image.py {posargs}


### PR DESCRIPTION
Although the transition to black in July 2020 fixed this for the Python
code, it never hit either code-strings - which Pex uses a few of - or
`tox.ini`. Fix these.