### PR TITLE
Remove `Pip.spawn_install_wheel` & optimize.

### DIFF
--- a/pex/jobs.py
+++ b/pex/jobs.py
@@ -680,18 +680,19 @@ def _mp_pool(size):
 MULTIPROCESSING_DEFAULT_MIN_AVERAGE_LOAD = 4
 
 
-def imap_parallel(
+def iter_map_parallel(
     inputs,  # type: Iterable[_I]
     function,  # type: Callable[[_I], _O]
     max_jobs=None,  # type: Optional[int]
     min_average_load=MULTIPROCESSING_DEFAULT_MIN_AVERAGE_LOAD,  # type: int
     costing_function=None,  # type: Optional[Callable[[_I], Comparable]]
     result_render_function=None,  # type: Optional[Callable[[_O], Any]]
+    noun="item",  # type: str
     verb="process",  # type: str
     verb_past="processed",  # type: str
 ):
     # type: (...) -> Iterator[_O]
-    """Enhanced version of `multiprocessing.Pool.imap` that optimizes pool size and input ordering.
+    """Enhanced `multiprocessing.Pool.imap_unordered` that optimizes pool size and input ordering.
 
     :param inputs: The items to process with `function`.
     :param function: A function that takes a single argument from `inputs` and returns a result.
@@ -700,6 +701,7 @@ def imap_parallel(
     :param costing_function: A function that can estimate the cost of processing each input.
     :param result_render_function: A function that can take a result from `function` and render an
                                    identifier for it.
+    :param noun: A noun indicating what the input type is; "item" by default.
     :param verb: A verb indicating what the function does; "process" by default.
     :param verb_past: The past tense of `verb`; "processed" by default.
     :return: An iterator over the mapped results.
@@ -756,11 +758,11 @@ def imap_parallel(
         "Elapsed time per {verb} job:\n  {times}".format(
             verb=verb,
             times="\n  ".join(
-                "{index}) [{pid}] {total_secs:.2f}s {count} {wheels}".format(
+                "{index}) [{pid}] {total_secs:.2f}s {count} {inputs}".format(
                     index=index,
                     pid=pid,
                     count=len(elapsed),
-                    wheels=pluralize(elapsed, "wheel"),
+                    inputs=pluralize(elapsed, noun),
                     total_secs=total_secs,
                 )
                 for index, (total_secs, pid, elapsed) in enumerate(
@@ -782,6 +784,7 @@ def map_parallel(
     min_average_load=MULTIPROCESSING_DEFAULT_MIN_AVERAGE_LOAD,  # type: int
     costing_function=None,  # type: Optional[Callable[[_I], Comparable]]
     result_render_function=None,  # type: Optional[Callable[[_O], Any]]
+    noun="item",  # type: str
     verb="process",  # type: str
     verb_past="processed",  # type: str
 ):
@@ -795,13 +798,14 @@ def map_parallel(
     :return: A list of the mapped results.
     """
     return list(
-        imap_parallel(
+        iter_map_parallel(
             inputs,
             function,
             max_jobs=max_jobs,
             min_average_load=min_average_load,
             costing_function=costing_function,
             result_render_function=result_render_function,
+            noun=noun,
             verb=verb,
             verb_past=verb_past,
         )

--- a/pex/jobs.py
+++ b/pex/jobs.py
@@ -4,17 +4,36 @@
 from __future__ import absolute_import
 
 import errno
+import functools
+import multiprocessing
+import os
 import subprocess
+import time
 from abc import abstractmethod
+from collections import defaultdict
 from contextlib import contextmanager
 from threading import BoundedSemaphore, Event, Thread
 
+from pex.common import pluralize
 from pex.compatibility import Queue, cpu_count
 from pex.tracer import TRACER
-from pex.typing import TYPE_CHECKING, Generic
+from pex.typing import TYPE_CHECKING, Generic, cast
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Iterable, Iterator, Optional, Text, Tuple, TypeVar, Union
+    from typing import (
+        Any,
+        Callable,
+        DefaultDict,
+        Iterable,
+        Iterator,
+        List,
+        Optional,
+        Protocol,
+        Text,
+        Tuple,
+        TypeVar,
+        Union,
+    )
 
     import attr  # vendor:skip
 
@@ -356,7 +375,7 @@ DEFAULT_MAX_JOBS = _CPU_COUNT
 
 
 def _sanitize_max_jobs(max_jobs=None):
-    assert max_jobs is None or isinstance(max_jobs, int)
+    # type: (Optional[int]) -> int
     if max_jobs is None or max_jobs <= 0:
         return DEFAULT_MAX_JOBS
     else:
@@ -477,7 +496,7 @@ def execute_parallel(
     max_jobs=None,  # type: Optional[int]
 ):
     # type: (...) -> Iterator[Union[_O, _SE, _JE]]
-    """Execute jobs for the given inputs in parallel.
+    """Execute jobs for the given inputs in parallel subprocesses.
 
     :param int max_jobs: The maximum number of parallel jobs to spawn.
     :param inputs: An iterable of the data to parallelize over `spawn_func`.
@@ -595,3 +614,195 @@ def execute_parallel(
                             error = e
             finally:
                 job_slots.release()
+
+
+if TYPE_CHECKING:
+
+    class Comparable(Protocol):
+        def __lt__(self, other):
+            # type: (Any) -> bool
+            pass
+
+
+now = getattr(time, "perf_counter", getattr(time, "clock", time.time))  # type: Callable[[], float]
+
+
+def _apply_function(
+    function,  # type: Callable[[_I], _O]
+    input_item,  # type: _I
+):
+    # type: (...) -> Tuple[int, _O, float]
+    start = now()
+    result = function(input_item)
+    return os.getpid(), result, now() - start
+
+
+if TYPE_CHECKING:
+
+    class Pool(Protocol):
+        def imap_unordered(
+            self,
+            func,  # type: Callable[[_I], _O]
+            iterable,  # type: Iterable[_I]
+            chunksize=1,  # type: int
+        ):
+            # type: (...) -> Iterator[_O]
+            pass
+
+        def close(self):
+            # type: () -> None
+            pass
+
+        def join(self):
+            # type: () -> None
+            pass
+
+
+@contextmanager
+def _mp_pool(size):
+    # type: (int) -> Iterator[Pool]
+    try:
+        context = multiprocessing.get_context("fork")  # type: ignore[attr-defined]
+        pool = cast("Pool", context.Pool(processes=size))
+    except (AttributeError, ValueError):
+        pool = multiprocessing.Pool(processes=size)
+
+    try:
+        yield pool
+    finally:
+        pool.close()
+        pool.join()
+
+
+# This is derived from experiment and backed up by multiprocessing internal default chunk size of
+# 4 for chunked mapping. The overhead of setting up and bookkeeping the multiprocessing pool
+# processes and communication pipes seems to be worth if at least 4 items are processed per slot.
+MULTIPROCESSING_DEFAULT_MIN_AVERAGE_LOAD = 4
+
+
+def imap_parallel(
+    inputs,  # type: Iterable[_I]
+    function,  # type: Callable[[_I], _O]
+    max_jobs=None,  # type: Optional[int]
+    min_average_load=MULTIPROCESSING_DEFAULT_MIN_AVERAGE_LOAD,  # type: int
+    costing_function=None,  # type: Optional[Callable[[_I], Comparable]]
+    result_render_function=None,  # type: Optional[Callable[[_O], Any]]
+    verb="process",  # type: str
+    verb_past="processed",  # type: str
+):
+    # type: (...) -> Iterator[_O]
+    """Enhanced version of `multiprocessing.Pool.imap` that optimizes pool size and input ordering.
+
+    :param inputs: The items to process with `function`.
+    :param function: A function that takes a single argument from `inputs` and returns a result.
+    :param max_jobs: The maximum number of Python processes to spawn to service the `inputs`.
+    :param min_average_load: The minimum avg. number of inputs each Python process should service.
+    :param costing_function: A function that can estimate the cost of processing each input.
+    :param result_render_function: A function that can take a result from `function` and render an
+                                   identifier for it.
+    :param verb: A verb indicating what the function does; "process" by default.
+    :param verb_past: The past tense of `verb`; "processed" by default.
+    :return: An iterator over the mapped results.
+    """
+    input_items = list(inputs)
+    if not input_items:
+        return
+
+    if costing_function is not None:
+        # We ensure no job slot is so unlucky as to get all the biggest jobs and thus become an
+        # un-necessarily long pole by sorting based on cost. Some examples to illustrate the effect
+        # using 6 input items and 2 job slots:
+        #
+        # 1.) Random worst case ordering:
+        #         [9, 1, 1, 1, 1, 10] -> slot1[9] slot2[1, 1, 1, 1, 10]: 14 long pole
+        #     Sorted becomes:
+        #         [10, 9, 1, 1, 1, 1] -> slot1[10, 1, 1] slot2[9, 1, 1]: 12 long pole
+        # 2.) Random worst case ordering:
+        #         [6, 4, 3, 10, 1, 1] -> slot1[6, 10] slot2[4, 3, 1, 1]: 16 long pole
+        #     Sorted becomes:
+        #         [10, 6, 4, 3, 1, 1] -> slot1[10, 3] slot2[6, 4, 1, 1]: 13 long pole
+        #
+        input_items.sort(key=costing_function, reverse=True)
+
+    # We want each of the job slots above to process MULTIPROCESSING_MIN_AVERAGE_LOAD on average in
+    # order to overcome multiprocessing overheads. Of course, if there are fewer available cores
+    # than that or the user has pinned max jobs lower, we clamp to that. Finally, we always want at
+    # least two slots to ensure we process input items in parallel.
+    pool_size = max(2, min(len(input_items) // min_average_load, _sanitize_max_jobs(max_jobs)))
+
+    perform_install = functools.partial(_apply_function, function)
+
+    slots = defaultdict(list)  # type: DefaultDict[int, List[float]]
+    with TRACER.timed(
+        "Using {pool_size} parallel jobs to {verb} {count} items".format(
+            pool_size=pool_size, verb=verb, count=len(input_items)
+        )
+    ):
+        with _mp_pool(size=pool_size) as pool:
+            for pid, result, elapsed_secs in pool.imap_unordered(perform_install, input_items):
+                TRACER.log(
+                    "[{pid}] {verbed} {result} in {elapsed_secs:.2f}s".format(
+                        pid=pid,
+                        verbed=verb_past,
+                        result=result_render_function(result) if result_render_function else result,
+                        elapsed_secs=elapsed_secs,
+                    ),
+                    V=2,
+                )
+                yield result
+                slots[pid].append(elapsed_secs)
+
+    TRACER.log(
+        "Elapsed time per {verb} job:\n  {times}".format(
+            verb=verb,
+            times="\n  ".join(
+                "{index}) [{pid}] {total_secs:.2f}s {count} {wheels}".format(
+                    index=index,
+                    pid=pid,
+                    count=len(elapsed),
+                    wheels=pluralize(elapsed, "wheel"),
+                    total_secs=total_secs,
+                )
+                for index, (total_secs, pid, elapsed) in enumerate(
+                    sorted(
+                        ((sum(elapsed), pid, elapsed) for pid, elapsed in slots.items()),
+                        reverse=True,
+                    ),
+                    start=1,
+                )
+            ),
+        )
+    )
+
+
+def map_parallel(
+    inputs,  # type: Iterable[_I]
+    function,  # type: Callable[[_I], _O]
+    max_jobs=None,  # type: Optional[int]
+    min_average_load=MULTIPROCESSING_DEFAULT_MIN_AVERAGE_LOAD,  # type: int
+    costing_function=None,  # type: Optional[Callable[[_I], Comparable]]
+    result_render_function=None,  # type: Optional[Callable[[_O], Any]]
+    verb="process",  # type: str
+    verb_past="processed",  # type: str
+):
+    # type: (...) -> List[_O]
+    """Enhanced version of `multiprocessing.Pool.map` that optimizes pool size and input ordering.
+
+    Unlike `multiprocessing.Pool.map`, the output order is not guaranteed.
+
+    Forwards all arguments to `imap_parallel`.
+
+    :return: A list of the mapped results.
+    """
+    return list(
+        imap_parallel(
+            inputs,
+            function,
+            max_jobs=max_jobs,
+            min_average_load=min_average_load,
+            costing_function=costing_function,
+            result_render_function=result_render_function,
+            verb=verb,
+            verb_past=verb_past,
+        )
+    )

--- a/pex/layout.py
+++ b/pex/layout.py
@@ -227,6 +227,7 @@ def _ensure_distributions_installed_parallel(
     map_parallel(
         inputs=pex_info.distributions.items(),
         function=install_distribution,
+        noun="wheel",
         verb="install",
         verb_past="installed",
         max_jobs=max_jobs,

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -20,7 +20,7 @@ from pex.common import safe_mkdir, safe_mkdtemp
 from pex.compatibility import url_unquote, urlparse
 from pex.dist_metadata import DistMetadata, Distribution, ProjectNameAndVersion, Requirement
 from pex.fingerprinted_distribution import FingerprintedDistribution
-from pex.jobs import Raise, SpawnedJob, execute_parallel, imap_parallel
+from pex.jobs import Raise, SpawnedJob, execute_parallel, iter_map_parallel
 from pex.network_configuration import NetworkConfiguration
 from pex.orderedset import OrderedSet
 from pex.pep_425 import CompatibilityTags
@@ -940,9 +940,10 @@ class BuildAndInstallRequest(object):
                 add_installation(install_result)
 
             try:
-                for install_result in imap_parallel(
+                for install_result in iter_map_parallel(
                     inputs=install_requests,
                     function=perform_install,
+                    noun="wheel",
                     verb="install",
                     verb_past="installed",
                     max_jobs=max_parallel_jobs,

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -21,13 +21,13 @@ from pex.dist_metadata import Distribution
 from pex.enum import Enum
 from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
+from pex.pep_427 import install_wheel_chroot
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
 from pex.pip.installation import get_pip
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.resolver_configuration import PipConfiguration
-from pex.targets import LocalInterpreter
 from pex.typing import TYPE_CHECKING
 from pex.util import named_temporary_file
 from pex.venv.virtualenv import Virtualenv
@@ -279,7 +279,7 @@ def make_bdist(
     with built_wheel(
         name=name, version=version, zip_safe=zip_safe, interpreter=interpreter, **kwargs
     ) as dist_location:
-        yield install_wheel(dist_location, interpreter=interpreter)
+        yield install_wheel(dist_location)
 
 
 def install_wheel(
@@ -288,13 +288,7 @@ def install_wheel(
 ):
     # type: (...) -> Distribution
     install_dir = os.path.join(safe_mkdtemp(), os.path.basename(wheel))
-    get_pip(
-        interpreter=interpreter, resolver=ConfiguredResolver(pip_configuration=PipConfiguration())
-    ).spawn_install_wheel(
-        wheel=wheel,
-        install_dir=install_dir,
-        target=LocalInterpreter.create(interpreter),
-    ).wait()
+    install_wheel_chroot(wheel_path=wheel, destination=install_dir)
     return Distribution.load(install_dir)
 
 

--- a/tests/test_dist_metadata.py
+++ b/tests/test_dist_metadata.py
@@ -22,6 +22,7 @@ from pex.dist_metadata import (
     requires_dists,
     requires_python,
 )
+from pex.pep_427 import install_wheel_chroot
 from pex.pep_503 import ProjectName
 from pex.pex_warnings import PEXWarning
 from pex.pip.installation import get_pip
@@ -36,7 +37,7 @@ if TYPE_CHECKING:
 def installed_wheel(wheel_path):
     # type: (str) -> Iterator[Distribution]
     with temporary_dir() as install_dir:
-        get_pip().spawn_install_wheel(wheel=wheel_path, install_dir=install_dir).wait()
+        install_wheel_chroot(wheel_path=wheel_path, destination=install_dir)
         yield Distribution.load(install_dir)
 
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -149,7 +149,7 @@ def assert_force_local_implicit_ns_packages_issues_598(
     def add_wheel(builder, content):
         # type: (PEXBuilder, Dict[str, str]) -> None
         with temporary_content(content) as project:
-            dist = install_wheel(WheelBuilder(project).bdist())
+            dist = install_wheel(WheelBuilder(project, interpreter=builder.interpreter).bdist())
             builder.add_dist_location(dist.location)
 
     def add_sources(builder, content):

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -149,7 +149,7 @@ def assert_force_local_implicit_ns_packages_issues_598(
     def add_wheel(builder, content):
         # type: (PEXBuilder, Dict[str, str]) -> None
         with temporary_content(content) as project:
-            dist = install_wheel(WheelBuilder(project, interpreter=builder.interpreter).bdist())
+            dist = install_wheel(WheelBuilder(project).bdist())
             builder.add_dist_location(dist.location)
 
     def add_sources(builder, content):

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -12,9 +12,9 @@ from pex.finders import (
     get_script_from_distributions,
 )
 from pex.pep_376 import InstalledWheel
+from pex.pep_427 import install_wheel_chroot
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
-from pex.pip.installation import get_pip
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -50,7 +50,7 @@ def test_get_script_from_distributions(tmpdir):
     assert "aws_cfn_bootstrap-1.4.data/scripts/cfn-signal" == dist_script.path
 
     install_dir = os.path.join(str(tmpdir), os.path.basename(whl_path))
-    get_pip().spawn_install_wheel(wheel=whl_path, install_dir=install_dir).wait()
+    install_wheel_chroot(wheel_path=whl_path, destination=install_dir)
     installed_wheel_dist, dist_script = assert_script(Distribution.load(install_dir))
     assert InstalledWheel.load(install_dir).stashed_path("bin/cfn-signal") == dist_script.path
 

--- a/tests/tools/commands/test_repository.py
+++ b/tests/tools/commands/test_repository.py
@@ -15,6 +15,8 @@ import pytest
 
 from pex.common import DETERMINISTIC_DATETIME, open_zip, safe_open, temporary_dir
 from pex.dist_metadata import Distribution, Requirement
+from pex.pip.installation import get_pip
+from pex.pip.version import PipVersion
 from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.typing import TYPE_CHECKING
 from testing import PY310, ensure_python_venv, run_command_with_jitter, run_pex_command
@@ -211,6 +213,16 @@ def test_extract_deterministic_wheels(pex, pex_tools_env):
 
 def test_extract_lifecycle(pex, pex_tools_env, tmpdir):
     # type: (str, Dict[str, str], Any) -> None
+
+    # Since we'll be locking down indexes to just find-links, we need to include the wheel .whl
+    # needed by vendored Pip.
+    vendored_pip_dists_dir = os.path.join(str(tmpdir), "vendored-pip-dists")
+    get_pip().spawn_download_distributions(
+        download_dir=vendored_pip_dists_dir,
+        requirements=[PipVersion.VENDORED.wheel_requirement],
+        build=False,
+    ).wait()
+
     dists_dir = os.path.join(str(tmpdir), "dists")
     pid_file = os.path.join(str(tmpdir), "pid")
     os.mkfifo(pid_file)
@@ -238,6 +250,8 @@ def test_extract_lifecycle(pex, pex_tools_env, tmpdir):
             "--no-pypi",
             "--find-links",
             find_links_url,
+            "--find-links",
+            vendored_pip_dists_dir,
             "example",
             "-c",
             "example",


### PR DESCRIPTION
Now both the build time resolve code and the run time layout code use
the same parallelization logic to install wheels using `pex.pep_427` via
a new pair of `pex.jobs.{imap,map}_parallel` functions.

Previously, both used `pex.jobs.execute_parallel`, which incurs a
fork/exec per processed item along with the ensuing overhead of
re-importing all the Pex code needed to do a `pex.pep_427` wheel
install. Although this makes sense for calling Pip, which shares no code
with Pex, it is wasted effort to call pure Pex code. Although early
experiments with parallelizing `pex.pep_427` wheel installs with a
thread pool showed `pex.jobs.execute_parallel` to perform consistently
better, I never experimented with multiprocessing process-based pools.
These perform better than both; and, in hindsight, for two obvious
reasons:

1. A process pool only incurs a fork once per pool slot. Job inputs are
   then fed by pipe; so no fork per every input is required as it is
   when using `pex.jobs.execute_parallel`. As a result, the import price
   is paid at most once per slot instead of once per job input.
2. A process pool does not exec, at least on Linux; so all the imports
   done in the main process live on in the forked pool processes.