### PR TITLE
Kill unused `MANIFEST.in`.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-include *.py *.rst *.ini MANIFEST.in LICENSE
-recursive-include docs *
-recursive-include tests *
-recursive-include scripts *
-recursive-include pex/vendor/_vendored *
-recursive-exclude * *.pyc *~


### PR DESCRIPTION
This was no longer needed with the switch to the flit PEP-517 builder
back in #826 in 2019.