### PR TITLE
Experiment: Allow using pip 23.1.x with Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
           - py311-pip20
           - py311-pip22_3_1
           - py311-pip23_1_2
+          - py312-pip23_1
           - py312-pip23_3_2
           - pypy310-pip20
           - pypy310-pip22_3_1
@@ -66,6 +67,7 @@ jobs:
           - py311-pip20-integration
           - py311-pip22_3_1-integration
           - py311-pip23_1_2-integration
+          - py312-pip23_1_0-integration
           - py312-pip23_3_2-integration
           - pypy310-pip20-integration
           - pypy310-pip22_3_1-integration

--- a/pex/pip/version.py
+++ b/pex/pip/version.py
@@ -190,21 +190,21 @@ class PipVersion(Enum["PipVersionValue"]):
         version="23.1",
         setuptools_version="67.6.1",
         wheel_version="0.40.0",
-        requires_python=">=3.7,<3.12",
+        requires_python=">=3.7",
     )
 
     v23_1_1 = PipVersionValue(
         version="23.1.1",
         setuptools_version="67.7.1",
         wheel_version="0.40.0",
-        requires_python=">=3.7,<3.12",
+        requires_python=">=3.7",
     )
 
     v23_1_2 = PipVersionValue(
         version="23.1.2",
         setuptools_version="67.7.2",
         wheel_version="0.40.0",
-        requires_python=">=3.7,<3.12",
+        requires_python=">=3.7",
     )
 
     v23_2 = PipVersionValue(


### PR DESCRIPTION
This adjusts the Python version upper bounds for the pip 23.1.x series, since they seem to work with Python 3.12 locally, but this was excluded by the range.

In #2172, support for Python 3.12 was added to pex. At that time, it seemed like pip 23.1.x didn't work with Python 3.12, but, some naive tests suggests it does, now:

```shell
python3.12 -m venv /tmp/venv-3.12
. /tmp/venv-3.12/bin/activate

python -m pip install -U pip==23.1 setuptools==67.6.1 wheel==0.40.0
python -m pip --version # pip 23.1 from /private/tmp/v312/lib/python3.12/site-packages/pip (python 3.12)

# example:
python -m pip install pandas
```

Does pex's CI agree? Is there background to the ranges chosen #2172 that isn't recorded somewhere I could find?