### PR TITLE
Lower noop wheel install overhead.

### DIFF
--- a/pex/jobs.py
+++ b/pex/jobs.py
@@ -732,7 +732,7 @@ def iter_map_parallel(
     # least two slots to ensure we process input items in parallel.
     pool_size = max(2, min(len(input_items) // min_average_load, _sanitize_max_jobs(max_jobs)))
 
-    perform_install = functools.partial(_apply_function, function)
+    apply_function = functools.partial(_apply_function, function)
 
     slots = defaultdict(list)  # type: DefaultDict[int, List[float]]
     with TRACER.timed(
@@ -741,7 +741,7 @@ def iter_map_parallel(
         )
     ):
         with _mp_pool(size=pool_size) as pool:
-            for pid, result, elapsed_secs in pool.imap_unordered(perform_install, input_items):
+            for pid, result, elapsed_secs in pool.imap_unordered(apply_function, input_items):
                 TRACER.log(
                     "[{pid}] {verbed} {result} in {elapsed_secs:.2f}s".format(
                         pid=pid,

--- a/pex/vendor/_vendored/attrs/.layout.json
+++ b/pex/vendor/_vendored/attrs/.layout.json
@@ -1,1 +1,1 @@
-{"record_relpath": "attrs-21.5.0.dev0.dist-info/RECORD", "stash_dir": ".prefix"}
+{"fingerprint": "13e0015aa58e8f470b17936f42a5d5f874a20194156c371d2a4c695dc8c16d9e", "record_relpath": "attrs-21.5.0.dev0.dist-info/RECORD", "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/packaging_20_9/.layout.json
+++ b/pex/vendor/_vendored/packaging_20_9/.layout.json
@@ -1,1 +1,1 @@
-{"record_relpath": "packaging-20.9.dist-info/RECORD", "stash_dir": ".prefix"}
+{"fingerprint": "5a3fc5dcd563b4a4474944cd0d73ee4a51fb53132af553abfb203dc1cdf8f7c3", "record_relpath": "packaging-20.9.dist-info/RECORD", "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/packaging_21_3/.layout.json
+++ b/pex/vendor/_vendored/packaging_21_3/.layout.json
@@ -1,1 +1,1 @@
-{"record_relpath": "packaging-21.3.dist-info/RECORD", "stash_dir": ".prefix"}
+{"fingerprint": "2a93da49a5fc8217a0f710ff0ca3cfc56fefa35eddcf6a64786d452bfa284525", "record_relpath": "packaging-21.3.dist-info/RECORD", "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/packaging_23_1/.layout.json
+++ b/pex/vendor/_vendored/packaging_23_1/.layout.json
@@ -1,1 +1,1 @@
-{"record_relpath": "packaging-23.1.dist-info/RECORD", "stash_dir": ".prefix"}
+{"fingerprint": "a98c4a74d7b6a62763df7ad330ac4c7a0779323fc36e961aeb8f20865e21a191", "record_relpath": "packaging-23.1.dist-info/RECORD", "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/pip/.layout.json
+++ b/pex/vendor/_vendored/pip/.layout.json
@@ -1,1 +1,1 @@
-{"record_relpath": "pip-20.3.4.dist-info/RECORD", "stash_dir": ".prefix"}
+{"fingerprint": "120267325b80f5c4b4adac019eb6617ab3319395c043d2871eedf70dd6ae2954", "record_relpath": "pip-20.3.4.dist-info/RECORD", "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/setuptools/.layout.json
+++ b/pex/vendor/_vendored/setuptools/.layout.json
@@ -1,1 +1,1 @@
-{"record_relpath": "setuptools-44.0.0+3acb925dd708430aeaf197ea53ac8a752f7c1863.dist-info/RECORD", "stash_dir": ".prefix"}
+{"fingerprint": "ebe3717ba6bad87ca328cbf3d3eb3f5475105bccb51dc09a69d37eff6b2e5210", "record_relpath": "setuptools-44.0.0+3acb925dd708430aeaf197ea53ac8a752f7c1863.dist-info/RECORD", "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/toml/.layout.json
+++ b/pex/vendor/_vendored/toml/.layout.json
@@ -1,1 +1,1 @@
-{"record_relpath": "toml-0.10.2.dist-info/RECORD", "stash_dir": ".prefix"}
+{"fingerprint": "3d44cdc5911c31b190a0225202daafbb22f7f74e6761fb086742dadb5dff5384", "record_relpath": "toml-0.10.2.dist-info/RECORD", "stash_dir": ".prefix"}


### PR DESCRIPTION
Previously, installing a wheel that was already installed incurred the
cost of hashing the installed wheel chroot every time. The overhead of
this wasted work for a warm cache was egregious for large distributions
like PyTorch, with gigabytes of files to hash taking seconds.

Work towards #2312.