### PR TITLE
Fix `third_party.exposed()`.

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -19,7 +19,6 @@ from textwrap import dedent
 
 from pex import third_party
 from pex.common import is_exe, safe_mkdtemp, safe_rmtree
-from pex.compatibility import commonpath
 from pex.executor import Executor
 from pex.jobs import Job, Retain, SpawnedJob, execute_parallel
 from pex.orderedset import OrderedSet
@@ -188,19 +187,9 @@ class PythonIdentity(object):
         internal_entries = frozenset(
             (pythonpath.split(os.pathsep) if pythonpath else []) + list(third_party.exposed())
         )
-
-        def is_internal_entry(entry):
-            # type: (str) -> bool
-            if entry in internal_entries:
-                return True
-            if not os.path.isabs(entry):
-                return False
-            for internal_entry in internal_entries:
-                if internal_entry == commonpath((internal_entry, entry)):
-                    return True
-            return False
-
-        sys_path = OrderedSet(entry for entry in sys.path if entry and not is_internal_entry(entry))
+        sys_path = OrderedSet(
+            entry for entry in sys.path if entry and entry not in internal_entries
+        )
 
         site_packages = OrderedSet(
             path

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -213,13 +213,11 @@ class VendorImporter(object):
     ):
         # type: (...) -> Iterator[VendorImporter]
         root = cls._abs_root(root)
-        vendored_paths = set(cls._vendored_path_items())
         for importer in cls._iter_all_installed_vendor_importers():
             # All Importables for a given VendorImporter will have the same prefix.
             if importer._importables and importer._importables[0].prefix == prefix:
                 if importer._root == root:
-                    if {importable.path for importable in importer._importables} == vendored_paths:
-                        yield importer
+                    yield importer
 
     @classmethod
     def install_vendored(


### PR DESCRIPTION
This cleans up #2328 by fixing the root cause of the interpreter
identification leak of exposed `attrs`. The API to report exposed
`sys.path` elements, `third_party.exposed()`, worked at build time,
with a full Pex distribution available, but returned an empty iterator
at run time, with the subset of Pex available in the runtime
`.bootstrap/`.