### PR TITLE
Upgrade readthedocs requirements.

### DIFF
--- a/docs/rtd/requirements.txt
+++ b/docs/rtd/requirements.txt
@@ -1,10 +1,4 @@
-# N.B.: Pex RTD started failing upon release of docutil 0.18; work around by pinning low.
-# See: https://github.com/pantsbuild/pex/issues/1508
-docutils<0.18
-
-sphinx==3.2.1
-sphinx_rtd_theme==0.5.0
-
-# N.B.: Sphinx doesn't work with jinja2 3.1.0.
-# See: https://github.com/sphinx-doc/sphinx/issues/10291
-jinja2<3.1.0
+docutils==0.20.1
+sphinx==7.2.6
+sphinx_rtd_theme==2.0.0
+jinja2==3.1.3


### PR DESCRIPTION
Our older pins were no longer compatible with production RTD.

Fixes #2337 