### PR TITLE
Remove the free disk space CI step.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,18 +77,6 @@ jobs:
           - pypy310-pip22_3_1-integration
           - pypy310-pip23_1_2-integration
     steps:
-      - name: Free Up Disk Space
-        uses: jlumbroso/free-disk-space@v1.3.0
-        with:
-          android: true # ~14GB
-          dotnet: true # ~2GB
-          tool-cache: true # ~12GB
-
-          # Too little space savings or too slow.
-          haskell: false
-          large-packages: false
-          docker-images: false
-          swap-storage: false
       - name: Checkout Pex
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
I've confirmed the recent announcement by GitHub is true re beefier
Linux runners. We now consistently have 30GB free which is more than we
need. Removing this step saves ~1 minute of run time for each Linux
test shard.