### PR TITLE
Fix CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,18 @@ jobs:
           - pypy310-pip22_3_1-integration
           - pypy310-pip23_1_2-integration
     steps:
+      - name: Free Up Disk Space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true # ~14GB
+          dotnet: true # ~2GB
+          tool-cache: true # ~12GB
+
+          # Too little space savings or too slow.
+          haskell: false
+          large-packages: false
+          docker-images: false
+          swap-storage: false
       - name: Checkout Pex
         uses: actions/checkout@v3
         with:

--- a/tests/resolve/test_pex_repository_resolver.py
+++ b/tests/resolve/test_pex_repository_resolver.py
@@ -128,6 +128,8 @@ def pex_repository(
         "urllib3==1.26.1",
         # The 22.0.0 release of pyOpenSSL drops support for Python 2.7; so we pin lower.
         "pyOpenSSL<22",
+        # The 2022 and later releases only support Python>=3.6; so we pin lower.
+        "certifi<2022",
     )
 
     return create_pex_repository(


### PR DESCRIPTION
This change fixes a bitrotted test as well as restoring the
free-disk-space CI step. For the latter, we appear to be hitting
diskfulls in the GitHub action runner logging code; so hopefully this
helps.