### PR TITLE
Switch back to deadsnakes for 3.13.

### DIFF
--- a/docker/base/install_pythons.sh
+++ b/docker/base/install_pythons.sh
@@ -11,6 +11,7 @@ DEADSNAKES_VERSIONS=(
   "3.8 {dev,venv,distutils}=3.8.20"
   "3.9 {dev,venv,distutils}=3.9.23"
   "3.10 {dev,venv,distutils}=3.10.18"
+  "3.13 {dev,venv}=3.13.8"
   "3.14 {dev,venv}=3.14.0"
 )
 
@@ -36,7 +37,6 @@ PYENV_VERSIONS=(
   3.5.10
   3.6.15
   3.12.11
-  3.13.8
   pypy2.7-7.3.20
   pypy3.5-7.0.0
   pypy3.6-7.3.3


### PR DESCRIPTION
They were slower than devpi on the 3.13.8 release but have since caught
up.