### PR TITLE
Complete support for universal lock splitting.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,19 @@
 # Release Notes
 
+## 2.62.0
+
+This release brings full support for universal lock splitting. You can now declare conflicting
+top-level requirements for different (marker) environments and these will be isolated in separate
+lock resolves in the same universal lock file. These split resolves are performed in parallel and
+the appropriate split lock is later selected automatically when building a PEX or a venv from the
+lock.
+
+As part of this work, locks also filter wheels more faithfully. If you supply interpreter
+constraints that constraint to CPython, the resulting lock will now only contain `cp`
+platform-specific wheels (and, for example, not PyPy wheels).
+
+* Complete support for universal lock splitting. (#2940)
+
 ## 2.61.1
 
 This release fixes a long standing bug hashing local project directories when building PEXes. Pex

--- a/pex/resolve/lockfile/targets.py
+++ b/pex/resolve/lockfile/targets.py
@@ -1,24 +1,45 @@
 from __future__ import absolute_import
 
 import itertools
-from collections import defaultdict
+import os.path
+import tempfile
+from collections import OrderedDict, defaultdict
 
+from pex import atexit
+from pex.common import pluralize, safe_delete
 from pex.interpreter_constraints import iter_compatible_versions
 from pex.interpreter_implementation import InterpreterImplementation
 from pex.network_configuration import NetworkConfiguration
 from pex.orderedset import OrderedSet
 from pex.pep_503 import ProjectName
-from pex.requirements import LocalProjectRequirement
 from pex.resolve.package_repository import ReposConfiguration
 from pex.resolve.requirement_configuration import RequirementConfiguration
-from pex.resolve.target_system import MarkerEnv, TargetSystem, UniversalTarget, has_marker
+from pex.resolve.target_system import (
+    ExtraMarkers,
+    MarkerEnv,
+    TargetSystem,
+    UniversalTarget,
+    has_marker,
+)
+from pex.resolver import DownloadRequest
 from pex.targets import LocalInterpreter, Targets
 from pex.third_party.packaging.markers import Marker
 from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import DefaultDict, Dict, FrozenSet, Iterator, List, Mapping, Optional, Tuple
+    from typing import (
+        DefaultDict,
+        Dict,
+        FrozenSet,
+        Iterable,
+        Iterator,
+        List,
+        Mapping,
+        Optional,
+        Text,
+        Tuple,
+    )
 
     import attr  # vendor:skip
 else:
@@ -43,7 +64,7 @@ def _calculate_split_markers(
 
     projects_with_markers = defaultdict(dict)  # type: DefaultDict[ProjectName, Dict[str, Marker]]
     for requirement in requirement_configuration.parse_requirements(network_configuration):
-        if not isinstance(requirement, LocalProjectRequirement) and requirement.marker:
+        if requirement.project_name and requirement.marker:
             projects_with_markers[requirement.project_name][
                 str(requirement.marker)
             ] = requirement.marker
@@ -147,33 +168,278 @@ def _iter_universal_targets(
         )
 
 
+if TYPE_CHECKING:
+    from pex.requirements import ParsedRequirement
+
+
 @attr.s(frozen=True)
-class LockTargets(object):
-    @classmethod
-    def calculate(
-        cls,
-        targets,  # type: Targets
-        requirement_configuration,  # type: RequirementConfiguration
-        network_configuration,  # type: NetworkConfiguration
-        repos_configuration,  # type: ReposConfiguration
-        universal_target=None,  # type: Optional[UniversalTarget]
+class DownloadInput(object):
+    download_requests = attr.ib()  # type: Tuple[DownloadRequest, ...]
+    direct_requirements = attr.ib()  # type: Tuple[ParsedRequirement, ...]
+
+
+def _comment_out_requirements(
+    requirements_file,  # type: Text
+    requirements,  # type: Iterable[ParsedRequirement]
+):
+    # type: (...) -> Text
+
+    lines_to_comment_out = set(
+        itertools.chain.from_iterable(
+            range(requirement.line.start_line, requirement.line.end_line + 1)
+            for requirement in requirements
+        )
+    )
+
+    # N.B.: We create the edited requirements file in the same directory as the original so that any
+    # relative path references in the requirements file are still valid.
+    out_fd, edited_requirements_file = tempfile.mkstemp(
+        dir=os.path.dirname(requirements_file),
+        prefix="pex_lock_split.",
+        suffix=".{file_name}".format(file_name=os.path.basename(requirements_file)),
+    )
+    atexit.register(safe_delete, edited_requirements_file)
+    try:
+        with open(requirements_file, "rb") as in_fp:
+            for line_no, text in enumerate(in_fp, start=1):
+                if line_no in lines_to_comment_out:
+                    os.write(out_fd, b"# ")
+                os.write(out_fd, text)
+    finally:
+        os.close(out_fd)
+    return edited_requirements_file
+
+
+@attr.s
+class Split(object):
+    requirements_by_project_name = attr.ib(
+        factory=OrderedDict
+    )  # type: OrderedDict[ProjectName, ParsedRequirement]
+    provenance = attr.ib(factory=OrderedSet)  # type: OrderedSet[ParsedRequirement]
+
+    def applies(
+        self,
+        universal_target,  # type: UniversalTarget
+        requirement,  # type: ParsedRequirement
     ):
-        # type: (...) -> LockTargets
+        # type: (...) -> bool
 
-        if not universal_target:
-            return cls(targets=targets)
+        if not requirement.marker:
+            return True
 
-        targets = Targets.from_target(LocalInterpreter.create(targets.interpreter))
-        split_markers = _calculate_split_markers(
-            requirement_configuration, network_configuration, repos_configuration
+        requirements = [(req.marker, str(req)) for req in self.provenance if req.marker]
+        if not requirements:
+            return True
+
+        marker_env = attr.evolve(
+            universal_target, extra_markers=ExtraMarkers.extract(requirements)
+        ).marker_env()
+        return marker_env.evaluate(requirement.marker)
+
+    def add(
+        self,
+        universal_target,  # type: UniversalTarget
+        project_name,  # type: ProjectName
+        requirement,  # type: ParsedRequirement
+    ):
+        # type: (...) -> Optional[Split]
+
+        if not self.applies(universal_target, requirement):
+            return None
+
+        existing_requirement = self.requirements_by_project_name.setdefault(
+            project_name, requirement
         )
-        if not split_markers:
-            return cls(targets=targets, universal_targets=(universal_target,))
+        if existing_requirement == requirement:
+            return None
 
-        return cls(
-            targets=targets,
-            universal_targets=tuple(_iter_universal_targets(universal_target, split_markers)),
+        self.provenance.add(existing_requirement)
+
+        provenance = OrderedSet(req for req in self.provenance if req != existing_requirement)
+        provenance.add(requirement)
+
+        requirements_by_project_name = self.requirements_by_project_name.copy()
+        requirements_by_project_name[project_name] = requirement
+
+        return Split(
+            requirements_by_project_name=requirements_by_project_name, provenance=provenance
         )
 
-    targets = attr.ib()  # type: Targets
-    universal_targets = attr.ib(default=())  # type: Tuple[UniversalTarget, ...]
+    def requirement_configuration(
+        self,
+        unnamed_requirements,  # type: Iterable[ParsedRequirement]
+        requirement_configuration,  # type: RequirementConfiguration
+        network_configuration=None,  # type: Optional[NetworkConfiguration]
+    ):
+        # type: (...) -> RequirementConfiguration
+
+        if not self.provenance:
+            return requirement_configuration
+
+        requirements = list(str(req) for req in unnamed_requirements)
+
+        requirement_files = OrderedSet(
+            os.path.realpath(requirement_file)
+            for requirement_file in requirement_configuration.requirement_files
+        )  # type: OrderedSet[Text]
+        if requirement_files:
+            provenance_by_project_name = {
+                parsed_requirement.project_name: parsed_requirement
+                for parsed_requirement in self.provenance
+                if parsed_requirement.project_name
+            }
+
+            requirements_to_comment_out_by_source = defaultdict(
+                list
+            )  # type: DefaultDict[Text, List[ParsedRequirement]]
+            for parsed_requirement in requirement_configuration.parse_requirements(
+                network_configuration=network_configuration
+            ):
+                if not parsed_requirement.project_name:
+                    continue
+
+                provenance = provenance_by_project_name.get(parsed_requirement.project_name)
+                if provenance and (parsed_requirement != provenance):
+                    if parsed_requirement.line.source in requirement_files:
+                        # We comment out the requirement
+                        requirements_to_comment_out_by_source[
+                            parsed_requirement.line.source
+                        ].append(parsed_requirement)
+                    else:
+                        # We drop the requirement
+                        pass
+                elif parsed_requirement.line.source not in requirement_files:
+                    requirements.append(str(parsed_requirement))
+            if requirements_to_comment_out_by_source:
+                new_requirement_files = OrderedSet()  # type: OrderedSet[Text]
+                for source, parsed_requirements in requirements_to_comment_out_by_source.items():
+                    if source in requirement_files:
+                        new_requirement_files.add(
+                            _comment_out_requirements(source, parsed_requirements)
+                        )
+                    else:
+                        new_requirement_files.add(source)
+                requirement_files = new_requirement_files
+        else:
+            requirements.extend(str(req) for req in self.requirements_by_project_name.values())
+
+        return RequirementConfiguration(
+            requirements=tuple(requirements),
+            requirement_files=tuple(requirement_files),
+            constraint_files=requirement_configuration.constraint_files,
+        )
+
+
+def calculate_download_input(
+    targets,  # type: Targets
+    requirement_configuration,  # type: RequirementConfiguration
+    network_configuration,  # type: NetworkConfiguration
+    repos_configuration,  # type: ReposConfiguration
+    universal_target=None,  # type: Optional[UniversalTarget]
+):
+    # type: (...) -> DownloadInput
+
+    direct_requirements = requirement_configuration.parse_requirements(network_configuration)
+    if not universal_target:
+        return DownloadInput(
+            download_requests=tuple(
+                DownloadRequest.create(
+                    target=target, requirement_configuration=requirement_configuration
+                )
+                for target in targets.unique_targets()
+            ),
+            direct_requirements=direct_requirements,
+        )
+
+    target = LocalInterpreter.create(targets.interpreter)
+    split_markers = _calculate_split_markers(
+        requirement_configuration, network_configuration, repos_configuration
+    )
+    if not split_markers:
+        return DownloadInput(
+            download_requests=tuple(
+                [
+                    DownloadRequest.create(
+                        target=target,
+                        universal_target=universal_target,
+                        requirement_configuration=requirement_configuration,
+                    )
+                ]
+            ),
+            direct_requirements=direct_requirements,
+        )
+
+    named_requirements = (
+        OrderedDict()
+    )  # type: OrderedDict[ProjectName, OrderedSet[ParsedRequirement]]
+    unnamed_requirements = OrderedSet()  # type: OrderedSet[ParsedRequirement]
+    for direct_requirement in direct_requirements:
+        if direct_requirement.project_name:
+            named_requirements.setdefault(direct_requirement.project_name, OrderedSet()).add(
+                direct_requirement
+            )
+        else:
+            unnamed_requirements.add(direct_requirement)
+
+    requirement_splits_by_universal_target = defaultdict(
+        lambda: [Split()]
+    )  # type: DefaultDict[UniversalTarget, List[Split]]
+    for universal_target in _iter_universal_targets(universal_target, split_markers):
+        marker_env = universal_target.marker_env()
+        requirement_splits = requirement_splits_by_universal_target[universal_target]
+        for project_name, remote_requirements in named_requirements.items():
+            for requirement_split in list(requirement_splits):
+                for remote_requirement in remote_requirements:
+                    if remote_requirement.marker and not marker_env.evaluate(
+                        remote_requirement.marker
+                    ):
+                        continue
+                    new_split = requirement_split.add(
+                        universal_target, project_name, remote_requirement
+                    )
+                    if new_split:
+                        requirement_splits.append(new_split)
+
+    download_requests = []
+    for universal_target, splits in requirement_splits_by_universal_target.items():
+        if len(splits) == 1:
+            download_requests.append(
+                DownloadRequest.create(
+                    target=target,
+                    universal_target=universal_target,
+                    requirement_configuration=splits[0].requirement_configuration(
+                        unnamed_requirements,
+                        requirement_configuration,
+                        network_configuration=network_configuration,
+                    ),
+                )
+            )
+            continue
+
+        for split in splits:
+            download_requests.append(
+                DownloadRequest.create(
+                    target=target,
+                    universal_target=attr.evolve(
+                        universal_target,
+                        extra_markers=ExtraMarkers.extract(
+                            (requirement.marker, str(requirement))
+                            for requirement in split.provenance
+                            if requirement.marker
+                        ),
+                    ),
+                    requirement_configuration=split.requirement_configuration(
+                        unnamed_requirements,
+                        requirement_configuration,
+                        network_configuration=network_configuration,
+                    ),
+                    provenance="split by {requirements} {reqs}".format(
+                        requirements=pluralize(split.provenance, "requirement"),
+                        reqs=", ".join("'{req}'".format(req=req) for req in split.provenance),
+                    ),
+                )
+            )
+
+    return DownloadInput(
+        download_requests=tuple(download_requests), direct_requirements=direct_requirements
+    )

--- a/pex/resolve/requirement_configuration.py
+++ b/pex/resolve/requirement_configuration.py
@@ -17,7 +17,7 @@ from pex.requirements import (
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Iterable, List, Optional
+    from typing import Iterable, List, Optional, Tuple
 
     import attr  # vendor:skip
 
@@ -26,14 +26,21 @@ else:
     from pex.third_party import attr
 
 
+def _as_str_tuple(items):
+    # type: (Optional[Iterable[str]]) -> Tuple[str, ...]
+    if not items:
+        return ()
+    return items if isinstance(items, tuple) else tuple(items)
+
+
 @attr.s(frozen=True)
 class RequirementConfiguration(object):
-    requirements = attr.ib(default=None)  # type: Optional[Iterable[str]]
-    requirement_files = attr.ib(default=None)  # type: Optional[Iterable[str]]
-    constraint_files = attr.ib(default=None)  # type: Optional[Iterable[str]]
+    requirements = attr.ib(default=(), converter=_as_str_tuple)  # type: Tuple[str, ...]
+    requirement_files = attr.ib(default=(), converter=_as_str_tuple)  # type: Tuple[str, ...]
+    constraint_files = attr.ib(default=(), converter=_as_str_tuple)  # type: Tuple[str, ...]
 
     def parse_requirements(self, network_configuration=None):
-        # type: (Optional[NetworkConfiguration]) -> Iterable[ParsedRequirement]
+        # type: (Optional[NetworkConfiguration]) -> Tuple[ParsedRequirement, ...]
         parsed_requirements = []  # type: List[ParsedRequirement]
         if self.requirements:
             parsed_requirements.extend(parse_requirement_strings(self.requirements))
@@ -50,10 +57,10 @@ class RequirementConfiguration(object):
                         (PyPIRequirement, URLRequirement, VCSRequirement, LocalProjectRequirement),
                     )
                 )
-        return parsed_requirements
+        return tuple(parsed_requirements)
 
     def parse_constraints(self, network_configuration=None):
-        # type: (Optional[NetworkConfiguration]) -> Iterable[Constraint]
+        # type: (Optional[NetworkConfiguration]) -> Tuple[Constraint, ...]
         parsed_constraints = []  # type: List[Constraint]
         if self.constraint_files:
             fetcher = URLFetcher(network_configuration=network_configuration)
@@ -65,7 +72,7 @@ class RequirementConfiguration(object):
                     )
                     if isinstance(requirement_or_constraint, Constraint)
                 )
-        return parsed_constraints
+        return tuple(parsed_constraints)
 
     @property
     def has_requirements(self):

--- a/pex/resolve/target_system.py
+++ b/pex/resolve/target_system.py
@@ -6,6 +6,9 @@ from __future__ import absolute_import
 import operator
 import sys
 
+from pex import pex_warnings
+from pex.common import pluralize
+from pex.compatibility import string
 from pex.enum import Enum
 from pex.exceptions import production_assert, reportable_unexpected_error_msg
 from pex.interpreter_constraints import InterpreterConstraint, iter_compatible_versions
@@ -16,7 +19,7 @@ from pex.pep_503 import ProjectName
 from pex.sorted_tuple import SortedTuple
 from pex.third_party.packaging.markers import Marker, Variable
 from pex.third_party.packaging.specifiers import Specifier, SpecifierSet
-from pex.typing import TYPE_CHECKING, cast
+from pex.typing import TYPE_CHECKING, Generic, cast
 
 if TYPE_CHECKING:
     from typing import (
@@ -30,6 +33,7 @@ if TYPE_CHECKING:
         Optional,
         Sequence,
         Tuple,
+        TypeVar,
         Union,
     )
 
@@ -84,19 +88,132 @@ def _marker_items(marker):
     return cast("Iterable[Any]", marker._markers)
 
 
+class MarkerVisitor(Generic["_C"]):
+    def visit_and(
+        self,
+        marker,  # type: Marker
+        context,  # type: _C
+    ):
+        # type: (...) -> None
+        pass
+
+    def visit_or(
+        self,
+        marker,  # type: Marker
+        context,  # type: _C
+    ):
+        # type: (...) -> None
+        pass
+
+    def begin_visit_group(
+        self,
+        group,  # type: List[Any]
+        marker,  # type: Marker
+        context,  # type: _C
+    ):
+        # type: (...) -> Optional[_C]
+        return None
+
+    def end_visit_group(
+        self,
+        group,  # type: List[Any]
+        marker,  # type: Marker
+        context,  # type: _C
+        group_context,  # type: Optional[_C]
+    ):
+        # type: (...) -> None
+        pass
+
+    def visit_op(
+        self,
+        lhs,  # type: Any
+        op,  # type: Any
+        rhs,  # type: Any
+        marker,  # type: Marker
+        context,  # type: _C
+    ):
+        # type: (...) -> None
+        pass
+
+
+if TYPE_CHECKING:
+    _C = TypeVar("_C")
+
+
+class MarkerParser(Generic["_C"]):
+    def __init__(self, visitor):
+        # type: (MarkerVisitor["_C"]) -> None
+        self._visitor = visitor
+
+    def _parse_marker_item(
+        self,
+        item,  # type: Union[str, List, Tuple]
+        marker,  # type: Marker
+        context,  # type: _C
+    ):
+        # type: (...) -> None
+
+        if item == "and":
+            self._visitor.visit_and(marker, context)
+        elif item == "or":
+            self._visitor.visit_or(marker, context)
+        elif isinstance(item, list):
+            group_context = self._visitor.begin_visit_group(item, marker, context)
+            element_context = group_context if group_context is not None else context
+            for element in item:
+                self._parse_marker_item(element, marker, element_context)
+            self._visitor.end_visit_group(item, marker, context, group_context)
+        elif isinstance(item, tuple):
+            lhs, op, rhs = item
+            self._visitor.visit_op(lhs, op, rhs, marker, context)
+        else:
+            raise ValueError("Marker is invalid: {marker}".format(marker=marker))
+
+    def parse(
+        self,
+        marker,  # type: Marker
+        context,  # type: _C
+    ):
+        # type: (...) -> _C
+
+        for item in _marker_items(marker):
+            self._parse_marker_item(item, marker, context)
+        return context
+
+
+class HasMarkerVisitor(MarkerVisitor[None]):
+    def __init__(self, name):
+        # type: (str) -> None
+        self._name = name
+        self.has_marker = False
+
+    def visit_op(
+        self,
+        lhs,  # type: Any
+        op,  # type: Any
+        rhs,  # type: Any
+        marker,  # type: Marker
+        context,  # type: None
+    ):
+        # type: (...) -> None
+        if self.has_marker:
+            return
+
+        for term in lhs, rhs:
+            if is_variable(term) and self._name == str(term):
+                self.has_marker = True
+                break
+
+
 def has_marker(
     marker,  # type: Marker
     name,  # type: str
 ):
     # type: (...) -> bool
 
-    for item in _marker_items(marker):
-        if isinstance(item, tuple):
-            lhs, _, rhs = item
-            for term in lhs, rhs:
-                if isinstance(term, Variable) and name == str(term):
-                    return True
-    return False
+    visitor = HasMarkerVisitor(name)
+    MarkerParser(visitor).parse(marker, None)
+    return visitor.has_marker
 
 
 if TYPE_CHECKING:
@@ -122,6 +239,17 @@ _VERSION_MARKER_OP_FLIPPED = {
     ">": "<",
 }
 
+_VERSION_CMP_OPS = {
+    "<",
+    "<=",
+    "==",
+    "!=",
+    ">=",
+    ">",
+    "~=",
+    "===",
+}
+
 
 class _Op(object):
     def __init__(self, lhs):
@@ -143,79 +271,157 @@ class _Or(_Op):
         return self.lhs(marker_env) or cast("EvalMarker", self.rhs)(marker_env)
 
 
-def _get_values_func(marker):
-    # type: (str) -> Optional[Callable[[MarkerEnv], Iterable[str]]]
+@attr.s(frozen=True)
+class Values(object):
+    @classmethod
+    def from_dict(cls, data):
+        # type: (Dict[str, Any]) -> Values
+        return cls(
+            marker_name=data.pop("marker_name"),
+            values=tuple(data.pop("values", ())),
+            inclusive=data.pop("inclusive", True),
+        )
 
-    if marker == "extra":
-        return lambda marker_env: marker_env.extras
-    elif marker == "os_name":
-        return lambda marker_env: marker_env.os_names
-    elif marker == "platform_system":
-        return lambda marker_env: marker_env.platform_systems
-    elif marker == "sys_platform":
-        return lambda marker_env: marker_env.sys_platforms
-    elif marker == "platform_python_implementation":
-        return lambda marker_env: marker_env.platform_python_implementations
-    elif marker == "python_version":
-        return lambda marker_env: marker_env.python_versions
-    elif marker == "python_full_version":
-        return lambda marker_env: marker_env.python_full_versions
-    return None
+    marker_name = attr.ib()  # type: str
+    values = attr.ib(default=())  # type: Tuple[str, ...]
+    inclusive = attr.ib(default=True)  # type: bool
+
+    def to_dict(self):
+        # type: () -> Dict[str, Any]
+        return {"marker_name": self.marker_name, "values": self.values, "inclusive": self.inclusive}
+
+    def apply(self, func):
+        # type: (Callable[[str], bool]) -> bool
+        if len(self.values) == 0:
+            return self.marker_name != "extra"
+        if self.inclusive:
+            return any(map(func, self.values))
+        return all((not result) for result in map(func, self.values))
+
+    def __len__(self):
+        # type: () -> int
+        return len(self.values)
+
+    def __iter__(self):
+        # type: () -> Iterator[str]
+        return iter(self.values)
 
 
-def _parse_marker_item(
-    stack,  # type: List[EvalMarker]
-    item,  # type: Union[str, List, Tuple]
-    marker,  # type: Marker
-):
-    # type: (...) -> None
+def _get_values_func(marker_name):
+    # type: (str) -> Callable[[MarkerEnv], Values]
 
-    if item == "and":
-        stack.append(_And(stack.pop()))
-    elif item == "or":
-        stack.append(_Or(stack.pop()))
-    elif isinstance(item, list):
-        group = []  # type: List[EvalMarker]
-        for element in item:
-            _parse_marker_item(group, element, marker)
-        production_assert(len(group) == 1)
-        if stack:
-            production_assert(isinstance(stack[-1], _Op))
-            cast(_Op, stack[-1]).rhs = group[0]
+    if marker_name == "extra":
+        return lambda marker_env: Values(marker_name, marker_env.extras)
+    elif marker_name == "os_name":
+        return lambda marker_env: Values(marker_name, marker_env.os_names)
+    elif marker_name == "platform_system":
+        return lambda marker_env: Values(marker_name, marker_env.platform_systems)
+    elif marker_name == "sys_platform":
+        return lambda marker_env: Values(marker_name, marker_env.sys_platforms)
+    elif marker_name == "platform_python_implementation":
+        return lambda marker_env: Values(marker_name, marker_env.platform_python_implementations)
+    elif marker_name == "python_version":
+        return lambda marker_env: Values(marker_name, marker_env.python_versions)
+    elif marker_name == "python_full_version":
+        return lambda marker_env: Values(marker_name, marker_env.python_full_versions)
+    return lambda marker_env: marker_env.extra_markers.get_values(marker_name)
+
+
+class UniversalMarkerVisitor(MarkerVisitor["List[EvalMarker]"]):
+    @classmethod
+    def parse_marker(cls, marker):
+        # type: (Marker) -> EvalMarker
+
+        checks = MarkerParser(cls()).parse(marker, context=[])
+        production_assert(len(checks) == 1)
+        return checks[0]
+
+    def visit_and(
+        self,
+        marker,  # type: Marker
+        context,  # type: List[EvalMarker]
+    ):
+        # type: (...) -> None
+        context.append(_And(context.pop()))
+
+    def visit_or(
+        self,
+        marker,  # type: Marker
+        context,  # type: List[EvalMarker]
+    ):
+        # type: (...) -> None
+        context.append(_Or(context.pop()))
+
+    def begin_visit_group(
+        self,
+        group,  # type: List[Any]
+        marker,  # type: Marker
+        context,  # type: List[EvalMarker]
+    ):
+        # type: (...) -> Optional[List[EvalMarker]]
+        return []
+
+    def end_visit_group(
+        self,
+        group,  # type: List[Any]
+        marker,  # type: Marker
+        context,  # type: List[EvalMarker]
+        group_context,  # type: Optional[List[EvalMarker]]
+    ):
+        # type: (...) -> None
+
+        if group_context is None or len(group_context) != 1:
+            raise AssertionError(reportable_unexpected_error_msg())
+
+        if context:
+            production_assert(isinstance(context[-1], _Op))
+            cast(_Op, context[-1]).rhs = group_context[0]
         else:
-            stack.extend(group)
-    elif isinstance(item, tuple):
-        lhs, op, rhs = item
+            context.extend(group_context)
+
+    def visit_op(
+        self,
+        lhs,  # type: Any
+        op,  # type: Any
+        rhs,  # type: Any
+        marker,  # type: Marker
+        context,  # type: List[EvalMarker]
+    ):
+        # type: (...) -> None
+
         check = EvalMarkerFunc.create(lhs, op, rhs)
-        if stack:
-            production_assert(isinstance(stack[-1], _Op))
-            cast(_Op, stack[-1]).rhs = check
+        if context:
+            production_assert(isinstance(context[-1], _Op))
+            cast(_Op, context[-1]).rhs = check
         else:
-            stack.append(check)
-    else:
-        raise ValueError("Marker is invalid: {marker}".format(marker=marker))
+            context.append(check)
 
 
-def _parse_marker_check(marker):
-    # type: (Marker) -> EvalMarker
-    checks = []  # type: List[EvalMarker]
-    for item in _marker_items(marker):
-        _parse_marker_item(checks, item, marker)
-    production_assert(len(checks) == 1)
-    return checks[0]
-
-
-_MARKER_CHECKS = {}  # type: Dict[str, EvalMarker]
+_MARKER_CHECKS = {}  # type: Dict[Union[Marker, str], EvalMarker]
 
 
 def _parse_marker(marker):
     # type: (Marker) -> EvalMarker
-    maker_str = str(marker)
-    eval_marker = _MARKER_CHECKS.get(maker_str)
+    eval_marker = _MARKER_CHECKS.get(marker)
     if not eval_marker:
-        eval_marker = _parse_marker_check(marker)
-        _MARKER_CHECKS[maker_str] = eval_marker
+        marker_str = str(marker)
+        eval_marker = _MARKER_CHECKS.get(marker_str)
+        if not eval_marker:
+            eval_marker = UniversalMarkerVisitor.parse_marker(marker)
+            _MARKER_CHECKS[marker] = eval_marker
+            _MARKER_CHECKS[marker_str] = eval_marker
     return eval_marker
+
+
+def is_variable(value):
+    # type: (Any) -> bool
+
+    if isinstance(value, Variable):
+        return True
+
+    # N.B.: This allows interop with Pip vendored packaging which has the same types in a different
+    # namespace.
+    return type(value).__name__ == "Variable"
 
 
 class EvalMarkerFunc(object):
@@ -228,39 +434,32 @@ class EvalMarkerFunc(object):
     ):
         # type: (...) -> Callable[[MarkerEnv], bool]
 
-        if isinstance(lhs, Variable):
-            marker_name = str(lhs)
+        for var, operand, operand_side in ((lhs, rhs, "rhs"), (rhs, lhs, "lhs")):
+            if not is_variable(var):
+                continue
+            marker_name = str(var)
             get_values = _get_values_func(marker_name)
-            if get_values:
-                value = str(rhs)
-                if marker_name == "extra":
-                    value = ProjectName(value).normalized
-                return cls(
-                    get_values=get_values,
-                    op=str(op),
-                    rhs=value,
-                    is_version_comparison=marker_name in ("python_version", "python_full_version"),
-                )
-
-        if isinstance(rhs, Variable):
-            marker_name = str(rhs)
-            get_values = _get_values_func(marker_name)
-            if get_values:
-                value = str(lhs)
-                if marker_name == "extra":
-                    value = ProjectName(value).normalized
-                return cls(
-                    get_values=get_values,
-                    op=str(op),
-                    lhs=value,
-                    is_version_comparison=marker_name in ("python_version", "python_full_version"),
-                )
+            value = str(operand)
+            if marker_name == "extra":
+                value = ProjectName(value).normalized
+            op_string = str(op)
+            operand_side_arg = {operand_side: value}
+            return cls(
+                get_values=get_values,
+                op=op_string,
+                is_version_comparison=(
+                    marker_name
+                    in ("python_version", "python_full_version", "implementation_version")
+                    and op_string in _VERSION_CMP_OPS
+                ),
+                **operand_side_arg
+            )
 
         return lambda _: True
 
     def __init__(
         self,
-        get_values,  # type: Callable[[MarkerEnv], Iterable[str]]
+        get_values,  # type: Callable[[MarkerEnv], Values]
         op,  # type: str
         lhs=None,  # type: Optional[str]
         rhs=None,  # type: Optional[str]
@@ -275,7 +474,13 @@ class EvalMarkerFunc(object):
                     "{flipped_op}{lhs}".format(lhs=lhs, flipped_op=flipped_op)
                 )
                 self._func = lambda value: cast(
-                    bool, version_specifier.contains(value, prereleases=True)
+                    bool,
+                    version_specifier.contains(
+                        # N.B.: This handles `implementation_version` for Python dev releases in the
+                        # same way `packaging` does.
+                        (value + "local") if value.endswith("+") else value,
+                        prereleases=True,
+                    ),
                 )
             else:
                 oper = _OPERATORS[op]
@@ -284,7 +489,13 @@ class EvalMarkerFunc(object):
             if is_version_comparison:
                 version_specifier = Specifier("{op}{rhs}".format(op=op, rhs=rhs))
                 self._func = lambda value: cast(
-                    bool, version_specifier.contains(value, prereleases=True)
+                    bool,
+                    version_specifier.contains(
+                        # N.B.: This handles `implementation_version` for Python dev releases in the
+                        # same way `packaging` does.
+                        (value + "local") if value.endswith("+") else value,
+                        prereleases=True,
+                    ),
                 )
             else:
                 oper = _OPERATORS[op]
@@ -299,8 +510,158 @@ class EvalMarkerFunc(object):
     def __call__(self, marker_env):
         # type: (MarkerEnv) -> bool
 
-        values = self._get_values(marker_env)
-        return any(map(self._func, values)) if values else True
+        return self._get_values(marker_env).apply(self._func)
+
+
+class ExtraMarkersVisitor(MarkerVisitor[str]):
+    def __init__(self):
+        # type: () -> None
+        self.conflicts = OrderedSet()  # type: OrderedSet[str]
+        self._marker_values = {}  # type: Dict[str, Tuple[str, OrderedSet[str], bool]]
+
+    def visit_op(
+        self,
+        lhs,  # type: Any
+        op,  # type: Any
+        rhs,  # type: Any
+        marker,  # type: Marker
+        context,  # type: str
+    ):
+        # type: (...) -> None
+
+        op_symbol = str(op)
+        if is_variable(lhs):
+            name = str(lhs)
+            value = str(rhs)
+        elif is_variable(rhs):
+            name = str(rhs)
+            value = str(lhs)
+        else:
+            return
+
+        if name in (
+            "extra",
+            "os_name",
+            "platform_system",
+            "sys_platform",
+            "platform_python_implementation",
+            "python_version",
+            "python_full_version",
+        ):
+            return
+
+        if op_symbol == "==":
+            requirement, values, inclusive = self._marker_values.setdefault(
+                name, (context, OrderedSet(), True)
+            )
+            if not inclusive:
+                self.conflicts.add(
+                    "The requirement {context} includes {value} for {name} but the requirement "
+                    "{requirement} established {name} as an exclusive set with values: "
+                    "{values}.".format(
+                        context=context,
+                        value=value,
+                        name=name,
+                        requirement=requirement,
+                        values=" ".join(values),
+                    )
+                )
+            else:
+                values.add(value)
+        elif op_symbol == "!=":
+            requirement, values, inclusive = self._marker_values.setdefault(
+                name, (context, OrderedSet(), False)
+            )
+            if inclusive:
+                self.conflicts.add(
+                    "The requirement {context} excludes {value} for {name} but the requirement "
+                    "{requirement} established {name} as an inclusive set with values: "
+                    "{values}.".format(
+                        context=context,
+                        value=value,
+                        name=name,
+                        requirement=requirement,
+                        values=" ".join(values),
+                    )
+                )
+            else:
+                values.add(value)
+        else:
+            pex_warnings.warn(
+                "Cannot split universal lock on all clauses of the marker in `{requirement}`.\n"
+                "The clause `{lhs} {op} {rhs}` uses comparison `{op}` but only `==` and `!=` are "
+                "supported for splitting on '{name}'.\n"
+                "Ignoring this clause in split calculations; lock results may be "
+                "unexpected.".format(requirement=context, lhs=lhs, op=op, rhs=rhs, name=name)
+            )
+
+    def marker_values(self):
+        # type: () -> Tuple[Values, ...]
+        return tuple(
+            Values(marker_name=name, values=tuple(values), inclusive=inclusive)
+            for name, (_, values, inclusive) in self._marker_values.items()
+        )
+
+
+@attr.s(frozen=True)
+class ExtraMarkers(object):
+    @classmethod
+    def extract(cls, requirements):
+        # type: (Iterable[Tuple[Marker, str]]) -> Optional[ExtraMarkers]
+
+        visitor = ExtraMarkersVisitor()
+        marker_parser = MarkerParser(visitor)
+
+        markers = []  # type: List[Marker]
+        for marker, provenance in requirements:
+            marker_parser.parse(marker, context=provenance)
+            markers.append(marker)
+
+        if visitor.conflicts:
+            raise ValueError(
+                "Encountered {count} {conflicts} when extracting universal lock splits from "
+                "top-level requirement markers:\n{items}".format(
+                    count=len(visitor.conflicts),
+                    conflicts=pluralize(visitor.conflicts, "conflict"),
+                    items="\n".join(
+                        "{index}. {conflict}".format(index=index, conflict=conflict)
+                        for index, conflict in enumerate(visitor.conflicts, start=1)
+                    ),
+                )
+            )
+
+        return cls(markers=tuple(markers), marker_values=visitor.marker_values())
+
+    @classmethod
+    def from_dict(cls, data):
+        # type: (Dict[str, Any]) -> ExtraMarkers
+        return cls(
+            markers=tuple(Marker(marker) for marker in data.pop("markers", ())),
+            marker_values=tuple(
+                Values.from_dict(marker_values) for marker_values in data.pop("marker_values", ())
+            ),
+        )
+
+    markers = attr.ib(default=())  # type: Tuple[Marker, ...]
+    marker_values = attr.ib(default=())  # type: Tuple[Values, ...]
+
+    def to_dict(self):
+        # type: () -> Dict[str, Any]
+        return {
+            "markers": [str(marker) for marker in self.markers],
+            "marker_values": [values.to_dict() for values in self.marker_values],
+        }
+
+    def get_values(self, marker_name):
+        # type: (str) -> Values
+        for values in self.marker_values:
+            if marker_name == values.marker_name:
+                return values
+        return Values(marker_name)
+
+    def __iter__(self):
+        # type: () -> Iterator[Marker]
+        return iter(self.markers)
 
 
 @attr.s(frozen=True)
@@ -353,7 +714,7 @@ class MarkerEnv(object):
                 sys_platforms.append("win32")
 
         return cls(
-            extras=SortedTuple(ProjectName(extra).normalized for extra in (extras or [""])),
+            extras=SortedTuple(ProjectName(extra).normalized for extra in extras),
             os_names=SortedTuple(os_names),
             platform_systems=SortedTuple(platform_systems),
             sys_platforms=SortedTuple(sys_platforms),
@@ -365,23 +726,17 @@ class MarkerEnv(object):
                 ".".join(map(str, python_full_version))
                 for python_full_version in python_full_versions
             ),
+            extra_markers=universal_target.extra_markers if universal_target else ExtraMarkers(),
         )
 
-    extras = attr.ib(converter=SortedTuple, default=SortedTuple())  # type: SortedTuple[str]
-    os_names = attr.ib(converter=SortedTuple, default=SortedTuple())  # type: SortedTuple[str]
-    platform_systems = attr.ib(
-        converter=SortedTuple, default=SortedTuple()
-    )  # type: SortedTuple[str]
-    sys_platforms = attr.ib(converter=SortedTuple, default=SortedTuple())  # type: SortedTuple[str]
-    platform_python_implementations = attr.ib(
-        converter=SortedTuple, default=SortedTuple()
-    )  # type: SortedTuple[str]
-    python_versions = attr.ib(
-        converter=SortedTuple, default=SortedTuple()
-    )  # type: SortedTuple[str]
-    python_full_versions = attr.ib(
-        converter=SortedTuple, default=SortedTuple()
-    )  # type: SortedTuple[str]
+    extras = attr.ib()  # type: SortedTuple[str]
+    os_names = attr.ib()  # type: SortedTuple[str]
+    platform_systems = attr.ib()  # type: SortedTuple[str]
+    sys_platforms = attr.ib()  # type: SortedTuple[str]
+    platform_python_implementations = attr.ib()  # type: SortedTuple[str]
+    python_versions = attr.ib()  # type: SortedTuple[str]
+    python_full_versions = attr.ib()  # type: SortedTuple[str]
+    extra_markers = attr.ib()  # type: ExtraMarkers
 
     def as_dict(self):
         # type: () -> Dict[str, Any]
@@ -426,9 +781,46 @@ def _as_python_version_marker(specifier):
 
 @attr.s(frozen=True)
 class UniversalTarget(object):
+    @classmethod
+    def from_dict(cls, data):
+        # type: (Dict[str, Any]) -> UniversalTarget
+
+        raw_implementation = data.pop("implementation", None)
+        implementation = None  # type: Optional[InterpreterImplementation.Value]
+        if raw_implementation:
+            if not isinstance(raw_implementation, string):
+                raise AssertionError(
+                    reportable_unexpected_error_msg(
+                        "Expected UniversalTarget `implementation` value to be a str, found "
+                        "{value} of type {type}.",
+                        value=raw_implementation,
+                        type=type(raw_implementation),
+                    )
+                )
+            implementation = InterpreterImplementation.for_value(raw_implementation)
+
+        return cls(
+            implementation=implementation,
+            requires_python=tuple(
+                SpecifierSet(specifier) for specifier in data.pop("requires_python", ())
+            ),
+            systems=tuple(TargetSystem.for_value(system) for system in data.pop("systems", ())),
+            extra_markers=ExtraMarkers.from_dict(data.pop("extra_markers", {})),
+        )
+
     implementation = attr.ib(default=None)  # type: Optional[InterpreterImplementation.Value]
     requires_python = attr.ib(default=())  # type: Tuple[SpecifierSet, ...]
     systems = attr.ib(default=())  # type: Tuple[TargetSystem.Value, ...]
+    extra_markers = attr.ib(default=ExtraMarkers())  # type: ExtraMarkers
+
+    def to_dict(self):
+        # type: () -> Dict[str, Any]
+        return {
+            "implementation": str(self.implementation) if self.implementation else None,
+            "requires_python": [str(specifier) for specifier in self.requires_python],
+            "systems": [str(system) for system in self.systems],
+            "extra_markers": self.extra_markers.to_dict(),
+        }
 
     def iter_interpreter_constraints(self):
         # type: () -> Iterator[InterpreterConstraint]
@@ -456,8 +848,8 @@ class UniversalTarget(object):
         marker_envs = OrderedSet(
             MarkerEnv.create(
                 extras=(),
-                universal_target=UniversalTarget(
-                    implementation=self.implementation,
+                universal_target=attr.evolve(
+                    self,
                     requires_python=tuple(
                         [SpecifierSet("=={version}".format(version=".".join(map(str, version))))]
                     ),
@@ -512,4 +904,5 @@ class UniversalTarget(object):
             clauses.append(
                 "({requires_pythons})".format(requires_pythons=" or ".join(python_version_markers))
             )
+        clauses.extend("({marker})".format(marker=marker) for marker in self.extra_markers)
         return Marker(" and ".join(clauses)) if clauses else None

--- a/pex/venv/venv_pex.py
+++ b/pex/venv/venv_pex.py
@@ -186,7 +186,7 @@ def boot(
             "_PEX_PATCHED_TAGS_FILE",
             # These are used by Pex's Pip venv to implement universal locks.
             "_PEX_PYTHON_VERSIONS_FILE",
-            "_PEX_TARGET_SYSTEMS_FILE",
+            "_PEX_UNIVERSAL_TARGET_FILE",
             # This is used to implement Pex --exclude and --override support.
             "_PEX_DEP_CONFIG_FILE",
             # This is used to implement --source support.

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.61.1"
+__version__ = "2.62.0"

--- a/tests/integration/resolve/test_universal_lock_splits.py
+++ b/tests/integration/resolve/test_universal_lock_splits.py
@@ -1,0 +1,216 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, print_function
+
+import re
+from textwrap import dedent
+from typing import Dict, Sequence
+
+from pex.pep_440 import Version
+from pex.pep_503 import ProjectName
+from pex.resolve.lockfile import json_codec
+from pex.third_party.packaging.markers import Marker
+from pex.typing import TYPE_CHECKING
+from testing.cli import run_pex3
+from testing.pytest_utils.tmp import Tempdir
+
+if TYPE_CHECKING:
+    from typing import Any, List, Optional, Tuple  # noqa
+
+
+def assert_split_lock(
+    lockfile_path,  # type: str
+    cowsay5_marker="platform_machine == 'x86_64'",  # type: str
+    cowsay6_marker="platform_machine != 'x86_64'",  # type: str
+    additional5_pins=(),  # type: Sequence[Tuple[str, str]]
+    additional6_pins=(),  # type: Sequence[Tuple[str, str]]
+):
+    # type: (...) -> None
+
+    lock = json_codec.load(lockfile_path=lockfile_path)
+    assert 2 == len(lock.locked_resolves)
+
+    # N.B.: Marker objects don't implement value equals; so we normalize markers to their string
+    # representations for consistent comparison.
+
+    locked_resolve_by_marker = {
+        str(locked_resolve.marker): locked_resolve for locked_resolve in lock.locked_resolves
+    }
+
+    def index_lock(marker):
+        # type: (str) -> Dict[ProjectName, Version]
+        return {
+            locked_requirement.pin.project_name: locked_requirement.pin.version
+            for locked_requirement in locked_resolve_by_marker.pop(
+                str(Marker(marker))
+            ).locked_requirements
+        }
+
+    cowsay5_lock = index_lock(cowsay5_marker)
+    assert 1 + len(additional5_pins) == len(cowsay5_lock)
+    assert Version("5") == cowsay5_lock.pop(ProjectName("cowsay"))
+    for project_name, version in additional5_pins:
+        assert Version(version) == cowsay5_lock.pop(ProjectName(project_name))
+
+    cowsay6_lock = index_lock(cowsay6_marker)
+    assert 1 + len(additional6_pins) == len(cowsay6_lock)
+    assert Version("6") == cowsay6_lock.pop(ProjectName("cowsay"))
+    for project_name, version in additional6_pins:
+        assert Version(version) == cowsay6_lock.pop(ProjectName(project_name))
+
+
+def test_split_positional_requirements(tmpdir):
+    # type: (Tempdir) -> None
+
+    pex_root = tmpdir.join("pex-root")
+    lock = tmpdir.join("lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--pex-root",
+        pex_root,
+        "--style",
+        "universal",
+        "cowsay==5; platform_machine == 'x86_64'",
+        "cowsay==6; platform_machine != 'x86_64'",
+        "--indent",
+        "2",
+        "-o",
+        lock,
+    ).assert_success()
+    assert_split_lock(lock)
+
+
+def test_split_requirements_txt(tmpdir):
+    # type: (Tempdir) -> None
+
+    requirements_txt = tmpdir.join("requirements.txt")
+    with open(requirements_txt, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                # Header comments.
+                
+                # Old.
+                cowsay==5; platform_machine == 'x86_64'
+                
+                # New.
+                cowsay==6; platform_machine != 'x86_64'
+                """
+            )
+        )
+
+    pex_root = tmpdir.join("pex-root")
+    lock = tmpdir.join("lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--pex-root",
+        pex_root,
+        "--style",
+        "universal",
+        "-r",
+        requirements_txt,
+        "--indent",
+        "2",
+        "-o",
+        lock,
+    ).assert_success()
+    assert_split_lock(lock)
+
+
+def test_split_mixed_positional_requirements_and_requirements_txt(tmpdir):
+    # type: (Tempdir) -> None
+
+    requirements_txt = tmpdir.join("requirements.txt")
+    with open(requirements_txt, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                # Header comments.
+                
+                # Multiline.
+                cowsay==6; \\
+                    platform_machine != 'x86_64'
+                """
+            )
+        )
+
+    pex_root = tmpdir.join("pex-root")
+    lock = tmpdir.join("lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--pex-root",
+        pex_root,
+        "--style",
+        "universal",
+        "cowsay==5; platform_machine == 'x86_64'",
+        "-r",
+        requirements_txt,
+        "--indent",
+        "2",
+        "-o",
+        lock,
+    ).assert_success()
+    assert_split_lock(lock)
+
+
+def test_split_warn(tmpdir):
+    # type: (Tempdir) -> None
+
+    pex_root = tmpdir.join("pex-root")
+    lock = tmpdir.join("lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--pex-root",
+        pex_root,
+        "--style",
+        "universal",
+        "cowsay==5; platform_machine >= 'x86_64'",
+        "cowsay==6; platform_machine != 'x86_64'",
+        "--indent",
+        "2",
+        "-o",
+        lock,
+    ).assert_success(
+        expected_error_re=r"^.*{warning}.*$".format(
+            warning=re.escape(
+                "PEXWarning: Cannot split universal lock on all clauses of the marker in "
+                "`cowsay==5; platform_machine >= 'x86_64'`.\n"
+                "The clause `platform_machine >= x86_64` uses comparison `>=` but only `==` and "
+                "`!=` are supported for splitting on 'platform_machine'.\n"
+                "Ignoring this clause in split calculations; lock results may be unexpected."
+            )
+        ),
+        re_flags=re.DOTALL,
+    )
+    assert_split_lock(lock, cowsay5_marker="platform_machine >= 'x86_64'")
+
+
+def test_split_merge_non_conflicting(tmpdir):
+    # type: (Tempdir) -> None
+
+    pex_root = tmpdir.join("pex-root")
+    lock = tmpdir.join("lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--pex-root",
+        pex_root,
+        "--style",
+        "universal",
+        "cowsay==5; platform_machine == 'x86_64'",
+        "cowsay==6; platform_machine != 'x86_64'",
+        "ansicolors==1.1.7; platform_machine == 'x86_64'",
+        "ansicolors==1.1.8; platform_machine != 'x86_64'",
+        "--indent",
+        "2",
+        "-o",
+        lock,
+    ).assert_success()
+    assert_split_lock(
+        lock, additional5_pins=[("ansicolors", "1.1.7")], additional6_pins=[("ansicolors", "1.1.8")]
+    )

--- a/tests/integration/test_issue_2897.py
+++ b/tests/integration/test_issue_2897.py
@@ -138,8 +138,11 @@ def test_ic_implementation_respected(
 
     lock_file = tmpdir.join("lock.json")
 
-    def assert_vcr_lock(interpreter_constraint):
-        # type: (str) -> LockedRequirement
+    def assert_vcr_lock(
+        interpreter_constraint,  # type: str
+        *extra_args  # type: str
+    ):
+        # type: (...) -> LockedRequirement
 
         run_pex3(
             "lock",
@@ -154,6 +157,7 @@ def test_ic_implementation_respected(
             lock_file,
             "--indent",
             "2",
+            *extra_args
         ).assert_success()
 
         lock = json_codec.load(lock_file)
@@ -197,5 +201,7 @@ def test_ic_implementation_respected(
         InterpreterConstraint.matches(pypy_constraint, interpreter)
         for interpreter in PythonInterpreter.iter()
     ):
-        urllib3 = assert_vcr_lock(pypy_constraint)
+        # N.B.: The lock is `--no-build` and there is no PyYAML .whl published for PyPy; so we
+        # exclude it.
+        urllib3 = assert_vcr_lock(pypy_constraint, "--exclude", "PyYAML")
         assert urllib3.pin.version < pypy_version_ceiling

--- a/tests/integration/test_issue_661.py
+++ b/tests/integration/test_issue_661.py
@@ -1,35 +1,26 @@
 # Copyright 2021 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os
-
 import pytest
 
-from pex.common import temporary_dir
 from testing import IS_ARM_64, IS_PYPY, run_pex_command, subprocess
+from testing.pytest_utils.tmp import Tempdir
 
 
 @pytest.mark.skipif(
     IS_ARM_64 or IS_PYPY,
     reason=(
-        "No wheels are published for arm and the sdist fails to compile against modern OpenSSL. "
-        "Also, on PyPy we get this error: Failed to execute PEX file. Needed "
-        "manylinux2014_x86_64-pp-272-pypy_41 compatible dependencies for 1: "
-        "cryptography==2.5 But this pex only contains "
-        "cryptography-2.5-pp27-pypy_41-linux_x86_64.whl. "
-        "Temporarily skipping the test on PyPy allows us to get tests passing again, until we can "
-        "address this."
+        "No wheels are published for arm or PyPy and the sdist fails to compile against modern "
+        "OpenSSL."
     ),
 )
-def test_devendoring_required():
-    # type: () -> None
+def test_devendoring_required(tmpdir):
+    # type: (Tempdir) -> None
     # The cryptography distribution does not have a whl released for python3 on linux at version 2.5.
     # As a result, we're forced to build it under python3 and, prior to the fix for
     # https://github.com/pex-tool/pex/issues/661, this would fail using the vendored setuptools
     # inside pex.
-    with temporary_dir() as td:
-        cryptography_pex = os.path.join(td, "cryptography.pex")
-        res = run_pex_command(["cryptography==2.5", "-o", cryptography_pex])
-        res.assert_success()
+    cryptography_pex = tmpdir.join("cryptography.pex")
+    run_pex_command(["cryptography==2.5", "-o", cryptography_pex]).assert_success()
 
-        subprocess.check_call([cryptography_pex, "-c", "import cryptography"])
+    subprocess.check_call([cryptography_pex, "-c", "import cryptography"])

--- a/tests/test_target_system.py
+++ b/tests/test_target_system.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import
 
-from pex.resolve.target_system import MarkerEnv, UniversalTarget
+from pex.resolve.target_system import MarkerEnv, UniversalTarget, has_marker
 from pex.third_party.packaging.markers import Marker
 from pex.third_party.packaging.specifiers import SpecifierSet
 
@@ -80,4 +80,18 @@ def test_marker_env_grouping():
             "   )"
             ")"
         )
+    )
+
+
+def test_has_marker():
+    # type: () -> None
+
+    assert has_marker(Marker("python_version >= '3.9'"), "python_version")
+    assert not has_marker(Marker("python_version >= '3.9'"), "python_full_version")
+
+    assert has_marker(
+        Marker(
+            "platform_machine == 'x86_64' and (sys_platform == 'darwin' or python_version >= '3.9')"
+        ),
+        "python_version",
     )


### PR DESCRIPTION
Previously, `--style universal` locks could be split via scoped
`--index` and `--find-links` repositories as well as by certain
top-level conflicting requirements. Now all conflicting top-level
requirements will contribute to splitting.

Fixes: https://github.com/pantsbuild/pants/issues/18555