### PR TITLE
Make zip hashing consistent with dir hashing.

### DIFF
--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -470,10 +470,7 @@ class PEXBuilder(object):
     def _prepare_code(self):
         chroot_path = self._chroot.path()
         self._pex_info.code_hash = CacheHelper.pex_code_hash(
-            chroot_path,
-            exclude_dirs=tuple(
-                os.path.join(chroot_path, d) for d in (layout.BOOTSTRAP_DIR, layout.DEPS_DIR)
-            ),
+            chroot_path, exclude_dirs=(layout.BOOTSTRAP_DIR, layout.DEPS_DIR)
         )
         self._pex_info.pex_hash = hashlib.sha1(self._pex_info.dump().encode("utf-8")).hexdigest()
         self._chroot.write(self._pex_info.dump().encode("utf-8"), PexInfo.PATH, label="manifest")

--- a/pex/resolve/lock_downloader.py
+++ b/pex/resolve/lock_downloader.py
@@ -154,6 +154,7 @@ class VCSArtifactDownloadManager(DownloadManager[VCSArtifact]):
         local_distribution = downloaded_vcs.local_distributions[0]
         filename = os.path.basename(local_distribution.path)
         digest_vcs_archive(
+            project_name=project_name,
             archive_path=local_distribution.path,
             vcs=artifact.vcs,
             digest=digest,

--- a/pex/resolve/locker.py
+++ b/pex/resolve/locker.py
@@ -371,8 +371,8 @@ class Locker(LogAnalyzer):
                 if isinstance(artifact_url.scheme, VCSScheme):
                     source_fingerprint, archive_path = fingerprint_downloaded_vcs_archive(
                         download_dir=self._download_dir,
-                        project_name=str(build_result.pin.project_name),
-                        version=str(build_result.pin.version),
+                        project_name=build_result.pin.project_name,
+                        version=build_result.pin.version,
                         vcs=artifact_url.scheme.vcs,
                     )
                     verified = True


### PR DESCRIPTION
Use this to eliminate a TODO hashing VCS archives produced by Pip.