### PR TITLE
Upgrade science to 0.17.0 & scie-jump to 1.9.1.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 2.73.0
+
+This release upgrades the floor of `science` to 0.17.0 and `scie-jump` to 1.9.1 to pick up support
+for producing PEX scies for Linux aarch64 & x86_64 that link against glibc. Previously the embedded
+interpreter would link against glibc but the `scie-jump` at the PEX scie tip was a musl libc static
+binary and this could cause problems in those areas where glibc and musl diverge.
+
+* Upgrade science to 0.17.0 & scie-jump to 1.9.1. (#3033)
+
 ## 2.72.2
 
 This release fixes a regression introduced in the Pex 2.60.0 release when installing wheels with

--- a/pex/scie/science.py
+++ b/pex/scie/science.py
@@ -68,7 +68,7 @@ class Manifest(object):
 
 
 SCIENCE_RELEASES_URL = "https://github.com/a-scie/lift/releases"
-MIN_SCIENCE_VERSION = Version("0.16.0")
+MIN_SCIENCE_VERSION = Version("0.17.0")
 SCIENCE_REQUIREMENT = SpecifierSet("~={min_version}".format(min_version=MIN_SCIENCE_VERSION))
 
 
@@ -83,7 +83,7 @@ def _science_binary_url(suffix=""):
 
 
 PTEX_VERSION = "1.7.0"
-SCIE_JUMP_VERSION = "1.8.3"
+SCIE_JUMP_VERSION = "1.9.1"
 
 
 class Filenames(Enum["Filenames.Value"]):

--- a/pex/sysconfig.py
+++ b/pex/sysconfig.py
@@ -175,13 +175,13 @@ class SysPlatform(Enum["SysPlatform.Value"]):
     class Value(_PlatformValue):
         pass
 
-    LINUX_AARCH64 = Value(Os.LINUX, "aarch64")
+    LINUX_AARCH64 = Value(Os.LINUX, "aarch64", LibC.GLIBC)
     MUSL_LINUX_AARCH64 = Value(Os.LINUX, "aarch64", LibC.MUSL)
     LINUX_ARMV7L = Value(Os.LINUX, "armv7l")
     LINUX_PPC64LE = Value(Os.LINUX, "powerpc64")
     LINUX_RISCV64 = Value(Os.LINUX, "riscv64")
     LINUX_S390X = Value(Os.LINUX, "s390x")
-    LINUX_X86_64 = Value(Os.LINUX, "x86_64")
+    LINUX_X86_64 = Value(Os.LINUX, "x86_64", LibC.GLIBC)
     MUSL_LINUX_X86_64 = Value(Os.LINUX, "x86_64", LibC.MUSL)
     MACOS_AARCH64 = Value(Os.MACOS, "aarch64")
     MACOS_X86_64 = Value(Os.MACOS, "x86_64")

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.72.2"
+__version__ = "2.73.0"

--- a/tests/integration/scie/test_pex_scie.py
+++ b/tests/integration/scie/test_pex_scie.py
@@ -341,7 +341,7 @@ def test_specified_science_binary(tmpdir):
 
     local_science_binary = os.path.join(str(tmpdir), "science")
     with open(local_science_binary, "wb") as write_fp, URLFetcher().get_body_stream(
-        "https://github.com/a-scie/lift/releases/download/v0.16.0/{binary}".format(
+        "https://github.com/a-scie/lift/releases/download/v0.17.0/{binary}".format(
             binary=SysPlatform.CURRENT.qualified_binary_name("science")
         )
     ) as read_fp:
@@ -385,7 +385,7 @@ def test_specified_science_binary(tmpdir):
         cached_science_binaries
     ), "Expected the local science binary to be used but not cached."
     assert (
-        "0.16.0"
+        "0.17.0"
         == subprocess.check_output(args=[local_science_binary, "--version"]).decode("utf-8").strip()
     )
 


### PR DESCRIPTION
This picks up support for using glibc-linked scie-jumps on Linux
`{aarch,x86_}64`.