### PR TITLE
Add scie support for direct exec of venv scripts.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 2.76.0
+
+This release adds support for `--no-scie-pex-entrypoint-env-passthrough` to trigger direct execution
+of `--venv` PEX scie script entrypoints. This performance optimization mirrors the existing default
+`--no-scie-busybox-pex-entrypoint-env-passthrough` for busybox scies, but must be selected by 
+passing `--no-scie-pex-entrypoint-env-passthrough` explicitly. In addition, the `VIRTUAL_ENV` env
+var is now guaranteed to be set for all `--venv` PEX scies.
+
+* Add scie support for direct exec of venv scripts. (#3053)
+
 ## 2.75.2
 
 This release updates vendored Pip's vendored certifi's cacert.pem to that from certifi 2025.11.12.

--- a/pex/scie/__init__.py
+++ b/pex/scie/__init__.py
@@ -157,16 +157,19 @@ def register_options(parser):
         ),
     )
     parser.add_argument(
+        "--scie-pex-entrypoint-env-passthrough",
         "--scie-busybox-pex-entrypoint-env-passthrough",
+        "--no-scie-pex-entrypoint-env-passthrough",
         "--no-scie-busybox-pex-entrypoint-env-passthrough",
-        dest="scie_busybox_pex_entrypoint_env_passthrough",
-        default=False,
+        dest="scie_pex_entrypoint_env_passthrough",
+        default=None,
         type=bool,
         action=HandleBoolAction,
         help=(
-            "When creating a busybox, allow overriding the primary entrypoint at runtime via "
-            "PEX_INTERPRETER, PEX_SCRIPT and PEX_MODULE. Note that when using --venv this adds "
-            "modest startup overhead on the order of 10ms."
+            "Allow overriding the primary entrypoint at runtime via PEX_INTERPRETER, PEX_SCRIPT "
+            "and PEX_MODULE. Note that when using --venv with a script entrypoint this adds modest "
+            "startup overhead on the order of 10ms. Defaults to false for busybox scies and true "
+            "for single entrypoint scies."
         ),
     )
     parser.add_argument(
@@ -346,8 +349,11 @@ def render_options(options):
         entrypoints = list(options.busybox_entrypoints.console_scripts_manifest.iter_specs())
         entrypoints.extend(map(str, options.busybox_entrypoints.ad_hoc_entry_points))
         args.append(",".join(entrypoints))
-    if options.busybox_pex_entrypoint_env_passthrough:
-        args.append("--scie-busybox-pex-entrypoint-env-passthrough")
+    if options.pex_entrypoint_env_passthrough is not None:
+        if options.pex_entrypoint_env_passthrough:
+            args.append("--scie-busybox-pex-entrypoint-env-passthrough")
+        else:
+            args.append("--no-scie-pex-entrypoint-env-passthrough")
     for platform in options.platforms:
         args.append("--scie-platform")
         args.append(str(platform))
@@ -468,7 +474,7 @@ def extract_options(options):
         scie_only=options.scie_only,
         load_dotenv=options.scie_load_dotenv,
         busybox_entrypoints=entry_points,
-        busybox_pex_entrypoint_env_passthrough=options.scie_busybox_pex_entrypoint_env_passthrough,
+        pex_entrypoint_env_passthrough=options.scie_pex_entrypoint_env_passthrough,
         platforms=tuple(OrderedSet(options.scie_platforms)),
         pbs_release=options.scie_pbs_release,
         pypy_release=options.scie_pypy_release,

--- a/pex/scie/configure-binding.py
+++ b/pex/scie/configure-binding.py
@@ -28,6 +28,7 @@ def write_bindings(
         print("PYTHON=" + sys.executable, file=fp)
         print("PEX=" + pex, file=fp)
         if venv_bin_dir:
+            print("VIRTUAL_ENV=" + os.path.dirname(venv_bin_dir), file=fp)
             print("VENV_BIN_DIR_PLUS_SEP=" + venv_bin_dir + os.path.sep, file=fp)
 
 

--- a/pex/scie/model.py
+++ b/pex/scie/model.py
@@ -297,7 +297,7 @@ class ScieOptions(object):
     scie_only = attr.ib(default=False)  # type: bool
     load_dotenv = attr.ib(default=False)  # type: bool
     busybox_entrypoints = attr.ib(default=None)  # type: Optional[BusyBoxEntryPoints]
-    busybox_pex_entrypoint_env_passthrough = attr.ib(default=False)  # type: bool
+    pex_entrypoint_env_passthrough = attr.ib(default=None)  # type: Optional[bool]
     platforms = attr.ib(default=())  # type: Tuple[SysPlatform.Value, ...]
     pbs_release = attr.ib(default=None)  # type: Optional[str]
     pypy_release = attr.ib(default=None)  # type: Optional[str]

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.75.2"
+__version__ = "2.76.0"


### PR DESCRIPTION
Previously this support was only provided for busybox scies, but now you
can pass `--no-scie-pex-entrypoint-env-passthrough` for single script
entrypoint `--venv` PEX scies as well.