### PR TITLE
Fix `test_statically_linked_musl_libc_cpython_support`.

### DIFF
--- a/tests/integration/test_issue_2017.py
+++ b/tests/integration/test_issue_2017.py
@@ -29,7 +29,7 @@ def musl_libc_capable_pip_versions():
     for version in PipVersion.values():
         if not version.requires_python_applies():
             continue
-        if version is PipVersion.VENDORED or version >= PipVersion.v24_2:
+        if version >= PipVersion.v24_2:
             yield version
 
 
@@ -65,9 +65,8 @@ def statically_linked_musl_libc_cpython(shared_integration_test_tmpdir):
 @pytest.mark.skipif(
     not MUSL_LIBC_CAPABLE_PIP_VERSIONS,
     reason=(
-        "Although Pex's vendored Pip is patched to handle statically linked musl libc CPython, no "
-        "version of Pip Pex supports handles these Pythons until Pip 24.2 and none of these "
-        "versions are supported by the current interpreter."
+        "No version of Pip Pex supports handles statically linked musl libc CPython until Pip 24.2 "
+        "and none of these versions are supported by the current interpreter."
     ),
 )
 @pytest.mark.skipif(


### PR DESCRIPTION
Since we're using an ephemeral interpreter, do not attempt to create a
venv from it. This avoids the venv base interpreter going missing later.