### PR TITLE
Fix `.desktop` files installed by PEX scies.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 2.88.1
+
+This release fixes `.desktop` files installed by `--scie-icon` and `--scie-desktop-file` PEX scies
+to be more robust. They now work even if the original PEX scie they were installed by is (re)moved
+as well as properly handling a `SCIE_BASE` with spaces in the path.
+
+* Fix `.desktop` files installed by PEX scies. (#3099)
+
 ## 2.88.0
 
 This release adds support for `--pip-version 26.0.1`.

--- a/pex/scie/model.py
+++ b/pex/scie/model.py
@@ -374,7 +374,7 @@ class DesktopApp(object):
         parser.ensure_set("Version", default="1.0")
         parser.ensure_set("Type", default="Application")
         parser.ensure_set("Name", default=app_name)
-        parser.ensure_set("Exec", default="{exe}")
+        parser.ensure_set("Exec", default="{default_exec}")
         if self.icon:
             parser.ensure_set("Icon", default="{icon}")
 

--- a/pex/scie/science.py
+++ b/pex/scie/science.py
@@ -69,7 +69,7 @@ class Manifest(object):
 
 
 SCIENCE_RELEASES_URL = "https://github.com/a-scie/lift/releases"
-MIN_SCIENCE_VERSION = Version("0.17.2")
+MIN_SCIENCE_VERSION = Version("0.18.1")
 SCIENCE_REQUIREMENT = SpecifierSet("~={min_version}".format(min_version=MIN_SCIENCE_VERSION))
 
 
@@ -84,7 +84,7 @@ def _science_binary_url(suffix=""):
 
 
 PTEX_VERSION = "1.7.0"
-SCIE_JUMP_VERSION = "1.9.2"
+SCIE_JUMP_VERSION = "1.11.2"
 
 
 class Filenames(Enum["Filenames.Value"]):
@@ -125,7 +125,7 @@ def _is_free_threaded_pex(pex_info):
 
 def create_manifests(
     configuration,  # type: ScieConfiguration
-    name,  # type: str
+    app_name,  # type: str
     pex,  # type: PEX
     use_platform_suffix=None,  # type: Optional[bool]
 ):
@@ -332,7 +332,7 @@ def create_manifests(
     )
 
     lift_template = {
-        "name": name,
+        "name": app_name,
         "load_dotenv": configuration.options.load_dotenv,
         "scie_jump": scie_jump_config,
     }  # type: Dict[str, Any]
@@ -410,7 +410,7 @@ def create_manifests(
 
         manifest_path = os.path.join(
             safe_mkdtemp(),
-            interpreter.platform.qualified_file_name("{name}-lift.toml".format(name=name)),
+            interpreter.platform.qualified_file_name("{name}-lift.toml".format(name=app_name)),
         )
 
         version_str = interpreter.version_str
@@ -450,7 +450,16 @@ def create_manifests(
             )
         if interpreter.platform.os is Os.LINUX and configuration.options.desktop_app:
             extra_configure_binding_args.extend(
-                ("--desktop-file", Filenames.DESKTOP_FILE.placeholder)
+                (
+                    "--desktop-file",
+                    Filenames.DESKTOP_FILE.placeholder,
+                    "--scie-name",
+                    app_name,
+                    "--scie-jump",
+                    "{scie.jump}",
+                    "--scie-lift",
+                    "{scie.lift}",
+                )
             )
             if not configuration.options.desktop_app.prompt_install:
                 extra_configure_binding_args.append("--no-prompt-desktop-install")

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.88.0"
+__version__ = "2.88.1"

--- a/tests/integration/scie/test_pex_scie.py
+++ b/tests/integration/scie/test_pex_scie.py
@@ -350,7 +350,7 @@ def test_specified_science_binary(tmpdir):
 
     local_science_binary = os.path.join(str(tmpdir), "science")
     with open(local_science_binary, "wb") as write_fp, URLFetcher().get_body_stream(
-        "https://github.com/a-scie/lift/releases/download/v0.17.2/{binary}".format(
+        "https://github.com/a-scie/lift/releases/download/v0.18.1/{binary}".format(
             binary=SysPlatform.CURRENT.qualified_binary_name("science")
         )
     ) as read_fp:
@@ -394,7 +394,7 @@ def test_specified_science_binary(tmpdir):
         cached_science_binaries
     ), "Expected the local science binary to be used but not cached."
     assert (
-        "0.17.2"
+        "0.18.1"
         == subprocess.check_output(args=[local_science_binary, "--version"]).decode("utf-8").strip()
     )
 


### PR DESCRIPTION
Fix `.desktop` files installed by `--scie-icon` / `--scie-desktop-file`
PEX scies to be more robust. They now work even if the original PEX
scie they were installed by is (re)moved as well as properly handling a
`SCIE_BASE` with spaces in the path.