### PR TITLE
Hoist realpath calls out of per-file loop in install_wheel.

### DIFF
--- a/pex/pep_427.py
+++ b/pex/pep_427.py
@@ -965,6 +965,11 @@ def install_wheel(
     provenance = []  # type: List[Tuple[Text, Text]]
     symlinked = set()  # type: Set[Tuple[Text, Text]]
     warned_bad_record = False
+    resolved_install_paths = [
+        (path_name, os.path.realpath(installed_path))
+        for path_name, installed_path in wheel.iter_install_paths_by_name()
+    ]
+    resolved_wheel_location = os.path.realpath(wheel.location)
     for installed_file_or_dir in _read_record_lines(record_data.decode("utf-8").splitlines()):
         if isinstance(installed_file_or_dir, InstalledDirectory):
             installed_files.append(installed_file_or_dir)
@@ -984,7 +989,9 @@ def install_wheel(
             continue
 
         src_file = os.path.normpath(os.path.join(wheel.location, installed_file.path))
-        src_file_realpath = os.path.realpath(src_file)
+        src_file_realpath = os.path.normpath(
+            os.path.join(resolved_wheel_location, installed_file.path)
+        )
         if not os.path.exists(src_file_realpath):
             if not warned_bad_record:
                 pex_warnings.warn(
@@ -997,8 +1004,7 @@ def install_wheel(
             continue
 
         dst_components = None  # type: Optional[Tuple[Text, Text, bool]]
-        for path_name, installed_path in wheel.iter_install_paths_by_name():
-            installed_path = os.path.realpath(installed_path)
+        for path_name, installed_path in resolved_install_paths:
 
             src_path = None  # type: Optional[Text]
             if installed_path == commonpath((installed_path, src_file_realpath)):


### PR DESCRIPTION
While searching for the root cause for the performance issue that lead to https://github.com/pex-tool/pex/pull/3123 I also stumbled upon this.
`install_wheel` calls `realpath` on every file in every wheel AND on the same ~5 install paths per file inside an inner loop. Hoisting these resolves out of the per-file loop halves venv creation time.

Re-resolving symlinks within a wheel is redundant as far as I can tell; wheels cannot contains symlinks. Only argument against would be future-compat with https://peps.python.org/pep-0778/ .

Repro / perf-test:

```shell
#!/usr/bin/env bash
set -euo pipefail

#
# Run from the pex repo root on the fix branch:
#   ./repro.sh

WORK=$(mktemp -d)
trap 'rm -rf "$WORK"' EXIT

BRANCH=$(git rev-parse --abbrev-ref HEAD)

PYTHON=$(python3 -c "import sys; print(sys.executable)")

build_pex_from_ref() {
    local ref=$1 dest=$2
    git checkout -q "$ref"
    uv pip install -e . -q 2>/dev/null
    python3 -m pex.bin.pex \
        --output-file "$dest" \
        --python "$PYTHON" \
        --layout packed \
        --venv prepend \
        --no-emit-warnings \
        --console-script pip \
        matplotlib pandas scikit-learn scipy pip
}

echo "=== Building test PEX from main ==="
build_pex_from_ref main "$WORK/test.pex"

dist_count=$(python3 -c "
import json
info = json.load(open('$WORK/test.pex/PEX-INFO'))
print(len(info.get('distributions', {})))
")
echo "PEX: $(du -sh "$WORK/test.pex" | cut -f1), $dist_count distributions"

PEX_ROOT="$WORK/pex_root"

run_benchmark() {
    local label=$1
    echo ""
    echo "=== $label ==="
    # Warmup
    rm -rf "$PEX_ROOT/venvs"
    PEX_ROOT="$PEX_ROOT" "$PYTHON" "$WORK/test.pex" --version > /dev/null 2>&1
    # Timed runs
    for _ in 1 2 3; do
        rm -rf "$PEX_ROOT/venvs"
        t=$( { /usr/bin/time -f "%e" env PEX_ROOT="$PEX_ROOT" "$PYTHON" "$WORK/test.pex" --version > /dev/null; } 2>&1 )
        echo "  ${t}s"
    done
}

patch_bootstrap() {
    local ref=$1
    while IFS= read -r bootstrap; do
        git show "$ref":pex/pep_427.py > "$bootstrap"
        find "$(dirname "$bootstrap")/__pycache__" -name 'pep_427*' -delete 2>/dev/null || true
    done < <(find "$PEX_ROOT" -name "pep_427.py" -path "*/pex/*" 2>/dev/null)
}

# First run to populate the bootstrap cache
PEX_ROOT="$PEX_ROOT" "$PYTHON" "$WORK/test.pex" --version > /dev/null 2>&1

patch_bootstrap main
run_benchmark "main"

patch_bootstrap "$BRANCH"
run_benchmark "$BRANCH"

git checkout -q "$BRANCH"
```