### PR TITLE
Make ephemeral exec and scie compatible.

### DIFF
--- a/pex/pex_boot.py
+++ b/pex/pex_boot.py
@@ -229,7 +229,7 @@ def boot(
             if os.path.isfile(pex_exe):
                 sys.argv[0] = pex_exe
 
-    overridden_entry_point = os.environ.get("__PEX_ENTRY_POINT__", None)
+    overridden_entry_point = os.environ.pop("__PEX_ENTRY_POINT__", None)
     sys.path[0] = os.path.abspath(sys.path[0])
     sys.path.insert(
         0, os.path.abspath(os.path.join(overridden_entry_point or entry_point, bootstrap_dir))

--- a/pex/venv/venv_pex.py
+++ b/pex/venv/venv_pex.py
@@ -288,6 +288,11 @@ def boot(
                     # subprocesses is the same as the sys.executable in the parent process.
                     os.environ["__PEX_EXTRA_SYS_PATH__"] = os.environ["PEX_EXTRA_SYS_PATH"]
                 del os.environ[key]
+        # These are set by the scie to point back at itself and its installed PEX. If not
+        # stripped, they leak into processes spawned by the venv entry point and corrupt
+        # their boot by making them think they were launched from the scie.
+        os.environ.pop("__PEX_ENTRY_POINT__", None)
+        os.environ.pop("__PEX_EXE__", None)
 
     for name, value in inject_env:
         os.environ.setdefault(name, value)

--- a/tests/integration/scie/test_scie_ephemeral_run.py
+++ b/tests/integration/scie/test_scie_ephemeral_run.py
@@ -1,0 +1,66 @@
+# Copyright 2026 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import subprocess
+import sys
+
+import pytest
+
+from pex.typing import TYPE_CHECKING
+from testing import make_env, run_pex_command
+from testing.pytest_utils.tmp import Tempdir
+from testing.scie import skip_if_no_provider
+
+if TYPE_CHECKING:
+    from typing import List
+
+
+@pytest.mark.parametrize(
+    "execution_mode_args",
+    [
+        pytest.param([], id="ZIPAPP"),
+        pytest.param(["--venv"], id="VENV"),
+    ],
+)
+@skip_if_no_provider
+def test_scie_ephemeral_run(
+    tmpdir,  # type: Tempdir
+    pex_wheel,  # type: str
+    execution_mode_args,  # type: List[str]
+):
+    # type: (...) -> None
+
+    pex_scie = tmpdir.join("pex")
+    run_pex_command(
+        args=[pex_wheel, "-c", "pex", "-o", pex_scie, "--scie", "eager"] + execution_mode_args
+    ).assert_success()
+
+    ic = "CPython=={major}.{minor}.*".format(major=sys.version_info[0], minor=sys.version_info[1])
+
+    # Verify the scie can perform an ephemeral run with `-- -c`.
+    output = subprocess.check_output(
+        args=[
+            pex_scie,
+            "--interpreter-constraint",
+            ic,
+            "--",
+            "-c",
+            "import sys; print(sys.executable)",
+        ],
+        env=make_env(PATH=None),
+    )
+    assert output.decode("utf-8").strip()
+
+    # Verify the scie can drop into a REPL via ephemeral run.
+    process = subprocess.Popen(
+        args=[pex_scie, "--interpreter-constraint", ic, "--"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=make_env(PATH=None),
+    )
+    stdout, stderr = process.communicate(input=b"import sys; print(sys.executable)\nquit()\n")
+    assert process.returncode == 0, stderr.decode("utf-8")
+    assert b">>>" in stdout or b">>>" in stderr


### PR DESCRIPTION
Assuming main checked out, I wanted this to work:

```shell
#!/usr/bin/env bash
set -euo pipefail

TMPDIR=$(mktemp -d)
PEX_ROOT="$TMPDIR/pex_root"
uv run python -m pex . -c pex -o "$TMPDIR/pex.pex" --scie eager --venv --pex-root "$PEX_ROOT" --runtime-pex-root "$PEX_ROOT" 2>&1 | tail -1

echo "=== Venv scie: -- -c ==="
"$TMPDIR/pex" --pex-root "$PEX_ROOT" --runtime-pex-root "$PEX_ROOT" --interpreter-constraint 'CPython>=3.12' -- -c 'import sys; print(sys.executable)' 2>&1
echo "EXIT: $?"

echo ""
echo "=== Venv scie: REPL ==="
echo 'import sys; print("REPL:", sys.executable); quit()' | "$TMPDIR/pex" --pex-root "$PEX_ROOT" --runtime-pex-root "$PEX_ROOT" --interpreter-constraint 'CPython>=3.12' -- 2>&1
echo "EXIT: $?"

echo ""
echo "=== Non-venv scie: -- -c ==="
TMPDIR2=$(mktemp -d)
uv run python -m pex . -c pex -o "$TMPDIR2/pex.pex" --scie eager 2>&1 | tail -1
"$TMPDIR2/pex" --interpreter-constraint 'CPython>=3.12' -- -c 'import sys; print(sys.executable)' 2>&1
echo "EXIT: $?"
```