### PR TITLE
Fix universal lock splitting for extra markers.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 2.92.3
+
+This release fixes universal lock splits that use extra markers not directly related to
+`--style universal` target systems or `--interpreter-constraints`. Previously these triggered an
+internal exception. That bug is now fixed and the scope of manually induced splits is now
+broadened to include extra markers when used alone.
+
+* Fix universal lock splitting for extra markers. (#3150)
+
 ## 2.92.2
 
 This release fixes `pex3 lock create --avoid-downloads` hashing of VCS requirements where the VCS

--- a/pex/resolve/lockfile/targets.py
+++ b/pex/resolve/lockfile/targets.py
@@ -161,11 +161,23 @@ def _iter_universal_targets(
             implementations.add(implementation)
             requires_python.add(python_specifier)
         impl = implementations.pop() if len(implementations) == 1 else None
-        yield UniversalTarget(
-            implementation=impl,
-            systems=tuple(systems),
-            requires_python=tuple(requires_python),
+        conflicts = ExtraMarkers.extract_conflicts(
+            tuple(split_markers[marker] for marker in markers)
         )
+        if conflicts:
+            for extra_markers in conflicts:
+                yield UniversalTarget(
+                    implementation=impl,
+                    systems=tuple(systems),
+                    requires_python=tuple(requires_python),
+                    extra_markers=extra_markers,
+                )
+        else:
+            yield UniversalTarget(
+                implementation=impl,
+                systems=tuple(systems),
+                requires_python=tuple(requires_python),
+            )
 
 
 if TYPE_CHECKING:

--- a/pex/resolve/target_system.py
+++ b/pex/resolve/target_system.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import operator
 import sys
+from collections import OrderedDict
 
 from pex import pex_warnings
 from pex.common import pluralize
@@ -290,6 +291,25 @@ class Values(object):
         # type: () -> Dict[str, Any]
         return {"marker_name": self.marker_name, "values": self.values, "inclusive": self.inclusive}
 
+    def as_marker(self):
+        # type: () -> Marker
+
+        op = "==" if self.inclusive else "!="
+
+        def format_clause(value):
+            # type: (str) -> str
+            return "{name} {op} '{value}'".format(name=self.marker_name, op=op, value=value)
+
+        if len(self.values) == 1:
+            return Marker(format_clause(self.values[0]))
+
+        conjunction = " or " if self.inclusive else " and "
+        return Marker(
+            "({values})".format(
+                values=conjunction.join(format_clause(value) for value in self.values)
+            )
+        )
+
     def apply(self, func):
         # type: (Callable[[str], bool]) -> bool
         if len(self.values) == 0:
@@ -516,7 +536,7 @@ class EvalMarkerFunc(object):
 class ExtraMarkersVisitor(MarkerVisitor[str]):
     def __init__(self):
         # type: () -> None
-        self.conflicts = OrderedSet()  # type: OrderedSet[str]
+        self.conflicts = OrderedDict()  # type: OrderedDict[str, Tuple[str, OrderedSet[str], bool]]
         self._marker_values = {}  # type: Dict[str, Tuple[str, OrderedSet[str], bool]]
 
     def visit_op(
@@ -555,7 +575,7 @@ class ExtraMarkersVisitor(MarkerVisitor[str]):
                 name, (context, OrderedSet(), True)
             )
             if not inclusive:
-                self.conflicts.add(
+                conflict = (
                     "The requirement {context} includes {value} for {name} but the requirement "
                     "{requirement} established {name} as an exclusive set with values: "
                     "{values}.".format(
@@ -566,6 +586,10 @@ class ExtraMarkersVisitor(MarkerVisitor[str]):
                         values=" ".join(values),
                     )
                 )
+                _, conflicting_values, _ = self.conflicts.setdefault(
+                    conflict, (name, OrderedSet(), True)
+                )
+                conflicting_values.add(value)
             else:
                 values.add(value)
         elif op_symbol == "!=":
@@ -573,7 +597,7 @@ class ExtraMarkersVisitor(MarkerVisitor[str]):
                 name, (context, OrderedSet(), False)
             )
             if inclusive:
-                self.conflicts.add(
+                conflict = (
                     "The requirement {context} excludes {value} for {name} but the requirement "
                     "{requirement} established {name} as an inclusive set with values: "
                     "{values}.".format(
@@ -584,6 +608,10 @@ class ExtraMarkersVisitor(MarkerVisitor[str]):
                         values=" ".join(values),
                     )
                 )
+                _, conflicting_values, _ = self.conflicts.setdefault(
+                    conflict, (name, OrderedSet(), False)
+                )
+                conflicting_values.add(value)
             else:
                 values.add(value)
         else:
@@ -605,6 +633,38 @@ class ExtraMarkersVisitor(MarkerVisitor[str]):
 
 @attr.s(frozen=True)
 class ExtraMarkers(object):
+    @classmethod
+    def extract_conflicts(cls, markers):
+        # type: (Iterable[Marker]) -> Tuple[ExtraMarkers, ...]
+
+        visitor = ExtraMarkersVisitor()
+        marker_parser = MarkerParser(visitor)
+        for marker in markers:
+            marker_parser.parse(marker, context=str(marker))
+
+        conflicts = []
+        if visitor.conflicts:
+            values_by_marker_name = {
+                values.marker_name: values for values in visitor.marker_values()
+            }
+            for (name, conflicting_vals, inclusive) in visitor.conflicts.values():
+                values = values_by_marker_name[name]
+                conflicts.append(
+                    cls(markers=tuple([values.as_marker()]), marker_values=tuple([values]))
+                )
+                conflicting_values = Values(
+                    marker_name=name,
+                    values=tuple(conflicting_vals),
+                    inclusive=inclusive,
+                )
+                conflicts.append(
+                    cls(
+                        markers=tuple([conflicting_values.as_marker()]),
+                        marker_values=tuple([conflicting_values]),
+                    )
+                )
+        return tuple(conflicts)
+
     @classmethod
     def extract(cls, requirements):
         # type: (Iterable[Tuple[Marker, str]]) -> Optional[ExtraMarkers]
@@ -669,7 +729,16 @@ class MarkerEnv(object):
     @classmethod
     def from_dict(cls, data):
         # type: (Dict[str, Any]) -> MarkerEnv
-        return cls(**data)
+        return cls(
+            extras=SortedTuple(data["extras"]),
+            os_names=SortedTuple(data["os_names"]),
+            platform_systems=SortedTuple(data["platform_systems"]),
+            sys_platforms=SortedTuple(data["sys_platforms"]),
+            platform_python_implementations=SortedTuple(data["platform_python_implementations"]),
+            python_versions=SortedTuple(data["python_versions"]),
+            python_full_versions=SortedTuple(data["python_full_versions"]),
+            extra_markers=ExtraMarkers.from_dict(data["extra_markers"]),
+        )
 
     @classmethod
     def create(
@@ -740,7 +809,16 @@ class MarkerEnv(object):
 
     def as_dict(self):
         # type: () -> Dict[str, Any]
-        return attr.asdict(self)
+        return {
+            "extras": self.extras,
+            "os_names": self.os_names,
+            "platform_systems": self.platform_systems,
+            "sys_platforms": self.sys_platforms,
+            "platform_python_implementations": self.platform_python_implementations,
+            "python_versions": self.python_versions,
+            "python_full_versions": self.python_full_versions,
+            "extra_markers": self.extra_markers.to_dict(),
+        }
 
     def evaluate(self, marker):
         # type: (Marker) -> bool

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.92.2"
+__version__ = "2.92.3"

--- a/tests/integration/test_scoped_repos.py
+++ b/tests/integration/test_scoped_repos.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 
 import os.path
+import platform
 import shutil
 import subprocess
 import sys
@@ -20,6 +21,7 @@ from pex.http.server import Server
 from pex.os import LINUX, MAC, WINDOWS
 from pex.pip.version import PipVersion
 from pex.requirements import as_parsed_requirement
+from pex.resolve.lockfile import json_codec
 from pex.typing import TYPE_CHECKING
 from testing import (
     IS_MAC,
@@ -678,7 +680,7 @@ def create_app_whl(
     tmpdir,  # type: Tempdir
     project_name,  # type: str
     require_ansicolors,  # type: bool
-    current_platform_system,  # type: str
+    current_system_marker,  # type: str
 ):
     # type: (...) -> str
 
@@ -738,8 +740,8 @@ def create_app_whl(
                     ansicolors=(
                         "ansicolors"
                         if require_ansicolors
-                        else "ansicolors; platform_system == '{current}'".format(
-                            current=current_platform_system
+                        else "ansicolors; {current_system_marker}".format(
+                            current_system_marker=current_system_marker
                         )
                     ),
                 )
@@ -757,6 +759,76 @@ def create_app_whl(
             )
         )
     return WheelBuilder(source_dir=project_dir).bdist()
+
+
+def assert_universal_scope_split(
+    tmpdir,  # type: Tempdir
+    marker_name,  # type: str
+    current_system_marker_value,  # type: str
+):
+    # type: (...) -> None
+
+    project_name = "app-{uuid}".format(uuid=uuid.uuid4().hex)
+
+    current_system_marker = "{marker_name} == '{current_system_marker_value}'".format(
+        marker_name=marker_name, current_system_marker_value=current_system_marker_value
+    )
+    other_system_marker = "{marker_name} != '{current_system_marker_value}'".format(
+        marker_name=marker_name, current_system_marker_value=current_system_marker_value
+    )
+
+    current_fl = safe_mkdir(tmpdir.join("current-fl"))
+    shutil.move(
+        create_app_whl(
+            tmpdir,
+            project_name=project_name,
+            require_ansicolors=True,
+            current_system_marker=current_system_marker,
+        ),
+        current_fl,
+    )
+
+    other_fl = safe_mkdir(tmpdir.join("other-fl"))
+    shutil.move(
+        create_app_whl(
+            tmpdir,
+            project_name=project_name,
+            require_ansicolors=False,
+            current_system_marker=current_system_marker,
+        ),
+        other_fl,
+    )
+
+    pex_root = tmpdir.join("pex-root")
+    lock_file = tmpdir.join("lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--pex-root",
+        pex_root,
+        "--style",
+        "universal",
+        "--find-links",
+        "current_fl={current_fl}".format(current_fl=current_fl),
+        "--source",
+        "current_fl=app-.*; {current_system_marker}".format(
+            current_system_marker=current_system_marker
+        ),
+        "--find-links",
+        "other_fl={other_fl}".format(other_fl=other_fl),
+        "--source",
+        "other_fl=app-.*; {other_system_marker}".format(other_system_marker=other_system_marker),
+        project_name,
+        "--indent",
+        "2",
+        "-o",
+        lock_file,
+        "--pip-log",
+        tmpdir.join("pip.log"),
+    ).assert_success()
+
+    lock = json_codec.load(lock_file)
+    assert len(lock.locked_resolves) == 2
 
 
 @pytest.fixture
@@ -777,54 +849,14 @@ def test_different_requirements_per_scope(
 ):
     # type: (...) -> None
 
-    project_name = "app-{uuid}".format(uuid=uuid.uuid4().hex)
-
-    current_fl = safe_mkdir(tmpdir.join("current-fl"))
-    shutil.move(
-        create_app_whl(
-            tmpdir,
-            project_name=project_name,
-            require_ansicolors=True,
-            current_platform_system=current_platform_system,
-        ),
-        current_fl,
+    assert_universal_scope_split(
+        tmpdir, marker_name="platform_system", current_system_marker_value=current_platform_system
     )
 
-    other_fl = safe_mkdir(tmpdir.join("other-fl"))
-    shutil.move(
-        create_app_whl(
-            tmpdir,
-            project_name=project_name,
-            require_ansicolors=False,
-            current_platform_system=current_platform_system,
-        ),
-        other_fl,
+
+def test_different_requirements_per_scope_issue_3147(tmpdir):
+    # type: (Tempdir) -> None
+
+    assert_universal_scope_split(
+        tmpdir, marker_name="platform_machine", current_system_marker_value=platform.machine()
     )
-
-    pex_root = tmpdir.join("pex-root")
-    lock_file = tmpdir.join("lock.json")
-    run_pex3(
-        "lock",
-        "create",
-        "--pex-root",
-        pex_root,
-        "--style",
-        "universal",
-        "--find-links",
-        "current_fl={current_fl}".format(current_fl=current_fl),
-        "--source",
-        "current_fl=app-.*; platform_system == '{current}'".format(current=current_platform_system),
-        "--find-links",
-        "other_fl={other_fl}".format(other_fl=other_fl),
-        "--source",
-        "other_fl=app-.*; platform_system != '{current}'".format(current=current_platform_system),
-        project_name,
-        "--indent",
-        "2",
-        "-o",
-        lock_file,
-        "--pip-log",
-        tmpdir.join("pip.log"),
-    ).assert_success()
-
-    run_pex3("lock", "export", "--format", "pep-751", lock_file).assert_success()


### PR DESCRIPTION
Previously, splits that used extra markers not directly related to
`--style universal` target systems or `--interpreter-constraints` led to
an internal bug. That bug is now fixed and the scope of manually induced
splits is now broadened to include extra markers when used alone.

Fixes #3147